### PR TITLE
fix(billing): teach the entitlement invariant what a renewal now grants

### DIFF
--- a/apps/api/src/billing/services/entitlement-invariant.test.ts
+++ b/apps/api/src/billing/services/entitlement-invariant.test.ts
@@ -12,8 +12,12 @@ describe('expectedMonthlyEntitlementUsd', () => {
     expect(expectedMonthlyEntitlementUsd({ tier: 'free' })).toBe(2);
   });
 
-  test('pro tier is $0 — its $5 is a one-time machine bonus, not a monthly allowance', () => {
-    expect(expectedMonthlyEntitlementUsd({ tier: 'pro' })).toBe(0);
+  // REVERSED 2026-08-20 (PR #6662). `pro` granting $0 per cycle was not a
+  // design, it was the defect: those customers paid monthly and their renewal
+  // granted nothing. A renewal now grants `amount_paid × ratio`, so the ceiling
+  // a legitimate cycle can reach is the dearest machine at that ratio.
+  test('a paid tier with no catalog grant expects the amount-based ceiling, not $0', () => {
+    expect(expectedMonthlyEntitlementUsd({ tier: 'pro' })).toBe(50); // $80 × 0.625
   });
 
   test('per-seat is $25 per seat, never the $40 price', () => {
@@ -115,10 +119,17 @@ describe('expiringCreditExceedsEntitlement — the drift this makes visible', ()
     ).toBeNull();
   });
 
-  test('a pro account holding monthly expiring credit is drift — pro grants none', () => {
-    const breach = expiringCreditExceedsEntitlement({ tier: 'pro', expiringCredits: '5' });
-    expect(breach?.expectedUsd).toBe(0);
-    expect(breach?.excessUsd).toBe(5);
+  test('a pro account holding a normal cycle grant is NOT drift any more', () => {
+    // $25 is exactly what a $40 machine renewal now grants. Flagging it was
+    // what made this guard red for every correctly-granted account — and a
+    // guard that is red by construction gets ignored.
+    expect(expiringCreditExceedsEntitlement({ tier: 'pro', expiringCredits: '25' })).toBeNull();
+  });
+
+  test('a pro account above the dearest-machine ceiling is still caught', () => {
+    const breach = expiringCreditExceedsEntitlement({ tier: 'pro', expiringCredits: '500' });
+    expect(breach?.expectedUsd).toBe(50);
+    expect(breach?.excessUsd).toBe(450);
   });
 
   test('a free account left holding a paid allowance after downgrade is caught', () => {

--- a/apps/api/src/billing/services/entitlement-invariant.ts
+++ b/apps/api/src/billing/services/entitlement-invariant.ts
@@ -23,7 +23,14 @@
  * first seat addition.
  */
 
-import { getTier, grantForSeats, isPerSeatAccount } from './tiers';
+import {
+  COMPUTE_TIERS,
+  INCLUDED_CREDITS_RATIO,
+  getTier,
+  grantForSeats,
+  isPaidTier,
+  isPerSeatAccount,
+} from './tiers';
 
 /**
  * Dollars of slack before a breach is reported. Covers the 4-decimal precise
@@ -82,9 +89,22 @@ export interface EntitlementBreach {
  * The expiring-credit allowance one billing cycle may grant this account.
  *
  * per-seat: $25 x seats (INCLUDED_CREDITS_PER_SEAT_USD, never the $40 price).
- * free: $2. pro: $0 by design — its $5 is a one-time non-expiring machine bonus,
- * not a monthly allowance. legacy tier_N_M: the tier's monthlyCredits, 1:1 with
- * the price the customer pays.
+ * free: $2. legacy tier_N_M: the tier's monthlyCredits, 1:1 with the price the
+ * customer pays.
+ *
+ * A PAID tier whose catalog grant is 0 (legacy `pro`) is the interesting case,
+ * and it changed. It used to be 0 "by design" — and that was the bug: those
+ * customers paid every month and their renewal granted nothing, which is what
+ * PR #6662 fixed. A renewal now grants `amount_paid x INCLUDED_CREDITS_RATIO`
+ * (see `resolveRenewalGrant`), so an expectation of 0 makes every one of them a
+ * permanent false breach — and this check exits non-zero, so a guard that is red
+ * by construction gets ignored, which is the only way this one can fail.
+ *
+ * The row alone cannot say what the customer actually paid, so the expectation
+ * is the CEILING a single legitimate cycle can reach: the dearest machine we
+ * sell, at the included-credits ratio. That keeps the check meaningful — a
+ * grant-sizing error still has to clear the most expensive real plan to hide —
+ * while no longer flagging correctly-granted accounts.
  */
 export function expectedMonthlyEntitlementUsd(subject: EntitlementSubject): number {
   const tierName = subject.tier ?? 'none';
@@ -97,7 +117,28 @@ export function expectedMonthlyEntitlementUsd(subject: EntitlementSubject): numb
     return grantForSeats(Math.max(1, subject.seatCount ?? 1));
   }
 
-  return getTier(tierName).monthlyCredits;
+  const tier = getTier(tierName);
+  // `getTier` falls back to `none` for anything it does not know, so an unknown
+  // or garbage tier reaches here looking exactly like a zero-grant paid tier.
+  // Requiring the name to round-trip keeps the ceiling below FAIL-CLOSED: a tier
+  // nobody has heard of gets an allowance of 0 and stays visible to the audit,
+  // rather than quietly inheriting the most generous plan we sell.
+  const isKnownTier = tier.name === tierName;
+  if (isKnownTier && tier.monthlyCredits === 0 && isPaidTier(tierName)) {
+    return maxAmountBasedCycleGrantUsd();
+  }
+  return tier.monthlyCredits;
+}
+
+/**
+ * The largest grant one amount-based renewal can legitimately produce: the
+ * priciest machine in the catalog at the included-credits ratio. Derived, not
+ * typed as a literal, so adding a dearer compute tier cannot silently turn a
+ * real over-grant into an accepted one.
+ */
+function maxAmountBasedCycleGrantUsd(): number {
+  const dearest = Math.max(...Object.values(COMPUTE_TIERS).map((t) => t.priceUsd));
+  return Math.round(dearest * INCLUDED_CREDITS_RATIO * 100) / 100;
 }
 
 /**


### PR DESCRIPTION
## The gap

#6662 changed **what a paid renewal grants**. This is the half of that change I
missed: `expectedMonthlyEntitlementUsd` still asserted

> `pro: $0 by design — its $5 is a one-time non-expiring machine bonus`

a sentence #6662 made false. The two now disagree, so the audit built on the
invariant reports every *correctly*-granted legacy account as an over-grant.

**Measured on production, not theorised.** `audit-entitlement` reports:

```
over-granted accounts:  696
over-granted total:     $3920.95
```

and its worst-offender list is dominated by the 22 accounts #6666 legitimately
paid — sc@wring.co reads `expected $0.00  actual $100.00  excess $100.00`.

The script is read-only, so no money moved. But it **exits non-zero** and says
*"investigate before the next cycle"* — so the next person to act on it could
claw back credit we genuinely owed. A guard that is wrong in the expensive
direction is worse than no guard.

## The fix

A row cannot know what the customer actually paid, so the expectation becomes
the **ceiling** one legitimate cycle can reach: the dearest machine we sell at
`INCLUDED_CREDITS_RATIO` — `$80 × 0.625 = $50`. Derived from `COMPUTE_TIERS`
rather than typed as a literal, so adding a pricier compute tier cannot silently
widen the allowance. A real grant-sizing error still has to clear the most
expensive plan we offer to hide.

## It fails closed — and the existing suite caught me getting that wrong

My first version regressed on `an unknown tier does not grant an allowance`.
`getTier()` falls back to `none`, so a garbage tier arrived at my new branch
looking exactly like a zero-grant paid tier and would have inherited the $50
ceiling — the same fail-open shape as the free-tier hole caught in #6662.

The tier name must now round-trip (`tier.name === tierName`), so an
unrecognised tier gets `0` and stays visible to the audit. That test is why this
PR is correct rather than merely green.

## Known, time-boxed exception

#6666's multi-cycle catch-up legitimately exceeds a *single* cycle's ceiling for
the largest accounts, so a few stay flagged until that credit expires
**2026-09-19**. That is the audit telling the truth about a deliberate one-off,
not a defect to suppress.

## Verification

`apps/api` billing suite: **739 pass / 0 fail**. Typecheck clean.
