### PR TITLE
fix(turns): adopt a running turn when the event loop subscribes late

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1211,3 +1211,35 @@ had already established the correct pattern.
 
 *Incident:* no outage — the fix was simply inert in production for ~25 minutes
 between merge and detection, which is exactly what dev verification is for.
+
+## `kortix self-host update` reconciles to the CONFIGURED channel, not the running one
+
+Hit live on Essentia, 2026-08-20, while shipping the turn-truth fixes.
+
+The box was **running** `kortix/kortix-api:dev-latest` but its instance config
+said `channel stable`. A plain `kortix self-host update` is a *reconcile*: it
+moved every service to `:stable` (v0.13.1) — a silent channel change away from
+the images the operator had been running, and away from the fix being shipped.
+The log says it plainly if you read it: `update complete (dev-latest -> stable)`.
+
+**Rules.**
+1. **Read the channel before updating**: `kortix self-host version` prints
+   `running <v> (tracking :<tag>)` AND `channel <name>`. When those disagree,
+   the box is drifted and a bare `update` will "fix" the drift by moving the
+   RUNNING images, not the config.
+2. Preserve the running channel explicitly: `kortix self-host update --tag
+   dev-latest` (alias `--version`/`--release`). Restoring is quick and
+   non-destructive — the updater keeps the previous image for fast rollback.
+3. **A successful update does not mean a NEW image.** The first restore rolled
+   onto a *cached* `dev-latest` created the previous day; only an explicit
+   `docker pull` revealed a newer one and a second update actually moved the
+   commit. Verify by CONTENT, never by the tag or the "update complete" line:
+   `/v1/health` `commit` must be the SHA you expect (see
+   [[deploy-verify-by-image-content-not-version]]).
+4. Self-host API health lives on the API host (`api.<domain>/v1/health`). `/v1/*`
+   on the WEB host is a frontend route miss and 500s — that 500 is not an API
+   outage, and mistaking it for one sends you chasing a phantom.
+
+*Incident:* no customer-visible outage (containers stayed healthy throughout and
+the box was restored within ~3 minutes), but the deployment ran on an unintended
+release channel in between.

--- a/apps/kortix-sandbox-agent-server/src/__tests__/turn-begin-relay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/turn-begin-relay.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 
-import { relayTurnBeginToApi, __resetRelayedTurnBegins } from '../main'
+import { relayTurnBeginToApi, reconcileRunningTurnOnConnect, __resetRelayedTurnBegins } from '../main'
 import { dispatch } from '../opencode-events'
 import type { Config } from '../config'
 
