### PR TITLE
fix(session): polish the session UX end to end

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,23 @@ linked, not inlined.
 
 ## Register
 
+### A URL that carries a credential must never reach a log line (2026-08-20)
+
+**When:** logging any URL you did not build literally on that line —
+WebSocket connect URLs, presigned links, proxy targets, redirect targets.
+Browser WebSockets cannot send headers, so auth is smuggled in the query
+string (`?token=`), which turns "log the URL you are dialing" into "print the
+user's session JWT". Log `url.split('?')[0]`, or the origin + path, never the
+whole thing. Reconnect backoffs make it worse: one flapping sandbox reprints
+the credential every 1-15s for as long as it flaps.
+*Incident:* `pty-terminal.tsx` logged the full PTY WebSocket URL from
+`getKortixPtyWebSocketUrl`, which appends the live Supabase access token, on
+every connect AND every reconnect. The same file already carried a comment
+saying never to echo the token-bearing URL into the visible buffer — the rule
+existed, the enforcement did not. Found by audit, not by an incident; fixed in
+PR #6663. **No enforcer yet** — a lint rule banning bare `wsUrl`/`url`
+identifiers as console arguments is the TODO.
+
 ### A per-host credential never goes in a client-wide header bag (2026-08-20)
 
 **When:** giving any browser/HTTP client a token that authorises ONE origin —

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -349,6 +349,16 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   // lifecycle, so nothing under it remounts as the boot advances.
   const [chatReady, setChatReady] = useState(false);
   const [loaderMounted, setLoaderMounted] = useState(true);
+  // Belt and braces for the `onTransitionEnd` unmount below: `transitionend`
+  // never fires when the tab is backgrounded mid-fade, nor under
+  // `prefers-reduced-motion` where the duration is 0. Without this the loader
+  // subtree — including its 1s boot-clock interval — stays mounted behind
+  // `opacity-0` for the rest of the session.
+  useEffect(() => {
+    if (!chatReady || !loaderMounted) return;
+    const t = setTimeout(() => setLoaderMounted(false), 350);
+    return () => clearTimeout(t);
+  }, [chatReady, loaderMounted]);
   // Seeded ONCE, on mount, in a single initializer — both halves of the hand-off
   // are read in the same pass and land in the same commit, so they cannot come
   // apart the way the old render-phase ref/setState pair could. There is no

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -46,6 +46,7 @@ import {
   isDormantSessionWithoutRuntime,
   isUnmaterializedSessionFailure,
 } from '@/features/session/session-terminal-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/session-delete-modal';
 import { useAccountState } from '@/hooks/billing';
 import { useSandboxConnection } from '@/hooks/platform/use-sandbox-connection';
@@ -587,6 +588,11 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
         <InlineSessionError
           title="Couldn't start session"
           message="This session is no longer available, or you do not have access to it."
+          action={
+            <Button variant="outline" size="sm" onClick={() => router.push(`/projects/${projectId}`)}>
+              Back to project
+            </Button>
+          }
         />
       );
     }
@@ -662,6 +668,11 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
           title="This session's computer was lost"
           message="Its cloud sandbox disappeared on the provider side, so this session cannot be restarted or recovered. This is a fault on our end, not something you did — it has been reported automatically. Anything committed and pushed from this session is safe in your project's repository."
           detail={sandbox?.external_id ? `${sandbox.provider} · ${sandbox.external_id}` : undefined}
+          action={
+            <Button variant="outline" size="sm" onClick={() => setDeleteOpen(true)}>
+              Delete session
+            </Button>
+          }
         />
       );
     }
