### PR TITLE
perf(boot): bake the generic scaffold checkout

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -441,6 +441,64 @@ describe('daemon proxy auth gate', () => {
     }
   })
 
+  it('discards a baked scaffold for a fresh session when the base SHA is unavailable', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-fresh-without-base-sha-'))
+    const originalFetch = globalThis.fetch
+    const requests: string[] = []
+    try {
+      const scaffoldSource = join(root, 'scaffold-source')
+      const scaffold = join(root, 'scaffold.git')
+      const importedSource = join(root, 'imported-source')
+      const importedRemote = join(root, 'imported.git')
+      const target = join(root, 'workspace')
+
+      mkdirSync(scaffoldSource)
+      git(['init', '-b', 'main'], scaffoldSource)
+      writeFileSync(join(scaffoldSource, 'README.md'), 'generic scaffold\n')
+      git(['add', 'README.md'], scaffoldSource)
+      git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'scaffold'], scaffoldSource)
+      git(['clone', '--bare', scaffoldSource, scaffold])
+      git(['clone', scaffold, target])
+
+      mkdirSync(importedSource)
+      git(['init', '-b', 'main'], importedSource)
+      writeFileSync(join(importedSource, 'README.md'), 'imported repository\n')
+      git(['add', 'README.md'], importedSource)
+      git(['-c', 'user.email=owner@example.com', '-c', 'user.name=Owner', 'commit', '-m', 'imported'], importedSource)
+      const importedSha = gitOutput(['-C', importedSource, 'rev-parse', 'HEAD'])
+      git(['clone', '--bare', importedSource, importedRemote])
+
+      __setScaffoldRepoPathForTests(scaffold)
+      globalThis.fetch = (async (url: string | URL | Request) => {
+        const href = typeof url === 'string' || url instanceof URL ? String(url) : url.url
+        requests.push(href)
+        return new Response(JSON.stringify({ auth: { token: 'clone-token' } }), {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }) as unknown as typeof fetch
+
+      await materializeRepo(baseConfig({
+        autoClone: true,
+        projectId: 'project-123',
+        apiUrl: 'http://api.local/v1',
+        projectTarget: target,
+        repoUrl: importedRemote,
+        defaultBranch: 'main',
+        branchName: 'session-fresh',
+        sessionFresh: true,
+        baseSha: undefined,
+      }))
+
+      expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(1)
+      expect(readFileSync(join(target, 'README.md'), 'utf8')).toBe('imported repository\n')
+      expect(gitOutput(['-C', target, 'rev-parse', 'HEAD'])).toBe(importedSha)
+    } finally {
+      globalThis.fetch = originalFetch
+      __setScaffoldRepoPathForTests()
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('materializes an exact fresh-project delta bundle without fetching clone credentials', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-delta-bundle-scaffold-'))
     const originalFetch = globalThis.fetch

--- a/apps/kortix-sandbox-agent-server/src/git.ts
+++ b/apps/kortix-sandbox-agent-server/src/git.ts
@@ -692,10 +692,11 @@ export async function materializeRepo(cfg: Config): Promise<void> {
     // the baked content IS this session's base — i.e. a fresh scaffold-rooted
     // project (baked HEAD == the server-resolved KORTIX_BASE_SHA). When it isn't
     // (an imported repo / diverged project), the baked scaffold is the WRONG
-    // content: discard it and re-materialize the real repo below. Restart/resume
-    // (no baseSha) keep the old "reuse whatever's baked" behaviour unchanged.
+    // content: discard it and re-materialize the real repo below. A fresh
+    // session with no baseSha is also unverified and must fall back. Only a
+    // restart/resume can safely reuse its existing checkout without baseSha.
     const bakedHead = (await execGit(['-C', target, 'rev-parse', 'HEAD'])).stdout.trim()
-    const mismatched = cfg.sessionFresh && !!cfg.baseSha && bakedHead !== cfg.baseSha
+    const mismatched = cfg.sessionFresh && (!cfg.baseSha || bakedHead !== cfg.baseSha)
     if (!mismatched) {
       logger.info('[git] using baked repo checkout (warm)', { target, head: bakedHead })
       const setUrl = await execGit(['-C', target, 'remote', 'set-url', 'origin', cfg.repoUrl])

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -54,6 +54,9 @@ expect(dockerfile).toContain('FROM ubuntu:24.04');
     expect(dockerfile.indexOf('kortixOpenCodeInstallSentinel')).toBeLessThan(
       dockerfile.indexOf('instance keep'),
     );
+    expect(dockerfile).toContain(
+      'sudo -u kortix env HOME=/home/kortix git -C /workspace status',
+    );
     expect(dockerfile.indexOf('bun build tools/*.ts')).toBeGreaterThan(
       dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
     );

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -42,14 +42,25 @@ expect(dockerfile).toContain('FROM ubuntu:24.04');
     expect(dockerfile).toContain(
       '/home/kortix/.bun/bin/bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check',
     );
-    expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup instance wipe');
+    expect(dockerfile).toContain('git clone -q /opt/kortix/scaffold.git /workspace');
+    expect(dockerfile).toContain('kortixOpenCodeInstallSentinel');
+    expect(dockerfile).toContain('bash /tmp/kortix-opencode-warmup instance keep');
+    expect(dockerfile.indexOf('/opt/kortix/scaffold.git')).toBeLessThan(
+      dockerfile.indexOf('instance keep'),
+    );
+    expect(dockerfile.indexOf('git clone -q /opt/kortix/scaffold.git /workspace')).toBeLessThan(
+      dockerfile.indexOf('instance keep'),
+    );
+    expect(dockerfile.indexOf('kortixOpenCodeInstallSentinel')).toBeLessThan(
+      dockerfile.indexOf('instance keep'),
+    );
     expect(dockerfile.indexOf('bun build tools/*.ts')).toBeGreaterThan(
       dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
     );
-    expect(dockerfile.indexOf('instance wipe')).toBeGreaterThan(
+    expect(dockerfile.indexOf('instance keep')).toBeGreaterThan(
       dockerfile.indexOf('bun build tools/*.ts'),
     );
-    expect(dockerfile.indexOf('instance wipe')).toBeGreaterThan(
+    expect(dockerfile.indexOf('instance keep')).toBeGreaterThan(
       dockerfile.indexOf('/opt/kortix/warm-config/.kortix/opencode/'),
     );
     expect(dockerfile).toContain('/opt/kortix/runtime-versions.json');

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -134,8 +134,8 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \
  && rm -rf /tmp/opencode-tools-bundle-check
 RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
       bash /tmp/kortix-opencode-warmup instance keep \
- && test -z "$(git -C /workspace status --porcelain --untracked-files=no)" \
- && test "$(git -C /workspace rev-parse HEAD)" = "$(git --git-dir=/opt/kortix/scaffold.git rev-parse HEAD)" \
+ && test -z "$(sudo -u kortix env HOME=/home/kortix git -C /workspace status --porcelain --untracked-files=no)" \
+ && test "$(sudo -u kortix env HOME=/home/kortix git -C /workspace rev-parse HEAD)" = "$(sudo -u kortix env HOME=/home/kortix git --git-dir=/opt/kortix/scaffold.git rev-parse HEAD)" \
  && rm -f /tmp/kortix-opencode-warmup
 COPY --chown=kortix:kortix ${options.catalogPath} /opt/kortix/llm-catalog.json
 COPY --chown=kortix:kortix ${options.managedSkillsPath}/ /opt/kortix/managed-skills/

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -118,6 +118,13 @@ COPY --chown=kortix:kortix ${options.opencodeWarmupScriptPath} /tmp/kortix-openc
 RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
       bash /tmp/kortix-opencode-warmup migration
 
+COPY --chown=kortix:kortix ${options.scaffoldPath}/ /opt/kortix/scaffold.git/
+RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
+      git clone -q /opt/kortix/scaffold.git /workspace \
+ && printf '%s\\n' \
+      '{"name":"kortix-opencode-config","version":"0.0.0","lockfileVersion":3,"requires":true,"kortixOpenCodeInstallSentinel":1,"packages":{"":{"dependencies":{"@opencode-ai/plugin":"*","zod":"4.1.8"}}}}' \
+      | sudo -u kortix tee /workspace/.kortix/opencode/package-lock.json >/dev/null
+
 COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /ephemeral/kortix-master/opencode/
 COPY --chown=kortix:kortix ${options.opencodeConfigPath}/ /opt/kortix/warm-config/.kortix/opencode/
 RUN cd /opt/kortix/warm-config/.kortix/opencode \
@@ -126,12 +133,13 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \
  && /home/kortix/.bun/bin/bun build tools/*.ts --target=bun --outdir=/tmp/opencode-tools-bundle-check \
  && rm -rf /tmp/opencode-tools-bundle-check
 RUN sudo -u kortix env HOME=/home/kortix PATH="${'$'}{PATH}" \
-      bash /tmp/kortix-opencode-warmup instance wipe \
+      bash /tmp/kortix-opencode-warmup instance keep \
+ && test -z "$(git -C /workspace status --porcelain --untracked-files=no)" \
+ && test "$(git -C /workspace rev-parse HEAD)" = "$(git --git-dir=/opt/kortix/scaffold.git rev-parse HEAD)" \
  && rm -f /tmp/kortix-opencode-warmup
 COPY --chown=kortix:kortix ${options.catalogPath} /opt/kortix/llm-catalog.json
 COPY --chown=kortix:kortix ${options.managedSkillsPath}/ /opt/kortix/managed-skills/
 COPY --chown=kortix:kortix ${options.runtimeVersionsPath} /opt/kortix/runtime-versions.json
-COPY --chown=kortix:kortix ${options.scaffoldPath}/ /opt/kortix/scaffold.git/
 COPY --chown=kortix:kortix ${options.lazyToolsPath}/ /opt/kortix/lazy-tools/
 COPY ${options.machineDocPath} /MACHINE.md
 COPY ${options.entrypointScriptPath} /usr/local/bin/kortix-entrypoint


### PR DESCRIPTION
## Problem

The experimental cold-boot image starts with an empty `/workspace`. Every fresh default session clones the same generic 1.37 MB scaffold during startup. The latest dev benchmark measured `repo-materialized` at 5.9 seconds p50 across five sessions.

## Change

- Bake the generic scaffold checkout into `/workspace` in the fast image.
- Warm OpenCode against that exact checkout.
- Preserve the checkout and the strict package sentinel in the image.
- Verify the baked checkout as the runtime `kortix` user during the image build.
- Reject the baked checkout for fresh sessions when `base_sha` is absent or different.
- Keep restart/resume reuse unchanged.

This does not create or retain running sandboxes. `KORTIX_FAST_COLD_BOOT_ENABLED=false` still selects the unchanged standard image.

## Verification

- Daemon: 676 pass, 0 fail.
- Shared sandbox image: 66 pass, 0 fail.
- API snapshot paths: 44 pass, 0 fail.
- Exact Docker build: 29/29 steps passed.
- Image: `sha256:d18c997287a67dc2071d979c10102a33762b70847d35a3fd8be905b086f4b8a7`, 1,485,043,486 bytes.
- Runtime checkout: clean, correct scaffold HEAD, strict dependency sentinel intact.
- Local successful starts: repo p50 444 ms; runtime-ready p50 3.23 s across eight starts.
- Same-machine control: repo p50 729 ms; runtime-ready p50 3.47 s.

## Known local emulator behavior

OpenCode hung after binding its port in 2 of 10 new-image starts. The prior image reproduced the same hang in 2 of 5 control starts. This is an existing amd64/QEMU OpenCode flake, not a baked-checkout regression.

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false`. The standard layered image remains unchanged.