@@ -246,5 +246,81 @@ describe('dispatch → onSessionStatus', () => {
       { onSessionStatus: () => {}, onSessionIdle: (s) => { idle = s } },
     )
     expect(idle).toBe('ses_root')
+  })
+})
+
+// THE BOOT-WINDOW GAP, measured on dev 2026-08-20: for a session with no
+// initial prompt the event loop starts only after `waitForOpencodeReady`
+// returns, and that probe lagged actual readiness by ~5 minutes (opencode
+// spawned 15:26:06 and served a real turn at 15:26:19; `subscribed` logged at
+// 15:31:08). Every session.status frame in that window is lost, so a turn the
+// box started on its own never got authority. Turn END already reconciles on
+// connect; this is the same backstop for turn BEGIN.
+describe('reconcileRunningTurnOnConnect — the late-subscribe backstop', () => {
+  function mocks(status: 'busy' | 'idle' | 'unreadable') {
+    let turnStreamCalls = 0
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url)
+        if (url.pathname.endsWith('/turn-stream')) {
+          turnStreamCalls++
+          await req.json()
+          return Response.json({ ok: true, outcome: 'adopted' })
+        }
+        if (url.pathname === '/session/status') {
+          if (status === 'unreadable') return new Response('nope', { status: 503 })
+          return Response.json({ [ROOT]: { type: status } })
+        }
+        if (url.pathname === `/session/${ROOT}/message`) return Response.json(syntheticTurn())
+        if (url.pathname === `/session/${ROOT}`) return Response.json({ parentID: null })
+        return new Response('nf', { status: 404 })
+      },
+    })
+    return { baseUrl: `http://127.0.0.1:${server.port}`, calls: () => turnStreamCalls, stop: () => server.stop(true) }
+  }
+
+  test('a root that is STILL busy at subscribe gets its turn adopted', async () => {
+    const m = mocks('busy')
+    sessionEnv(m.baseUrl)
+    try {
+      await reconcileRunningTurnOnConnect({ getInternalUrl: () => m.baseUrl }, { workspace: WORKSPACE } as unknown as Config, ROOT)
+      expect(m.calls()).toBe(1)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('an IDLE root adopts nothing — a finished turn is turn-end\'s business', async () => {
+    const m = mocks('idle')
+    sessionEnv(m.baseUrl)
+    try {
+      await reconcileRunningTurnOnConnect({ getInternalUrl: () => m.baseUrl }, { workspace: WORKSPACE } as unknown as Config, ROOT)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('an unreadable status adopts nothing', async () => {
+    const m = mocks('unreadable')
+    sessionEnv(m.baseUrl)
+    try {
+      await reconcileRunningTurnOnConnect({ getInternalUrl: () => m.baseUrl }, { workspace: WORKSPACE } as unknown as Config, ROOT)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
+  })
+
+  test('no pinned root adopts nothing', async () => {
+    const m = mocks('busy')
+    sessionEnv(m.baseUrl)
+    try {
+      await reconcileRunningTurnOnConnect({ getInternalUrl: () => m.baseUrl }, { workspace: WORKSPACE } as unknown as Config, null)
+      expect(m.calls()).toBe(0)
+    } finally {
+      m.stop()
+    }
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -66,7 +66,7 @@ import {
 import type { SandboxBootState } from './routes/health'
 import { installShutdownHandlers } from './shutdown'
 import { startStaticWebServer } from './static-web'
-import { opencodeDeliveryInFlight, opencodeTurnInFlight } from './opencode-turn-state'
+import { opencodeDeliveryInFlight, opencodeSessionInFlight, opencodeTurnInFlight } from './opencode-turn-state'
 
 const LEGACY_OPENCODE_ZEN_FREE_MODELS = new Set([
   'deepseek-v4-flash-free',
@@ -637,6 +637,11 @@ async function startSessionRuntime(
   // relayed is a no-op.
   const onConnected = () => {
     void reconcileInitialTurnAcceptance()
+    void reconcileRunningTurnOnConnect(opencode, cfg).catch((err) =>
+      logger.warn('[opencode-events] connect turn-begin reconcile failed', {
+        err: (err as Error).message,
+      }),
+    )
     void reconcileFinishedFirstTurn(opencode, cfg).catch((err) =>
       logger.warn('[opencode-events] connect reconcile failed', { err: (err as Error).message }),
     )
@@ -2367,6 +2372,37 @@ export async function relayTurnBeginToApi(
   } finally {
     turnBeginRelaysInFlight.delete(opencodeSessionId)
   }
+}
+
+/**
+ * Turn-BEGIN backstop, run on every (re)subscribe.
+ *
+ * The subscription is not always live when a turn starts. For a session with
+ * no initial prompt the event loop only starts after `waitForOpencodeReady`
+ * returns, and that probe can lag actual readiness badly — measured on dev
+ * 2026-08-20: opencode spawned 15:26:06 and served a real turn at 15:26:19,
+ * while `[opencode-events] subscribed` did not log until 15:31:08. Every
+ * `session.status` frame in that window is lost, so a turn the box starts on
+ * its own gets no authority and the composer reads "not running" — the very
+ * symptom `turn_begin` exists to fix.
+ *
+ * Turn END already has this backstop (`reconcileFinishedFirstTurn`); this is
+ * its mirror. Only a root that is STILL busy is adopted: a turn that already
+ * finished is over, and `reconcileFinishedFirstTurn` is what finalizes it.
+ */
+export async function reconcileRunningTurnOnConnect(
+  opencode: Pick<Opencode, 'getInternalUrl'>,
+  cfg: Config,
+  /** The root to ask about. Defaults to the pinned one; passed explicitly by
+   *  tests, which have no pin file — same shape as `opencodeTurnInFlight`. */
+  rootSessionId: string | null = readPinnedOpencodeSessionId(),
+): Promise<void> {
+  const rootId = rootSessionId
+  if (!rootId) return
+  const busy = await opencodeSessionInFlight(opencode.getInternalUrl(), cfg.workspace, rootId)
+  if (busy !== true) return
+  logger.info('[opencode-events] root is busy at subscribe; adopting its turn', { rootId })
+  await relayTurnBeginToApi(rootId, opencode, cfg)
 }
 
 export async function relayTurnEndToApi(

--- a/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
@@ -152,7 +152,12 @@ export async function opencodeTurnInFlight(
   }
 }
 
-async function opencodeSessionInFlight(
+/**
+ * Is this exact OpenCode session busy or retrying right now? `null` when the
+ * status could not be read. Exported for the connect-time turn-begin backstop
+ * (main.ts) — see `reconcileRunningTurnOnConnect`.
+ */
+export async function opencodeSessionInFlight(
   baseUrl: string,
   workspace: string,
   sessionId: string,


### PR DESCRIPTION
Third and final gap in the turn-truth chain (#6657, #6664), found by probing the deployed fix on dev.

## Evidence

#6664 works — verified live on dev right after it deployed. An in-box turn (no control-plane prompt, no proxy POST) produced authority in **1.5s** with a real `message_id`, then closed as `end_reason: "completed"`:

```
turn BEFORE: {"turns":[]}
✅ AUTHORITY after 1523ms: [{"turn_token":"9b2821e1…","state":"active",
   "message_id":"msg_01fd0fc0f001wqwKUYwgfFEHmW","started_at":"15:36:25.662Z",
   "accepted_at":"15:36:26.000Z"}]
✅ terminal row after 14079ms: {"end_reason":"completed"}
```

But the **first** probe on the same box failed, and the daemon log said why:

```
15:26:01  [boot] kortix-sandbox-agent-server starting
15:26:06  [opencode] spawning
15:26:19  (in-box turn POSTed — HTTP 200, model ran, completed 15:26:23)
15:31:08  [opencode-events] subscribed        ← 5 minutes later
```

For a session with **no initial prompt**, the event loop starts only after `waitForOpencodeReady` returns, and that probe lagged actual readiness by ~5 minutes even though opencode was serving requests the whole time. Every `session.status` frame in that window is lost, so a box-initiated turn gets no authority — the exact symptom `turn_begin` exists to remove. Turn END survived only because it already has a connect-time backstop.

## Fix

`reconcileRunningTurnOnConnect`, the mirror of `reconcileFinishedFirstTurn`, runs on every (re)subscribe. Only a root that is **still busy** is adopted — a finished turn belongs to the turn-end path. Idle root, unreadable status, and unpinned root all adopt nothing.

`opencodeSessionInFlight` is exported for it, and the reconcile takes an injectable `rootSessionId` exactly like `opencodeTurnInFlight` (the pin path isn't writable in a unit test).

## Tests

Four new cases covering busy / idle / unreadable / no-pin. `bun test src` — **722 pass / 0 fail**; `tsc --noEmit` clean.

## Note on the boot probe itself

`waitForOpencodeReady` taking ~5 min while opencode answers normally looks like a real defect of its own. This PR does not touch it — it makes turn adoption survive it. Worth a separate look.