@@ -826,16 +837,18 @@ function InlineSessionError({
 }) {
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center px-6">
-      <div className="flex max-w-md flex-col items-center gap-3 text-center">
-        <h2 className="text-foreground/90 text-sm font-medium">{title}</h2>
-        <p className="text-muted-foreground/70 text-xs leading-relaxed">{message}</p>
-        {detail ? (
-          <p className="border-border/60 bg-muted/40 text-muted-foreground max-w-full rounded-md border px-2 py-1 font-mono text-xs leading-relaxed">
-            {detail}
-          </p>
-        ) : null}
-        {action}
-      </div>
+      <ErrorState
+        title={title}
+        description={message}
+        action={action}
+        secondaryAction={
+          detail ? (
+            <code className="border-border/60 bg-muted/40 text-muted-foreground max-w-full rounded-md border px-2 py-1 font-mono text-xs leading-relaxed break-all">
+              {detail}
+            </code>
+          ) : undefined
+        }
+      />
     </div>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -223,6 +223,16 @@
   --color-kortix-green: var(--kortix-green);
   --color-kortix-purple: var(--kortix-purple);
   --color-kortix-red: var(--kortix-red);
+  /* Terminal surface. The PTY pane and its chrome (the connect strip, the
+     panel shell behind it) are always dark, in every app theme, because they
+     mirror a real shell — so these are literals, not light/dark pairs. One
+     set of tokens so the three files that paint that surface cannot drift
+     apart again. `terminalTheme` in features/session/pty-terminal.tsx must
+     keep `background` equal to --terminal-surface and `foreground` equal to
+     --terminal-fg: xterm's ITheme needs concrete colors, not CSS vars. */
+  --color-terminal-surface: var(--terminal-surface);
+  --color-terminal-fg: var(--terminal-fg);
+  --color-terminal-border: var(--terminal-border);
   /* Emoji-picker active-cell tints (src/components/ui/emoji-picker.tsx).
      Six hues the picker rotates through so the hovered/keyboard-active cell is
      never the same colour as the cell above it. They live here rather than as
@@ -693,6 +703,12 @@
   --kortix-green: oklch(0.581 0.165 146.619);
   --kortix-purple: oklch(0.675 0.131 306.212);
   --kortix-red: oklch(0.648 0.202 24.745);
+
+  /* Terminal surface — declared once, never re-declared under .dark: the PTY
+     pane keeps the same shell-black in both themes. See the @theme mapping. */
+  --terminal-surface: #0f0f0f;
+  --terminal-fg: #e5e5e5;
+  --terminal-border: rgb(255 255 255 / 0.1);
 
   /* Motion tokens (canonical values; mirrored in @theme for utilities) */
   --duration-fast: 100ms;
@@ -2000,8 +2016,13 @@ html[data-desktop='true'] .kx-titlebar-row[data-sidebar-collapsed] {
 /* Coarse-pointer (touch) targets inside the composer toolbar — added once
    here at the shell rather than per-button, since every toolbar button is a
    plain <button> with no shared class today. */
+/* The underbar is listed too. It holds the SAME attach control the toolbar
+   used to, so with only `.kortix-composer-toolbar` here one button was 40px on
+   project home (inline underbar, inside the toolbar) and 32px in a session
+   (row underbar, outside it). */
 @media (pointer: coarse) {
-  .kortix-composer-toolbar button {
+  .kortix-composer-toolbar button,
+  .kortix-composer-underbar button {
     min-height: 2.5rem;
     min-width: 2.5rem;
   }
@@ -2073,9 +2094,9 @@ html[data-desktop='true'] .kx-titlebar-row[data-sidebar-collapsed] {
    above. `composer.tsx` applies `.composer-locked-approval` to the
    editor's own wrapper only while `lockForApproval` is true; scoped to the
    placeholder `::before` alone so it can never affect real typed text. */
+/* `--kortix-yellow`, not Tailwind's raw amber scale: the token is already
+   defined for both themes, so one rule replaces the light/dark pair that
+   hard-coded two palette colours the design system does not own. */
 .composer-locked-approval .kortix-composer-editor .ProseMirror p.is-editor-empty:first-child::before {
-  color: var(--color-amber-600);
-}
-.dark .composer-locked-approval .kortix-composer-editor .ProseMirror p.is-editor-empty:first-child::before {
-  color: var(--color-amber-400);
+  color: var(--kortix-yellow);
 }

--- a/apps/web/src/components/markdown/code/code-block.tsx
+++ b/apps/web/src/components/markdown/code/code-block.tsx
@@ -4,7 +4,7 @@ import { CopyButton } from '@/components/markdown/copy-button';
 import { languageLabel } from '@/components/markdown/unified-markdown-utils';
 import { cn } from '@/lib/utils';
 import { useTheme } from 'next-themes';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   highlightAsync,
@@ -74,8 +74,38 @@ export function CodeBlock({
   isStreaming?: boolean;
   className?: string;
 }) {
+  const scrollRef = useRef<HTMLPreElement>(null);
+  const pinRaf = useRef<number | null>(null);
+
+  // Follow the tail while the block is still streaming. Without this the
+  // `max-h-[520px]` clamp holds the reader at the top of a block that keeps
+  // growing underneath it — the newest lines, the only ones worth watching,
+  // stay off-screen until the turn ends.
+  //
+  // `el.scrollHeight` is a layout read. Doing it once per streamed token in a
+  // layout effect forces a synchronous layout flush per delta; scheduling it
+  // in `requestAnimationFrame` moves the read to the point the browser is
+  // already computing layout for that frame's paint. Cancelling a pending rAF
+  // before scheduling a new one collapses several deltas that land in the same
+  // frame into the single measurement that frame actually paints.
+  useEffect(() => {
+    if (!isStreaming) return;
+    if (pinRaf.current !== null) cancelAnimationFrame(pinRaf.current);
+    pinRaf.current = requestAnimationFrame(() => {
+      pinRaf.current = null;
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+    return () => {
+      if (pinRaf.current !== null) {
+        cancelAnimationFrame(pinRaf.current);
+        pinRaf.current = null;
+      }
+    };
+  }, [isStreaming, code]);
+
   return (
-    <div
+    <figure
       className={cn(
         'group not-prose bg-card dark:bg-muted relative my-5 overflow-hidden rounded-md border',
         className,
@@ -91,16 +121,17 @@ export function CodeBlock({
         {code && !isStreaming && <CopyButton code={code} />}
       </figcaption>
       <pre
+        ref={scrollRef}
         className={cn(
           'bg-popover max-h-[520px] overflow-auto py-2.5',
-          'text-foreground rounded-t-sm font-mono text-xs leading-[1.65]',
+          'text-foreground font-mono text-xs leading-[1.65]',
           '[&_code]:border-none [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-xs',
           '[&_.shiki]:!bg-transparent [&_span]:border-none [&_span]:!bg-transparent [&_span]:outline-none',
         )}
       >
         {children}
       </pre>
-    </div>
+    </figure>
   );
 }
 

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -243,13 +243,21 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
         ),
 
         // GFM task-list checkbox.
-        input: ({ checked, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => (
+        input: ({
+          checked,
+          className: inputClassName,
+          node: _node,
+          ...props
+        }: React.InputHTMLAttributes<HTMLInputElement> & { node?: unknown }) => (
           <input
+            {...props}
             type="checkbox"
             checked={checked}
             readOnly
-            className="border-border accent-secondary relative -top-[1px] mr-2 size-4 cursor-default rounded align-middle"
-            {...props}
+            className={cn(
+              inputClassName,
+              'border-border accent-secondary relative -top-[1px] mr-2 size-4 cursor-default rounded-sm align-middle',
+            )}
           />
         ),
 
@@ -258,8 +266,9 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           children,
           style,
           className: divClassName,
+          node: _node,
           ...props
-        }: React.HTMLAttributes<HTMLDivElement>) => {
+        }: React.HTMLAttributes<HTMLDivElement> & { node?: unknown }) => {
           if (isKatexClassName(divClassName)) {
             return (
               <div
@@ -285,8 +294,9 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
           children,
           style,
           className: spanClassName,
+          node: _node,
           ...props
-        }: React.HTMLAttributes<HTMLSpanElement>) => {
+        }: React.HTMLAttributes<HTMLSpanElement> & { node?: unknown }) => {
           if (isKatexClassName(spanClassName)) {
             return (
               <span
@@ -314,6 +324,20 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
 
     const safeContent = typeof content === 'string' ? content : content ? String(content) : '';
 
+    // Three whole-string rewrites (KaTeX prep, system-tag strip, autolink). Run
+    // bare, they re-ran on EVERY render of this component — including every
+    // render caused by something other than a new token — for the full length
+    // of the answer. Memoising on the string collapses that to once per
+    // distinct value. It sits ABOVE the empty-content early return so the hook
+    // order stays fixed.
+    const finalContent = useMemo(
+      () =>
+        safeContent
+          ? autoLinkUrls(stripKortixSystemTags(prepareMarkdownForKatex(safeContent)))
+          : '',
+      [safeContent],
+    );
+
     if (!safeContent) {
       return (
         <div className={cn('text-muted-foreground text-sm', className)}>
@@ -321,8 +345,6 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
         </div>
       );
     }
-
-    const finalContent = autoLinkUrls(stripKortixSystemTags(prepareMarkdownForKatex(safeContent)));
 
     return (
       <div

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -27,7 +27,7 @@ const badgeColors = {
 type BadgeColor = keyof typeof badgeColors;
 
 const badgeVariants = cva(
-  'border-transparent disabled:border-alpha-300 focus-visible:ring-offset-background outline-hidden has-focus-visible:ring-2 pointer-events-none inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium leading-none ring-blue-600 transition-all focus-visible:ring-2 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:ring-0 [&>svg]:pointer-events-none bg-accent text-accent-foreground hover:bg-accent focus:bg-accent focus-visible:bg-accent has-[>svg]:gap-2 has-[>svg]:pl-[10px] [&>svg]:size-3 h-6 rounded-full',
+  'border-transparent disabled:border-alpha-300 focus-visible:ring-offset-background outline-hidden has-focus-visible:ring-2 pointer-events-none inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium leading-none ring-blue-600 transition-[color,background-color,border-color,box-shadow,opacity,scale] focus-visible:ring-2 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:ring-0 [&>svg]:pointer-events-none bg-accent text-accent-foreground hover:bg-accent focus:bg-accent focus-visible:bg-accent has-[>svg]:gap-2 has-[>svg]:pl-[10px] [&>svg]:size-3 h-6 rounded-full',
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50  [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none  aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center cursor-pointer shadow-none data-[state=open]:ring-0 focus-visible:outline-none focus-visible:ring-kortix-base focus-visible:ring-[0.6px]",
+  "flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,opacity,scale,translate] disabled:pointer-events-none disabled:opacity-50  [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none  aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive text-center cursor-pointer shadow-none data-[state=open]:ring-0 focus-visible:outline-none focus-visible:ring-kortix-base focus-visible:ring-[0.6px]",
 
   {
     variants: {

--- a/apps/web/src/components/ui/disclosure.tsx
+++ b/apps/web/src/components/ui/disclosure.tsx
@@ -8,6 +8,13 @@ import { createContext, useCallback, useContext, useId, useMemo, useState } from
 export type DisclosureContextType = {
   open: boolean;
   toggle: () => void;
+  /**
+   * Minted once per disclosure so the trigger can point `aria-controls` at the
+   * region it expands. `DisclosureContent` stamps the same id on its element —
+   * a locally-minted id there could not be reached by the trigger, which is why
+   * the attribute was missing entirely.
+   */
+  contentId: string;
   variants?: { expanded: Variant; collapsed: Variant };
 };
 
@@ -78,6 +85,7 @@ function DisclosureProvider({
   variants,
 }: DisclosureProviderProps) {
   const isControlled = openProp !== undefined;
+  const contentId = useId();
   const [uncontrolledOpen, setUncontrolledOpen] = useState<boolean>(defaultOpen);
   const open = isControlled ? openProp : uncontrolledOpen;
 
@@ -95,7 +103,10 @@ function DisclosureProvider({
    * tool's own collapsible, sometimes a group), so the churn multiplied by every
    * row on screen.
    */
-  const value = useMemo(() => ({ open, toggle, variants }), [open, toggle, variants]);
+  const value = useMemo(
+    () => ({ open, toggle, contentId, variants }),
+    [open, toggle, contentId, variants],
+  );
 
   return <DisclosureContext.Provider value={value}>{children}</DisclosureContext.Provider>;
 }
@@ -181,7 +192,7 @@ export function DisclosureTrigger({
   className?: string;
   variant?: 'default' | 'outline';
 }) {
-  const { toggle, open } = useDisclosure();
+  const { toggle, open, contentId } = useDisclosure();
 
   return (
     <>
@@ -193,6 +204,7 @@ export function DisclosureTrigger({
           onClick?: React.MouseEventHandler;
           role?: string;
           'aria-expanded'?: boolean;
+          'aria-controls'?: string;
           tabIndex?: number;
           onKeyDown?: React.KeyboardEventHandler;
           className?: string;
@@ -205,6 +217,9 @@ export function DisclosureTrigger({
           onClick: toggle,
           role: 'button',
           'aria-expanded': open,
+          // The region is unmounted while collapsed, so only promise an id that
+          // is actually in the document.
+          'aria-controls': open ? contentId : undefined,
           tabIndex: 0,
           onKeyDown: (e: React.KeyboardEvent) => {
             if (e.key === 'Enter' || e.key === ' ') {
@@ -236,8 +251,7 @@ export function DisclosureContent({
   contentClassName?: string;
   variant?: 'default' | 'outline';
 }) {
-  const { open, variants } = useDisclosure();
-  const uniqueId = useId();
+  const { open, variants, contentId } = useDisclosure();
 
   const BASE_VARIANTS: Variants = {
     expanded: {
@@ -266,7 +280,7 @@ export function DisclosureContent({
       <AnimatePresence initial={false}>
         {open && (
           <m.div
-            id={uniqueId}
+            id={contentId}
             initial="collapsed"
             animate="expanded"
             exit="collapsed"

--- a/apps/web/src/features/file-viewer/file-content-renderer.tsx
+++ b/apps/web/src/features/file-viewer/file-content-renderer.tsx
@@ -7,8 +7,10 @@ import { CodeEditor } from '@/components/file-editors/code-editor';
 import { MarkdownWithFrontmatter } from '@/components/markdown/markdown-frontmatter';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
+import { StatusDot } from '@/components/ui/status';
 import { errorToast, successToast } from '@/components/ui/toast';
 import {
   appendPreviewToken,
@@ -249,7 +251,7 @@ function FileNotFoundState({ filePath }: { filePath: string }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
-      <div className="bg-muted/50 flex h-12 w-12 items-center justify-center rounded-2xl">
+      <div className="bg-muted/50 flex h-12 w-12 items-center justify-center rounded-sm">
         <FileX className="text-muted-foreground/40 h-6 w-6" />
       </div>
       <p className="text-muted-foreground text-sm font-medium">
@@ -726,6 +728,10 @@ export function FileContentRenderer({
     targetLine,
   };
 
+  const discardLabel: string = tHardcodedUi.raw(
+    'featuresFilesComponentsFileContentRenderer.line600JsxAttrTitleDiscardChanges',
+  );
+
   return (
     <div className={cn('flex h-full flex-col', className)}>
       {/* Header */}
@@ -736,10 +742,7 @@ export function FileContentRenderer({
             {/* Edit state indicator */}
             {!readOnly && hasUnsavedChanges && (
               <Badge variant="warning" size="sm" className="shrink-0">
-                <span className="relative flex h-1.5 w-1.5">
-                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-amber-400 opacity-75"></span>
-                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-500"></span>
-                </span>
+                <StatusDot tone="warning" pulse />
                 Edited
               </Badge>
             )}
@@ -760,13 +763,13 @@ export function FileContentRenderer({
             {(fileDiagErrorCount > 0 || fileDiagWarningCount > 0) && (
               <span className="inline-flex shrink-0 items-center gap-1.5">
                 {fileDiagErrorCount > 0 && (
-                  <span className="text-destructive inline-flex items-center gap-0.5 text-xs font-medium">
+                  <span className="text-destructive inline-flex items-center gap-0.5 text-xs font-medium tabular-nums">
                     <CircleAlert className="h-3 w-3" />
                     {fileDiagErrorCount}
                   </span>
                 )}
                 {fileDiagWarningCount > 0 && (
-                  <span className="inline-flex items-center gap-0.5 text-xs font-medium text-yellow-500">
+                  <span className="text-kortix-orange inline-flex items-center gap-0.5 text-xs font-medium tabular-nums">
                     <AlertTriangle className="h-3 w-3" />
                     {fileDiagWarningCount}
                   </span>
@@ -796,57 +799,66 @@ export function FileContentRenderer({
                   )}
                   Save
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="text-muted-foreground hover:text-foreground h-7 w-7"
-                  onClick={handleDiscard}
-                  title={tHardcodedUi.raw(
-                    'featuresFilesComponentsFileContentRenderer.line600JsxAttrTitleDiscardChanges',
-                  )}
-                >
-                  <RotateCcw className="h-3.5 w-3.5" />
-                </Button>
+                <Hint label={discardLabel} side="bottom">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={discardLabel}
+                    className="text-muted-foreground hover:text-foreground h-7 w-7 active:scale-[0.96]"
+                    onClick={handleDiscard}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </Button>
+                </Hint>
               </>
             )}
 
             {/* HTML preview toggle */}
             {isHtmlFile && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn('h-7 w-7', isHtmlPreview && 'text-primary')}
-                onClick={() => setIsHtmlPreview((v) => !v)}
-                title={isHtmlPreview ? 'View source' : 'Preview'}
-              >
-                {isHtmlPreview ? <Code className="h-4 w-4" /> : <Globe className="h-4 w-4" />}
-              </Button>
+              <Hint label={isHtmlPreview ? 'View source' : 'Preview'} side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={isHtmlPreview ? 'View source' : 'Preview'}
+                  aria-pressed={isHtmlPreview}
+                  className={cn('h-7 w-7 active:scale-[0.96]', isHtmlPreview && 'text-primary')}
+                  onClick={() => setIsHtmlPreview((v) => !v)}
+                >
+                  {isHtmlPreview ? <Code className="h-4 w-4" /> : <Globe className="h-4 w-4" />}
+                </Button>
+              </Hint>
             )}
 
             {/* JSON tree toggle */}
             {isJsonFile && fileContent?.type === 'text' && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn('h-7 w-7', isJsonTreeView && 'text-primary')}
-                onClick={() => setIsJsonTreeView((v) => !v)}
-                title={isJsonTreeView ? 'View source' : 'Tree view'}
-              >
-                <Braces className="h-4 w-4" />
-              </Button>
+              <Hint label={isJsonTreeView ? 'View source' : 'Tree view'} side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={isJsonTreeView ? 'View source' : 'Tree view'}
+                  aria-pressed={isJsonTreeView}
+                  className={cn('h-7 w-7 active:scale-[0.96]', isJsonTreeView && 'text-primary')}
+                  onClick={() => setIsJsonTreeView((v) => !v)}
+                >
+                  <Braces className="h-4 w-4" />
+                </Button>
+              </Hint>
             )}
 
             {/* Markdown preview toggle */}
             {isMarkdownFile && fileContent?.type === 'text' && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className={cn('h-7 w-7', isMarkdownPreview && 'text-primary')}
-                onClick={() => setIsMarkdownPreview((v) => !v)}
-                title={isMarkdownPreview ? 'View source' : 'Preview'}
-              >
-                {isMarkdownPreview ? <Code className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </Button>
+              <Hint label={isMarkdownPreview ? 'View source' : 'Preview'} side="bottom">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  aria-label={isMarkdownPreview ? 'View source' : 'Preview'}
+                  aria-pressed={isMarkdownPreview}
+                  className={cn('h-7 w-7 active:scale-[0.96]', isMarkdownPreview && 'text-primary')}
+                  onClick={() => setIsMarkdownPreview((v) => !v)}
+                >
+                  {isMarkdownPreview ? <Code className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </Button>
+              </Hint>
             )}
 
             {/* Additional header actions from parent */}
@@ -858,7 +870,7 @@ export function FileContentRenderer({
               className="h-7 gap-1.5 px-3 text-xs font-medium"
               onClick={handleDownload}
               disabled={!fileContent && !blobUrl && !rawBlob}
-              title="Download"
+              aria-label="Download"
             >
               <Download className="h-3.5 w-3.5" />
               Download
@@ -873,7 +885,7 @@ export function FileContentRenderer({
         <ClientErrorBoundary
           fallback={() => (
             <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
-              <div className="bg-destructive/10 flex h-12 w-12 items-center justify-center rounded-2xl">
+              <div className="bg-destructive/10 flex h-12 w-12 items-center justify-center rounded-sm">
                 <FileWarning className="text-destructive/50 h-6 w-6" />
               </div>
               <p className="text-muted-foreground text-sm font-medium">
@@ -905,9 +917,7 @@ export function FileContentRenderer({
           {contentError && !showLoadingState && isSandboxWaking && (
             <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
               <Loading className="text-muted-foreground/40 h-4 w-4" />
-              <p className="text-muted-foreground text-sm font-medium">
-                Waking up the workspace…
-              </p>
+              <p className="text-muted-foreground text-sm font-medium">Waking up the workspace…</p>
               <p className="text-muted-foreground/50 max-w-sm font-mono text-xs break-all">
                 {filePath}
               </p>
@@ -927,7 +937,7 @@ export function FileContentRenderer({
               <FileNotFoundState filePath={filePath} />
             ) : (
               <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
-                <div className="bg-destructive/10 flex h-12 w-12 items-center justify-center rounded-2xl">
+                <div className="bg-destructive/10 flex h-12 w-12 items-center justify-center rounded-sm">
                   <FileWarning className="text-destructive/50 h-6 w-6" />
                 </div>
                 <p className="text-muted-foreground text-sm font-medium">
@@ -1012,7 +1022,7 @@ export function FileContentRenderer({
           {/* Audio preview */}
           {isContentReady && fileCategory === 'audio' && blobUrl && (
             <div className="flex h-full flex-col items-center justify-center gap-5 p-8">
-              <div className="bg-muted/50 flex h-14 w-14 items-center justify-center rounded-2xl">
+              <div className="bg-muted/50 flex h-14 w-14 items-center justify-center rounded-sm">
                 <svg
                   className="text-muted-foreground/40 h-6 w-6"
                   viewBox="0 0 24 24"
@@ -1110,7 +1120,7 @@ export function FileContentRenderer({
             !isHeicImage &&
             !['pdf', 'docx', 'pptx', 'xlsx', 'sqlite', 'video', 'audio'].includes(fileCategory) && (
               <div className="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
-                <div className="bg-muted/50 flex h-12 w-12 items-center justify-center rounded-2xl">
+                <div className="bg-muted/50 flex h-12 w-12 items-center justify-center rounded-sm">
                   <FileWarning className="text-muted-foreground/30 h-6 w-6" />
                 </div>
                 <p className="text-muted-foreground/50 text-sm">
@@ -1245,7 +1255,7 @@ function JsonNode({
     return (
       <div style={{ paddingLeft: depth * 20 }}>
         {keyName !== null && <span className="text-primary/70">{`"${keyName}"`}: </span>}
-        <span className="text-yellow-500/80">{String(value)}</span>
+        <span className="text-kortix-yellow">{String(value)}</span>
       </div>
     );
   }
@@ -1254,7 +1264,7 @@ function JsonNode({
     return (
       <div style={{ paddingLeft: depth * 20 }}>
         {keyName !== null && <span className="text-primary/70">{`"${keyName}"`}: </span>}
-        <span className="text-cyan-500/80">{String(value)}</span>
+        <span className="text-kortix-blue">{String(value)}</span>
       </div>
     );
   }
@@ -1264,7 +1274,7 @@ function JsonNode({
     return (
       <div style={{ paddingLeft: depth * 20 }} className="break-all">
         {keyName !== null && <span className="text-primary/70">{`"${keyName}"`}: </span>}
-        <span className="text-emerald-500/80">
+        <span className="text-kortix-green">
           {tHardcodedUi.raw('featuresFilesComponentsFileContentRenderer.line963JsxTextQuot')}
           {value.length > 200 ? value.slice(0, 200) + '...' : value}
           {tHardcodedUi.raw(
@@ -1276,7 +1286,7 @@ function JsonNode({
             href={value}
             target="_blank"
             rel="noopener noreferrer"
-            className="ml-1 text-xs text-blue-400/60 hover:text-blue-400"
+            className="text-kortix-blue/70 hover:text-kortix-blue ml-1 text-xs"
           >
             open
           </a>
@@ -1289,9 +1299,11 @@ function JsonNode({
     const count = value.length;
     return (
       <div>
-        <div
+        <button
+          type="button"
           style={{ paddingLeft: depth * 20 }}
-          className="hover:bg-muted/30 inline-flex cursor-pointer items-center gap-1 rounded-lg transition-colors"
+          aria-expanded={!isCollapsed}
+          className="hover:bg-muted/30 inline-flex cursor-pointer items-center gap-1 rounded-sm text-left transition-colors"
           onClick={() => setIsCollapsed((v) => !v)}
         >
           <span className="text-muted-foreground/40 w-3.5 text-center text-xs select-none">
@@ -1305,7 +1317,7 @@ function JsonNode({
           ) : (
             <span className="text-muted-foreground/30">[</span>
           )}
-        </div>
+        </button>
         {!isCollapsed && (
           <>
             {value.map((item, idx) => (
@@ -1325,9 +1337,11 @@ function JsonNode({
     const count = entries.length;
     return (
       <div>
-        <div
+        <button
+          type="button"
           style={{ paddingLeft: depth * 20 }}
-          className="hover:bg-muted/30 inline-flex cursor-pointer items-center gap-1 rounded-lg transition-colors"
+          aria-expanded={!isCollapsed}
+          className="hover:bg-muted/30 inline-flex cursor-pointer items-center gap-1 rounded-sm text-left transition-colors"
           onClick={() => setIsCollapsed((v) => !v)}
         >
           <span className="text-muted-foreground/40 w-3.5 text-center text-xs select-none">
@@ -1341,7 +1355,7 @@ function JsonNode({
           ) : (
             <span className="text-muted-foreground/30">{'{'}</span>
           )}
-        </div>
+        </button>
         {!isCollapsed && (
           <>
             {entries.map(([k, v]) => (

--- a/apps/web/src/features/file-viewer/file-preview-modal.tsx
+++ b/apps/web/src/features/file-viewer/file-preview-modal.tsx
@@ -2,6 +2,7 @@
 
 import { PublicShareLinkButton } from '@/components/projects/public-share-link-button';
 import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { dialogContentZ, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
@@ -278,15 +279,17 @@ export function FilePreviewModal({
   const toolbar = (
     <>
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground hover:text-foreground h-8 w-8 shrink-0"
-          onClick={onClose}
-          title="Back"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </Button>
+        <Hint label="Back" side="bottom">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Back"
+            className="text-muted-foreground hover:text-foreground h-8 w-8 shrink-0 active:scale-[0.96]"
+            onClick={onClose}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+        </Hint>
         <div className="flex min-w-0 items-center gap-2">
           {renderFileIcon(fileName)}
           <span
@@ -306,41 +309,47 @@ export function FilePreviewModal({
 
       <div className="flex shrink-0 items-center gap-0.5">
         {isMarkdownFile && (
+          <Hint label={markdownPreview ? 'View source' : 'Preview'} side="bottom">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={markdownPreview ? 'View source' : 'Preview'}
+              aria-pressed={!markdownPreview}
+              className={cn(
+                'h-8 w-8 active:scale-[0.96]',
+                markdownPreview
+                  ? 'text-muted-foreground hover:text-foreground'
+                  : 'text-foreground bg-muted',
+              )}
+              onClick={() => setMarkdownPreview((v) => !v)}
+            >
+              {markdownPreview ? <Code className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            </Button>
+          </Hint>
+        )}
+        <Hint label={historyLabel} side="bottom">
           <Button
             variant="ghost"
             size="icon"
+            aria-label={historyLabel}
+            aria-pressed={!!historyPath}
             className={cn(
-              'h-8 w-8',
-              markdownPreview
-                ? 'text-muted-foreground hover:text-foreground'
-                : 'text-foreground bg-muted',
+              'h-8 w-8 active:scale-[0.96]',
+              historyPath
+                ? 'text-foreground bg-muted'
+                : 'text-muted-foreground hover:text-foreground',
             )}
-            onClick={() => setMarkdownPreview((v) => !v)}
-            title={markdownPreview ? 'View source' : 'Preview'}
+            onClick={() => setHistoryPath(historyPath ? null : selectedFilePath)}
           >
-            {markdownPreview ? <Code className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            <History className="h-4 w-4" />
           </Button>
-        )}
-        <Button
-          variant="ghost"
-          size="icon"
-          className={cn(
-            'h-8 w-8',
-            historyPath
-              ? 'text-foreground bg-muted'
-              : 'text-muted-foreground hover:text-foreground',
-          )}
-          onClick={() => setHistoryPath(historyPath ? null : selectedFilePath)}
-          title={historyLabel}
-        >
-          <History className="h-4 w-4" />
-        </Button>
+        </Hint>
         <Button
           variant="outline"
           size="sm"
           className="h-8 gap-1.5 px-3 text-xs font-medium"
           onClick={handleDownload}
-          title="Download"
+          aria-label="Download"
         >
           <Download className="h-3.5 w-3.5" />
           Download
@@ -358,28 +367,38 @@ export function FilePreviewModal({
         )}
         {extraActions}
         {embedded && (
+          <Hint label={expanded ? 'Collapse to panel' : 'Expand'} side="bottom">
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label={expanded ? 'Collapse to panel' : 'Expand'}
+              aria-pressed={expanded}
+              className="text-muted-foreground hover:text-foreground h-8 w-8 active:scale-[0.96]"
+              onClick={() => setExpanded((v) => !v)}
+            >
+              {expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            </Button>
+          </Hint>
+        )}
+        <div className="bg-border/50 mx-1 h-5 w-px" />
+        <Hint
+          label={tI18nHardcoded.raw(
+            'autoFeaturesFileViewerFilePreviewModalJsxAttrTitleClosea40d0510',
+          )}
+          side="bottom"
+        >
           <Button
             variant="ghost"
             size="icon"
-            className="text-muted-foreground hover:text-foreground h-8 w-8"
-            onClick={() => setExpanded((v) => !v)}
-            title={expanded ? 'Collapse to panel' : 'Expand'}
+            aria-label={tI18nHardcoded.raw(
+              'autoFeaturesFileViewerFilePreviewModalJsxAttrTitleClosea40d0510',
+            )}
+            className="text-muted-foreground hover:text-foreground h-8 w-8 active:scale-[0.96]"
+            onClick={onClose}
           >
-            {expanded ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            <X className="h-4 w-4" />
           </Button>
-        )}
-        <div className="bg-border/50 mx-1 h-5 w-px" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground hover:text-foreground h-8 w-8"
-          onClick={onClose}
-          title={tI18nHardcoded.raw(
-            'autoFeaturesFileViewerFilePreviewModalJsxAttrTitleClosea40d0510',
-          )}
-        >
-          <X className="h-4 w-4" />
-        </Button>
+        </Hint>
       </div>
     </>
   );
@@ -428,7 +447,7 @@ export function FilePreviewModal({
       </div>
 
       {historyPath && (
-        <div className="bg-popover border-border/60 animate-in slide-in-from-bottom-4 fade-in-0 absolute right-4 bottom-4 z-30 overflow-hidden rounded-2xl border shadow-2xl duration-150">
+        <div className="bg-popover border-border/60 animate-in slide-in-from-bottom-4 fade-in-0 absolute right-4 bottom-4 z-30 overflow-hidden rounded-md border shadow-md duration-150">
           <HistoryContent filePath={historyPath} onClose={() => setHistoryPath(null)} />
         </div>
       )}
@@ -478,7 +497,7 @@ export function FilePreviewModal({
         aria-modal="true"
         aria-label={`File preview${fileName ? `: ${fileName}` : ''}`}
         tabIndex={-1}
-        className="kx-fullscreen-modal border-border/60 bg-background animate-in fade-in-0 zoom-in-[0.98] pointer-events-auto fixed inset-3 flex flex-col overflow-hidden rounded-2xl border shadow-2xl duration-150 outline-none sm:inset-4"
+        className="kx-fullscreen-modal border-border/60 bg-background animate-in fade-in-0 zoom-in-[0.98] pointer-events-auto fixed inset-3 flex flex-col overflow-hidden rounded-xl border shadow-lg duration-150 outline-none sm:inset-4"
         style={{ zIndex: dialogContentZ(dialogDepth + 1) }}
       >
         {panelInner}

--- a/apps/web/src/features/files/sandbox-file-explorer.tsx
+++ b/apps/web/src/features/files/sandbox-file-explorer.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { DriveExplorer, FileExplorerSourceProvider } from '@/features/project-files';
 import { useRuntimeStore } from '@kortix/sdk/react';
 import {
@@ -39,28 +41,43 @@ function SandboxServerGate({ children }: { children: React.ReactNode }) {
   const serverUrl = useRuntimeStore((s) => s.getActiveServerUrl());
   const { data: health, isLoading: isHealthLoading, refetch } = useServerHealth();
 
-  if (!isHealthLoading && !health?.healthy) {
+  // Hold the gate closed while the first probe is in flight. Rendering the
+  // explorer during the probe made it mount, fail its own listing, and paint a
+  // second failure UI a moment before this one replaced it.
+  if (isHealthLoading) {
     return (
-      <div className="bg-background flex h-full flex-col items-center justify-center gap-4 p-8 text-center">
-        <ServerOff className="text-muted-foreground/30 h-12 w-12" />
-        <div>
-          <h3 className="text-foreground text-base font-medium">
-            {tHardcodedUi.raw(
-              'featuresFilesComponentsFileExplorerPage.line546JsxTextServerNotReachable',
-            )}
-          </h3>
-          <p className="text-muted-foreground mt-1.5 text-sm">
+      <div className="bg-background flex h-full flex-col gap-2 p-4">
+        <Skeleton className="h-8 w-full py-0" />
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-full py-0" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!health?.healthy) {
+    return (
+      <ErrorState
+        icon={ServerOff}
+        className="bg-background h-full"
+        title={tHardcodedUi.raw(
+          'featuresFilesComponentsFileExplorerPage.line546JsxTextServerNotReachable',
+        )}
+        description={
+          <>
             {tHardcodedUi.raw(
               'featuresFilesComponentsFileExplorerPage.line548JsxTextCouldNotConnectTo',
             )}{' '}
             <code className="bg-muted rounded px-1.5 py-0.5 text-xs">{serverUrl}</code>
-          </p>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => refetch()}>
-          <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-          Retry
-        </Button>
-      </div>
+          </>
+        }
+        action={
+          <Button variant="outline" size="sm" className="gap-1.5" onClick={() => refetch()}>
+            <RefreshCw className="size-3.5 shrink-0" />
+            Retry
+          </Button>
+        }
+      />
     );
   }
 

--- a/apps/web/src/features/session/action-panel/browser-panel.tsx
+++ b/apps/web/src/features/session/action-panel/browser-panel.tsx
@@ -13,6 +13,9 @@ import { FaviconAvatar } from '@/components/ui/favicon-avatar';
 import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import { isKortixAppUrl } from '@/features/session/kortix-app-url';
 import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-url';
 import { usePublicShareLink } from '@/hooks/use-public-share-link';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
@@ -20,7 +23,6 @@ import { useSessionPublicShares } from '@/hooks/use-session-public-shares';
 import { INTERACTIVE_PREVIEW_IFRAME_SANDBOX } from '@/lib/security/iframe-sandbox';
 import { cn } from '@/lib/utils';
 import { focusWithoutScroll } from '@/lib/utils/focus-without-scroll';
-import { isKortixAppUrl } from '@/features/session/kortix-app-url';
 import {
   buildWebProxyUrl,
   isExternalUrl,
@@ -523,7 +525,7 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
               type="text"
               size="xs"
               value={urlParts ? fullUrl : addressValue}
-              title={tHardcodedUi.raw(
+              aria-label={tHardcodedUi.raw(
                 'autoComponentsTabsPreviewTabContentJsxAttrTitleEnterA2bdb9e26',
               )}
               onChange={(e) => {
@@ -635,29 +637,25 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
 
           {/* Error state */}
           {hasError && (
-            <div className="bg-background absolute inset-0 z-10 flex items-center justify-center">
-              <div className="flex max-w-sm flex-col items-center gap-4 text-center">
-                <span className="bg-kortix-orange/15 flex size-9 items-center justify-center rounded-sm">
-                  <AlertTriangle className="text-kortix-orange size-5" />
-                </span>
-                <div>
-                  <p className="text-sm font-medium">
-                    {tHardcodedUi.raw(
-                      'componentsTabsPreviewTabContent.line492JsxTextFailedToLoadPreview',
-                    )}
-                  </p>
-                  <p className="text-muted-foreground mt-1 text-xs">
-                    {isExternalBrowsing
-                      ? 'Could not reach the target website.'
-                      : `The service on port ${port} may not be running yet.`}
-                  </p>
-                </div>
+            <ErrorState
+              icon={AlertTriangle}
+              size="sm"
+              className="bg-background absolute inset-0 z-10"
+              title={tHardcodedUi.raw(
+                'componentsTabsPreviewTabContent.line492JsxTextFailedToLoadPreview',
+              )}
+              description={
+                isExternalBrowsing
+                  ? 'Could not reach the target website.'
+                  : `The service on port ${port} may not be running yet.`
+              }
+              action={
                 <Button variant="outline" size="sm" className="gap-1.5" onClick={handleRefresh}>
                   <RefreshCw className="size-3.5 shrink-0" />
                   Retry
                 </Button>
-              </div>
-            </div>
+              }
+            />
           )}
 
           <iframe
@@ -703,27 +701,20 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
               </section>
             </div>
           ) : (
-            <div className="flex h-full items-center justify-center">
-              <div className="text-muted-foreground flex max-w-sm flex-col items-center gap-4 px-4 text-center">
-                <Globe className="size-12 opacity-20" />
-                <div>
-                  <p className="text-foreground text-sm font-medium">
-                    {tHardcodedUi.raw(
-                      'autoComponentsTabsPreviewTabContentJsxTextPreviewBrowser8136da05',
-                    )}
-                  </p>
-                  <p className="mt-1.5 text-xs leading-relaxed text-balance">
-                    {tHardcodedUi.raw(
-                      'autoComponentsTabsPreviewTabContentJsxTextOpenAnAppda305669',
-                    )}{' '}
-                    <span className="text-foreground/80 font-mono">3000</span>{' '}
-                    {tHardcodedUi.raw(
-                      'autoComponentsTabsPreviewTabContentJsxTextIfYouKnow6745fa88',
-                    )}
-                  </p>
-                </div>
-              </div>
-            </div>
+            <EmptyState
+              icon={Globe}
+              className="h-full"
+              title={tHardcodedUi.raw(
+                'autoComponentsTabsPreviewTabContentJsxTextPreviewBrowser8136da05',
+              )}
+              description={
+                <>
+                  {tHardcodedUi.raw('autoComponentsTabsPreviewTabContentJsxTextOpenAnAppda305669')}{' '}
+                  <span className="text-foreground/80 font-mono">3000</span>{' '}
+                  {tHardcodedUi.raw('autoComponentsTabsPreviewTabContentJsxTextIfYouKnow6745fa88')}
+                </>
+              }
+            />
           )}
         </div>
       )}

--- a/apps/web/src/features/session/action-panel/easy/app-preview.tsx
+++ b/apps/web/src/features/session/action-panel/easy/app-preview.tsx
@@ -23,6 +23,7 @@ import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-url';
 import { usePublicShareLink } from '@/hooks/use-public-share-link';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
@@ -37,7 +38,6 @@ import { useIsExpanded, useToggleExpanded } from '@/stores/kortix-computer-store
 import { type CreateSessionPublicShareInput, probePreviewPort } from '@kortix/sdk';
 import { useRuntimeConnectionStore } from '@kortix/sdk/react';
 import {
-  WarningIcon as AlertTriangle,
   ArrowLeftIcon as ArrowLeft,
   ArrowRightIcon as ArrowRight,
   ArrowSquareOutIcon,
@@ -526,34 +526,30 @@ export function AppPreview({
         )}
 
         {hasError && !noApp && (
-          <div className="bg-background absolute inset-0 z-10 flex items-center justify-center">
-            <div className="flex max-w-sm flex-col items-center gap-4 px-4 text-center">
-              <span className="bg-kortix-yellow/15 flex size-9 items-center justify-center rounded-md">
-                <WarningIcon className="text-kortix-yellow size-5" />
-              </span>
-              <div>
-                <p className="text-sm font-medium">Couldn&apos;t load {name}</p>
-                {/* The single most common cause, said plainly: the agent started
-                    the server a moment ago and it isn't listening yet. Only a
-                    SETTLED `dead` verdict earns the stopped-workspace wording —
-                    see `previewErrorReason`. */}
-                <p className="text-muted-foreground mt-1 text-xs">
-                  {previewErrorReason({ sandbox: sandboxHealth, port })}
-                </p>
-              </div>
-              <div className="flex items-center justify-center gap-2">
-                <Button variant="outline" size="sm" className="gap-1.5" onClick={reload}>
-                  Retry
+          <ErrorState
+            icon={WarningIcon}
+            size="sm"
+            className="bg-background absolute inset-0 z-10"
+            title={`Couldn't load ${name}`}
+            /* The single most common cause, said plainly: the agent started the
+               server a moment ago and it isn't listening yet. Only a SETTLED
+               `dead` verdict earns the stopped-workspace wording — see
+               `previewErrorReason`. */
+            description={previewErrorReason({ sandbox: sandboxHealth, port })}
+            action={
+              <Button variant="outline" size="sm" className="gap-1.5" onClick={reload}>
+                Retry
+              </Button>
+            }
+            secondaryAction={
+              onSendToAgent ? (
+                <Button size="sm" className="gap-1.5" onClick={onSendToAgent}>
+                  <SparklesSolid weight="fill" className="size-3.5 shrink-0" />
+                  Send to agent
                 </Button>
-                {onSendToAgent && (
-                  <Button size="sm" className="gap-1.5" onClick={onSendToAgent}>
-                    <SparklesSolid weight="fill" className="size-3.5 shrink-0" />
-                    Send to agent
-                  </Button>
-                )}
-              </div>
-            </div>
-          </div>
+              ) : null
+            }
+          />
         )}
 
         {noApp ? (

--- a/apps/web/src/features/session/action-panel/easy/detail-view.tsx
+++ b/apps/web/src/features/session/action-panel/easy/detail-view.tsx
@@ -146,7 +146,7 @@ export function DetailSidebarToggle({ className }: { className?: string }) {
  * own sidebar instead of a view inside this shell. Shared, the two cannot drift.
  */
 const CARD_FRAME =
-  'bg-popover border-border absolute inset-y-3 right-3 left-3 flex min-w-0 flex-col overflow-hidden rounded-md border shadow';
+  'bg-popover border-border absolute inset-y-3 right-3 left-3 flex min-w-0 flex-col overflow-hidden rounded-md border shadow-md';
 
 /**
  * A layer that lives inside the detail card frame but must NEVER unmount.

--- a/apps/web/src/features/session/action-panel/session-detail-panel.tsx
+++ b/apps/web/src/features/session/action-panel/session-detail-panel.tsx
@@ -24,8 +24,8 @@ import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/u
 import { SessionTerminalPanel } from '@/features/session/session-terminal-panel';
 import { useIsMobile } from '@/hooks/utils';
 import { TerminalIcon } from '@phosphor-icons/react';
-import { EasyPanel } from './easy/easy-panel';
 import { CloseButton, DetailLayer, type PersistentLayer } from './easy/detail-view';
+import { EasyPanel } from './easy/easy-panel';
 import { useOptionalSessionPanel } from './session-panel-provider';
 
 export function SessionDetailPanel() {
@@ -65,10 +65,7 @@ export function SessionDetailPanel() {
             room for a persistent absolutely positioned layer inside a bottom
             sheet. */}
         <Drawer open={terminalOpen} onOpenChange={(next) => !next && closeTerminal()}>
-          <DrawerContent
-            bar={false}
-            className="flex h-[95dvh] max-h-[95dvh] flex-col overflow-hidden p-0"
-          >
+          <DrawerContent className="flex h-[95dvh] max-h-[95dvh] flex-col overflow-hidden p-0">
             <DrawerHeader className="shrink-0 px-4 py-3 text-left">
               <DrawerTitle className="flex items-center justify-between gap-2 text-base">
                 <span className="flex items-center gap-2.5">

--- a/apps/web/src/features/session/attachment-tile.tsx
+++ b/apps/web/src/features/session/attachment-tile.tsx
@@ -34,9 +34,11 @@ export const TILE_SURFACE =
  * nothing or force a name to wrap across more lines than the two-line clamp
  * allows, so non-image tiles get the extra width instead.
  *
- * `max-w-60` is the hard cap that makes `line-clamp-2` fire: without it the
- * tile grows to the filename's max-content width and the ellipsis never
- * appears. `min-w-40` keeps short names from collapsing to the image square.
+ * `h-20 w-30` — 80px tall, 120px wide. That FIXED width is what makes
+ * `line-clamp-2` fire: without a bound the tile grows to the filename's
+ * max-content width and the ellipsis never appears. (It was written
+ * `size-20 w-30`, which sets the width twice and left the real value depending
+ * on stylesheet order rather than on the class list.)
  *
  * Kept as its own constant (not folded into `TILE_SURFACE`) for the same
  * reason `TILE_SURFACE` exists at all: one definition, shared by the sent
@@ -44,7 +46,7 @@ export const TILE_SURFACE =
  * cannot land in one surface without the other.
  */
 export const FILE_TILE_SURFACE =
-  'border-border bg-background relative block size-20 w-30 shrink-0 overflow-hidden rounded-sm border';
+  'border-border bg-background relative block h-20 w-30 shrink-0 overflow-hidden rounded-sm border';
 
 /**
  * The press/hover feel every attachment tile shares — a file pill, an image
@@ -72,13 +74,17 @@ export function FileTileBody({ filename, pending }: { filename: string; pending?
     // `min-w-0` is required on the flex column and the filename: flex items
     // default to `min-width: auto`, which refuses to shrink below the name's
     // max-content width — so a long name expands the tile instead of
-    // clamping. With a bounded tile (`FILE_TILE_SURFACE`'s `max-w-60`) and
+    // clamping. With a bounded tile (`FILE_TILE_SURFACE`'s `w-30`) and
     // `min-w-0`, `line-clamp-2` can actually ellipsize.
     //
     // Do not add `truncate` here. It sets `white-space: nowrap`, which
     // overrides the wrap `line-clamp-2` needs and is the measured cause of
     // "ellipsis missing on long names" (tile grows; nothing clamps).
-    <span className="flex size-20 w-full flex-col justify-between gap-1 p-2">
+    //
+    // `h-20 w-full`, not `size-20 w-full`: the latter set the width twice and
+    // the file tile is 120px wide, not 80 — which of the two won was left to
+    // stylesheet order.
+    <span className="flex h-20 w-full flex-col justify-between gap-1 p-2">
       {pending ? (
         <Loading className="text-muted-foreground size-5 shrink-0" variant="spokes" />
       ) : (

--- a/apps/web/src/features/session/composer/agent-selector.tsx
+++ b/apps/web/src/features/session/composer/agent-selector.tsx
@@ -209,11 +209,24 @@ export function AgentSelector({
         >
           {metaSelected && <MetaFolder className="size-3.5 shrink-0" weight="fill" />}
           <span className={cn('max-w-[100px] truncate', triggerLabelClassName)}>{displayName}</span>
-          <CaretDownIcon className={cn('size-3', open && 'rotate-180')} />
+          <CaretDownIcon
+            className={cn(
+              'size-3 transition-transform duration-200 ease-out',
+              open && 'rotate-180',
+            )}
+          />
         </Button>
       </CommandPopoverTrigger>
 
-      <CommandPopoverContent side="top" align="start" sideOffset={8} className="w-[300px]">
+      {/* `min(...)`, not a hard `300px`: on a 320px viewport a fixed 300px
+          popover plus the trigger's own inset pushed the panel off-screen.
+          Same shape `mention-menu.tsx` uses. */}
+      <CommandPopoverContent
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="w-[min(300px,calc(100vw-1.5rem))]"
+      >
         {/*
           A search field over four agents is a control that costs a row of
           chrome to save nobody any time — the whole list is already on screen

--- a/apps/web/src/features/session/composer/animated-placeholder.tsx
+++ b/apps/web/src/features/session/composer/animated-placeholder.tsx
@@ -120,7 +120,7 @@ export function AnimatedComposerPlaceholder({
       // `inset-x-2` mirrors the wrapper's `px-2`; the font classes mirror
       // `ComposerEditor`'s own, so the overlay sits exactly where the static
       // placeholder would. `overflow-hidden` clips the roll to one line.
-      className="text-muted-foreground pointer-events-none absolute inset-x-2 top-0 overflow-hidden text-[15px] sm:text-[14px]"
+      className="text-muted-foreground pointer-events-none absolute inset-x-2 top-0 overflow-hidden text-base sm:text-sm"
     >
       <AnimatePresence mode="popLayout" initial={false}>
         <m.span

--- a/apps/web/src/features/session/composer/attachment-tiles.tsx
+++ b/apps/web/src/features/session/composer/attachment-tiles.tsx
@@ -45,6 +45,16 @@ function attachmentName(af: AttachedFile): string {
 function AttachmentImageTile({ af, name }: { af: AttachedFile; name: string }) {
   const isHeic = isHeicFile(name);
   const [heicUrl, setHeicUrl] = useState<string | null>(null);
+  // WHICH file failed, not merely "something failed". Storing the attachment
+  // itself makes the reset free: a new `af` no longer matches, so the flag
+  // clears by comparison instead of by a `setState` in the effect body (which
+  // is a cascading render, and what the React Compiler rule flags).
+  //
+  // Before this existed, a failed decode was indistinguishable from one still
+  // running — `.catch(() => {})` swallowed the rejection and the tile spun
+  // forever on a file that was never going to render.
+  const [failedFor, setFailedFor] = useState<AttachedFile | null>(null);
+  const failed = failedFor === af;
 
   useEffect(() => {
     if (!isHeic || af.kind !== 'local') return;
@@ -56,7 +66,9 @@ function AttachmentImageTile({ af, name }: { af: AttachedFile; name: string }) {
         objectUrl = URL.createObjectURL(jpeg);
         setHeicUrl(objectUrl);
       })
-      .catch(() => {});
+      .catch(() => {
+        if (!cancelled) setFailedFor(af);
+      });
     return () => {
       cancelled = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
@@ -67,11 +79,20 @@ function AttachmentImageTile({ af, name }: { af: AttachedFile; name: string }) {
 
   const src = isHeic ? heicUrl : af.kind === 'local' ? af.localUrl : af.url;
 
+  // Fall back to the named tile — the file is still attached and still sends;
+  // only the thumbnail is unavailable.
+  if (failed) return <FileTileBody filename={name} />;
   if (!src) return <FileTileBody filename={name} pending />;
 
   return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src={src} alt={name} className="size-full object-cover" draggable={false} />
+    <img
+      src={src}
+      alt={name}
+      className="size-full object-cover"
+      draggable={false}
+      onError={() => setFailedFor(af)}
+    />
   );
 }
 
@@ -129,7 +150,18 @@ function AttachmentFileTile({ af, name }: { af: AttachedFile; name: string }) {
     if (af.kind !== 'local' || !isPreviewableTextExtension(ext)) return;
     const reader = new FileReader();
     reader.onload = () => setTextPreview(truncateTextPreview(reader.result as string));
+    // An unreadable file (revoked handle, permissions) rejected silently and
+    // left the read hanging; the tile just never showed a peek. Clear it
+    // explicitly so the state is a decision, not a leftover.
+    reader.onerror = () => setTextPreview(null);
     reader.readAsText(af.file.slice(0, 2048));
+    // Aborting on unmount: without it the read completes into a component that
+    // is gone, and `onload` fires a `setState` on it.
+    return () => {
+      reader.onload = null;
+      reader.onerror = null;
+      if (reader.readyState === FileReader.LOADING) reader.abort();
+    };
   }, [af, ext]);
 
   return <FileTileWithPreview filename={name} preview={textPreview} />;
@@ -174,9 +206,19 @@ export function AttachmentTiles({
                 onClick={() => onRemove(i)}
                 aria-label={`Remove ${name}`}
                 className={cn(
+                  // `bg-foreground text-background` — the semantic pair that
+                  // already flips with the theme. The old `bg-black text-white
+                  // dark:bg-white dark:text-black` was the same idea written as
+                  // four raw colours that no token change can follow.
                   'border-card absolute -top-1.5 -right-1.5 z-10 flex size-5 items-center justify-center',
-                  'rounded-full border-2 bg-black text-white dark:bg-white dark:text-black',
-                  'opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
+                  'bg-foreground text-background rounded-full border-2',
+                  // `hit-area-1` extends the pressable box past the 20px glyph
+                  // without moving it — the visible dot stays a dot.
+                  'hit-area-1',
+                  // Not fully hidden at rest. `opacity-0` meant the only way to
+                  // discover the remove control was to hope it was there; at
+                  // 60% it reads as available and firms up on hover.
+                  'opacity-60 transition-opacity group-hover:opacity-100 focus-visible:opacity-100',
                   '[@media(pointer:coarse)]:opacity-100',
                 )}
               >

--- a/apps/web/src/features/session/composer/composer-logic.test.ts
+++ b/apps/web/src/features/session/composer/composer-logic.test.ts
@@ -142,7 +142,7 @@ describe('resolveEditorPlaceholder', () => {
         lockForQuestion: true,
         questionButtonLabel: null,
       }),
-    ).toBe('Type your answer...');
+    ).toBe('Type your answer…');
   });
 
   test('lockForQuestion with a questionButtonLabel offers the custom-answer hint instead', () => {
@@ -152,7 +152,7 @@ describe('resolveEditorPlaceholder', () => {
         lockForQuestion: true,
         questionButtonLabel: 'Next',
       }),
-    ).toBe('Or type your own answer...');
+    ).toBe('Or type your own answer…');
   });
 
   test('an empty-string questionButtonLabel is falsy, same as null', () => {
@@ -162,7 +162,7 @@ describe('resolveEditorPlaceholder', () => {
         lockForQuestion: true,
         questionButtonLabel: '',
       }),
-    ).toBe('Type your answer...');
+    ).toBe('Type your answer…');
   });
 });
 

--- a/apps/web/src/features/session/composer/composer-logic.ts
+++ b/apps/web/src/features/session/composer/composer-logic.ts
@@ -318,7 +318,7 @@ export function resolveEditorPlaceholder({
 }: ResolveEditorPlaceholderInput): string {
   if (lockForApproval) return 'Approve or deny the action above to continue…';
   if (lockForQuestion) {
-    return questionButtonLabel ? 'Or type your own answer...' : 'Type your answer...';
+    return questionButtonLabel ? 'Or type your own answer…' : 'Type your answer…';
   }
   return placeholder;
 }

--- a/apps/web/src/features/session/composer/composer-toolbar.test.tsx
+++ b/apps/web/src/features/session/composer/composer-toolbar.test.tsx
@@ -76,6 +76,18 @@ describe('ComposerToolbar toolbarSlot', () => {
   });
 });
 
+describe('ComposerToolbar voice input', () => {
+  // Exactly the `toolbarSlot` failure above, one prop over: `onTranscription`
+  // and `voiceDisabled` were declared, threaded from `composer.tsx`, and
+  // destructured here — and `VoiceRecorder` was never placed in the JSX. The
+  // whole dictation feature was unreachable from every composer in the app,
+  // with nothing type-checking wrong.
+  test('renders the microphone control', () => {
+    const html = render(undefined);
+    expect(html).toContain('aria-label="Start voice input"');
+  });
+});
+
 describe('ComposerToolbar rewound-path control', () => {
   // The "Session rewound" notice moved off the input strip and onto this bar,
   // beside send/stop — send is the action that commits the rewound path. These
@@ -125,12 +137,16 @@ describe('ComposerToolbar — send is refused with no accessible agent', () => {
       submitDisabled: true,
       agentUnavailable: true,
     });
-    const button = /<button[^>]*aria-label="No agents available to you[^"]*"[^>]*>/.exec(html)?.[0];
+    // The control's NAME stays "Send message" in every state — a screen reader
+    // that hears "No agents available to you" and nothing else has lost what
+    // the button DOES. The reason rides `title` (and the tooltip) instead.
+    const button = /<button[^>]*aria-label="Send message"[^>]*>/.exec(html)?.[0];
 
     expect(button).toBeDefined();
     expect(button).toMatch(/\sdisabled=""/);
     // The exact line the agent picker's tooltip carries — one reason, one
     // wording, on both controls.
+    expect(button).toContain('No agents available to you');
     expect(html).toContain('No agents available to you — ask a manager for access');
   });
 });

--- a/apps/web/src/features/session/composer/composer-toolbar.tsx
+++ b/apps/web/src/features/session/composer/composer-toolbar.tsx
@@ -10,6 +10,7 @@ import type { FlatModel } from '../model-flatten';
 import type { ModelDefaultControls } from '../model-selector';
 import { ModelSelector } from '../model-selector';
 import { ReasoningEffortSelector } from '../reasoning-effort-selector';
+import { VoiceRecorder } from '../voice-recorder';
 import { SendStopControl } from './send-stop-control';
 
 /**
@@ -101,6 +102,8 @@ export interface ComposerToolbarProps {
 
   onTranscription: (text: string) => void;
   voiceDisabled: boolean;
+  /** Counter that starts a recording from the `/` palette — see `VoiceRecorder`. */
+  voiceStartRequestId?: number | null;
 
   isSending: boolean;
   isBusy: boolean;
@@ -141,6 +144,7 @@ export function ComposerToolbar({
   leading,
   onTranscription,
   voiceDisabled,
+  voiceStartRequestId,
   isSending,
   isBusy,
   onStop,
@@ -218,6 +222,16 @@ export function ComposerToolbar({
         )}
 
         {toolbarSlot}
+
+        {/* Voice, then send — the order the header comment above describes.
+            This render is the whole feature: the props were threaded here and
+            destructured, but `VoiceRecorder` was never placed in the JSX, so
+            dictation was unreachable from every composer in the app. */}
+        <VoiceRecorder
+          onTranscription={onTranscription}
+          disabled={voiceDisabled}
+          startRequestId={voiceStartRequestId}
+        />
 
         <SendStopControl
           isSending={isSending}

--- a/apps/web/src/features/session/composer/composer-underbar.tsx
+++ b/apps/web/src/features/session/composer/composer-underbar.tsx
@@ -116,11 +116,15 @@ export function ComposerUnderbar({
   const inline = variant === 'inline';
 
   return (
+    // `kortix-composer-underbar` is not decoration — `globals.css` hangs the
+    // coarse-pointer 40×40 minimum off it. Without the class this row's
+    // buttons stayed 32px on touch while the identical controls inside
+    // `.kortix-composer-toolbar` were 40px.
     <div
       className={
         inline
-          ? 'flex min-w-0 items-center gap-1'
-          : 'flex items-center justify-between gap-2 px-px pt-1.5 pb-2'
+          ? 'kortix-composer-underbar flex min-w-0 items-center gap-1'
+          : 'kortix-composer-underbar flex items-center justify-between gap-2 px-px pt-1.5 pb-2'
       }
     >
       <div className="flex min-w-0 items-center gap-1">
@@ -134,7 +138,10 @@ export function ComposerUnderbar({
             size="icon-base"
             onClick={onAttachClick}
             aria-label="Attach files"
-            className="text-muted-foreground rounded-lg"
+            // `hit-area-1` — the same extension the toolbar's send/voice
+            // buttons carry. The visible chip stays 32px; the pressable box
+            // grows to 40, on a mouse as well as on a finger.
+            className="text-muted-foreground hit-area-1 rounded-lg"
           >
             <Paperclip className="size-4 shrink-0" />
           </Button>

--- a/apps/web/src/features/session/composer/composer.tsx
+++ b/apps/web/src/features/session/composer/composer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { toast } from '@/lib/toast';
+import { errorToast } from '@/components/ui/toast';
 import { cn } from '@/lib/utils';
 import { isImageFile } from '@/lib/utils/file-utils';
 import type { Agent, Command, MessageWithParts, ProviderListResponse } from '@kortix/sdk/react';
@@ -373,7 +373,7 @@ function ComposerImpl({
   modelRequired = false,
   modelsLoading = false,
   autoFocus,
-  placeholder = 'Ask anything...',
+  placeholder = 'Ask anything…',
   prefill = null,
   onPrefillApplied,
   attachRequestId = null,
@@ -408,6 +408,8 @@ function ComposerImpl({
     attachedFilesRef.current = attachedFiles;
   }, [attachedFiles]);
   const [isDragOver, setIsDragOver] = useState(false);
+  /** Bumped by the `/` palette's "Start voice input" row — see `VoiceRecorder`. */
+  const [voiceStartRequestId, setVoiceStartRequestId] = useState(0);
   const [isEmpty, setIsEmpty] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -885,10 +887,12 @@ function ComposerImpl({
         case 'attach-file':
           fileInputRef.current?.click();
           return;
-        default:
-          // `set-scope` and `start-voice` remain no-ops: `VoiceRecorder` owns
-          // its own state with no external control, and scope lives outside
-          // this component entirely.
+        case 'start-voice':
+          // A counter, not a boolean: `VoiceRecorder` owns its own recording
+          // state, and this is the one signal that reaches into it. Two
+          // consecutive `/start-voice` selections must both arrive, which a
+          // boolean already `true` cannot express.
+          setVoiceStartRequestId((n) => n + 1);
           return;
       }
     },
@@ -899,11 +903,11 @@ function ComposerImpl({
     // Ahead of the model check: with no agent to run it, the model this prompt
     // would have used is not the user's problem.
     if (agentUnavailable) {
-      toast.error(NO_AGENT_ACCESS_LABEL, { description: NO_AGENT_ACCESS_HINT });
+      errorToast(NO_AGENT_ACCESS_LABEL, { description: NO_AGENT_ACCESS_HINT });
       return;
     }
     if (modelUnavailable) {
-      toast.error(NO_MODEL_AVAILABLE_MESSAGE, {
+      errorToast(NO_MODEL_AVAILABLE_MESSAGE, {
         description: NO_MODEL_AVAILABLE_ACTION_MESSAGE,
       });
       return;
@@ -922,7 +926,7 @@ function ComposerImpl({
     });
     if (submissionBlocker) {
       const copy = sendBlockerMessage(submissionBlocker);
-      toast.error(copy.message, copy.description ? { description: copy.description } : undefined);
+      errorToast(copy.message, copy.description ? { description: copy.description } : undefined);
       return;
     }
 
@@ -950,7 +954,7 @@ function ComposerImpl({
         attachmentCount: filesNow.length,
       });
       if (guard.kind === 'refuse') {
-        toast.error(guard.message, { description: guard.description });
+        errorToast(guard.message, { description: guard.description });
         return;
       }
 
@@ -983,7 +987,7 @@ function ComposerImpl({
       });
       if (blocker) {
         const copy = sendBlockerMessage(blocker);
-        toast.error(copy.message, copy.description ? { description: copy.description } : undefined);
+        errorToast(copy.message, copy.description ? { description: copy.description } : undefined);
         return;
       }
       onCommand?.(plan.command, plan.args, draft?.commandSplit);
@@ -1207,12 +1211,15 @@ function ComposerImpl({
             shell around it kept painting as an empty sliver.
           */}
           {showQueueStrip && (
-            <div className="bg-sidebar border-border flex w-[96%] flex-col items-center gap-2 rounded-t-xl border border-b-0 p-[0.3rem]  empty:hidden">
+            <div className="bg-sidebar border-border flex w-[96%] flex-col items-center gap-2 rounded-t-xl border border-b-0 p-1 empty:hidden">
               {threadContext && (
                 <button
                   onClick={threadContext.onBackToParent}
                   className={cn(
-                    'text-muted-foreground hover:text-foreground hover:bg-muted/80 flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+                    // `group`, or the arrow's `group-hover:` transforms below
+                    // have no group to hover — the nudge was written and never
+                    // fired.
+                    'group text-muted-foreground hover:text-foreground hover:bg-muted/80 flex cursor-pointer items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
                   )}
                 >
                   <ArrowUpLeft className="text-muted-foreground size-3.5 flex-shrink-0 transition-transform group-hover:-translate-x-0.5 group-hover:-translate-y-0.5" />
@@ -1295,15 +1302,38 @@ function ComposerImpl({
         onDragLeave={handleDragLeave}
         onDrop={handleDropFiles}
         className={cn(
-          'bg-sidebar shadow-card border-border relative isolate z-10 w-full rounded-xl border shadow-xl',
-          'pt-3 shadow-[0_0_4px_oklch(0_0_0/0.03)] dark:shadow-md',
+          // One shadow, from the ladder. `shadow-card` is defined nowhere in
+          // `globals.css` and `shadow-xl` was dead — twMerge dropped it for the
+          // arbitrary `shadow-[…oklch…]` that followed, which was the only
+          // raw colour left in the composer.
+          'bg-sidebar border-border relative isolate z-10 w-full rounded-xl border',
+          'pt-3 shadow-sm',
           'transition-[border-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)]',
           'motion-reduce:transition-none',
           cardClassName,
-          isDragOver && 'border-kortix-blue/80 ring-primary/40 border opacity-30 ring',
+          // NO `opacity-30` here. It used to sit on the card AND on the column
+          // inside it, and the two multiplied — 0.3 × 0.3 = 0.09 — so the whole
+          // composer, border and drop target included, went all but invisible
+          // the moment a file crossed it. The card keeps full opacity and its
+          // highlighted border; only the CONTENT dims, under the label below.
+          isDragOver && 'border-kortix-blue/80 ring-primary/40 border ring',
           (replyTo || notice) && 'rounded-t-none',
         )}
       >
+        {/* What the dimmed card is asking for. Without it the drag state said
+            only "something is happening" — it never named the action or its
+            result. `pointer-events-none` so it can never eat the drop. */}
+        {isDragOver && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0 z-[2] flex items-center justify-center"
+          >
+            <span className="text-foreground bg-sidebar/80 rounded-md px-3 py-1.5 text-sm font-medium">
+              Drop files to attach
+            </span>
+          </div>
+        )}
+
         <div
           className={cn(
             'relative z-[1] flex w-full flex-col overflow-visible',
@@ -1451,6 +1481,7 @@ function ComposerImpl({
               rewind={rewind}
               onTranscription={handleTranscription}
               voiceDisabled={submitDisabled || isBusy}
+              voiceStartRequestId={voiceStartRequestId}
               isSending={isSending}
               isBusy={isBusy}
               onStop={onStop}

--- a/apps/web/src/features/session/composer/editor/composer-editor.tsx
+++ b/apps/web/src/features/session/composer/editor/composer-editor.tsx
@@ -518,15 +518,15 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
            * looks right instead. It still grows with the text past this
            * floor.
            *
-           * The `vh` caps are the reference's, verbatim, including the fact
-           * that the middle band is the SHORTEST. Tailwind emits base → sm →
-           * lg in that order, so the effective ladder is: below 640px 45vh,
-           * 640–1023px 25vh, 1024px and up 40vh. That is a strange curve, and
-           * it is deliberate to keep it here rather than "fix" it silently —
-           * change the `sm:` step if the tablet cap turns out to be wrong.
+           * The `vh` cap ladder used to be 45vh / **25vh** / 40vh — the middle
+           * band, 640–1023px, was the SHORTEST of the three, so a tablet or a
+           * narrow desktop window capped the draft at barely a quarter of the
+           * viewport while a phone got 45%. That was carried over verbatim from
+           * a reference and left in place with a note inviting this change. The
+           * curve is now monotonic: 45vh below 640px (a phone keyboard eats the
+           * rest of the screen anyway), 40vh above it.
            */
-          class:
-            'outline-none min-h-[3.5em] max-h-[45vh] sm:max-h-[25vh] lg:max-h-[40vh] overflow-y-auto',
+          class: 'outline-none min-h-[3.5em] max-h-[45vh] sm:max-h-[40vh] overflow-y-auto',
         },
         handleKeyDown,
       },
@@ -568,7 +568,11 @@ export const ComposerEditor = forwardRef<ComposerEditorHandle, ComposerEditorPro
       <EditorContent
         editor={editor}
         className={cn(
-          'kortix-composer-editor w-full text-[15px] sm:text-[14px]',
+          // `text-base` (16px) on mobile, NOT 15px: iOS Safari force-zooms the
+          // page on focus for any input under 16px, and the composer is the one
+          // field on the screen. `sm:text-sm` above 640px, which is the size
+          // `globals.css`'s slash-trigger rule already documents.
+          'kortix-composer-editor w-full text-base sm:text-sm',
           disabled && 'opacity-50',
         )}
       />

--- a/apps/web/src/features/session/composer/editor/mention-node.test.ts
+++ b/apps/web/src/features/session/composer/editor/mention-node.test.ts
@@ -152,7 +152,10 @@ describe('renderHTML output', () => {
     // failure. What must hold is the visual contract — every chip carries the
     // faint primary tint in BOTH themes and rides the line it sits on.
     expect(attrs.class).toContain('bg-primary/[0.08]');
-    expect(attrs.class).toContain('dark:bg-primary/[0.08]');
+    // ONE `bg-primary/[0.08]`, no `dark:` twin. `--primary` is a themed token,
+    // so the single declaration is already correct in both modes; the twin
+    // that used to be asserted here resolved to the identical rule.
+    expect(attrs.class).not.toContain('dark:bg-primary/[0.08]');
     expect(attrs.class).toContain('align-baseline');
     expect(content).toBe('@README.md');
   });
@@ -183,10 +186,6 @@ describe('renderHTML output', () => {
     // not this file — would pick the winner.
     expect(attrs.class).toContain('bg-primary/[0.08]');
     expect(attrs.class).not.toContain('bg-muted');
-    // `dark:bg-*` is a different variant group, so an unprefixed `bg-*` cannot
-    // stand in for it. Without the explicit dark override the chip loses its
-    // tint in dark mode only.
-    expect(attrs.class).toContain('dark:bg-primary/[0.08]');
     expect(attrs.class).not.toContain('dark:bg-card');
   });
 });

--- a/apps/web/src/features/session/composer/hooks/use-composer-focus.ts
+++ b/apps/web/src/features/session/composer/hooks/use-composer-focus.ts
@@ -2,13 +2,26 @@
 
 import { type RefObject, useEffect, useRef } from 'react';
 
-/** True for elements that already handle their own typing. */
+/**
+ * True for elements the type-ahead redirect must leave alone.
+ *
+ * Two groups, and the second one is the bug fix. Fields that handle their own
+ * typing, obviously — but ALSO any control or overlay that binds a key of its
+ * own. A focused `<button>` treats Space as "activate"; a menu, listbox or
+ * dialog treats it as a selection. Without them here, Space anywhere in an open
+ * dropdown pulled focus into the composer and typed a space into the draft
+ * instead of choosing the highlighted row.
+ */
 function isTextEditingElement(el: Element | null): boolean {
   if (!el) return false;
   const html = el as HTMLElement;
   if (html.isContentEditable) return true;
   const tag = html.tagName;
-  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (tag === 'BUTTON' || tag === 'A') return true;
+  return !!html.closest?.(
+    '[role="dialog"],[role="menu"],[role="listbox"],[role="menuitem"],[role="option"],[role="alertdialog"]',
+  );
 }
 
 /** Only the composer inside the visible tab should answer a global event. */
@@ -116,6 +129,11 @@ export function useComposerFocus({
       if (disabled || e.defaultPrevented) return;
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (typeof e.key !== 'string' || e.key.length !== 1) return;
+      // Space is `length === 1` but it is not type-ahead — it is the activate
+      // key for every focused control on the page. Redirecting it stole the
+      // press AND typed a leading space into an empty draft. A real word starts
+      // with a letter; the composer picks it up on that character.
+      if (e.key === ' ') return;
       const el = ref.current;
       if (!isVisible(el)) return;
       if (document.activeElement === el || el.contains(document.activeElement)) return;

--- a/apps/web/src/features/session/composer/menus/mention-menu.tsx
+++ b/apps/web/src/features/session/composer/menus/mention-menu.tsx
@@ -34,16 +34,25 @@ export function MentionMenu({
    *  highlight honest: what you point at is what Enter takes. */
   onHover?: (row: MenuRow) => void;
 }) {
-  if (!sections.length && !loading) return null;
+  // A query that matches nothing keeps the card, with one dead row saying so.
+  // Returning `null` made the menu DISAPPEAR mid-word — indistinguishable from
+  // the menu having closed, and one backspace brought it back from nowhere.
+  if (!sections.length && !loading) {
+    return (
+      <MenuCard className="w-[min(26rem,calc(100vw-1.5rem))] rounded-lg">
+        <p role="status" className="text-muted-foreground px-3 py-2.5 text-sm">
+          No matches
+        </p>
+      </MenuCard>
+    );
+  }
 
   return (
-    // `rounded-xl` (12px) with `p-1.5` (6px) padding and `rounded-md` (6px)
-    // rows — concentric, 6 + 6 = 12. It was `rounded-md` on the card AND on
-    // the rows, which is the same radius on parent and child: the rows'
-    // corners visibly cut inside the card's at the four extremes.
-    //
-    // 12px, not the `/` menu's 16px: this one floats at the caret and is half
-    // the width, so it should read as lighter than the docked palette.
+    // `rounded-lg` (8px) — the cap `menu-shell.tsx` documents for app
+    // containers, and the same radius the `/` palette uses, so the two menus
+    // read as one system. It was `rounded-md` on the card AND on the rows,
+    // which is the same radius on parent and child: the rows' corners visibly
+    // cut inside the card's at the four extremes.
     <MenuCard className="w-[min(26rem,calc(100vw-1.5rem))] rounded-lg">
       <div
         role="listbox"

--- a/apps/web/src/features/session/composer/menus/slash-actions.test.ts
+++ b/apps/web/src/features/session/composer/menus/slash-actions.test.ts
@@ -59,7 +59,7 @@ describe('controlToOpenFor', () => {
   });
 
   test('every other action opens nothing', () => {
-    for (const id of ['switch-agent', 'attach-file', 'start-voice', 'set-scope'] as const) {
+    for (const id of ['switch-agent', 'attach-file', 'start-voice'] as const) {
       expect(controlToOpenFor(id)).toBeNull();
     }
   });

--- a/apps/web/src/features/session/composer/menus/slash-actions.ts
+++ b/apps/web/src/features/session/composer/menus/slash-actions.ts
@@ -3,8 +3,7 @@ export type SlashActionId =
   | 'switch-agent'
   | 'set-reasoning-effort'
   | 'attach-file'
-  | 'start-voice'
-  | 'set-scope';
+  | 'start-voice';
 
 export interface SlashAction {
   id: SlashActionId;
@@ -49,8 +48,19 @@ export const SLASH_ACTIONS: SlashAction[] = [
     description: 'How much thinking the model does before answering',
   },
   { id: 'attach-file', label: 'Attach file', description: 'Add an image or document' },
-  { id: 'set-scope', label: 'Set scope', description: 'Limit which files this session may touch' },
+  {
+    id: 'start-voice',
+    label: 'Start voice input',
+    description: 'Dictate the message with your microphone',
+  },
 ];
+
+/*
+ * `set-scope` used to be a sixth row here. It was REMOVED, not forgotten: no
+ * scope panel exists for it to open, so `handleSelectAction` fell to its
+ * `default: return` and the row highlighted, offered a "Use" button, and did
+ * nothing. Re-add it only together with the control it names.
+ */
 
 /** A composer control a `/` row can open. */
 export type SlashActionControl = 'model' | 'reasoning';

--- a/apps/web/src/features/session/composer/menus/slash-items.test.ts
+++ b/apps/web/src/features/session/composer/menus/slash-items.test.ts
@@ -125,18 +125,18 @@ describe('buildSlashSections', () => {
   });
 
   test('filters actions via the same query, alongside commands', () => {
-    // Queried 'voice' against a 'Start voice input' action until that action
-    // was removed from SLASH_ACTIONS, at which point this asserted a label
-    // that no longer existed and could only ever fail. 'scope' now matches
-    // one of each — the "alongside commands" the test name claims — and the
-    // expected order doubles as a check that Actions render before Commands.
+    // 'voice' matches one of each — the "alongside commands" the test name
+    // claims — and the expected order doubles as a check that Actions render
+    // before Commands. It queried 'scope' while `set-scope` existed; that row
+    // was removed because it opened nothing, and `start-voice` came back with
+    // a real control behind it (`VoiceRecorder` in the composer toolbar).
     const sections = buildSlashSections({
-      commands: [cmd('build'), cmd('scope-check')],
-      query: 'scope',
+      commands: [cmd('build'), cmd('voice-check')],
+      query: 'voice',
     });
     const rows = sections.flatMap((s) => s.rows);
 
-    expect(rows.map((r) => r.name)).toEqual(['Set scope', 'scope-check']);
+    expect(rows.map((r) => r.name)).toEqual(['Start voice input', 'voice-check']);
   });
 
   test('no commands leaves just the Actions section, indices starting at 0', () => {
@@ -167,12 +167,12 @@ describe('buildSlashSections', () => {
   test('a custom actions list overrides the SLASH_ACTIONS default', () => {
     const sections = buildSlashSections({
       commands: [],
-      actions: [{ id: 'set-scope', label: 'Set scope', description: 'x' }],
+      actions: [{ id: 'attach-file', label: 'Only row', description: 'x' }],
       query: '',
     });
     const rows = sections.flatMap((s) => s.rows);
     expect(rows).toHaveLength(1);
-    expect(rows[0].name).toBe('Set scope');
+    expect(rows[0].name).toBe('Only row');
   });
 });
 

--- a/apps/web/src/features/session/composer/menus/slash-menu.tsx
+++ b/apps/web/src/features/session/composer/menus/slash-menu.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Kbd } from '@/components/ui/kbd';
 import { cn } from '@/lib/utils';
 import {
   ArrowsClockwiseIcon,
@@ -10,7 +11,6 @@ import {
   PuzzlePieceIcon,
   RobotIcon,
   SlidersHorizontalIcon,
-  TargetIcon,
   TerminalWindowIcon,
 } from '@phosphor-icons/react';
 
@@ -55,8 +55,6 @@ function SlashRowIcon({
         return <PaperclipIcon className={className} />;
       case 'start-voice':
         return <MicrophoneIcon className={className} />;
-      case 'set-scope':
-        return <TargetIcon className={className} />;
       default:
         return <SlidersHorizontalIcon className={className} />;
     }
@@ -97,11 +95,11 @@ function SlashRowIcon({
  * no match, or no menu open — contributes no gap at all: the margin cannot
  * exist without a card to own it.
  *
- * `rounded-xl` matches the composer card it stacks onto, so the two read as
- * one object split in two rather than a popover that happens to be nearby.
- * The list's `p-1.5` + the rows' `rounded-md` make that radius concentric
- * (6px inner + 6px padding = 12px outer); mismatched nesting here is the
- * single most visible way a card like this reads as "off".
+ * `rounded-lg` (8px) is the cap `menu-shell.tsx` documents for app containers,
+ * and it is the same radius the `@` menu uses — the two palettes read as one
+ * system rather than two different popovers. It is deliberately NOT the
+ * composer card's `rounded-xl`: this card floats above the card, so matching
+ * it exactly made the seam between them read as a rendering glitch.
  */
 export function SlashMenu({
   sections,
@@ -114,7 +112,19 @@ export function SlashMenu({
   onSelect: (row: SlashRow) => void;
   onHover?: (row: SlashRow) => void;
 }) {
-  if (!sections.length) return null;
+  // A query that matches nothing keeps the card, with one dead row saying so.
+  // Returning `null` made the palette DISAPPEAR mid-word — the user could not
+  // tell "no match" from "the menu closed", and one backspace brought it back
+  // from nowhere.
+  if (!sections.length) {
+    return (
+      <MenuCard className={cn('mb-2.5 w-full rounded-lg')}>
+        <p role="status" className="text-muted-foreground px-3 py-2.5 text-sm">
+          No matching command or action
+        </p>
+      </MenuCard>
+    );
+  }
 
   const rows = sections.flatMap((section) =>
     section.rows.map((row) => ({ row, heading: section.heading })),
@@ -122,16 +132,21 @@ export function SlashMenu({
   const active = rows.find(({ row }) => row.index === selectedIndex) ?? rows[0];
 
   return (
-    // `rounded-2xl` (16px) tracks the composer card this stacks onto, so the
-    // two read as one object split in two rather than a popover that happens
-    // to be nearby. The list's `p-2` (8px) plus the rows' `rounded-lg` (8px)
-    // makes that radius concentric: 8 + 8 = 16.
-    <MenuCard className={cn('mb-2.5 flex max-h-96 h-88 overflow-hidden w-full rounded-lg shadow-none')}>
+    // `max-h-96` and no fixed height: `h-88` pinned the card to 352px whether
+    // it held one row or thirty, so a single match rendered a mostly-empty
+    // panel taller than the composer under it. `MenuCard`'s own `shadow-md`
+    // is kept — `shadow-none` erased the only thing separating this card from
+    // the transcript behind it.
+    <MenuCard className={cn('mb-2.5 flex max-h-96 w-full overflow-hidden rounded-lg')}>
       <div
         role="listbox"
         aria-label="Commands and actions"
         aria-activedescendant={`slash-row-${selectedIndex}`}
-        tabIndex={0}
+        // `-1`, matching `mention-menu.tsx`: focusable for AT, but never a tab
+        // stop. Keyboard interaction stays in the composer editor, which
+        // proxies arrow/Enter to this listbox — a real tab stop here trapped
+        // Tab between the palette and the composer.
+        tabIndex={-1}
         className="min-w-0 flex-1 space-y-2 overflow-y-auto p-2"
       >
         {sections.map((section) => (
@@ -168,11 +183,7 @@ export function SlashMenu({
                       {row.value}
                     </span>
                   )}
-                  {row.hint && (
-                    <kbd className="bg-muted text-muted-foreground rounded-sm px-1.5 py-0.5 font-sans text-[0.6875rem]">
-                      {row.hint}
-                    </kbd>
-                  )}
+                  {row.hint && <Kbd className="shrink-0">{row.hint}</Kbd>}
                 </MenuRow>
               ))}
             </div>
@@ -198,8 +209,8 @@ export function SlashMenu({
             </p>
           )}
           <div className="mt-auto flex items-center justify-end gap-2 pt-4">
-            <span className="text-muted-foreground text-xs">
-              <kbd className="bg-muted rounded-sm px-1.5 py-0.5 font-sans">↵</kbd> to use
+            <span className="text-muted-foreground flex items-center gap-1 text-xs">
+              <Kbd>↵</Kbd> to use
             </span>
             <button
               type="button"

--- a/apps/web/src/features/session/composer/send-stop-control.tsx
+++ b/apps/web/src/features/session/composer/send-stop-control.tsx
@@ -5,11 +5,24 @@ import Hint from '@/components/ui/hint';
 import { Kbd } from '@/components/ui/kbd';
 import Loading from '@/components/ui/loading';
 import { ArrowUpIcon as ArrowUp, SquareIcon } from '@phosphor-icons/react';
+import { AnimatePresence, m } from 'motion/react';
 import { NO_MODEL_AVAILABLE_ACTION_MESSAGE } from '../model-availability';
 import { NO_AGENT_ACCESS_MESSAGE } from './composer-agent-access';
 
 const ICON_BUTTON =
-  'shrink-0 rounded-full p-0 hit-area-1 transition-[color,background-color,opacity,scale] active:scale-[0.96] active:duration-150 duration-300 ease-out ';
+  'shrink-0 rounded-full p-0 hit-area-1 transition-[color,background-color,opacity,scale] active:scale-[0.96] active:duration-150 duration-300 ease-out';
+
+/**
+ * Send ⇄ stop ⇄ pending cross-fade. The three states used to be three separate
+ * `return`s, so the glyph hard-cut between them on every turn boundary — the
+ * most-watched control in the app changing identity with no transition.
+ */
+const ICON_SWAP = {
+  initial: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  animate: { scale: 1, opacity: 1, filter: 'blur(0px)' },
+  exit: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  transition: { type: 'spring', duration: 0.3, bounce: 0 },
+} as const;
 
 export interface SendStopControlProps {
   isSending: boolean;
@@ -58,15 +71,26 @@ export function SendStopControl({
     : modelUnavailable
       ? NO_MODEL_AVAILABLE_ACTION_MESSAGE
       : null;
+
   if (isSending && !lockForQuestion) {
     return (
-      <Button size="icon-base" disabled className={ICON_BUTTON}>
-        <Loading className="size-4" />
+      <Button size="icon-base" aria-label="Sending" disabled className={ICON_BUTTON}>
+        <AnimatePresence mode="popLayout" initial={false}>
+          <m.span key="pending" className="flex items-center" {...ICON_SWAP}>
+            <Loading className="size-4" />
+          </m.span>
+        </AnimatePresence>
       </Button>
     );
   }
 
-  if (!isSending && isBusy && (onStop || stopDisabled) && !lockForQuestion) {
+  // The session is working, so STOP is the only honest control here — even
+  // while the host has not handed one down yet. It used to require
+  // `onStop || stopDisabled`, and with neither the whole component fell
+  // through to `return null` and the button VANISHED mid-turn. A disabled stop
+  // says "working, cannot cancel yet"; nothing at all says "broken", and
+  // `project-home.tsx:249` had to pass a dummy `stopDisabled` to work around it.
+  if (!isSending && isBusy && !lockForQuestion) {
     return (
       <div className="relative flex items-center">
         {escCount > 0 && (
@@ -92,55 +116,64 @@ export function SendStopControl({
             disabled={stopDisabled || !onStop}
             className={ICON_BUTTON}
           >
-            <SquareIcon weight="fill" className="size-4 shrink-0" />
+            <AnimatePresence mode="popLayout" initial={false}>
+              <m.span key="stop" className="flex items-center" {...ICON_SWAP}>
+                <SquareIcon weight="fill" className="size-4 shrink-0" />
+              </m.span>
+            </AnimatePresence>
           </Button>
         </Hint>
       </div>
     );
   }
 
-  if (!isSending && (!isBusy || lockForQuestion)) {
+  if (lockForQuestion && questionButtonLabel && !hasText) {
     return (
-      <div className="opacity-100">
-        {lockForQuestion && questionButtonLabel && !hasText ? (
-          <Button
-            size="sm"
-            disabled={!questionCanAct || disabled}
-            onClick={onSubmit}
-            className="hit-area-1 shrink-0 rounded-lg transition-[color,background-color,opacity,scale] duration-300 ease-out active:scale-[0.96] active:duration-150"
-          >
-            {questionButtonLabel}
-          </Button>
-        ) : (
-          <Hint side="top" label={refusal ?? 'Send message'}>
-            {/* The span, not the button, carries the tooltip trigger: a
-                disabled button takes no pointer events, so the reason the send
-                is off would never open — which is exactly the state where the
-                reason matters most. */}
-            <span className="inline-flex">
-              <Button
-                size="icon-base"
-                disabled={
-                  lockForQuestion
-                    ? (!canSubmit && !questionCanAct) || disabled
-                    : !canSubmit || submitDisabled
-                }
-                onClick={onSubmit}
-                aria-label={refusal ?? 'Send message'}
-                className={ICON_BUTTON}
-              >
-                {disabled ? (
-                  <div className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                ) : (
-                  <ArrowUp className="size-4" />
-                )}
-              </Button>
-            </span>
-          </Hint>
-        )}
-      </div>
+      <Button
+        size="sm"
+        disabled={!questionCanAct || disabled}
+        onClick={onSubmit}
+        className="hit-area-1 shrink-0 rounded-lg transition-[color,background-color,opacity,scale] duration-300 ease-out active:scale-[0.96] active:duration-150"
+      >
+        {questionButtonLabel}
+      </Button>
     );
   }
 
-  return null;
+  return (
+    <Hint side="top" label={refusal ?? 'Send message'}>
+      {/* The span, not the button, carries the tooltip trigger: a disabled
+          button takes no pointer events, so the reason the send is off would
+          never open — which is exactly the state where the reason matters
+          most. */}
+      <span className="inline-flex">
+        <Button
+          size="icon-base"
+          disabled={
+            lockForQuestion
+              ? (!canSubmit && !questionCanAct) || disabled
+              : !canSubmit || submitDisabled
+          }
+          onClick={onSubmit}
+          // The control's NAME stays "Send message" in every state. The
+          // refusal is a `aria-describedby`-style detail, not an identity —
+          // swapping the name for it made a screen reader announce the button
+          // as "No agent available", with nothing left saying what it does.
+          aria-label="Send message"
+          title={refusal ?? undefined}
+          className={ICON_BUTTON}
+        >
+          <AnimatePresence mode="popLayout" initial={false}>
+            <m.span key={disabled ? 'busy' : 'send'} className="flex items-center" {...ICON_SWAP}>
+              {disabled ? (
+                <Loading className="size-3.5 shrink-0" />
+              ) : (
+                <ArrowUp className="size-4" />
+              )}
+            </m.span>
+          </AnimatePresence>
+        </Button>
+      </span>
+    </Hint>
+  );
 }

--- a/apps/web/src/features/session/composer/token-progress.tsx
+++ b/apps/web/src/features/session/composer/token-progress.tsx
@@ -393,6 +393,11 @@ export function TokenProgress({
             variant="transparent"
             size="icon"
             type="button"
+            // `hit-area-1`: the ring is a 28px control and, on a phone, the
+            // ONLY way into the context modal — the hover card that carries
+            // the same detail never opens on touch. The glyph keeps its size;
+            // the pressable box reaches 40px.
+            className="hit-area-1"
             aria-label={ariaLabel}
             onPointerDown={(e) => {
               e.stopPropagation();

--- a/apps/web/src/features/session/connector-required-notice.tsx
+++ b/apps/web/src/features/session/connector-required-notice.tsx
@@ -23,7 +23,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useConnectorGateStore } from '@/stores/connector-gate-store';
 import type { KortixSendError, KortixSendErrorConnector } from '@kortix/sdk/react';
-import { PlugIcon as Plug } from '@phosphor-icons/react';
+import { PlugIcon } from '@phosphor-icons/react';
 
 export interface ConnectorNoticeCopy {
   /** "Gmail" · "Gmail and Slack" · "Gmail, Slack and Notion". */
@@ -78,7 +78,7 @@ export function ConnectorRequiredNotice({
     <div className={cn('bg-popover rounded-md border px-4 py-3.5', className)}>
       <div className="flex items-start gap-3">
         <div className="bg-kortix-orange/10 grid size-9 shrink-0 place-items-center rounded-sm">
-          <Plug className="text-kortix-orange size-4" weight="bold" />
+          <PlugIcon className="text-kortix-orange size-4" weight="fill" />
         </div>
         <div className="min-w-0 flex-1">
           <p className="text-foreground text-sm font-medium">
@@ -103,7 +103,7 @@ export function ConnectorRequiredNotice({
                 })
               }
             >
-              <Plug className="size-3.5 shrink-0" weight="bold" />
+              <PlugIcon className="size-3.5 shrink-0" />
               {connectable.length === 1 ? `Connect ${connectable[0].name}` : 'Connect accounts'}
             </Button>
           ) : (

--- a/apps/web/src/features/session/diff-dialog.tsx
+++ b/apps/web/src/features/session/diff-dialog.tsx
@@ -2,15 +2,11 @@
 
 import { useTranslations } from 'next-intl';
 
-import { useState } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Modal, ModalContent, ModalTitle } from '@/components/ui/modal';
 import { SessionDiffViewer } from '@/features/session/session-diff-viewer';
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { cn } from '@/lib/utils';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { useState } from 'react';
 
 interface DiffDialogProps {
   sessionId: string;
@@ -23,24 +19,38 @@ export function DiffDialog({ sessionId, open, onOpenChange }: DiffDialogProps) {
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   return (
-    <Dialog open={open} onOpenChange={(v) => { if (!v) setIsFullscreen(false); onOpenChange(v); }}>
-      <DialogContent
+    <Modal
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) setIsFullscreen(false);
+        onOpenChange(v);
+      }}
+    >
+      <ModalContent
         className={cn(
-          'flex flex-col p-0 gap-0 overflow-hidden transition-colors duration-200',
+          // `space-y-0`: ModalContent ships `space-y-4` for stacked
+          // header/body/footer slots. This modal is a single full-bleed pane.
+          'flex flex-col gap-0 space-y-0 overflow-hidden transition-[max-width] duration-200',
           isFullscreen
-            ? 'sm:max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] h-[calc(100vh-2rem)]'
-            : 'sm:max-w-4xl max-h-[80vh]',
+            ? 'h-[calc(100vh-2rem)] lg:max-h-[calc(100vh-2rem)] lg:max-w-[calc(100vw-2rem)]'
+            : 'h-[80vh] lg:max-h-[80vh] lg:max-w-4xl',
         )}
       >
-        <VisuallyHidden><DialogTitle>{tHardcodedUi.raw('componentsSessionDiffDialog.line32JsxTextFileChanges')}</DialogTitle></VisuallyHidden>
-        <div className="flex-1 min-h-0 overflow-hidden">
+        <VisuallyHidden>
+          <ModalTitle>
+            {tHardcodedUi.raw('componentsSessionDiffDialog.line32JsxTextFileChanges')}
+          </ModalTitle>
+        </VisuallyHidden>
+        <div className="min-h-0 flex-1 overflow-hidden">
           <SessionDiffViewer
             sessionId={sessionId}
             isFullscreen={isFullscreen}
             onToggleFullscreen={() => setIsFullscreen((v) => !v)}
+            // Only this mount sits under ModalContent's floating close button.
+            reserveCloseGutter
           />
         </div>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/apps/web/src/features/session/image-preview.tsx
+++ b/apps/web/src/features/session/image-preview.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import { useState } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { Modal, ModalContent, ModalTitle } from '@/components/ui/modal';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+import { useState } from 'react';
 
 interface ImagePreviewProps {
   src: string;
@@ -16,34 +12,34 @@ interface ImagePreviewProps {
 
 /**
  * ImagePreview — wraps a clickable image thumbnail. On click, opens a full-size
- * preview dialog matching the SolidJS `ImagePreview` component.
+ * preview in the system `Modal` (feature code never reaches for `Dialog`).
  */
 export function ImagePreview({ src, alt = 'Image preview', children }: ImagePreviewProps) {
   const [open, setOpen] = useState(false);
 
   return (
     <>
-      <button
-        type="button"
-        className="cursor-zoom-in"
-        onClick={() => setOpen(true)}
-      >
+      <button type="button" className="cursor-zoom-in" onClick={() => setOpen(true)}>
         {children}
       </button>
 
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-[90vw] max-h-[90vh] p-2 bg-black/95 border-none">
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent
+          variant="transparent"
+          className="max-h-[90vh] space-y-0 border-none bg-black/95 p-2 lg:max-w-[90vw]"
+          aria-describedby={undefined}
+        >
           <VisuallyHidden>
-            <DialogTitle>{alt}</DialogTitle>
+            <ModalTitle>{alt}</ModalTitle>
           </VisuallyHidden>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={src}
             alt={alt}
-            className="max-w-full max-h-[85vh] object-contain mx-auto rounded"
+            className="mx-auto max-h-[85vh] max-w-full rounded-md object-contain"
           />
-        </DialogContent>
-      </Dialog>
+        </ModalContent>
+      </Modal>
     </>
   );
 }

--- a/apps/web/src/features/session/mention-chip.tsx
+++ b/apps/web/src/features/session/mention-chip.tsx
@@ -38,28 +38,27 @@ export function chipAriaLabel(kind: string, label: string): string {
  * One visual register for every chip. Mentions and commands share the faint
  * primary tint — the surface says "this token is structured", and the prefix
  * (`@` vs `/` from `chipPrefix`) says whether it is a reference or an
- * instruction. The tint is duplicated as `dark:bg-primary/[0.08]` on purpose:
- * an unprefixed `bg-*` does not reach into the dark variant group, and without
- * the explicit override the chip would lose its tint in dark mode only.
+ * instruction. `--primary` is a themed token, so ONE `bg-primary/[0.08]` is
+ * correct in both modes; the class carried a `dark:bg-primary/[0.08]` twin
+ * that resolved to the identical declaration and changed nothing.
  * `align-baseline` keeps the chip riding the surrounding line instead of
  * stretching it.
  *
- * `text-[0.95em]`, not `text-base sm:text-sm`. The size has to be relative
- * because this chip now sits in two type contexts: the composer's editor
- * (`text-[15px] sm:text-[14px]`) and the message bubble's `text-[0.9rem]`. A
- * fixed `text-base` is very slightly smaller than the composer's own body on
- * desktop, which is what the chip already looked like — but dropped into the
- * 14.4px bubble it would render LARGER than the sentence around it. An `em`
- * keeps the chip a fixed fraction of whatever line it lands on, so "the chip
- * looks the same in both places" holds by construction rather than by two
- * files agreeing on a pixel value.
+ * `text-[0.95em]`, not a fixed size. The size has to be relative because this
+ * chip sits in two type contexts: the composer's editor (`text-base sm:text-sm`)
+ * and the message bubble's `text-[0.9rem]`. A fixed `text-base` is very
+ * slightly smaller than the composer's own body on desktop, which is what the
+ * chip already looked like — but dropped into the 14.4px bubble it would render
+ * LARGER than the sentence around it. An `em` keeps the chip a fixed fraction
+ * of whatever line it lands on, so "the chip looks the same in both places"
+ * holds by construction rather than by two files agreeing on a pixel value.
  *
  * The `kind` parameter is kept even though every kind currently resolves to
  * the same class: callers pass it, and a future kind-specific surface changes
  * this one function rather than every call site.
  */
 export function chipClass(_kind: string): string {
-  return 'rounded-sm border-[0.5px] px-1.5 py-[0.08rem] [overflow-wrap:anywhere] font-medium whitespace-nowrap align-baseline text-[0.95em] bg-primary/[0.08] text-foreground dark:bg-primary/[0.08]';
+  return 'rounded-sm border-[0.5px] px-1.5 py-[0.08rem] [overflow-wrap:anywhere] font-medium whitespace-nowrap align-baseline text-[0.95em] bg-primary/[0.08] text-foreground';
 }
 
 /**

--- a/apps/web/src/features/session/mobile-tool-drawer.tsx
+++ b/apps/web/src/features/session/mobile-tool-drawer.tsx
@@ -56,10 +56,7 @@ export function MobileToolDrawer({
 
   return (
     <Drawer open={view !== null} onOpenChange={(next) => !next && closeMobileTool()}>
-      <DrawerContent
-        bar={false}
-        className="flex h-[95dvh] max-h-[95dvh] min-h-[95dvh] flex-col overflow-hidden p-0"
-      >
+      <DrawerContent className="flex h-[95dvh] max-h-[95dvh] min-h-[95dvh] flex-col overflow-hidden p-0">
         <DrawerHeader className="shrink-0 px-4 py-3 text-left">
           <DrawerTitle className="flex items-center justify-between gap-2 text-base">
             <span className="flex items-center gap-2.5">

--- a/apps/web/src/features/session/model-connection-gate.tsx
+++ b/apps/web/src/features/session/model-connection-gate.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CreditCardIcon as CreditCard, KeyIcon as KeyRound } from '@phosphor-icons/react';
+import { CreditCardIcon, KeyIcon } from '@phosphor-icons/react';
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 
 import { Button } from '@/components/ui/button';
@@ -32,7 +32,7 @@ export function ModelConnectionGate({
       {modal}
       <EmptyState
         className={className}
-        icon={KeyRound}
+        icon={KeyIcon}
         size={size}
         title="Connect a model to start chatting"
         description={
@@ -43,12 +43,12 @@ export function ModelConnectionGate({
         action={
           showUpgradeOption ? (
             <Button type="button" size="sm" onClick={openUpgrade}>
-              <CreditCard className="size-3.5" />
+              <CreditCardIcon className="size-3.5" />
               Upgrade
             </Button>
           ) : (
             <Button type="button" size="sm" onClick={() => openConnectProvider('providers')}>
-              <KeyRound className="size-3.5" />
+              <KeyIcon className="size-3.5" />
               Bring your own key
             </Button>
           )
@@ -61,7 +61,7 @@ export function ModelConnectionGate({
               variant="outline"
               onClick={() => openConnectProvider('providers')}
             >
-              <KeyRound className="size-3.5" />
+              <KeyIcon className="size-3.5" />
               Bring your own key
             </Button>
           ) : undefined
@@ -116,11 +116,11 @@ export function ModelConnectionBar({ show }: { show: boolean }) {
               initial={reduceMotion ? false : { y: '-100%' }}
               animate={reduceMotion ? undefined : { y: '0%', transition: BAR_ENTER }}
               exit={reduceMotion ? undefined : { y: '-100%', transition: BAR_EXIT }}
-              className="border-border bg-foreground/10 dark:bg-accent mx-3 -mt-3 rounded-b-xl border"
+              className="border-border bg-muted mx-3 -mt-3 rounded-b-md border"
             >
               <div className="flex items-center justify-between gap-3 pt-[18px] pr-2 pb-1.5 pl-4">
                 <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-xs">
-                  <KeyRound className="size-3.5 shrink-0" />
+                  <KeyIcon className="size-3.5 shrink-0" />
                   <span className="truncate">
                     No model connected
                     <span className="hidden sm:inline"> — connect one to start chatting</span>
@@ -128,22 +128,25 @@ export function ModelConnectionBar({ show }: { show: boolean }) {
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
                   {showUpgradeOption && (
-                    <button
+                    <Button
                       type="button"
+                      variant="ghost"
+                      size="sm"
                       onClick={openUpgrade}
-                      className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-full px-2.5 text-xs font-medium transition-[color,background-color,transform] active:scale-[0.96]"
+                      className="hit-area-1 gap-1.5 rounded-full text-xs"
                     >
-                      <CreditCard className="size-3.5" />
+                      <CreditCardIcon className="size-3.5 shrink-0" />
                       Upgrade
-                    </button>
+                    </Button>
                   )}
-                  <button
+                  <Button
                     type="button"
+                    size="sm"
                     onClick={() => openConnectProvider('providers')}
-                    className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-7 cursor-pointer items-center rounded-full px-3 text-xs font-medium transition-[background-color,transform] active:scale-[0.96]"
+                    className="hit-area-1 rounded-full text-xs"
                   >
                     Connect model
-                  </button>
+                  </Button>
                 </div>
               </div>
             </m.div>

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -270,14 +270,24 @@ function ModelRow({
               'group-hover:pointer-events-auto group-hover:opacity-100',
               'group-data-[selected=true]:pointer-events-auto group-data-[selected=true]:opacity-100',
               'focus-visible:pointer-events-auto focus-visible:opacity-100',
-              'focus-visible:ring-kortix-base focus-visible:ring-[0.6px] focus-visible:outline-none',
+              /* A 0.6px ring with `outline-none` is not a focus indicator —
+                 on a 1x display it rounds away entirely, so keyboard users
+                 tabbing to the default-star had no visible target at all. */
+              'focus-visible:ring-kortix-base focus-visible:ring-2 focus-visible:outline-none',
               /* The default keeps its star at rest ONLY when the check is not
                  already using the slot. Selected wins; see above. */
               isAccountDefault && 'text-foreground cursor-default hover:bg-transparent',
               isAccountDefault && !isSelected && 'pointer-events-auto opacity-100',
             )}
           >
-            <Star weight={isAccountDefault ? 'fill' : 'regular'} className="size-3.5" />
+            {/* `weight="fill"` or no weight at all — Phosphor's `regular` IS the
+                default, so passing it made the two states read as a deliberate
+                pair when only one of them says anything. */}
+            {isAccountDefault ? (
+              <Star weight="fill" className="size-3.5" />
+            ) : (
+              <Star className="size-3.5" />
+            )}
           </button>
         )}
       </span>
@@ -422,6 +432,14 @@ export function ModelSelector({
       .sort((a, b) => a.modelName.localeCompare(b.modelName));
   }, [baseModels, search]);
 
+  /** Is there anything to pick AT ALL, ignoring the search box? The empty
+   *  state below branches on this: "no models match your search" and "you have
+   *  no models" are different problems with different ways out. */
+  const hasAnyModel = useMemo(
+    () => baseModels.some((m) => m.enabled !== false),
+    [baseModels],
+  );
+
   const grouped = useMemo(() => {
     const groups = new Map<
       string,
@@ -516,11 +534,24 @@ export function ModelSelector({
         <CommandPopoverTrigger>
           <Button type="button" variant="ghost" size="sm" className="text-foreground/70 rounded-lg">
             <span className={cn('max-w-30 truncate', triggerLabelClassName)}>{displayName}</span>
-            <ChevronDown className={cn('size-3', open && 'rotate-180')} />
+            <ChevronDown
+              className={cn(
+                'size-3 transition-transform duration-200 ease-out',
+                open && 'rotate-180',
+              )}
+            />
           </Button>
         </CommandPopoverTrigger>
 
-        <CommandPopoverContent side="top" align="start" sideOffset={8} className="w-[300px]">
+        {/* `min(...)`, not a hard `300px`: on a 320px viewport a fixed 300px
+            popover plus the trigger's own inset pushed the panel off-screen.
+            Same shape `mention-menu.tsx` uses. */}
+        <CommandPopoverContent
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[min(300px,calc(100vw-1.5rem))]"
+        >
           <>
             <CommandInput
               compact
@@ -536,7 +567,7 @@ export function ModelSelector({
                       'componentsSessionModelSelector.line239JsxTextConnectProvider',
                     )}
                     side="top"
-                    className="z-999999999"
+                    className="z-50"
                   >
                     <button
                       type="button"
@@ -552,7 +583,7 @@ export function ModelSelector({
                       'componentsSessionModelSelector.line251JsxTextManageModels',
                     )}
                     side="top"
-                    className="z-999999999"
+                    className="z-50"
                   >
                     <button
                       type="button"
@@ -655,6 +686,23 @@ export function ModelSelector({
                     </Fragment>
                   ))}
                 </>
+              ) : hasAnyModel ? (
+                /* Models ARE connected — the SEARCH matched none of them.
+                   `grouped` is built from `visibleModels`, which is already
+                   filtered by `search`, so the branch below could not tell the
+                   two apart: typing "zzz" with 40 models connected showed
+                   "No models available" and a Connect-provider CTA. */
+                <div className="px-3 py-5 text-center">
+                  <div className="text-foreground text-sm font-medium">No models match</div>
+                  <p className="text-muted-foreground mx-auto mt-1 max-w-[220px] text-xs leading-5">
+                    Nothing matches “{search.trim()}”. Try a different search.
+                  </p>
+                  <div className="mt-4 flex items-center justify-center">
+                    <Button type="button" size="xs" variant="outline" onClick={() => setSearch('')}>
+                      Clear search
+                    </Button>
+                  </div>
+                </div>
               ) : (
                 <div className="px-3 py-5 text-center">
                   <div className="text-foreground text-sm font-medium">No models available</div>
@@ -718,8 +766,6 @@ export function ModelSelector({
 const extrasChipBase =
   'text-muted-foreground hover:text-foreground hover:bg-muted inline-flex h-7 shrink-0 cursor-pointer items-center rounded-full px-2.5 text-[11px] font-medium capitalize transition-colors duration-200';
 const extrasChipSelected = 'bg-foreground/[0.06] text-foreground';
-const extrasChipLocked =
-  'hover:text-muted-foreground pointer-events-none cursor-not-allowed opacity-60 hover:bg-transparent';
 const extrasRowLabel =
   'text-muted-foreground/60 px-1 text-[10px] font-semibold tracking-wide uppercase';
 

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useRef, useEffect, useCallback, useState, useImperativeHandle, forwardRef } from 'react';
+import { ArrowClockwiseIcon } from '@phosphor-icons/react';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { Terminal as XTerm, ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
@@ -17,6 +19,10 @@ import { classifyPtyClose, shouldExpirePtyConnect } from './pty-connection';
 
 // Neutral (zero-chroma) surface matching the app's dark background — no blue
 // tint. Selection stays neutral so it reads on any ANSI color underneath.
+//
+// `background` and `foreground` MUST stay equal to `--terminal-surface` and
+// `--terminal-fg` in globals.css — the connect bar and the panel shell paint
+// those tokens, and xterm's ITheme only accepts literal colors, never vars.
 const terminalTheme: ITheme = {
   background: '#0f0f0f',
   foreground: '#e5e5e5',
@@ -47,6 +53,9 @@ const terminalTheme: ITheme = {
 
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 const PTY_CONNECT_TIMEOUT_MS = 15_000;
+// xterm's default is 1000 lines — a single `npm install` or test run scrolls
+// past that, and the buffer is the only place that output exists client-side.
+const PTY_SCROLLBACK_LINES = 10_000;
 
 export interface PtyTerminalHandle {
   focus: () => void;
@@ -139,8 +148,14 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
   // Until this timestamp, drop capability-query responses (see isTerminalReport)
   // so the scrollback replayed on connect doesn't echo garbage at the prompt.
   const suppressReportsUntilRef = useRef(0);
+  // Set by the effect below; lets the manual "Reconnect now" control jump the
+  // backoff queue without reaching into the effect's closure from outside.
+  const reconnectNowRef = useRef<(() => void) | null>(null);
 
   const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+  // True while a backoff timer is armed. The backoff saturates at 15s, so
+  // without an escape hatch a user who fixed the problem still waits it out.
+  const [reconnectPending, setReconnectPending] = useState(false);
   const updatePty = useUpdatePty({ serverUrl, onError: () => {} });
 
   const updateStatus = useCallback((s: ConnectionStatus) => {
@@ -212,6 +227,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
       fontSize: 13,
       fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
       theme: terminalTheme,
+      scrollback: PTY_SCROLLBACK_LINES,
       allowProposedApi: true,
     });
 
@@ -266,9 +282,11 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
       term.writeln(`\r\n\x1b[33mReconnecting in ${Math.ceil(delay / 1000)}s${suffix}...\x1b[0m`);
       updateStatus('connecting');
+      setReconnectPending(true);
 
       reconnectTimeoutRef.current = setTimeout(() => {
         reconnectTimeoutRef.current = null;
+        setReconnectPending(false);
         connectWebSocket();
       }, delay);
     };
@@ -300,7 +318,9 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
       // Bail out if a newer connection was requested while we were resolving the URL
       if (connectionIdRef.current !== myConnectionId || disposedRef.current) return;
-      console.log('[PtyTerminal] Connecting WebSocket:', wsUrl);
+      // `wsUrl` carries the auth token as a query param (see getKortixPtyWebSocketUrl).
+      // Log the token-free origin+path only — never the query string.
+      console.log('[PtyTerminal] Connecting WebSocket:', wsUrl.split('?')[0]);
 
       const ws = new WebSocket(wsUrl);
       wsRef.current = ws;
@@ -341,6 +361,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
         }
         console.log('[PtyTerminal] WebSocket connected');
         reconnectAttemptsRef.current = 0;
+        setReconnectPending(false);
         // Suppress capability-query echoes while the server replays scrollback.
         // We deliberately do NOT reset()/clear() here — the PTY is persistent,
         // so reconnecting should re-attach to the existing shell, not wipe it.
@@ -407,6 +428,19 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
       };
     };
 
+    // Skip the armed backoff timer and dial immediately. Attempts reset so the
+    // next automatic retry (if this one also fails) starts at 1s again.
+    reconnectNowRef.current = () => {
+      if (disposedRef.current) return;
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+      reconnectAttemptsRef.current = 0;
+      setReconnectPending(false);
+      connectWebSocket();
+    };
+
     // Delay fit + initial WS connect to ensure the container has real dimensions
     const initTimer = setTimeout(() => {
       safeFit(fitAddon, container);
@@ -418,34 +452,56 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
       window.removeEventListener('resize', handleResize);
       resizeObserver.disconnect();
       if (resizeTimeoutRef.current) clearTimeout(resizeTimeoutRef.current);
+      reconnectNowRef.current = null;
+      setReconnectPending(false);
       disconnect();
       term.dispose();
       xtermRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [pty.id]); // eslint-disable-line react-hooks/exhaustive-deps
+    // `serverUrl` is a real input: the WS host is resolved from it, so after a
+    // sandbox move the old socket must be torn down and redialled. The cleanup
+    // above disposes the terminal and closes the socket, so re-running is safe.
+  }, [pty.id, serverUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Re-fit and focus when becoming visible (tab switch)
   useEffect(() => {
-    if (!hidden) {
-      requestAnimationFrame(() => {
-        safeFit(fitAddonRef.current, terminalRef.current);
-        xtermRef.current?.focus();
-      });
-    }
+    if (hidden) return;
+    requestAnimationFrame(() => {
+      safeFit(fitAddonRef.current, terminalRef.current);
+      // Never steal focus on a touch device: the mobile tool drawer mounts this
+      // with `hidden` undefined, and focusing xterm there throws up the
+      // on-screen keyboard over the terminal on every open.
+      if (typeof window !== 'undefined' && window.matchMedia?.('(pointer: coarse)').matches) {
+        return;
+      }
+      xtermRef.current?.focus();
+    });
   }, [hidden]);
 
   return (
     <div
-      ref={terminalRef}
       className={cn(
-        'overflow-hidden',
-        'bg-[#0f0f0f]',
-        'px-3 py-2',
+        'bg-terminal-surface relative overflow-hidden',
         hidden && 'invisible pointer-events-none',
         className,
       )}
-    />
+    >
+      <div ref={terminalRef} className="h-full w-full px-3 py-2" />
+      {reconnectPending && !hidden ? (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center p-3">
+          <Button
+            size="sm"
+            variant="secondary"
+            className="pointer-events-auto gap-1.5 shadow-md active:scale-[0.96]"
+            onClick={() => reconnectNowRef.current?.()}
+          >
+            <ArrowClockwiseIcon className="size-3.5 shrink-0" />
+            Reconnect now
+          </Button>
+        </div>
+      ) : null}
+    </div>
   );
 });
 

--- a/apps/web/src/features/session/question-prompt.tsx
+++ b/apps/web/src/features/session/question-prompt.tsx
@@ -12,7 +12,7 @@
 
 import { cn } from '@/lib/utils';
 import type { QuestionAnswer, QuestionInfo, QuestionRequest } from '@/ui';
-import { ChatCircleIcon as MessageCircle } from '@phosphor-icons/react';
+import { CheckIcon, ChatCircleIcon as MessageCircle } from '@phosphor-icons/react';
 import React, { useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -290,36 +290,42 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
             {isSingle ? '' : `${questions.length} questions \u00B7 `}
             <span className="text-foreground/80 truncate font-medium">{headerSummary}</span>
           </span>
-          <span
-            role="button"
-            tabIndex={0}
+          {/* A real <button>: Enter AND Space activate it natively, and Space no
+              longer scrolls the transcript out from under the question. */}
+          <button
+            type="button"
             onClick={reject}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                reject();
-              }
-            }}
-            className="text-muted-foreground/40 hover:text-foreground hover:bg-muted inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
+            aria-label="Dismiss question"
+            className="text-muted-foreground/40 hover:text-foreground hover:bg-muted hit-area-2 inline-flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md transition-colors"
           >
             <Close className="size-3" />
-          </span>
+          </button>
         </div>
 
         {/* Body — scrollable so long option lists don't blow up the card */}
         <div className="border-border/30 max-h-[420px] overflow-y-auto border-t">
           {/* Tab bar (multi-question only) */}
           {!isSingle && (
-            <div className="scrollbar-hide border-border/30 bg-muted/20 flex items-center gap-0.5 overflow-x-auto border-b px-2 py-1">
+            <div
+              role="tablist"
+              aria-label="Questions"
+              className="scrollbar-hide border-border/30 bg-muted/20 flex items-center gap-0.5 overflow-x-auto border-b px-2 py-1"
+            >
               {questions.map((q, i) => {
                 const isAnswered = (answers[i]?.length ?? 0) > 0;
                 return (
                   <button
                     key={q.question}
+                    type="button"
+                    role="tab"
+                    id={`${request.id}-tab-${i}`}
+                    aria-selected={tab === i}
+                    aria-controls={`${request.id}-panel`}
                     onClick={() => {
                       setTab(i);
                     }}
                     className={cn(
-                      'flex cursor-pointer items-center gap-1 rounded-2xl border px-2 py-0.5 text-sm font-medium whitespace-nowrap transition-colors duration-150',
+                      'flex cursor-pointer items-center gap-1 rounded-full border px-2 py-0.5 text-sm font-medium whitespace-nowrap transition-colors duration-150',
                       tab === i
                         ? 'bg-background/80 text-foreground border-border/70'
                         : 'text-muted-foreground hover:text-foreground hover:bg-muted/70 border-transparent',
@@ -335,17 +341,7 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
                             : 'border-border',
                       )}
                     >
-                      {isAnswered && (
-                        <svg viewBox="0 0 12 12" fill="none" width="7" height="7">
-                          <path
-                            d="M3 7.18L5.03 8.85L9 3.5"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="square"
-                            className="text-foreground"
-                          />
-                        </svg>
-                      )}
+                      {isAnswered && <CheckIcon className="text-foreground size-2" />}
                       {!isAnswered && tab === i && (
                         <div className="bg-foreground size-0.5 rounded-full" />
                       )}
@@ -355,11 +351,16 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
                 );
               })}
               <button
+                type="button"
+                role="tab"
+                id={`${request.id}-tab-confirm`}
+                aria-selected={isConfirm}
+                aria-controls={`${request.id}-panel`}
                 onClick={() => {
                   setTab(questions.length);
                 }}
                 className={cn(
-                  'cursor-pointer rounded-2xl border px-2 py-0.5 text-sm font-medium transition-colors duration-150',
+                  'cursor-pointer rounded-full border px-2 py-0.5 text-sm font-medium transition-colors duration-150',
                   isConfirm
                     ? 'bg-background/80 text-foreground border-border/70'
                     : 'text-muted-foreground hover:text-foreground hover:bg-muted/70 border-transparent',
@@ -370,7 +371,18 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
             </div>
           )}
 
-          <div className="px-3 py-2">
+          <div
+            id={`${request.id}-panel`}
+            role={isSingle ? undefined : 'tabpanel'}
+            aria-labelledby={
+              isSingle
+                ? undefined
+                : isConfirm
+                  ? `${request.id}-tab-confirm`
+                  : `${request.id}-tab-${tab}`
+            }
+            className="px-3 py-2"
+          >
             {/* Confirm / review tab */}
             {isConfirm ? (
               <div className="space-y-0.5">
@@ -388,17 +400,7 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
                           done ? 'border-border bg-muted' : 'border-border',
                         )}
                       >
-                        {done && (
-                          <svg viewBox="0 0 12 12" fill="none" width="7" height="7">
-                            <path
-                              d="M3 7.18L5.03 8.85L9 3.5"
-                              stroke="currentColor"
-                              strokeWidth="1.5"
-                              strokeLinecap="square"
-                              className="text-foreground"
-                            />
-                          </svg>
-                        )}
+                        {done && <CheckIcon className="text-foreground size-2" />}
                       </span>
                       <span
                         className={cn(
@@ -431,9 +433,11 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
                     return (
                       <button
                         key={opt.label}
+                        type="button"
+                        aria-pressed={isMulti ? isPicked : undefined}
                         onClick={() => selectOption(i)}
                         className={cn(
-                          'group flex w-full cursor-pointer items-center gap-2 rounded-2xl border px-2 py-1.5 text-left transition-colors duration-150 ease-out active:scale-[0.998]',
+                          'group flex w-full cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 text-left transition-[color,background-color,border-color,scale] duration-150 ease-out active:scale-[0.998]',
                           isPicked
                             ? 'bg-primary/10 border-primary/30'
                             : 'hover:bg-muted/40 border-transparent',
@@ -447,17 +451,7 @@ export const QuestionPrompt = React.forwardRef<QuestionPromptHandle, QuestionPro
                               : 'border-border group-hover:border-foreground/30',
                           )}
                         >
-                          {isPicked && (
-                            <svg viewBox="0 0 12 12" fill="none" width="8" height="8">
-                              <path
-                                d="M3 7.18L5.03 8.85L9 3.5"
-                                stroke="currentColor"
-                                strokeWidth="1.5"
-                                strokeLinecap="square"
-                                className="text-foreground"
-                              />
-                            </svg>
-                          )}
+                          {isPicked && <CheckIcon className="text-foreground size-2.5" />}
                         </span>
                         <span className="min-w-0 text-xs leading-tight">
                           <span

--- a/apps/web/src/features/session/reasoning-effort-selector.tsx
+++ b/apps/web/src/features/session/reasoning-effort-selector.tsx
@@ -201,7 +201,7 @@ function EffortIcon({ value, className }: { value: string | null; className?: st
   switch (value) {
     case null:
     case 'auto':
-      return <GaugeIcon className={className} weight="bold" />;
+      return <GaugeIcon className={className} />;
     case 'none':
       return <CellSignalNoneIcon className={className} weight="fill" />;
     case 'low':
@@ -299,7 +299,12 @@ export function ReasoningEffortSelector({
         >
           <EffortIcon value={current} className="size-4 shrink-0" />
           <span className="max-w-[7rem] truncate">{current ? label(current) : 'Auto'}</span>
-          <CaretDownIcon className={cn('size-3 opacity-50', open && 'rotate-180')} />
+          <CaretDownIcon
+            className={cn(
+              'size-3 opacity-50 transition-transform duration-200 ease-out',
+              open && 'rotate-180',
+            )}
+          />
         </Button>
       </DropdownMenuTrigger>
 

--- a/apps/web/src/features/session/sandbox-url-detector.tsx
+++ b/apps/web/src/features/session/sandbox-url-detector.tsx
@@ -6,7 +6,7 @@ import { UnifiedMarkdown } from '@/components/markdown';
 import { CopyButton } from '@/components/markdown/copy-button';
 import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import Loading from '@/components/ui/loading';
 import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-url';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { INTERACTIVE_PREVIEW_IFRAME_SANDBOX } from '@/lib/security/iframe-sandbox';
@@ -126,7 +126,7 @@ function InlineIframePreview({ proxyUrl, port }: { proxyUrl: string; port: numbe
   return (
     <div
       className={cn(
-        'border-border/50 mt-2 overflow-hidden rounded-2xl border transition-colors duration-200',
+        'border-border/50 mt-2 overflow-hidden rounded-md border transition-colors duration-200',
         expanded ? 'h-[480px]' : 'h-[280px]',
       )}
     >
@@ -136,28 +136,26 @@ function InlineIframePreview({ proxyUrl, port }: { proxyUrl: string; port: numbe
           <Globe className="text-muted-foreground/50 h-3 w-3 shrink-0" />
           <span className="text-muted-foreground truncate font-mono text-xs">localhost:{port}</span>
         </div>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={handleRefresh}
-              className="hover:bg-muted/60 text-muted-foreground/50 hover:text-muted-foreground rounded p-1 transition-colors"
-            >
-              <RefreshCw className={cn('h-3 w-3', isLoading && 'animate-spin')} />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top">Refresh</TooltipContent>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => setExpanded((v) => !v)}
-              className="hover:bg-muted/60 text-muted-foreground/50 hover:text-muted-foreground rounded p-1 transition-colors"
-            >
-              {expanded ? <Minimize2 className="h-3 w-3" /> : <Maximize2 className="h-3 w-3" />}
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top">{expanded ? 'Collapse' : 'Expand'}</TooltipContent>
-        </Tooltip>
+        <Hint side="top" label="Refresh preview">
+          <button
+            type="button"
+            onClick={handleRefresh}
+            aria-label="Refresh preview"
+            className="hover:bg-muted/60 text-muted-foreground/50 hover:text-muted-foreground hit-area-2 rounded p-1 transition-colors active:scale-[0.96]"
+          >
+            <RefreshCw className={cn('size-3', isLoading && 'animate-spinner-spin')} />
+          </button>
+        </Hint>
+        <Hint side="top" label={expanded ? 'Collapse preview' : 'Expand preview'}>
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            aria-label={expanded ? 'Collapse preview' : 'Expand preview'}
+            className="hover:bg-muted/60 text-muted-foreground/50 hover:text-muted-foreground hit-area-2 rounded p-1 transition-colors active:scale-[0.96]"
+          >
+            {expanded ? <Minimize2 className="size-3" /> : <Maximize2 className="size-3" />}
+          </button>
+        </Hint>
       </div>
 
       {/* Iframe — only render once auth token is ready */}
@@ -165,7 +163,7 @@ function InlineIframePreview({ proxyUrl, port }: { proxyUrl: string; port: numbe
         {(isLoading || !isAuthReady) && (
           <div className="bg-background/60 absolute inset-0 z-10 flex items-center justify-center">
             <div className="text-muted-foreground flex items-center gap-2">
-              <RefreshCw className="h-4 w-4 animate-spin" />
+              <Loading className="size-4 shrink-0" />
               <span className="text-xs">{!isAuthReady ? 'Authenticating...' : 'Loading...'}</span>
             </div>
           </div>

--- a/apps/web/src/features/session/session-audit-panel.tsx
+++ b/apps/web/src/features/session/session-audit-panel.tsx
@@ -168,7 +168,7 @@ export function SessionAuditPanel({
                     <li key={event.event_id} className="border-border border-b last:border-b-0">
                       <button
                         type="button"
-                        className="hover:bg-primary/[0.03] flex min-h-12 w-full items-center gap-3 px-4 py-2 text-left transition-colors active:scale-[0.96]"
+                        className="hover:bg-primary/[0.03] flex min-h-12 w-full items-center gap-3 px-4 py-2 text-left transition-[background-color,transform] active:scale-[0.998]"
                         onClick={() => setSelectedEvent(event)}
                       >
                         <span className="text-muted-foreground w-8 shrink-0 text-right font-mono text-xs tabular-nums">
@@ -239,7 +239,7 @@ export function SessionAuditPanel({
                     >
                       <button
                         type="button"
-                        className="hover:bg-primary/[0.03] flex min-h-12 w-full items-center gap-3 px-4 py-2 text-left transition-colors"
+                        className="hover:bg-primary/[0.03] flex min-h-12 w-full items-center gap-3 px-4 py-2 text-left transition-[background-color,transform] active:scale-[0.998]"
                         onClick={() => setSelected(action)}
                       >
                         <div className="min-w-0 flex-1">

--- a/apps/web/src/features/session/session-busy-indicator.test.tsx
+++ b/apps/web/src/features/session/session-busy-indicator.test.tsx
@@ -51,4 +51,35 @@ describe('SessionBusyIndicator', () => {
     );
     expect(markup).toContain('Running tests');
   });
+
+  // Regression: the elapsed counter used to be concatenated into `statusText`,
+  // so the animated span's key changed once a second and replayed the roll-swap
+  // for the whole of any long tool call. The phrase markup either side of the
+  // elapsed span must stay byte-identical as the clock ticks.
+  test('elapsed time ticks without changing the animated phrase', () => {
+    const at21 = renderToStaticMarkup(
+      <SessionBusyIndicator statusText="Running tests" elapsedLabel="21s" />,
+    );
+    const at22 = renderToStaticMarkup(
+      <SessionBusyIndicator statusText="Running tests" elapsedLabel="22s" />,
+    );
+    expect(at21).toContain('21s');
+    expect(at22).toContain('22s');
+    expect(at21).toContain('tabular-nums');
+    expect(at21.replace('21s', 'X')).toBe(at22.replace('22s', 'X'));
+  });
+
+  test('omitting elapsedLabel renders no separator', () => {
+    const markup = renderToStaticMarkup(<SessionBusyIndicator statusText="Thinking" />);
+    expect(markup).not.toContain('&middot;');
+  });
+
+  // The ambient phrases rotate on a 4s timer and carry no information, so the
+  // live region is muted for them; a real status still announces.
+  test('ambient mutes the live region, real status announces', () => {
+    expect(renderToStaticMarkup(<SessionBusyIndicator ambient />)).toContain('aria-live="off"');
+    expect(renderToStaticMarkup(<SessionBusyIndicator statusText="Running tests" />)).toContain(
+      'aria-live="polite"',
+    );
+  });
 });

--- a/apps/web/src/features/session/session-busy-indicator.tsx
+++ b/apps/web/src/features/session/session-busy-indicator.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { SessionDotMatrix } from '@/components/ui/dot-matrix/session-dot-matrix';
 import { TextShimmer } from '@/components/ui/text-shimmer';
@@ -40,12 +40,20 @@ const FADE_SWAP = {
 
 export function SessionBusyIndicator({
   statusText,
+  elapsedLabel,
   retryLabel,
   ambient = false,
   sessionId,
   className,
 }: {
   statusText?: string;
+  /**
+   * Live elapsed time for the current status, e.g. `"24s"`. Rendered beside the
+   * phrase in its OWN non-animated span: it ticks once a second, and folding it
+   * into `statusText` would change the `AnimatePresence` key every second and
+   * replay the roll-swap forever during long tool calls.
+   */
+  elapsedLabel?: string;
   retryLabel?: string;
   ambient?: boolean;
   /**
@@ -57,14 +65,10 @@ export function SessionBusyIndicator({
   className?: string;
 }): React.ReactElement {
   const reduceMotion = useReducedMotion() ?? false;
-  const hasMounted = useRef(false);
   const retryText = retryLabel?.trim();
   const isRetrying = Boolean(retryText);
   const status = statusText?.trim();
-
-  useEffect(() => {
-    hasMounted.current = true;
-  }, []);
+  const elapsed = elapsedLabel?.trim();
 
   const [ambientIdx, setAmbientIdx] = useState(() =>
     Math.floor(Math.random() * AMBIENT_MESSAGES.length),
@@ -88,7 +92,11 @@ export function SessionBusyIndicator({
   return (
     <m.div
       role="status"
-      aria-live="polite"
+      // `role="status"` implies aria-live="polite". The ambient filler rotates
+      // on a 4s timer and carries no information, so it is muted — otherwise a
+      // screen reader re-reads a new phrase every 4 seconds for the whole turn.
+      // A real status or retry label still announces.
+      aria-live={useAmbient ? 'off' : 'polite'}
       data-testid="session-busy-indicator"
       className={cn(
         'text-muted-foreground flex w-full min-w-0 items-center gap-1.5 py-0.5 text-xs',
@@ -98,23 +106,32 @@ export function SessionBusyIndicator({
       <SessionDotMatrix sessionId={sessionId} size={14} className="shrink-0" />
       <span className="relative min-w-0 flex-1" aria-hidden>
         {isRetrying ? (
-          <span className="text-muted-foreground/70 block truncate text-sm leading-5">{label}</span>
+          <span className="text-muted-foreground/70 block truncate text-sm leading-5 tabular-nums">
+            {label}
+          </span>
         ) : (
-          <span className="relative block min-w-0 overflow-hidden leading-5">
-            <AnimatePresence mode="popLayout">
-              <m.span
-                key={label}
-                initial={hasMounted.current ? swap.initial : swap.animate}
-                animate={swap.animate}
-                exit={swap.exit}
-                transition={swap.transition}
-                className="block min-w-0 whitespace-nowrap"
-              >
-                <TextShimmer className="truncate text-center align-middle text-sm leading-5">
-                  {label}
-                </TextShimmer>
-              </m.span>
-            </AnimatePresence>
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="relative block min-w-0 flex-1 overflow-hidden leading-5">
+              <AnimatePresence initial={false} mode="popLayout">
+                <m.span
+                  key={label}
+                  initial={swap.initial}
+                  animate={swap.animate}
+                  exit={swap.exit}
+                  transition={swap.transition}
+                  className="block min-w-0 whitespace-nowrap"
+                >
+                  <TextShimmer className="truncate text-center align-middle text-sm leading-5">
+                    {label}
+                  </TextShimmer>
+                </m.span>
+              </AnimatePresence>
+            </span>
+            {elapsed ? (
+              <span className="text-muted-foreground/70 shrink-0 text-sm leading-5 tabular-nums">
+                &middot; {elapsed}
+              </span>
+            ) : null}
           </span>
         )}
       </span>

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -1242,10 +1242,17 @@ function SessionTurnImpl({
     const timer = setInterval(() => setStatusElapsedMs(Date.now() - statusSinceMs), 1000);
     return () => clearInterval(timer);
   }, [working, statusSinceMs]);
-  const statusWithElapsed =
+  /** The phrase alone — never the elapsed time. Folding the ticking duration in
+   *  here changed the busy indicator's animation key once a second, which
+   *  replayed its roll-swap forever during any long tool call. */
+  const statusPhrase =
     throttledStatus && working && statusElapsedMs >= STATUS_STALL_AFTER_MS
-      ? `${throttledStatus.replace(/(\.\.\.|…)$/, '')} · ${formatDuration(statusElapsedMs)}`
+      ? throttledStatus.replace(/(\.\.\.|…)$/, '')
       : throttledStatus;
+  const statusElapsedLabel =
+    throttledStatus && working && statusElapsedMs >= STATUS_STALL_AFTER_MS
+      ? formatDuration(statusElapsedMs)
+      : undefined;
 
   useEffect(() => {
     const newStatus = rawStatus;
@@ -1416,7 +1423,7 @@ function SessionTurnImpl({
   if (isCompaction && !working && response) {
     return (
       <div className="group/turn">
-        <div className="border-border/60 bg-card/50 overflow-hidden rounded-2xl border">
+        <div className="border-border/60 bg-card/50 overflow-hidden rounded-md border">
           <div className="border-border/40 bg-muted/40 flex items-center gap-2 border-b px-4 py-2.5">
             <Layers className="text-muted-foreground/70 size-3.5" />
             <span className="text-muted-foreground/70 text-xs font-medium tracking-wider uppercase">
@@ -1591,9 +1598,12 @@ function SessionTurnImpl({
         </div>
       )}
 
-      {/* ── Screen reader ── */}
+      {/* ── Screen reader ──
+          Announce COMPLETION only. Mirroring the full response here duplicated
+          every turn in the DOM, so select-all across the transcript copied each
+          answer twice. The visible markdown is already in the a11y tree. */}
       <div className="sr-only" aria-live="polite">
-        {!working && response ? response : ''}
+        {!working && response ? 'Response complete' : ''}
       </div>
 
       {/* Inline content: text and answered questions rendered in natural order.
@@ -1704,7 +1714,8 @@ function SessionTurnImpl({
           )}
           <SessionBusyIndicator
             sessionId={sessionId}
-            statusText={statusWithElapsed || undefined}
+            statusText={statusPhrase || undefined}
+            elapsedLabel={statusElapsedLabel}
             retryLabel={
               retryInfo
                 ? String(
@@ -1728,14 +1739,20 @@ function SessionTurnImpl({
 
       {/* Question prompt — now rendered inside the chat input card (questionSlot) */}
 
-      {/* ── Action bar (copy + turn meta) ── */}
-      {!working && response && (
+      {/* ── Action bar (copy + turn meta) ──
+          Gated on `!working` only. A turn that ends in tool calls has no closing
+          prose, but its finished-at / duration / cost are still turn facts —
+          `SessionTurnMeta` self-hides when it has no rows. Only the copy button
+          needs a response to copy. */}
+      {!working && (
         <div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/turn:opacity-100 focus-within:opacity-100 has-[[data-state=open]]:opacity-100">
+          {response ? (
           <Button
             variant="ghost"
             size="icon-sm"
             onClick={handleCopy}
             aria-label={copied ? 'Copied' : 'Copy response'}
+            className="hit-area-3"
           >
             <span className="relative inline-flex shrink-0 items-center justify-center">
               <AnimatePresence initial={false} mode="popLayout">
@@ -1756,6 +1773,7 @@ function SessionTurnImpl({
               </AnimatePresence>
             </span>
           </Button>
+          ) : null}
           <SessionTurnMeta
             endedAt={turnEndedAt}
             durationMs={turnDurationMs}
@@ -1817,6 +1835,24 @@ interface SessionChatProps {
   readOnly?: boolean;
   /** Start scrolled to the top instead of the bottom (e.g. sub-session modal viewer) */
   initialScrollTop?: boolean;
+}
+
+/**
+ * The "Compaction" rule that marks where history was summarised. Rendered in two
+ * places (the optimistic pass and the first turn after a landed compaction);
+ * they were byte-identical copies, so they live here to stay that way.
+ */
+function CompactionDivider(): React.ReactElement {
+  return (
+    <div className="my-3 flex items-center gap-3 py-4">
+      <div className="bg-border h-px flex-1" />
+      <div className="bg-muted/80 border-border/60 flex items-center gap-2 rounded-full border px-3 py-1.5">
+        <Layers className="text-muted-foreground size-3.5" />
+        <span className="text-muted-foreground text-xs font-semibold tracking-wide">Compaction</span>
+      </div>
+      <div className="bg-border h-px flex-1" />
+    </div>
+  );
 }
 
 export function SessionChat({
@@ -4319,7 +4355,17 @@ export function SessionChat({
   if (isDataLoading) {
     return (
       <div className="bg-background relative flex h-full flex-col" data-testid="session-chat">
-        <SessionStartingLoader stage="ready" variant="compact" />
+        {/* `projectId`/`sessionId` are what arm the loader's restart offer
+            (`canRestart`). Without them a session wedged in this state spun
+            forever with no way out but a page reload. The stage must also track
+            the real runtime — hardcoding "ready" froze the copy on
+            "Connecting" no matter what the boot was actually doing. */}
+        <SessionStartingLoader
+          stage={runtimeReady ? 'ready' : 'starting'}
+          variant="compact"
+          projectId={projectId}
+          sessionId={projectSessionId}
+        />
       </div>
     );
   }
@@ -4380,18 +4426,21 @@ export function SessionChat({
                   'componentsSessionSessionChat.line5821JsxTextThisSessionIsNotAccessibleRightNow',
                 )}
               </div>
-              <button
+              {/* Soft nav, not `window.location.assign` — a full page reload
+                  tore down the whole app to move one route. */}
+              <Button
                 type="button"
+                variant="outline"
+                size="sm"
                 onClick={() => {
                   try {
                     if (sessionId) useTabStore.getState().closeTab?.(sessionId);
                   } catch {}
-                  if (typeof window !== 'undefined') window.location.assign('/');
+                  router.push('/');
                 }}
-                className="text-primary text-sm hover:underline"
               >
                 {tHardcodedUi.raw('componentsSessionSessionChat.line5833JsxTextGoToHome')}
-              </button>
+              </Button>
             </div>
           ) : (
             <div ref={chatAreaRef} className="relative z-10 min-h-0 flex-1">
@@ -4433,16 +4482,7 @@ export function SessionChat({
                   <div className="flex min-w-0 flex-col">
                     {isOptimisticCompacting && !hasCompactionTurn && (
                       <div className="mt-12 space-y-3">
-                        <div className="my-3 flex items-center gap-3 py-4">
-                          <div className="bg-border h-px flex-1" />
-                          <div className="bg-muted/80 border-border/60 flex items-center gap-2 rounded-2xl border px-3 py-1.5">
-                            <Layers className="text-muted-foreground size-3.5" />
-                            <span className="text-muted-foreground text-xs font-semibold tracking-wide">
-                              Compaction
-                            </span>
-                          </div>
-                          <div className="bg-border h-px flex-1" />
-                        </div>
+                        <CompactionDivider />
                         <div className="flex items-center gap-3">
                           {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
@@ -4539,16 +4579,7 @@ export function SessionChat({
                           >
                             {/* Compaction divider — shown before the first turn after compaction */}
                             {hasCompaction && (
-                              <div className="my-3 flex items-center gap-3 py-4">
-                                <div className="bg-border h-px flex-1" />
-                                <div className="bg-muted/80 border-border/60 flex items-center gap-2 rounded-2xl border px-3 py-1.5">
-                                  <Layers className="text-muted-foreground size-3.5" />
-                                  <span className="text-muted-foreground text-xs font-semibold tracking-wide">
-                                    Compaction
-                                  </span>
-                                </div>
-                                <div className="bg-border h-px flex-1" />
-                              </div>
+                              <CompactionDivider />
                             )}
                             <SessionTurn
                               turn={turn}

--- a/apps/web/src/features/session/session-diff-viewer.tsx
+++ b/apps/web/src/features/session/session-diff-viewer.tsx
@@ -3,11 +3,16 @@
 import { useTranslations } from 'next-intl';
 
 import { DiffView } from '@/components/diff/diff-view';
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
 import { DiffStat, STATUS_TEXT, StatusBadge } from '@/components/ui/status';
-import { useRuntimeMessages, useRuntimeSessionDiff } from '@kortix/sdk/react';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
 import { cn } from '@/lib/utils';
 import type { ApplyPatchFile, FileDiff } from '@/ui/types';
+import { useRuntimeMessages, useRuntimeSessionDiff } from '@kortix/sdk/react';
 import {
   CaretDownIcon as ChevronDown,
   CaretRightIcon as ChevronRight,
@@ -92,7 +97,7 @@ function FileDiffCard({
     : '';
 
   return (
-    <div className="border-border/50 bg-card overflow-hidden rounded-2xl border">
+    <div className="border-border/50 bg-card overflow-hidden rounded-md border">
       {/* File header */}
       <button
         onClick={() => hasDiffContent && setExpanded(!expanded)}
@@ -157,12 +162,14 @@ function DiffSummaryBar({
   onViewModeChange,
   isFullscreen,
   onToggleFullscreen,
+  reserveCloseGutter,
 }: {
   diffs: FileDiff[];
   viewMode: 'unified' | 'split';
   onViewModeChange: (mode: 'unified' | 'split') => void;
   isFullscreen?: boolean;
   onToggleFullscreen?: () => void;
+  reserveCloseGutter?: boolean;
 }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const totals = useMemo(() => {
@@ -181,70 +188,104 @@ function DiffSummaryBar({
     return { additions, deletions, added, deleted, modified };
   }, [diffs]);
 
+  const unifiedLabel = tHardcodedUi.raw(
+    'componentsSessionSessionDiffViewer.line186JsxAttrTitleUnifiedView',
+  );
+  const splitLabel = tHardcodedUi.raw(
+    'componentsSessionSessionDiffViewer.line198JsxAttrTitleSideBySideView',
+  );
+  const fullscreenLabel = isFullscreen ? 'Exit fullscreen' : 'Fullscreen';
+
   return (
-    <div className="border-border/40 bg-muted/20 flex w-full items-center gap-3 border-b px-4 py-2.5 pr-12">
+    <div
+      className={cn(
+        'border-border/40 bg-muted/20 flex w-full items-center gap-3 border-b px-4 py-2.5',
+        // Only the modal mount has a floating close button to clear.
+        reserveCloseGutter && 'pr-14',
+      )}
+    >
       <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
         {diffs.length} {diffs.length === 1 ? 'file' : 'files'} changed
       </span>
-      <div className="flex shrink-0 items-center gap-2 text-xs whitespace-nowrap">
+      <div className="flex shrink-0 items-center gap-1 text-xs whitespace-nowrap">
         {totals.added > 0 && (
-          <span className={cn('flex items-center gap-1', STATUS_TEXT.success)}>
+          <span className={cn('flex items-center gap-1 tabular-nums', STATUS_TEXT.success)}>
             <FilePlus2 className="size-3" /> {totals.added}
           </span>
         )}
         {totals.modified > 0 && (
-          <span className={cn('flex items-center gap-1', STATUS_TEXT.info)}>
+          <span className={cn('flex items-center gap-1 tabular-nums', STATUS_TEXT.info)}>
             <FileEdit className="size-3" /> {totals.modified}
           </span>
         )}
         {totals.deleted > 0 && (
-          <span className={cn('flex items-center gap-1', STATUS_TEXT.destructive)}>
+          <span className={cn('flex items-center gap-1 tabular-nums', STATUS_TEXT.destructive)}>
             <FileX2 className="size-3" /> {totals.deleted}
           </span>
         )}
         <span className="text-muted-foreground/50 mx-1">|</span>
-        <DiffStat additions={totals.additions} deletions={totals.deletions} />
+        <DiffStat
+          additions={totals.additions}
+          deletions={totals.deletions}
+          className="tabular-nums"
+        />
 
-        {/* View mode toggle */}
+        {/* View mode toggle — a two-state group, so each control reports its
+            own pressed state instead of relying on colour alone. */}
         <span className="text-muted-foreground/50 mx-1">|</span>
-        <button
-          onClick={() => onViewModeChange('unified')}
-          className={cn(
-            'cursor-pointer rounded p-1 transition-colors',
-            viewMode === 'unified'
-              ? 'text-foreground bg-muted/60'
-              : 'text-muted-foreground/50 hover:text-muted-foreground',
-          )}
-          title={tHardcodedUi.raw(
-            'componentsSessionSessionDiffViewer.line186JsxAttrTitleUnifiedView',
-          )}
-        >
-          <Rows2 className="size-3.5" />
-        </button>
-        <button
-          onClick={() => onViewModeChange('split')}
-          className={cn(
-            'cursor-pointer rounded p-1 transition-colors',
-            viewMode === 'split'
-              ? 'text-foreground bg-muted/60'
-              : 'text-muted-foreground/50 hover:text-muted-foreground',
-          )}
-          title={tHardcodedUi.raw(
-            'componentsSessionSessionDiffViewer.line198JsxAttrTitleSideBySideView',
-          )}
-        >
-          <Columns2 className="size-3.5" />
-        </button>
+        <Hint label={unifiedLabel} side="bottom">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={unifiedLabel}
+            aria-pressed={viewMode === 'unified'}
+            onClick={() => onViewModeChange('unified')}
+            className={cn(
+              'active:scale-[0.96]',
+              viewMode === 'unified'
+                ? 'text-foreground bg-muted/60'
+                : 'text-muted-foreground/70 hover:text-foreground',
+            )}
+          >
+            <Rows2 className="size-3.5" />
+          </Button>
+        </Hint>
+        <Hint label={splitLabel} side="bottom">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={splitLabel}
+            aria-pressed={viewMode === 'split'}
+            onClick={() => onViewModeChange('split')}
+            className={cn(
+              'active:scale-[0.96]',
+              viewMode === 'split'
+                ? 'text-foreground bg-muted/60'
+                : 'text-muted-foreground/70 hover:text-foreground',
+            )}
+          >
+            <Columns2 className="size-3.5" />
+          </Button>
+        </Hint>
 
         {/* Fullscreen toggle */}
         {onToggleFullscreen && (
-          <button
-            onClick={onToggleFullscreen}
-            className="text-muted-foreground/50 hover:text-muted-foreground cursor-pointer rounded p-1 transition-colors"
-            title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-          >
-            {isFullscreen ? <Minimize2 className="size-3.5" /> : <Maximize2 className="size-3.5" />}
-          </button>
+          <Hint label={fullscreenLabel} side="bottom">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={fullscreenLabel}
+              aria-pressed={!!isFullscreen}
+              onClick={onToggleFullscreen}
+              className="text-muted-foreground/70 hover:text-foreground active:scale-[0.96]"
+            >
+              {isFullscreen ? (
+                <Minimize2 className="size-3.5" />
+              ) : (
+                <Maximize2 className="size-3.5" />
+              )}
+            </Button>
+          </Hint>
         )}
       </div>
     </div>
@@ -344,15 +385,38 @@ interface SessionDiffViewerProps {
   sessionId: string;
   isFullscreen?: boolean;
   onToggleFullscreen?: () => void;
+  /**
+   * True only where the viewer renders under a floating close button — the
+   * modal mount ({@link DiffDialog}). The side-panel mount has no such button,
+   * and reserving the gutter there left the toolbar floating 56px short of the
+   * right edge.
+   */
+  reserveCloseGutter?: boolean;
+}
+
+/** Shared header for the non-content states, so all three stay identical. */
+function DiffPanelHeader({ reserveCloseGutter }: { reserveCloseGutter?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'border-border/40 flex items-center gap-2 border-b px-5 py-4',
+        reserveCloseGutter && 'pr-14',
+      )}
+    >
+      <GitCompareArrows className="text-muted-foreground/40 size-4" />
+      <span className="text-muted-foreground text-xs font-medium">Changes</span>
+    </div>
+  );
 }
 
 export function SessionDiffViewer({
   sessionId,
   isFullscreen,
   onToggleFullscreen,
+  reserveCloseGutter,
 }: SessionDiffViewerProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
-  const { data: apiDiffs, isLoading, error } = useRuntimeSessionDiff(sessionId);
+  const { data: apiDiffs, isLoading, error, refetch } = useRuntimeSessionDiff(sessionId);
   const { data: messages } = useRuntimeMessages(sessionId);
   const [viewMode, setViewMode] = useState<'unified' | 'split'>('unified');
 
@@ -364,22 +428,13 @@ export function SessionDiffViewer({
   if (isLoading) {
     return (
       <div className="flex h-full flex-col">
-        <div className="border-border/40 flex items-center gap-2 border-b px-5 py-4 pr-12">
-          <GitCompareArrows className="text-muted-foreground/40 size-4" />
-          <span className="text-muted-foreground text-xs font-medium">Changes</span>
-        </div>
-        <div className="flex flex-1 items-center justify-center">
-          <div className="space-y-2">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3 px-5">
-                <div className="bg-muted/30 h-3 w-3 animate-pulse rounded" />
-                <div
-                  className="bg-muted/20 h-3 animate-pulse rounded"
-                  style={{ width: 120 + i * 40 }}
-                />
-              </div>
-            ))}
-          </div>
+        <DiffPanelHeader reserveCloseGutter={reserveCloseGutter} />
+        {/* Shape-matched to the file rows below and anchored to the top, so
+            content does not jump up from the middle of the pane on load. */}
+        <div className="min-h-0 flex-1 space-y-2 p-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-full py-0" />
+          ))}
         </div>
       </div>
     );
@@ -388,17 +443,19 @@ export function SessionDiffViewer({
   if (error && diffs.length === 0) {
     return (
       <div className="flex h-full flex-col">
-        <div className="border-border/40 flex items-center gap-2 border-b px-5 py-4 pr-12">
-          <GitCompareArrows className="text-muted-foreground/40 size-4" />
-          <span className="text-muted-foreground text-xs font-medium">Changes</span>
-        </div>
-        <div className="flex flex-1 items-center justify-center px-6 text-center">
-          <p className="text-muted-foreground text-xs">
-            {tHardcodedUi.raw(
-              'componentsSessionSessionDiffViewer.line355JsxTextFailedToLoadChanges',
-            )}
-          </p>
-        </div>
+        <DiffPanelHeader reserveCloseGutter={reserveCloseGutter} />
+        <ErrorState
+          size="sm"
+          className="min-h-0 flex-1"
+          title={tHardcodedUi.raw(
+            'componentsSessionSessionDiffViewer.line355JsxTextFailedToLoadChanges',
+          )}
+          action={
+            <Button variant="outline" size="sm" onClick={() => void refetch()}>
+              Retry
+            </Button>
+          }
+        />
       </div>
     );
   }
@@ -406,21 +463,15 @@ export function SessionDiffViewer({
   if (!diffs || diffs.length === 0) {
     return (
       <div className="flex h-full flex-col">
-        <div className="border-border/40 flex items-center gap-2 border-b px-5 py-4 pr-12">
-          <GitCompareArrows className="text-muted-foreground/40 size-4" />
-          <span className="text-muted-foreground text-xs font-medium">Changes</span>
-        </div>
-        <div className="flex min-h-[200px] flex-1 flex-col items-center justify-center px-6 py-12 text-center">
-          <FileCode2 className="text-muted-foreground/20 mb-4 size-10" />
-          <p className="text-muted-foreground text-base">
-            {tHardcodedUi.raw('componentsSessionSessionDiffViewer.line370JsxTextNoChangesYet')}
-          </p>
-          <p className="text-muted-foreground/50 mt-1.5 text-sm">
-            {tHardcodedUi.raw(
-              'componentsSessionSessionDiffViewer.line372JsxTextFileChangesWillAppearHereAsTheSession',
-            )}
-          </p>
-        </div>
+        <DiffPanelHeader reserveCloseGutter={reserveCloseGutter} />
+        <EmptyState
+          icon={FileCode2}
+          className="min-h-0 flex-1"
+          title={tHardcodedUi.raw('componentsSessionSessionDiffViewer.line370JsxTextNoChangesYet')}
+          description={tHardcodedUi.raw(
+            'componentsSessionSessionDiffViewer.line372JsxTextFileChangesWillAppearHereAsTheSession',
+          )}
+        />
       </div>
     );
   }
@@ -433,6 +484,7 @@ export function SessionDiffViewer({
         onViewModeChange={setViewMode}
         isFullscreen={isFullscreen}
         onToggleFullscreen={onToggleFullscreen}
+        reserveCloseGutter={reserveCloseGutter}
       />
       <ScrollArea className="min-h-0 flex-1">
         <div className="space-y-2 p-3">

--- a/apps/web/src/features/session/session-error-banner.tsx
+++ b/apps/web/src/features/session/session-error-banner.tsx
@@ -15,10 +15,9 @@ import { useAccountSettingsModalStore } from '@/stores/account-settings-modal-st
 import { isAbortError, type GatewayErrorDetails } from '@kortix/sdk';
 import type { KortixSendError } from '@kortix/sdk/react';
 import {
-  WarningCircleIcon as AlertCircle,
-  CreditCardIcon as CreditCard,
+  CreditCardIcon,
+  LightningIcon,
   WarningCircleIcon,
-  LightningIcon as Zap,
 } from '@phosphor-icons/react';
 
 // ============================================================================
@@ -65,11 +64,11 @@ function UsageLimitCard({ errorText, className }: { errorText: string; className
   return (
     <Checkpoint className={className}>
       <CheckpointIcon>
-        <Zap className="size-4 shrink-0" />
+        <LightningIcon className="size-4 shrink-0" />
       </CheckpointIcon>
       <CheckpointLabel className="overflow-visible whitespace-normal">{errorText}</CheckpointLabel>
       <CheckpointTrigger onClick={openBilling}>
-        <Zap className="size-3" />
+        <LightningIcon className="size-3" />
         Upgrade plan
       </CheckpointTrigger>
     </Checkpoint>
@@ -103,11 +102,11 @@ function InsufficientCreditsCard({
   return (
     <Checkpoint className={className}>
       <CheckpointIcon>
-        <CreditCard className="size-4 shrink-0" />
+        <CreditCardIcon className="size-4 shrink-0" />
       </CheckpointIcon>
       <CheckpointLabel className="overflow-visible whitespace-normal">{label}</CheckpointLabel>
       <CheckpointTrigger onClick={openBilling}>
-        <Zap className="size-3" />
+        <LightningIcon className="size-3" />
         {tHardcodedUi.raw('componentsSessionSessionErrorBanner.line74JsxTextEnableAutoTopUp')}
       </CheckpointTrigger>
       <CheckpointTrigger variant="outline" onClick={openBilling}>
@@ -288,7 +287,7 @@ export function TurnErrorDisplay({
     <div className={className}>
       <Checkpoint>
         <CheckpointIcon>
-          <AlertCircle className="text-muted-foreground size-4 shrink-0" />
+          <WarningCircleIcon className="text-muted-foreground size-4 shrink-0" />
         </CheckpointIcon>
         <CheckpointLabel className="overflow-visible whitespace-normal">{label}</CheckpointLabel>
       </Checkpoint>
@@ -327,7 +326,7 @@ export function SessionRetryDisplay({
         </ItemMedia>
         <ItemContent>
           <ItemTitle className="tabular-nums">
-            {title}
+            {title}{' '}
             <span className="text-muted-foreground font-normal">#{attempt}</span>
           </ItemTitle>
           <ItemDescription className={cn('text-pretty', !details && 'line-clamp-2')}>

--- a/apps/web/src/features/session/session-files-explorer.tsx
+++ b/apps/web/src/features/session/session-files-explorer.tsx
@@ -10,10 +10,11 @@ import {
 import { getSessionFilesStore } from '@/features/session/session-files-store-registry';
 import {
   SessionVersionHeader,
+  sessionVersionTabId,
   type SessionPanelMode,
 } from '@/features/session/session-version-header';
 import { useSessionBrowserStore } from '@/stores/session-browser-store';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 /**
  * Session side-panel "Files" surface.
@@ -140,10 +141,24 @@ function SessionFilesExplorerInner({
 
   const showDiff = mode === 'changes' && !!chatSessionId;
 
+  // One id per mount: two explorers (Advanced's tab + Easy's drill-in) can be
+  // in the DOM at once, so the tab/panel wiring must not collide.
+  const panelId = useId();
+
   return (
     <div className="flex h-full flex-col">
-      <SessionVersionHeader chatSessionId={chatSessionId} mode={mode} onModeChange={onModeChange} />
-      <div className="min-h-0 flex-1">
+      <SessionVersionHeader
+        chatSessionId={chatSessionId}
+        mode={mode}
+        onModeChange={onModeChange}
+        panelId={panelId}
+      />
+      <div
+        id={panelId}
+        role="tabpanel"
+        aria-labelledby={sessionVersionTabId(panelId, mode)}
+        className="min-h-0 flex-1"
+      >
         {showDiff ? (
           <SessionDiffViewer sessionId={chatSessionId!} />
         ) : (

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Drawer, DrawerContent } from '@/components/ui/drawer';
 import Hint from '@/components/ui/hint';
@@ -697,14 +698,19 @@ function PanelHeaderSwitcher({
           <TabsTrigger size="xs" value="browser" className="h-7 w-fit">
             Browser
           </TabsTrigger>
-          <TabsTrigger size="xs" value="explorer" className="h-7 w-fit">
+          <TabsTrigger size="xs" value="explorer" className="hit-area-2 h-7 w-fit">
             Files
           </TabsTrigger>
-          <TabsTrigger size="xs" value="terminal" className="h-7 w-fit">
+          <TabsTrigger size="xs" value="terminal" className="hit-area-2 h-7 w-fit">
             Terminal
           </TabsTrigger>
-          <TabsTrigger size="xs" value="audit" className="h-7 w-fit">
+          <TabsTrigger size="xs" value="audit" className="hit-area-2 h-7 w-fit gap-1.5">
             Audit
+            {auditBadge > 0 ? (
+              <Badge variant="secondary" size="xs" className="tabular-nums">
+                {auditBadge}
+              </Badge>
+            ) : null}
           </TabsTrigger>
         </TabsList>
       </Tabs>
@@ -713,7 +719,7 @@ function PanelHeaderSwitcher({
           variant="ghost"
           size="sm"
           onClick={onToggleMode}
-          className="text-muted-foreground hover:text-foreground h-7 cursor-pointer text-xs"
+          className="text-muted-foreground hover:text-foreground hit-area-2 h-7 cursor-pointer text-xs"
         >
           Easy
         </Button>

--- a/apps/web/src/features/session/session-permission-prompt.tsx
+++ b/apps/web/src/features/session/session-permission-prompt.tsx
@@ -36,7 +36,7 @@ import {
   ShieldWarningIcon as ShieldAlert,
 } from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 
 /** Full-text review is only worth an extra click for a detail that won't fit
  * on one line — short commands stay flat, no chevron. */
@@ -60,6 +60,57 @@ function permissionDetail(p: PermissionRequest): string | null {
   if (p.patterns?.length) return p.patterns.join('  ');
   const title = (p.metadata as Record<string, unknown> | undefined)?.title;
   return typeof title === 'string' ? title : null;
+}
+
+/** Wraps a permission detail: a real toggle when there is more to reveal,
+ *  inert markup when the detail already fits on one line. */
+function DetailShell({
+  expandable,
+  expanded,
+  onToggle,
+  children,
+}: {
+  expandable: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  if (!expandable) {
+    return <div className="mt-0.5 flex w-full items-start gap-1 text-left">{children}</div>;
+  }
+  return (
+    <button
+      type="button"
+      aria-expanded={expanded}
+      onClick={onToggle}
+      className="mt-0.5 flex w-full cursor-pointer items-start gap-1 text-left"
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * A button label that swaps to a spinner IN PLACE.
+ *
+ * Inserting a spinner alongside the label widens the button mid-press. On this
+ * card the three decision buttons sit shoulder to shoulder, so a widening
+ * "Deny" slides "Allow once" under a cursor that is still on its way down — a
+ * mis-click here grants access. Keeping the label in flow (`invisible`, not
+ * unmounted) holds the button at exactly its resting width while the reply is
+ * in flight.
+ */
+function PendingLabel({ pending, children }: { pending: boolean; children: ReactNode }) {
+  return (
+    <span className="relative inline-flex items-center justify-center">
+      <span className={cn('inline-flex items-center', pending && 'invisible')}>{children}</span>
+      {pending ? (
+        <span className="absolute inset-0 inline-flex items-center justify-center">
+          <Loading className="size-3 shrink-0" />
+        </span>
+      ) : null}
+    </span>
+  );
 }
 
 export function SessionPermissionPrompt({
@@ -236,13 +287,13 @@ export function SessionPermissionPrompt({
                   <span className="text-foreground text-xs font-medium">{permissionLabel(p)}</span>
                 </div>
                 {detail ? (
-                  <button
-                    type="button"
-                    onClick={expandable ? () => toggleExpanded(p.id) : undefined}
-                    className={cn(
-                      'mt-0.5 flex w-full items-start gap-1 text-left',
-                      expandable ? 'cursor-pointer' : 'cursor-default',
-                    )}
+                  // Only a detail that actually expands is a control. Rendering
+                  // the flat case as a `<button>` too put a dead stop in the tab
+                  // order of every permission row.
+                  <DetailShell
+                    expandable={expandable}
+                    expanded={expanded}
+                    onToggle={() => toggleExpanded(p.id)}
                   >
                     <code
                       title={expandable ? undefined : detail}
@@ -261,7 +312,7 @@ export function SessionPermissionPrompt({
                         )}
                       />
                     ) : null}
-                  </button>
+                  </DetailShell>
                 ) : null}
               </div>
               <div className="flex shrink-0 items-center gap-1.5">
@@ -271,8 +322,7 @@ export function SessionPermissionPrompt({
                   disabled={!!busy}
                   onClick={() => void reply(p.id, 'reject')}
                 >
-                  {busy === `${p.id}:reject` ? <Loading className="size-3 animate-spin" /> : null}
-                  Deny
+                  <PendingLabel pending={busy === `${p.id}:reject`}>Deny</PendingLabel>
                 </Button>
                 <Button
                   size="xs"
@@ -281,8 +331,9 @@ export function SessionPermissionPrompt({
                   disabled={!!busy}
                   onClick={() => void reply(p.id, 'always')}
                 >
-                  {busy === `${p.id}:always` ? <Loading className="size-3 animate-spin" /> : null}
-                  Allow for session
+                  <PendingLabel pending={busy === `${p.id}:always`}>
+                    Allow for session
+                  </PendingLabel>
                 </Button>
                 <Button
                   size="xs"
@@ -290,8 +341,7 @@ export function SessionPermissionPrompt({
                   disabled={!!busy}
                   onClick={() => void reply(p.id, 'once')}
                 >
-                  {busy === `${p.id}:once` ? <Loading className="size-3 animate-spin" /> : null}
-                  Allow once
+                  <PendingLabel pending={busy === `${p.id}:once`}>Allow once</PendingLabel>
                 </Button>
               </div>
             </li>
@@ -308,8 +358,7 @@ export function SessionPermissionPrompt({
           disabled={!!busy}
           onClick={() => void allowAllForSession()}
         >
-          {busy === 'session-all' ? <Loading className="size-3 animate-spin" /> : null}
-          Allow everything
+          <PendingLabel pending={busy === 'session-all'}>Allow everything</PendingLabel>
         </Button>
       </div>
       {canWriteConfig.allowed ? (
@@ -328,8 +377,9 @@ export function SessionPermissionPrompt({
               disabled={!!busy}
               onClick={() => void allowInConfig(type)}
             >
-              {busy === `config:${type}` ? <Loading className="size-3 animate-spin" /> : null}
-              Always allow "{PERMISSION_LABELS[type] || type}"
+              <PendingLabel pending={busy === `config:${type}`}>
+                Always allow "{PERMISSION_LABELS[type] || type}"
+              </PendingLabel>
             </Button>
           ))}
           <Button
@@ -339,8 +389,7 @@ export function SessionPermissionPrompt({
             disabled={!!busy}
             onClick={() => void allowInConfig('*')}
           >
-            {busy === 'config:*' ? <Loading className="size-3 animate-spin" /> : null}
-            Always allow everything
+            <PendingLabel pending={busy === 'config:*'}>Always allow everything</PendingLabel>
           </Button>
         </div>
       ) : null}

--- a/apps/web/src/features/session/session-starting-loader.tsx
+++ b/apps/web/src/features/session/session-starting-loader.tsx
@@ -187,7 +187,7 @@ function StepRing({ spinning }: { spinning: boolean }) {
       className={cn(
         'relative flex shrink-0 items-center justify-center transition-colors duration-300',
         spinning
-          ? 'text-kortix-green animate-spin motion-reduce:animate-none'
+          ? 'text-kortix-green animate-spinner-spin'
           : 'text-muted-foreground/60',
       )}
       aria-hidden
@@ -251,10 +251,7 @@ function StepGlyph({ done, current }: { done: boolean; current: boolean }) {
           className="absolute inset-0 flex items-center justify-center"
         >
           {done ? (
-            <CheckCircleSolid
-              className="text-kortix-green bg-background size-3.5"
-              strokeWidth={2.5}
-            />
+            <CheckCircleSolid className="text-kortix-green size-3.5" weight="fill" />
           ) : (
             <StepRing spinning={current} />
           )}
@@ -300,7 +297,7 @@ function BootCompactMessage({
     // bought nothing — a 20px glyph and a 2-line message coexist happily at
     // 256px — and it cost the one relationship that matters here: the spinner
     // reads as belonging to the message it sits beside.
-    <div className="flex flex-col items-start gap-2.5 sm:flex-row">
+    <div className="flex flex-row items-start gap-2.5">
       {/* mt-1 optically centres the 20px spinner on the headline's 28px line
           box — geometric top-alignment sits it visibly high against a bold cap. */}
       {/* `spokes` to match the reference: beside a headline the ticking wheel
@@ -368,7 +365,7 @@ function BootStepList({ active }: { active: number }) {
               className="items-center"
               aria-current={current ? 'step' : undefined}
             >
-              <StepperIndicator className="flex size-3.5 shrink-0 items-center justify-center rounded-none bg-none text-current">
+              <StepperIndicator className="flex size-3.5 shrink-0 items-center justify-center rounded-none bg-transparent text-current data-[state=active]:bg-transparent data-[state=completed]:bg-transparent">
                 <StepGlyph done={done} current={current} />
               </StepperIndicator>
               <StepperSeparator className="bg-border group-data-[state=completed]/step:bg-kortix-green/40 m-0 my-0.5 group-data-[orientation=vertical]/stepper:min-h-3" />
@@ -457,7 +454,10 @@ export function RestartFallback({
 }) {
   const reduce = useReducedMotion();
   return (
-    <AnimatePresence>
+    // `initial={false}`: `show` is false at mount, so the stall entrance still
+    // animates when it flips — this only suppresses a replay if the component
+    // remounts already-stalled.
+    <AnimatePresence initial={false}>
       {show ? (
         <m.div
           initial={{ opacity: 0, y: reduce ? 0 : 6 }}
@@ -487,7 +487,7 @@ export function RestartFallback({
             // whose column is NOT capped (the 768px chat thread) passes
             // `buttonClassName="w-auto"`, where full-bleed would read as a
             // banner rather than an offer.
-            className={cn('w-full active:scale-[0.98]', buttonClassName)}
+            className={cn('w-full active:scale-[0.97]', buttonClassName)}
             disabled={pending}
             onClick={onRestart}
           >

--- a/apps/web/src/features/session/session-terminal-connect-bar.tsx
+++ b/apps/web/src/features/session/session-terminal-connect-bar.tsx
@@ -27,16 +27,16 @@ export function SessionTerminalConnectBar({ projectSessionId }: { projectSession
   const installCmd = useDeploymentCliInstallCommand(undefined);
 
   return (
-    <div className="shrink-0 border-b border-white/10 bg-[#15151d] text-[13px]">
+    <div className="border-terminal-border bg-terminal-surface shrink-0 border-b text-[13px]">
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-white/60 transition-colors hover:text-white/80"
+        className="text-terminal-fg/60 hover:text-terminal-fg/85 flex min-h-9 w-full items-center gap-2 px-3 py-2 text-left transition-colors"
         aria-expanded={expanded}
       >
         <Laptop className="h-3.5 w-3.5 shrink-0" />
         <span className="shrink-0 font-medium">Connect from your machine</span>
-        <span className="min-w-0 flex-1 truncate font-mono text-white/35">{installCmd}</span>
+        <span className="text-terminal-fg/40 min-w-0 flex-1 truncate font-mono">{installCmd}</span>
         <ChevronRight
           className={cn('h-3.5 w-3.5 shrink-0 transition-transform', expanded && 'rotate-90')}
         />
@@ -44,10 +44,10 @@ export function SessionTerminalConnectBar({ projectSessionId }: { projectSession
 
       {expanded && (
         <div className="space-y-2.5 px-3 pt-0.5 pb-3">
-          <p className="text-xs leading-relaxed text-white/45">
+          <p className="text-terminal-fg/50 text-xs leading-relaxed">
             Attach your local OpenCode TUI straight to this session&apos;s sandbox. The CLI opens a
             local proxy, injects your Kortix token, then runs{' '}
-            <span className="font-mono text-white/60">opencode attach</span>.
+            <span className="text-terminal-fg/70 font-mono">opencode attach</span>.
           </p>
           <CommandRow label="1. Install the CLI (once)" command={installCmd} />
           <CommandRow label="2. Attach to this session" command={connectCmd} />
@@ -72,13 +72,17 @@ function CommandRow({ label, command }: { label: string; command: string }) {
 
   return (
     <div className="space-y-1">
-      <div className="text-[11px] font-medium tracking-wide text-white/35 uppercase">{label}</div>
-      <div className="flex items-center gap-2 rounded-md border border-white/10 bg-black/40 px-2.5 py-1.5">
-        <code className="min-w-0 flex-1 truncate font-mono text-white/80">{command}</code>
+      <div className="text-terminal-fg/40 text-[11px] font-medium tracking-wide uppercase">
+        {label}
+      </div>
+      <div className="border-terminal-border bg-terminal-fg/[0.06] flex items-center gap-2 rounded-md border px-2.5 py-1">
+        <code className="text-terminal-fg/90 min-w-0 flex-1 truncate font-mono">{command}</code>
+        {/* `after:-inset-1.5` lifts the 28px control to a 40px hit area
+            without growing the row it sits in. */}
         <button
           type="button"
           onClick={copy}
-          className="shrink-0 rounded p-1 text-white/40 transition-colors hover:bg-white/10 hover:text-white/80"
+          className="text-terminal-fg/50 hover:bg-terminal-fg/10 hover:text-terminal-fg/90 relative flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-[background-color,transform] after:absolute after:-inset-1.5 after:content-[''] active:scale-[0.96]"
           aria-label={copied ? 'Copied' : 'Copy command'}
         >
           {copied ? (

--- a/apps/web/src/features/session/session-terminal-panel.tsx
+++ b/apps/web/src/features/session/session-terminal-panel.tsx
@@ -240,7 +240,7 @@ export function SessionTerminalPanel({
   }
 
   return (
-    <div className="flex h-full w-full flex-col bg-[#0f0f14]">
+    <div className="bg-terminal-surface flex h-full w-full flex-col">
       {projectSessionId && <SessionTerminalConnectBar projectSessionId={projectSessionId} />}
       <div className="relative min-h-0 flex-1">{content}</div>
     </div>

--- a/apps/web/src/features/session/session-version-header.tsx
+++ b/apps/web/src/features/session/session-version-header.tsx
@@ -19,7 +19,10 @@ import {
   StackIcon as Layers,
 } from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
+import { useRef } from 'react';
 
+import Hint from '@/components/ui/hint';
+import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
 
 import { useGitStatus } from '@/features/files/hooks/use-git-status';
@@ -31,23 +34,44 @@ import { useOpenChangeRequest, useSessionBaseRef } from '@/features/session/sess
 
 export type SessionPanelMode = 'changes' | 'files';
 
+export type { SessionPanelMode as SessionVersionHeaderMode };
+
+/** Tab order — drives both render order and arrow-key traversal. */
+const TAB_ORDER: SessionPanelMode[] = ['files', 'changes'];
+
+/** Stable DOM id for a tab, derived from the panel id the parent owns. */
+export function sessionVersionTabId(panelId: string, mode: SessionPanelMode) {
+  return `${panelId}-tab-${mode}`;
+}
+
 /** Plain underline tab — mirrors the panel header's PanelTabButton. */
 function SubTab({
   active,
   onClick,
   label,
   count,
+  id,
+  controls,
+  tabRef,
 }: {
   active: boolean;
   onClick: () => void;
   label: string;
   count?: number;
+  id: string;
+  controls: string;
+  tabRef: (node: HTMLButtonElement | null) => void;
 }) {
   return (
     <button
+      ref={tabRef}
       type="button"
       role="tab"
+      id={id}
+      aria-controls={controls}
       aria-selected={active}
+      // Roving tabIndex: the strip is one tab stop, arrows move within it.
+      tabIndex={active ? 0 : -1}
       onClick={onClick}
       className={cn(
         // Constant weight in every state — only color + the underline change,
@@ -74,10 +98,13 @@ export function SessionVersionHeader({
   chatSessionId,
   mode,
   onModeChange,
+  panelId,
 }: {
   chatSessionId?: string;
   mode: SessionPanelMode;
   onModeChange: (mode: SessionPanelMode) => void;
+  /** DOM id of the tab panel this strip controls — owned by the parent. */
+  panelId: string;
 }) {
   // The git branch == the ROUTE session id; the chat session id is passed in.
 
@@ -97,6 +124,26 @@ export function SessionVersionHeader({
 
   const hasChanges = changedCount > 0;
 
+  const tabRefs = useRef<Partial<Record<SessionPanelMode, HTMLButtonElement | null>>>({});
+  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const current = TAB_ORDER.indexOf(mode);
+    let nextIndex = -1;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      nextIndex = (current + 1) % TAB_ORDER.length;
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      nextIndex = (current - 1 + TAB_ORDER.length) % TAB_ORDER.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = TAB_ORDER.length - 1;
+    }
+    if (nextIndex === -1) return;
+    event.preventDefault();
+    const next = TAB_ORDER[nextIndex];
+    onModeChange(next);
+    tabRefs.current[next]?.focus();
+  };
+
   return (
     <div className="border-border/60 shrink-0 border-b">
       {/* Compact header row — tabs (left) + version chip & CTA (right). */}
@@ -108,10 +155,16 @@ export function SessionVersionHeader({
             'autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463',
           )}
           className="flex items-center gap-5"
+          onKeyDown={handleTabKeyDown}
         >
           <SubTab
             active={mode === 'files'}
             onClick={() => onModeChange('files')}
+            id={sessionVersionTabId(panelId, 'files')}
+            controls={panelId}
+            tabRef={(node) => {
+              tabRefs.current.files = node;
+            }}
             label={tI18nHardcoded.raw(
               'autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738',
             )}
@@ -119,6 +172,11 @@ export function SessionVersionHeader({
           <SubTab
             active={mode === 'changes'}
             onClick={() => onModeChange('changes')}
+            id={sessionVersionTabId(panelId, 'changes')}
+            controls={panelId}
+            tabRef={(node) => {
+              tabRefs.current.changes = node;
+            }}
             label="Changes"
             count={changedCount}
           />
@@ -128,13 +186,19 @@ export function SessionVersionHeader({
             On "All files" the verbose framing lives in the tooltip; on
             "Changes" it's spelled out in the explanation strip below. */}
         <div className="ml-auto flex min-w-0 items-center gap-2">
-          <span
-            className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs"
-            title={`Version ${shortVersionId} · alternative version of ${baseRef}`}
+          <Hint
+            label={`Version ${shortVersionId} · alternative version of ${baseRef}`}
+            side="bottom"
           >
-            <Layers className="text-muted-foreground/70 size-3.5 shrink-0" />
-            <span className="text-foreground/80 truncate font-mono">{shortVersionId}</span>
-          </span>
+            <span
+              tabIndex={0}
+              aria-label={`Version ${shortVersionId} · alternative version of ${baseRef}`}
+              className="text-muted-foreground focus-visible:ring-kortix-base flex min-w-0 items-center gap-1.5 rounded-sm text-xs outline-none focus-visible:ring-[0.6px]"
+            >
+              <Layers className="text-muted-foreground/70 size-3.5 shrink-0" />
+              <span className="text-foreground/80 truncate font-mono">{shortVersionId}</span>
+            </span>
+          </Hint>
           {hasChanges && (
             <Button
               size="sm"
@@ -158,44 +222,51 @@ export function SessionVersionHeader({
       {/* Contextual explanation — only on the Changes tab, where the version
           framing matters most: what these changes are and how they reach main. */}
       {mode === 'changes' && (
-        <div className="border-border/60 bg-muted/15 flex gap-2 border-t px-4 py-2.5">
-          <Info className="text-muted-foreground/60 mt-px size-3.5 shrink-0" />
-          <p className="text-muted-foreground text-xs leading-relaxed">
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionVersionHeaderJsxTextWhatThisSession2da8e6ce',
-            )}{' '}
-            <span className="text-foreground/80 font-mono">{shortVersionId}</span>{' '}
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionVersionHeaderJsxTextASeparateVersionc3d7a454',
-            )}{' '}
-            <span className="text-foreground/80 font-mono">{baseRef}</span>
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionVersionHeaderJsxTextTheseEditsStaya67c1667',
-            )}{' '}
-            <span className="text-foreground/80 font-mono">{baseRef}</span>{' '}
-            {tI18nHardcoded.raw('autoFeaturesSessionSessionVersionHeaderJsxTextUntilYou3cf21807')}{' '}
-            {hasChanges ? (
-              <button
-                type="button"
-                onClick={openChangeRequest}
-                disabled={asking}
-                className="text-foreground font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid disabled:opacity-60"
-              >
-                {tI18nHardcoded.raw(
-                  'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
-                )}
-              </button>
-            ) : (
-              <span className="text-foreground/80 font-medium">
-                {tI18nHardcoded.raw(
-                  'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
-                )}
-              </span>
-            )}{' '}
-            {tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionVersionHeaderJsxTextToMergeThemde828b03',
-            )}
-          </p>
+        <div className="border-border/60 border-t px-4 py-2.5">
+          <InfoBanner
+            tone="neutral"
+            icon={<Info className="text-muted-foreground/60 mt-px size-3.5" />}
+            // Flat inline note: the strip's own top border already draws the
+            // seam, so the banner keeps only its icon + text layout.
+            className="items-start gap-2 border-0 bg-transparent px-0 py-0"
+          >
+            <p className="text-muted-foreground text-xs leading-relaxed">
+              {tI18nHardcoded.raw(
+                'autoFeaturesSessionSessionVersionHeaderJsxTextWhatThisSession2da8e6ce',
+              )}{' '}
+              <span className="text-foreground/80 font-mono">{shortVersionId}</span>{' '}
+              {tI18nHardcoded.raw(
+                'autoFeaturesSessionSessionVersionHeaderJsxTextASeparateVersionc3d7a454',
+              )}{' '}
+              <span className="text-foreground/80 font-mono">{baseRef}</span>
+              {tI18nHardcoded.raw(
+                'autoFeaturesSessionSessionVersionHeaderJsxTextTheseEditsStaya67c1667',
+              )}{' '}
+              <span className="text-foreground/80 font-mono">{baseRef}</span>{' '}
+              {tI18nHardcoded.raw('autoFeaturesSessionSessionVersionHeaderJsxTextUntilYou3cf21807')}{' '}
+              {hasChanges ? (
+                <button
+                  type="button"
+                  onClick={openChangeRequest}
+                  disabled={asking}
+                  className="text-foreground font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid disabled:opacity-60"
+                >
+                  {tI18nHardcoded.raw(
+                    'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
+                  )}
+                </button>
+              ) : (
+                <span className="text-foreground/80 font-medium">
+                  {tI18nHardcoded.raw(
+                    'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
+                  )}
+                </span>
+              )}{' '}
+              {tI18nHardcoded.raw(
+                'autoFeaturesSessionSessionVersionHeaderJsxTextToMergeThemde828b03',
+              )}
+            </p>
+          </InfoBanner>
         </div>
       )}
     </div>

--- a/apps/web/src/features/session/session-welcome.tsx
+++ b/apps/web/src/features/session/session-welcome.tsx
@@ -5,7 +5,7 @@ import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 export function SessionWelcome() {
   return (
     <div className="relative h-full w-full overflow-hidden">
-      <WallpaperBackground />{' '}
+      <WallpaperBackground />
     </div>
   );
 }

--- a/apps/web/src/features/session/sub-session-modal.tsx
+++ b/apps/web/src/features/session/sub-session-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Modal, ModalContent, ModalTitle } from '@/components/ui/modal';
 import { SessionChat } from '@/features/session/session-chat';
 import { cn } from '@/lib/utils';
 import { KanbanIcon as SquareKanban, XIcon as X } from '@phosphor-icons/react';
@@ -14,28 +14,31 @@ interface SubSessionModalProps {
 
 export function SubSessionModal({ open, onOpenChange, sessionId, title }: SubSessionModalProps) {
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        hideCloseButton
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent
+        showCloseButton={false}
         className={cn(
-          'flex flex-col gap-0 overflow-hidden p-0',
-          // sm:max-w-* is required — the base dialog sets sm:max-w-lg, which
+          'flex flex-col gap-0 space-y-0 overflow-hidden p-0',
+          // lg:max-w-* is required — the base modal sets lg:max-w-lg, which
           // tailwind-merge won't strip for an unprefixed max-w-* override.
-          'h-[80vh] max-h-[840px] w-[92vw] max-w-6xl sm:max-w-6xl',
+          'h-[80vh] max-h-[840px] lg:h-[80vh] lg:max-w-6xl',
         )}
         aria-describedby={undefined}
       >
         {/* Header bar */}
         <div className="border-border/50 bg-muted/30 flex shrink-0 items-center gap-2 border-b px-4 py-2.5">
           <SquareKanban className="text-muted-foreground size-3.5 shrink-0" />
-          <DialogTitle className="flex-1 truncate text-sm font-medium">
+          <ModalTitle className="flex-1 truncate text-sm font-medium">
             {title || 'Sub-session'}
-          </DialogTitle>
+          </ModalTitle>
           <button
             type="button"
             onClick={() => onOpenChange(false)}
+            aria-label="Close sub-session"
             className={cn(
-              'flex size-6 items-center justify-center rounded-md',
+              // size-6 visible, 40px hit area — the header is dense, so the
+              // target is grown with a pseudo-element instead of the box.
+              'hit-area-2 flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md',
               'text-muted-foreground hover:text-foreground',
               'hover:bg-muted/60 transition-colors',
             )}
@@ -48,7 +51,7 @@ export function SubSessionModal({ open, onOpenChange, sessionId, title }: SubSes
         <div className="min-h-0 flex-1 overflow-hidden">
           <SessionChat sessionId={sessionId} hideHeader readOnly initialScrollTop />
         </div>
-      </DialogContent>
-    </Dialog>
+      </ModalContent>
+    </Modal>
   );
 }

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -33,12 +33,12 @@ import { getActivePanelSessionId, sessionPreviewTabId } from '@/stores/session-b
 import { openTabAndNavigate, useTabStore } from '@/stores/tab-store';
 import {
   WarningIcon as AlertTriangle,
+  ArrowClockwiseIcon,
   ArrowSquareOutIcon,
   CaretRightIcon,
   CheckIcon as Check,
   WarningCircleIcon as CircleAlert,
   GlobeIcon as Globe,
-  ArrowClockwiseIcon as GrRefresh,
   SidebarSimpleIcon as PanelRight,
   MagnifyingGlassIcon as Search,
 } from '@phosphor-icons/react';
@@ -223,7 +223,7 @@ export function ServicePreviewActions({ preview }: { preview: ServicePreviewStat
     <div className="flex shrink-0 items-center gap-1">
       <Hint label="Refresh" side="top">
         <Button variant="ghost" size="icon-sm" type="button" onClick={handleRefresh}>
-          <GrRefresh className={cn('size-4', isLoading && 'animate-spinner-spin')} />
+          <ArrowClockwiseIcon className={cn('size-4', isLoading && 'animate-spinner-spin')} />
         </Button>
       </Hint>
       <Hint
@@ -297,7 +297,7 @@ export function ServicePreviewUrlFallback({ preview }: { preview: ServicePreview
             onClick={handleRefresh}
             className="text-muted-foreground gap-1.5"
           >
-            <GrRefresh className={cn('size-3.5', isLoading && 'animate-spinner-spin')} />
+            <ArrowClockwiseIcon className={cn('size-3.5', isLoading && 'animate-spinner-spin')} />
             Retry preview
           </Button>
         </Hint>
@@ -933,13 +933,31 @@ function InlineTriggerTitle({
             (running ? (
               <TextShimmer className="min-w-0 truncate text-sm">{trigger.subtitle}</TextShimmer>
             ) : (
+              // Painted as a link, so it must behave like one for the keyboard
+              // too. Kept as a <span role="button"> rather than a real <button>
+              // because this content is cloned into the disclosure's own trigger
+              // button — nesting one button in another is invalid HTML.
               <span
                 className={cn(
                   'text-muted-foreground min-w-0 truncate text-sm',
                   onSubtitleClick &&
                     'hover:text-foreground cursor-pointer underline-offset-2 hover:underline',
                 )}
+                role={onSubtitleClick ? 'button' : undefined}
+                tabIndex={onSubtitleClick ? 0 : undefined}
+                // Last, so the rendered markup keeps `title="…">…</span>` — the
+                // shape the memory-tool trigger tests pin.
                 title={trigger.subtitle}
+                onKeyDown={
+                  onSubtitleClick
+                    ? (e) => {
+                        if (e.key !== 'Enter' && e.key !== ' ') return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        onSubtitleClick();
+                      }
+                    : undefined
+                }
                 onClick={
                   onSubtitleClick
                     ? (e) => {

--- a/apps/web/src/features/session/tool/shared/show-helpers.tsx
+++ b/apps/web/src/features/session/tool/shared/show-helpers.tsx
@@ -38,6 +38,7 @@ import { buildStaticFileLocalUrl } from '@kortix/sdk';
 import type { Icon as PhosphorIcon } from '@phosphor-icons/react';
 import {
   WarningIcon as AlertTriangle,
+  ArrowClockwiseIcon,
   CodeSimpleIcon as Code2,
   ArrowSquareOutIcon as ExternalLink,
   FileCodeIcon as FileCode,
@@ -53,7 +54,6 @@ import {
   FileXlsIcon as FileXls,
   FileZipIcon as FileZip,
   GlobeIcon as Globe,
-  ArrowClockwiseIcon as GrRefresh,
   ImageIcon,
   ArrowsOutSimpleIcon as Maximize2,
   MusicNotesIcon as Music,
@@ -354,7 +354,7 @@ export function ShowFileActions({
           aria-label="Refresh"
           className="active:scale-[0.96]"
         >
-          <GrRefresh className={cn('size-4', refreshing && 'animate-spinner-spin')} />
+          <ArrowClockwiseIcon className={cn('size-4', refreshing && 'animate-spinner-spin')} />
         </Button>
       </Hint>
 

--- a/apps/web/src/features/session/tool/shared/structured-output.tsx
+++ b/apps/web/src/features/session/tool/shared/structured-output.tsx
@@ -65,7 +65,7 @@ export function StructuredOutput({ sections }: { sections: OutputSection[] }) {
             return (
               <div
                 key={key}
-                className="bg-muted/40 border-border/60 flex items-start gap-2 rounded-2xl border px-2.5 py-1.5"
+                className="bg-muted/40 border-border/60 flex items-start gap-2 rounded-md border px-2.5 py-1.5"
               >
                 <Ban className="text-muted-foreground/70 mt-0.5 size-3 shrink-0" />
                 <div className="min-w-0 flex-1">
@@ -131,7 +131,7 @@ export function StructuredOutput({ sections }: { sections: OutputSection[] }) {
               <div
                 key={key}
                 className={cn(
-                  'flex items-center gap-2 rounded-2xl border px-2.5 py-1.5',
+                  'flex items-center gap-2 rounded-md border px-2.5 py-1.5',
                   STATUS_BORDER.success,
                   STATUS_BG.success,
                 )}

--- a/apps/web/src/features/session/tool/tool-error.tsx
+++ b/apps/web/src/features/session/tool/tool-error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@/components/ui/badge';
 import { parseErrorContent } from '@/features/session/tool/shared/error-and-connector';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import { StructuredOutput } from '@/features/session/tool/shared/structured-output';
@@ -66,9 +67,9 @@ export function ToolError({ error, toolName }: { error: string; toolName?: strin
                 <CircleAlert className="text-muted-foreground/60 mt-0.5 size-3.5 shrink-0" />
                 <div className="min-w-0 flex-1">
                   {issue.path.length > 0 && (
-                    <span className="bg-muted/60 text-muted-foreground/70 mr-1.5 rounded-sm px-1.5 py-0.5 font-mono text-xs">
+                    <Badge variant="muted" size="xs" className="mr-1.5 font-mono">
                       {issue.path.join('.')}
-                    </span>
+                    </Badge>
                   )}
                   <span className="text-foreground/80 text-xs">{issue.message}</span>
                 </div>
@@ -83,12 +84,9 @@ export function ToolError({ error, toolName }: { error: string; toolName?: strin
                   </div>
                   <div className="flex flex-wrap gap-1">
                     {issue.values.map((val, vi) => (
-                      <span
-                        key={vi}
-                        className="bg-muted/40 text-muted-foreground/70 rounded-sm px-1.5 py-0.5 font-mono text-xs"
-                      >
+                      <Badge key={vi} variant="muted" size="xs" className="font-mono">
                         {val}
-                      </span>
+                      </Badge>
                     ))}
                   </div>
                 </div>

--- a/apps/web/src/features/session/turn/activity-burst.tsx
+++ b/apps/web/src/features/session/turn/activity-burst.tsx
@@ -617,16 +617,6 @@ function ActivityBurstImpl({
                   <ChainOfThoughtStep key={step.key}>{stepBody(step, bare)}</ChainOfThoughtStep>
                 ),
               )}
-
-              {/* The closing step. It is a step, not a footer, so `ChainOfThought`
-							    hands it `isLast` and the rail above it finally has somewhere to
-							    land — the chain reads as terminated rather than trailing off.
-							    Success is monochrome, at the same scale as every row: the cap is
-							    punctuation, and a success-green check would out-weigh the work it
-							    closes on every burst the reader opens.
-								    Failure is the one thing that earns colour here. "Done" over a
-								    burst that lost a page is a false summary of the chain it
-								    terminates, and it is the LAST line the reader sees. */}
             </ChainOfThought>
           </div>
         </ToolActivateContext.Provider>

--- a/apps/web/src/features/session/turn/activity-file-chips.tsx
+++ b/apps/web/src/features/session/turn/activity-file-chips.tsx
@@ -146,7 +146,9 @@ function FileChipImpl({ path, onOpen }: { path: string; onOpen: (path: string) =
         aria-label={`Open ${filename}`}
         onClick={() => onOpen(path)}
         className={cn(
-          'border-border bg-background hover:bg-muted/50 focus-visible:ring-ring/50 flex max-w-full cursor-pointer items-center gap-3 rounded-md border p-1.5 py-1 pr-3 shadow-xs transition-colors focus-visible:ring-2 focus-visible:outline-none active:scale-[0.97]',
+          // No shadow: this chip sits in the transcript flow, and in-flow
+          // surfaces in this system are flat with a border.
+          'border-border bg-background hover:bg-muted/50 focus-visible:ring-ring/50 flex max-w-full cursor-pointer items-center gap-3 rounded-md border p-1.5 py-1 pr-3 transition-[color,background-color,border-color,scale] focus-visible:ring-2 focus-visible:outline-none active:scale-[0.97]',
         )}
       >
         <span className="bg-muted flex size-9 flex-none items-center justify-center rounded-sm">

--- a/apps/web/src/features/session/turn/activity-step.tsx
+++ b/apps/web/src/features/session/turn/activity-step.tsx
@@ -96,9 +96,7 @@ function ActivityStepImpl({
       <span className="text-foreground/80 flex-none text-sm leading-[1.5]">{verb}</span>
       {label.object && (
         <span
-          className={cn(
-            'text-muted-foreground/70 min-w-0 truncate font-mono text-sm leading-[1.5]',
-          )}
+          className="text-muted-foreground/70 min-w-0 truncate font-mono text-sm leading-[1.5]"
           title={label.object}
         >
           {label.object}

--- a/apps/web/src/features/session/turn/expandable-output.test.tsx
+++ b/apps/web/src/features/session/turn/expandable-output.test.tsx
@@ -164,8 +164,9 @@ describe('ExpandableRegion — motion', () => {
     const markup = renderRegion();
     expect(markup).toContain('transition-[max-height]');
     expect(markup).toContain('transition-opacity');
-    // Principle: never `transition: all`. The Button base ships `transition-all`;
-    // the className below has to win the twMerge `transition` group.
+    // Principle: never `transition: all`. The Button base now ships an explicit
+    // property list, and the className below still has to win the twMerge
+    // `transition` group.
     expect(markup).toContain('transition-[color,scale]');
     expect(markup).not.toContain('transition-all');
     expect(markup).toContain('motion-reduce:transition-none');

--- a/apps/web/src/features/session/turn/plan-card.tsx
+++ b/apps/web/src/features/session/turn/plan-card.tsx
@@ -80,7 +80,7 @@ function PlanPie({
   className?: string;
 }) {
   const { sweep, state } = planPieState(done, total, running);
-  const fill = state === 'running' ? 'text-kortix-orange' : 'text-emerald-600';
+  const fill = state === 'running' ? 'text-kortix-orange' : 'text-kortix-green';
 
   return (
     <span

--- a/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
+++ b/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
@@ -83,7 +83,9 @@ function Action({
         size="icon-xs"
         aria-label={label}
         onClick={onClick}
-        className={cn(destructive && 'hover:text-destructive')}
+        // 24px visible, 40px target — the queued-prompt row packs several of
+        // these side by side.
+        className={cn('hit-area-2', destructive && 'hover:text-destructive')}
       >
         {children}
       </Button>

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -293,8 +293,14 @@ function DCPNotificationCard({ notification }: { notification: DCPNotification }
     <div className="border-border/60 bg-card/50 overflow-hidden rounded-lg border">
       {/* Header */}
       <Button
+        type="button"
         onClick={() => hasDetails && setExpanded(!expanded)}
         variant="ghost"
+        // `pointer-events-none` only stops the mouse. Without these, a card with
+        // nothing to reveal was still a tab stop that announced itself as a
+        // collapsed control.
+        tabIndex={hasDetails ? undefined : -1}
+        aria-expanded={hasDetails ? expanded : undefined}
         className={cn(
           'border-border/40 bg-muted/30 flex h-auto w-full items-center justify-start gap-2 rounded-none border-b px-3 py-2',
           !hasDetails && 'pointer-events-none',
@@ -901,6 +907,9 @@ export function UserMessageActions({
                 type="button"
                 variant="ghost"
                 size="icon-xs"
+                // 24px visible, 40px target — grown with a pseudo-element so the
+                // dense action row keeps its rhythm.
+                className="hit-area-2"
                 aria-label="Edit message and rewind session"
                 onClick={() => onRewind?.(messageId as string, rewindPromptText ?? '')}
               >
@@ -1150,7 +1159,6 @@ export function UserMessage({
 
   const [expanded, setExpanded] = useState(false);
   const [canExpand, setCanExpand] = useState(false);
-  const [copied, setCopied] = useState(false);
   const textRef = useRef<HTMLDivElement>(null);
 
   // Use ResizeObserver + rAF to reliably detect overflow after layout settles
@@ -1174,13 +1182,6 @@ export function UserMessage({
       ro.disconnect();
     };
   }, [bodyText, expanded]);
-
-  const handleCopy = async () => {
-    if (!text) return;
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   /**
    * Server-located mention spans. Deliberately dropped for a command message:
@@ -1282,9 +1283,14 @@ export function UserMessage({
     const brandColor = isTelegram ? CHANNEL_BRAND_COLOR.Telegram : CHANNEL_BRAND_COLOR.Slack;
     return (
       <div className="flex flex-col items-end gap-1">
-        <div className="border-border/60 bg-muted/40 inline-flex max-w-[85%] flex-col gap-1.5 rounded-lg border px-4 py-2.5">
+        <div className="border-border/60 bg-muted/40 inline-flex max-w-[80%] flex-col gap-1.5 rounded-lg border px-4 py-2.5">
           <div className="flex items-center gap-2">
-            <svg className="size-3.5 shrink-0" viewBox="0 0 24 24" fill={brandColor}>
+            <svg
+              className="size-3.5 shrink-0"
+              viewBox="0 0 24 24"
+              fill={brandColor}
+              aria-hidden="true"
+            >
               {isTelegram ? (
                 <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm4.64 6.8c-.15 1.58-.8 5.42-1.13 7.19-.14.75-.42 1-.68 1.03-.58.05-1.02-.38-1.58-.75-.88-.58-1.38-.94-2.23-1.5-.99-.65-.35-1.01.22-1.59.15-.15 2.71-2.48 2.76-2.69a.2.2 0 00-.05-.18c-.06-.05-.14-.03-.21-.02-.09.02-1.49.95-4.22 2.79-.4.27-.76.41-1.08.4-.36-.01-1.04-.2-1.55-.37-.63-.2-1.12-.31-1.08-.66.02-.18.27-.36.74-.55 2.92-1.27 4.86-2.11 5.83-2.51 2.78-1.16 3.35-1.36 3.73-1.36.08 0 .27.02.39.12.1.08.13.19.14.27-.01.06.01.24 0 .38z" />
               ) : (
@@ -1321,16 +1327,13 @@ export function UserMessage({
               {triggerEventInfo.data?.trigger || 'Scheduled Task'}
             </span>
             {triggerEventInfo.data?.data?.manual && (
-              <span className="text-muted-foreground bg-muted rounded px-1.5 py-0.5 text-xs font-medium">
+              <Badge variant="muted" size="sm">
                 Manual
-              </span>
+              </Badge>
             )}
           </div>
           {triggerEventInfo.prompt && (
-            <div
-              className="text-muted-foreground max-w-[400px] pl-5.5 text-xs wrap-break-word"
-              style={{ paddingLeft: '1.375rem' }}
-            >
+            <div className="text-muted-foreground max-w-[400px] pl-5.5 text-xs wrap-break-word">
               {triggerEventInfo.prompt}
             </div>
           )}

--- a/apps/web/src/features/session/voice-recorder.tsx
+++ b/apps/web/src/features/session/voice-recorder.tsx
@@ -1,22 +1,53 @@
+'use client';
+
 import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
 import Loading from '@/components/ui/loading';
+import { errorToast } from '@/components/ui/toast';
 import { useTranscription } from '@/hooks/transcription/use-transcription';
 import { cn } from '@/lib/utils';
 import { MicrophoneIcon as Mic, SquareIcon as Square } from '@phosphor-icons/react';
-import React, { memo, useEffect, useRef, useState } from 'react';
+import { AnimatePresence, m } from 'motion/react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 interface VoiceRecorderProps {
   onTranscription: (text: string) => void;
   disabled?: boolean;
+  /**
+   * Starts a recording from OUTSIDE the button — the `/` palette's "Start voice
+   * input" row. A monotonically increasing counter, not a boolean: two
+   * consecutive requests must both fire, and a boolean that is already `true`
+   * produces no change to react to. `null`/`0` never starts anything, so a
+   * toolbar rendered without it behaves exactly as before.
+   */
+  startRequestId?: number | null;
 }
 
 const MAX_RECORDING_TIME = 15 * 60 * 1000; // 15 minutes in milliseconds
 
+/** `mm:ss`, zero-padded, so the readout never changes width mid-recording. */
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** Icon state swaps cross-fade rather than cutting — same values everywhere. */
+const ICON_SWAP = {
+  initial: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  animate: { scale: 1, opacity: 1, filter: 'blur(0px)' },
+  exit: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  transition: { type: 'spring', duration: 0.3, bounce: 0 },
+} as const;
+
 export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRecorder({
   onTranscription,
   disabled = false,
+  startRequestId = null,
 }) {
   const [state, setState] = useState<'idle' | 'recording' | 'processing'>('idle');
+  const [elapsedMs, setElapsedMs] = useState(0);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
@@ -25,29 +56,63 @@ export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRe
 
   const transcriptionMutation = useTranscription();
 
+  const cleanupStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  // The 15-minute cap, plus the elapsed readout that makes it legible. Without
+  // the readout the cap is invisible: a recording just ends.
   useEffect(() => {
-    if (state === 'recording') {
-      recordingStartTimeRef.current = Date.now();
-      maxTimeoutRef.current = setTimeout(() => {
-        stopRecording();
-      }, MAX_RECORDING_TIME);
-    } else {
+    if (state !== 'recording') {
       recordingStartTimeRef.current = null;
+      setElapsedMs(0);
       if (maxTimeoutRef.current) {
         clearTimeout(maxTimeoutRef.current);
         maxTimeoutRef.current = null;
       }
+      return;
     }
 
+    const startedAt = Date.now();
+    recordingStartTimeRef.current = startedAt;
+    setElapsedMs(0);
+    maxTimeoutRef.current = setTimeout(() => stopRecording(), MAX_RECORDING_TIME);
+    const tick = setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+
     return () => {
+      clearInterval(tick);
       if (maxTimeoutRef.current) {
         clearTimeout(maxTimeoutRef.current);
+        maxTimeoutRef.current = null;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state]);
+  }, [state, stopRecording]);
 
-  const startRecording = async () => {
+  // The microphone must not outlive this component. Without this the stream
+  // stays open after the composer unmounts — the OS recording indicator keeps
+  // burning and the tab holds the mic until it is closed.
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop();
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, []);
+
+  const startRecording = useCallback(async () => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       streamRef.current = stream;
@@ -80,10 +145,10 @@ export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRe
             onTranscription(data.text);
             setState('idle');
           },
-          onError: (error) => {
-            console.error('Transcription failed:', error);
-            setState('idle');
-          },
+          // No toast here: `useTranscription`'s own `onError` already routes
+          // the failure through `handleApiError`, which toasts it. A second
+          // one would stack two cards for one failure.
+          onError: () => setState('idle'),
         });
 
         cleanupStream();
@@ -92,16 +157,25 @@ export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRe
       mediaRecorder.start();
       setState('recording');
     } catch (error) {
-      console.error('Error starting recording:', error);
+      // The common case here is a denied or missing microphone. It used to be
+      // `console.error` only, so the button lit up, went dark, and never said
+      // why.
+      cleanupStream();
       setState('idle');
+      const name = error instanceof Error ? error.name : '';
+      errorToast(
+        name === 'NotAllowedError' || name === 'SecurityError'
+          ? 'Microphone access denied'
+          : 'Could not start recording',
+        {
+          description:
+            name === 'NotAllowedError' || name === 'SecurityError'
+              ? 'Allow microphone access for this site, then try again.'
+              : 'No microphone was available. Check your input device and try again.',
+        },
+      );
     }
-  };
-
-  const stopRecording = () => {
-    if (mediaRecorderRef.current && state === 'recording') {
-      mediaRecorderRef.current.stop();
-    }
-  };
+  }, [cleanupStream, onTranscription, transcriptionMutation]);
 
   const cancelRecording = () => {
     if (mediaRecorderRef.current && state === 'recording') {
@@ -109,13 +183,6 @@ export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRe
       mediaRecorderRef.current.stop();
       cleanupStream();
       setState('idle');
-    }
-  };
-
-  const cleanupStream = () => {
-    if (streamRef.current) {
-      streamRef.current.getTracks().forEach((track) => track.stop());
-      streamRef.current = null;
     }
   };
 
@@ -134,30 +201,54 @@ export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRe
     }
   };
 
-  const getIcon = () => {
-    switch (state) {
-      case 'recording':
-        return <Square weight="fill" className="size-4 shrink-0 rounded-sm" />;
-      case 'processing':
-        return <Loading className="size-4 shrink-0" />;
-      default:
-        return <Mic className="size-4 shrink-0" />;
-    }
-  };
+  // An external start request (the `/` palette). Guarded on `idle` so a request
+  // that lands mid-recording is ignored rather than restarting the take.
+  const lastStartRequestRef = useRef<number | null>(startRequestId ?? null);
+  useEffect(() => {
+    if (startRequestId == null) return;
+    if (lastStartRequestRef.current === startRequestId) return;
+    lastStartRequestRef.current = startRequestId;
+    if (disabled || state !== 'idle') return;
+    startRecording();
+  }, [startRequestId, disabled, state, startRecording]);
+
+  const label =
+    state === 'recording'
+      ? 'Stop recording — right-click to discard'
+      : state === 'processing'
+        ? 'Transcribing…'
+        : 'Start voice input';
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-base"
-      onClick={handleClick}
-      onContextMenu={handleRightClick}
-      disabled={disabled || state === 'processing'}
-      className={cn(
-        'hit-area-1 shrink-0 p-0 duration-300 ease-out active:scale-[0.96] active:duration-150',
-      )}
-    >
-      {getIcon()}
-    </Button>
+    <Hint side="top" label={label}>
+      <Button
+        type="button"
+        variant="ghost"
+        size={state === 'recording' ? 'sm' : 'icon-base'}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+        disabled={disabled || state === 'processing'}
+        aria-label={label}
+        className={cn(
+          'hit-area-1 shrink-0 duration-300 ease-out active:scale-[0.96] active:duration-150',
+          state === 'recording' ? 'gap-1.5 px-2' : 'p-0',
+        )}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          <m.span key={state} className="flex items-center gap-1.5" {...ICON_SWAP}>
+            {state === 'recording' ? (
+              <Square weight="fill" className="size-4 shrink-0 rounded-sm" />
+            ) : state === 'processing' ? (
+              <Loading className="size-4 shrink-0" />
+            ) : (
+              <Mic className="size-4 shrink-0" />
+            )}
+            {state === 'recording' && (
+              <span className="text-xs tabular-nums">{formatElapsed(elapsedMs)}</span>
+            )}
+          </m.span>
+        </AnimatePresence>
+      </Button>
+    </Hint>
   );
 });


### PR DESCRIPTION
## What

A full audit of `apps/web/src/features/session/**` plus the session route, then the fixes. 71 files.

## The ones that matter

**Security.** `pty-terminal.tsx` logged the PTY WebSocket URL on every connect — and that URL carries the user's Supabase JWT as `?token=`. It reprinted on every reconnect of the 1s→15s backoff, so a flapping sandbox wrote the token to the console indefinitely. The file's own comment 70 lines below already said "never echo the token-bearing URL". Now logs origin + path only.

**The status label re-animated once a second.** `session-busy-indicator` keys its `AnimatePresence` on the label. `session-chat` concatenated the live elapsed counter into that label after 20s, so the key changed every second and replayed the roll-swap spring for the whole of any long tool call — exactly when you are staring at it. Elapsed now renders in its own non-animated `tabular-nums` span. There is a regression test asserting the phrase markup is byte-identical across ticks.

**Two restart dead ends.** `session-chat`'s loading branch hardcoded `stage="ready"` and passed no `projectId`/`sessionId`, so `canRestart` was false and the loader's restart offer could never appear. A session wedged there spun forever with no exit but a page reload. Same story for the session-missing and lost-computer screens, which offered no action at all.

**Dragging a file over the composer faded it to 9% opacity.** `opacity-30` was on the card and again on the column inside it; opacity on a parent creates a stacking context, so they multiplied. There was also no "drop files here" label anywhere — the only feedback was a blue ring around a ghost.

**Space bar was stolen from every focused button on the session page.** The composer's global key handler treated `' '` as a printable character and only exempted inputs/textareas, so tabbing to Attach and pressing Space focused the composer and typed a space instead of activating the button.

**Voice input did not exist.** `VoiceRecorder` was rendered nowhere, while `composer-toolbar` destructured `onTranscription` and `voiceDisabled` and dropped both. Now rendered and wired — plus the bugs that were waiting in it: the mic stream leaked on unmount, both failure paths were `console.error` only, and the button had no accessible name.

**Select-all copied every answer twice.** An `sr-only` mirror of each response kept the text in the selection range.

## Also

- Model search with no hits said "No models available" and offered to connect a provider — with models connected.
- Send/stop returned `null` when busy without an `onStop`, so the button vanished mid-turn (there was a comment at a call site working around this).
- Streaming code blocks clamp at 520px with their own scrollport and never followed the tail.
- Diff viewer error path had no retry; terminal had no manual reconnect once backoff saturated at 15s; xterm ran on the default 1000-line scrollback.
- The audit tab's pending-approval badge was computed, typed, documented, and never rendered.
- Permission buttons grew when pressed, sliding the neighbouring Allow buttons under the cursor — on a row where a mis-click grants access.

## Design law

Spinners → `Loading` / `animate-spinner-spin`. `Dialog` → `Modal`, `Tooltip` → `Hint`, `@/lib/toast` → toast helpers, hand-rolled chips → `Badge`, hand-rolled states → `ErrorState`/`EmptyState`/`InfoBanner`/`Skeleton`. Three different hard-coded terminal blacks collapsed into one token set. `transition-all` off the shared `Button` and `Badge` bases. Raw palette, no-op `dark:` variants, stray Phosphor `weight` props, `rounded-2xl` on app containers. Accessible names on icon-only controls, real tab semantics on two fake tablists, keyboard access for click-only rows, 40px hit areas, `tabular-nums` on counters that tick while you read them.

## Verification

- `bun test` — **7940 pass, 0 fail** across 624 files.
- `tsc --noEmit` — clean outside the 3 known `@types/bun` `test.each` files.
- `eslint` — 0 errors on every changed file; residual warnings are the pre-existing React Compiler cluster on untouched lines.
- Drove a real session in Chromium against a live Platinum sandbox on the local stack: session route renders with no console or page errors, light + dark + 390px, and the rendered HTML asserts no `transition-all`, no raw `animate-spin`, no `rounded-2xl` pill, no `rounded-b-xl` gate, and a stable `aria-label="Send message"`.

## Not verified

No live streaming turn ran (this project has no agent bound), so the streaming code-block tail-pin and the mid-press permission button widths are asserted by code and unit tests, not by a rendered stream. `Modal`'s default `side="bottom"` makes `sub-session-modal` and `image-preview` bottom sheets below `lg` where `Dialog` centred them — sanctioned pattern, but a real mobile layout change worth eyeballing.

## Deliberately left alone

- `outputs-card.tsx`'s `outline-black/10 dark:outline-white/10` — that is exactly what the polish skill mandates for image outlines, and it is the convention in 7 other places.
- `CHANNEL_BRAND_COLOR`'s Telegram/Slack hexes — third-party brand marks, not semantic UI colour.
- The panel-split reset per session (`session-layout.tsx`) — a product call, and the comment at `:211-213` contradicts the store's `partialize`. Flagging, not deciding.
- `transition-all` in `sidebar.tsx`, `navigation-menu.tsx`, `marketing/button.tsx` — app chrome outside the session scope.
