### PR TITLE
self-host: pass GATEWAY_AI_SDK_NATIVE to the standalone llm-gateway (fix native ingress split)

### DIFF
--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -123,6 +123,13 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       PORT: "8090"
+      # Caddy routes /v1/llm* to THIS standalone gateway, so it must agree with
+      # kortix-api on the AI-SDK-native flag. kortix-api reads it from `.env`
+      # (env_file), but this service has no env_file — without this line the
+      # gateway defaults it off while sessions are baked native, and every turn
+      # 404s "AI-SDK-native gateway ingress is not enabled". Inherit the same
+      # value (default on, matching the app-side default).
+      GATEWAY_AI_SDK_NATIVE: ${GATEWAY_AI_SDK_NATIVE:-true}
       KORTIX_API_URL: http://kortix-api:8008
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
     depends_on:


### PR DESCRIPTION
## Problem

On the Essentia self-host box, every session turn 404'd with **"AI-SDK-native gateway ingress is not enabled"**.

Caddy routes `/v1/llm*` to the **standalone `llm-gateway`** container, not the in-process kortix-api gateway. `kortix-api` reads `GATEWAY_AI_SDK_NATIVE` from `.env` (it has `env_file: .env`) and, when on, bakes `KORTIX_LLM_AI_SDK_NATIVE=true` into every session — so opencode calls the native `/v1/llm/language-model` ingress. But the `llm-gateway` service in `kortix-compose.yml` has an **explicit `environment:` block with no `env_file`**, so it never sees `GATEWAY_AI_SDK_NATIVE` and defaults it **off**. Result: sessions expect native, the serving gateway rejects it. Every compose regenerate re-introduced the split.

## Fix

Pass `GATEWAY_AI_SDK_NATIVE: ${GATEWAY_AI_SDK_NATIVE:-true}` to the llm-gateway service so it inherits the same value as kortix-api (default on, matching the app-side default).

```diff
     environment:
       PORT: "8090"
+      GATEWAY_AI_SDK_NATIVE: ${GATEWAY_AI_SDK_NATIVE:-true}
       KORTIX_API_URL: http://kortix-api:8008
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
```

## Verified

- Applied live on the box (added the line to the running compose + recreated both llm-gateway replicas): the "not enabled" error is gone (0 occurrences since), native ingress now accepts requests and resolves the model.
- `compose-assets.test.ts` green (55/55).
- `:-true` default means no new `.env`/registry key is required.
