### PR TITLE
perf(boot): make starter Git bundles provider-portable

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -286,6 +286,8 @@ mock.module('../projects/git', () => ({
   resolveFastBootGitHint: async () => ({
     baseSha: 'a'.repeat(40),
     gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
+    gitDeltaParentSha: 'b'.repeat(40),
+    gitDeltaParentCommitBase64: 'dHJlZSBkZWFkYmVlZgo=',
   }),
   resolveBranchTip: async () => 'a'.repeat(40),
   resolveBranchAheadState: async () => ({ ahead: 0, behind: 0 }),

--- a/apps/api/src/projects/git/commits.ts
+++ b/apps/api/src/projects/git/commits.ts
@@ -109,6 +109,8 @@ export async function resolveCommitSha(project: GitBackedProject, ref?: string):
 export interface FastBootGitHint {
   baseSha: string;
   gitDeltaBundleBase64?: string;
+  gitDeltaParentSha?: string;
+  gitDeltaParentCommitBase64?: string;
 }
 
 /**
@@ -119,7 +121,12 @@ export interface FastBootGitHint {
 export async function buildSingleParentDeltaBundle(
   repoPath: string,
   ref: string,
-): Promise<{ baseSha: string; parentSha: string; bundleBase64: string } | null> {
+): Promise<{
+  baseSha: string;
+  parentSha: string;
+  parentCommitBase64: string;
+  bundleBase64: string;
+} | null> {
   const treeRef = validateRef(ref);
   const revision = await runGit(
     ['rev-list', '--parents', '-n', '1', treeRef],
@@ -129,6 +136,9 @@ export async function buildSingleParentDeltaBundle(
   const [baseSha, ...parents] = revision.stdout.trim().split(/\s+/);
   if (!baseSha || !/^[0-9a-f]{40}$/.test(baseSha) || parents.length !== 1) return null;
   const parentSha = parents[0]!;
+  const parentCommitBase64 = Buffer.from(
+    (await runGit(['cat-file', 'commit', parentSha], repoPath, false)).stdout,
+  ).toString('base64');
   const temp = await mkdtemp(join(tmpdir(), 'kortix-fast-boot-bundle-'));
   const bundlePath = join(temp, 'delta.bundle');
   try {
@@ -138,10 +148,13 @@ export async function buildSingleParentDeltaBundle(
       false,
     );
     const bundleBase64 = (await readFile(bundlePath)).toString('base64');
-    if (Buffer.byteLength(bundleBase64, 'utf8') > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES) {
+    if (
+      Buffer.byteLength(bundleBase64 + parentCommitBase64, 'utf8') >
+      MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES
+    ) {
       return null;
     }
-    return { baseSha, parentSha, bundleBase64 };
+    return { baseSha, parentSha, parentCommitBase64, bundleBase64 };
   } finally {
     await rm(temp, { recursive: true, force: true });
   }
@@ -164,7 +177,12 @@ export async function resolveFastBootGitHint(
   try {
     const delta = await buildSingleParentDeltaBundle(repoPath, treeRef);
     return delta?.baseSha === baseSha
-      ? { baseSha, gitDeltaBundleBase64: delta.bundleBase64 }
+      ? {
+          baseSha,
+          gitDeltaBundleBase64: delta.bundleBase64,
+          gitDeltaParentSha: delta.parentSha,
+          gitDeltaParentCommitBase64: delta.parentCommitBase64,
+        }
       : { baseSha };
   } catch (error) {
     console.warn('[git] fast-boot delta bundle unavailable', {

--- a/apps/api/src/projects/git/fast-boot-bundle.test.ts
+++ b/apps/api/src/projects/git/fast-boot-bundle.test.ts
@@ -113,10 +113,16 @@ describe('buildSingleParentDeltaBundle', () => {
       const bundle = await buildSingleParentDeltaBundle(providerSource, 'main');
       expect(bundle?.baseSha).toBe(baseSha);
       expect(bundle?.parentSha).toBe(providerParentSha);
+      expect(bundle?.parentCommitBase64).toBeTruthy();
 
       git(['clone', '-q', scaffoldRepo, checkout], root);
       const bundlePath = join(root, 'provider.bundle');
+      const parentCommitPath = join(root, 'provider-parent.commit');
       writeFileSync(bundlePath, Buffer.from(bundle!.bundleBase64, 'base64'));
+      writeFileSync(parentCommitPath, Buffer.from(bundle!.parentCommitBase64, 'base64'));
+      expect(git(['hash-object', '-t', 'commit', '-w', parentCommitPath], checkout)).toBe(
+        providerParentSha,
+      );
       git(['bundle', 'unbundle', bundlePath], checkout);
       git(['checkout', '-q', '-B', 'main', baseSha], checkout);
 
@@ -167,7 +173,9 @@ describe('buildSingleParentDeltaBundle', () => {
 
       const bundle = await buildSingleParentDeltaBundle(source, 'main');
       expect(bundle).not.toBeNull();
-      expect(bundle!.bundleBase64.length).toBeLessThanOrEqual(24 * 1024);
+      expect(
+        Buffer.byteLength(bundle!.bundleBase64 + bundle!.parentCommitBase64, 'utf8'),
+      ).toBeLessThanOrEqual(24 * 1024);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/apps/api/src/projects/git/fast-boot-bundle.test.ts
+++ b/apps/api/src/projects/git/fast-boot-bundle.test.ts
@@ -62,6 +62,71 @@ describe('buildSingleParentDeltaBundle', () => {
     }
   });
 
+  test('imports when the provider gives the matching scaffold tree a different commit SHA', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-provider-fast-boot-bundle-'));
+    try {
+      const bakedSource = join(root, 'baked-source');
+      const providerSource = join(root, 'provider-source');
+      const scaffoldRepo = join(root, 'scaffold.git');
+      const checkout = join(root, 'checkout');
+      mkdirSync(bakedSource);
+      mkdirSync(providerSource);
+
+      const identity = {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      };
+      git(['init', '-b', 'main'], bakedSource);
+      writeFileSync(join(bakedSource, 'README.md'), 'generic scaffold\n');
+      git(['add', 'README.md'], bakedSource);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], bakedSource, {
+        ...identity,
+        GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+        GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+      });
+      const bakedSha = git(['rev-parse', 'HEAD'], bakedSource);
+      const bakedTree = git(['rev-parse', 'HEAD^{tree}'], bakedSource);
+      git(['clone', '--bare', bakedSource, scaffoldRepo], root);
+
+      git(['init', '-b', 'main'], providerSource);
+      writeFileSync(join(providerSource, 'README.md'), 'generic scaffold\n');
+      git(['add', 'README.md'], providerSource);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], providerSource, {
+        ...identity,
+        GIT_AUTHOR_DATE: '2026-01-02T00:00:00Z',
+        GIT_COMMITTER_DATE: '2026-01-02T00:00:00Z',
+      });
+      const providerParentSha = git(['rev-parse', 'HEAD'], providerSource);
+      expect(providerParentSha).not.toBe(bakedSha);
+      expect(git(['rev-parse', 'HEAD^{tree}'], providerSource)).toBe(bakedTree);
+
+      writeFileSync(join(providerSource, 'README.md'), 'customer project\n');
+      git(['add', 'README.md'], providerSource);
+      git(['commit', '-m', 'chore: project setup'], providerSource, {
+        ...identity,
+        GIT_AUTHOR_DATE: '2026-01-03T00:00:00Z',
+        GIT_COMMITTER_DATE: '2026-01-03T00:00:00Z',
+      });
+      const baseSha = git(['rev-parse', 'HEAD'], providerSource);
+      const bundle = await buildSingleParentDeltaBundle(providerSource, 'main');
+      expect(bundle?.baseSha).toBe(baseSha);
+      expect(bundle?.parentSha).toBe(providerParentSha);
+
+      git(['clone', '-q', scaffoldRepo, checkout], root);
+      const bundlePath = join(root, 'provider.bundle');
+      writeFileSync(bundlePath, Buffer.from(bundle!.bundleBase64, 'base64'));
+      git(['bundle', 'unbundle', bundlePath], checkout);
+      git(['checkout', '-q', '-B', 'main', baseSha], checkout);
+
+      expect(git(['rev-parse', 'HEAD'], checkout)).toBe(baseSha);
+      expect(readFileSync(join(checkout, 'README.md'), 'utf8')).toBe('customer project\n');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('keeps the current managed starter delta below the sandbox env limit', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-starter-fast-boot-bundle-'));
     try {

--- a/apps/api/src/projects/lib/fast-boot-git-hint.test.ts
+++ b/apps/api/src/projects/lib/fast-boot-git-hint.test.ts
@@ -18,6 +18,8 @@ const project: GitBackedProject = {
 const cachedHint: FastBootGitHint = {
   baseSha: 'a'.repeat(40),
   gitDeltaBundleBase64: Buffer.from('bundle').toString('base64'),
+  gitDeltaParentSha: 'b'.repeat(40),
+  gitDeltaParentCommitBase64: Buffer.from('tree deadbeef\n').toString('base64'),
 };
 
 function metadataFor(hint: FastBootGitHint = cachedHint, ref = 'main') {
@@ -30,6 +32,7 @@ function metadataFor(hint: FastBootGitHint = cachedHint, ref = 'main') {
 
 describe('fast boot Git hint cache', () => {
   test('reads a bounded cache entry for the requested ref', () => {
+    expect(metadataFor().git.fast_boot?.version).toBe(2);
     expect(readCachedFastBootGitHint(metadataFor(), 'main')).toEqual(cachedHint);
     expect(readCachedFastBootGitHint(metadataFor(cachedHint, 'dev'), 'main')).toBeNull();
   });
@@ -45,6 +48,14 @@ describe('fast boot Git hint cache', () => {
       buildCachedFastBootGitHint('main', {
         baseSha: 'a'.repeat(40),
         gitDeltaBundleBase64: Buffer.alloc(24 * 1024 + 1).toString('base64'),
+        gitDeltaParentSha: 'b'.repeat(40),
+        gitDeltaParentCommitBase64: Buffer.from('tree deadbeef\n').toString('base64'),
+      }),
+    ).toBeNull();
+    expect(
+      buildCachedFastBootGitHint('main', {
+        baseSha: 'a'.repeat(40),
+        gitDeltaBundleBase64: cachedHint.gitDeltaBundleBase64,
       }),
     ).toBeNull();
   });
@@ -71,6 +82,8 @@ describe('fast boot Git hint cache', () => {
     const freshHint = {
       baseSha: 'b'.repeat(40),
       gitDeltaBundleBase64: Buffer.from('fresh').toString('base64'),
+      gitDeltaParentSha: 'c'.repeat(40),
+      gitDeltaParentCommitBase64: Buffer.from('tree cafe\n').toString('base64'),
     };
     const forceRefreshes: boolean[] = [];
     const persisted: FastBootGitHint[] = [];

--- a/apps/api/src/projects/lib/fast-boot-git-hint.ts
+++ b/apps/api/src/projects/lib/fast-boot-git-hint.ts
@@ -7,13 +7,15 @@ import { MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES, resolveFastBootGitHint } from '.
 import type { GitBackedProject } from '../git/types';
 import { metadataMergeSubtree } from './metadata-merge';
 
-export const FAST_BOOT_GIT_HINT_CACHE_VERSION = 1;
+export const FAST_BOOT_GIT_HINT_CACHE_VERSION = 2;
 
 export interface CachedFastBootGitHint {
   version: typeof FAST_BOOT_GIT_HINT_CACHE_VERSION;
   ref: string;
   base_sha: string;
   bundle_base64: string;
+  parent_sha: string;
+  parent_commit_base64: string;
   cached_at: string;
 }
 
@@ -24,11 +26,18 @@ export function buildCachedFastBootGitHint(
 ): CachedFastBootGitHint | null {
   if (!/^[0-9a-f]{40}$/.test(hint.baseSha)) return null;
   const bundle = hint.gitDeltaBundleBase64;
+  const parentSha = hint.gitDeltaParentSha;
+  const parentCommit = hint.gitDeltaParentCommitBase64;
   if (
     !bundle ||
+    !parentSha ||
+    !/^[0-9a-f]{40}$/.test(parentSha) ||
+    !parentCommit ||
     bundle.length % 4 !== 0 ||
     !/^[A-Za-z0-9+/]+={0,2}$/.test(bundle) ||
-    Buffer.byteLength(bundle, 'utf8') > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES
+    parentCommit.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]+={0,2}$/.test(parentCommit) ||
+    Buffer.byteLength(bundle + parentCommit, 'utf8') > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES
   ) {
     return null;
   }
@@ -37,6 +46,8 @@ export function buildCachedFastBootGitHint(
     ref,
     base_sha: hint.baseSha,
     bundle_base64: bundle,
+    parent_sha: parentSha,
+    parent_commit_base64: parentCommit,
     cached_at: cachedAt,
   };
 }
@@ -54,6 +65,10 @@ export function readCachedFastBootGitHint(metadata: unknown, ref: string): FastB
       baseSha: typeof entry.base_sha === 'string' ? entry.base_sha : '',
       gitDeltaBundleBase64:
         typeof entry.bundle_base64 === 'string' ? entry.bundle_base64 : undefined,
+      gitDeltaParentSha:
+        typeof entry.parent_sha === 'string' ? entry.parent_sha : undefined,
+      gitDeltaParentCommitBase64:
+        typeof entry.parent_commit_base64 === 'string' ? entry.parent_commit_base64 : undefined,
     },
     typeof entry.cached_at === 'string' ? entry.cached_at : '',
   );
@@ -68,6 +83,8 @@ export function readCachedFastBootGitHint(metadata: unknown, ref: string): FastB
   return {
     baseSha: candidate.base_sha,
     gitDeltaBundleBase64: candidate.bundle_base64,
+    gitDeltaParentSha: candidate.parent_sha,
+    gitDeltaParentCommitBase64: candidate.parent_commit_base64,
   };
 }
 

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -119,17 +119,23 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
   test('sends fresh-session and base-tip hints when the experiment is enabled', () => {
     const baseSha = 'a'.repeat(40);
     const gitDeltaBundleBase64 = 'R0lUIEJVTkRMRQ==';
+    const gitDeltaParentSha = 'b'.repeat(40);
+    const gitDeltaParentCommitBase64 = 'dHJlZSBkZWFkYmVlZgo=';
     const env = buildSessionRuntimeEnv({
       ...BASE_INPUT,
       fastColdBootEnabled: true,
       freshSession: true,
       baseSha,
       gitDeltaBundleBase64,
+      gitDeltaParentSha,
+      gitDeltaParentCommitBase64,
     });
 
     expect(env.KORTIX_SESSION_FRESH).toBe('1');
     expect(env.KORTIX_BASE_SHA).toBe(baseSha);
     expect(env.KORTIX_GIT_DELTA_BUNDLE_BASE64).toBe(gitDeltaBundleBase64);
+    expect(env.KORTIX_GIT_DELTA_PARENT_SHA).toBe(gitDeltaParentSha);
+    expect(env.KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64).toBe(gitDeltaParentCommitBase64);
   });
 
   test('omits both hints when the experiment is disabled', () => {
@@ -139,11 +145,15 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
       freshSession: true,
       baseSha: 'a'.repeat(40),
       gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
+      gitDeltaParentSha: 'b'.repeat(40),
+      gitDeltaParentCommitBase64: 'dHJlZSBkZWFkYmVlZgo=',
     });
 
     expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
     expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
     expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_BUNDLE_BASE64');
+    expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_PARENT_SHA');
+    expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64');
   });
 
   test('omits both hints for resumed and non-repository sessions', () => {
@@ -154,6 +164,8 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
         freshSession: false,
         baseSha: 'a'.repeat(40),
         gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
+        gitDeltaParentSha: 'b'.repeat(40),
+        gitDeltaParentCommitBase64: 'dHJlZSBkZWFkYmVlZgo=',
       }),
       buildSessionRuntimeEnv({
         ...BASE_INPUT,
@@ -162,11 +174,15 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
         freshSession: true,
         baseSha: 'a'.repeat(40),
         gitDeltaBundleBase64: 'R0lUIEJVTkRMRQ==',
+        gitDeltaParentSha: 'b'.repeat(40),
+        gitDeltaParentCommitBase64: 'dHJlZSBkZWFkYmVlZgo=',
       }),
     ]) {
       expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
       expect(env).not.toHaveProperty('KORTIX_BASE_SHA');
       expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_BUNDLE_BASE64');
+      expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_PARENT_SHA');
+      expect(env).not.toHaveProperty('KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64');
     }
   });
 });

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -24,6 +24,10 @@ export interface SessionRuntimeEnvInput {
   baseSha?: string;
   /** Bounded Git bundle containing the exact base-tip commit above the baked scaffold. */
   gitDeltaBundleBase64?: string;
+  /** Exact parent commit required by the thin Git bundle. */
+  gitDeltaParentSha?: string;
+  /** Raw parent commit object. Its tree already exists in the baked scaffold. */
+  gitDeltaParentCommitBase64?: string;
   /** Server-compiled OpenCode agent config (JSON string) for a `kortix_version:
    *  2` project — see `compile-agent-config.ts`. `null`/omitted for a v1
    *  project: no key is emitted, so v1 sandbox env is byte-for-byte unchanged. */
@@ -47,6 +51,12 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
           ...(input.baseSha ? { KORTIX_BASE_SHA: input.baseSha } : {}),
           ...(input.gitDeltaBundleBase64
             ? { KORTIX_GIT_DELTA_BUNDLE_BASE64: input.gitDeltaBundleBase64 }
+            : {}),
+          ...(input.gitDeltaParentSha
+            ? { KORTIX_GIT_DELTA_PARENT_SHA: input.gitDeltaParentSha }
+            : {}),
+          ...(input.gitDeltaParentCommitBase64
+            ? { KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64: input.gitDeltaParentCommitBase64 }
             : {}),
         }
       : {};

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -308,6 +308,10 @@ export async function buildSessionSandboxEnvVars(input: {
   /** Bounded exact commit delta from the API mirror. The daemon imports it on
    *  top of the baked scaffold and verifies `baseSha` before use. */
   gitDeltaBundleBase64?: string;
+  /** Parent commit SHA required by the thin delta bundle. */
+  gitDeltaParentSha?: string;
+  /** Raw parent commit object used when the provider changed only commit metadata. */
+  gitDeltaParentCommitBase64?: string;
   /** Project git context, so the running agent's `secrets` grant in `agents:`
    *  can be resolved and applied by IDENTIFIER — secrets the agent isn't
    *  granted are dropped from the injected env (a prompt-injected agent then
@@ -531,6 +535,8 @@ export async function buildSessionSandboxEnvVars(input: {
       freshSession: input.freshSession,
       baseSha: input.baseSha,
       gitDeltaBundleBase64: input.gitDeltaBundleBase64,
+      gitDeltaParentSha: input.gitDeltaParentSha,
+      gitDeltaParentCommitBase64: input.gitDeltaParentCommitBase64,
     }),
     // The platform coordinator uses API-level delegation and never receives a
     // project checkout. Keep this override after buildSessionRuntimeEnv so the
@@ -1530,6 +1536,8 @@ export async function createProjectSession(input: {
             freshSession: true,
             baseSha: fastBootGitHint?.baseSha,
             gitDeltaBundleBase64: fastBootGitHint?.gitDeltaBundleBase64,
+            gitDeltaParentSha: fastBootGitHint?.gitDeltaParentSha,
+            gitDeltaParentCommitBase64: fastBootGitHint?.gitDeltaParentCommitBase64,
             defaultBranch: project.defaultBranch,
             manifestPath: project.manifestPath,
             workspaceMode,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-latency.test.ts
@@ -42,12 +42,16 @@ afterEach(async () => {
 })
 
 describe('clone depth configuration', () => {
-  test('loads the API-provided fast-boot Git delta bundle', () => {
+  test('loads the API-provided fast-boot Git delta bundle and parent commit', () => {
     const cfg = loadConfig({
       ...BASE_ENV,
       KORTIX_GIT_DELTA_BUNDLE_BASE64: 'R0lUIEJVTkRMRQ==',
+      KORTIX_GIT_DELTA_PARENT_SHA: 'a'.repeat(40),
+      KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64: 'dHJlZSBkZWFkYmVlZgo=',
     } as NodeJS.ProcessEnv)
     expect(cfg.gitDeltaBundleBase64).toBe('R0lUIEJVTkRMRQ==')
+    expect(cfg.gitDeltaParentSha).toBe('a'.repeat(40))
+    expect(cfg.gitDeltaParentCommitBase64).toBe('dHJlZSBkZWFkYmVlZgo=')
   })
 
   test('defaults to a shallow depth-1 clone', () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -52,6 +52,8 @@ function baseConfig(over: Partial<Config> = {}): Config {
     sessionFresh: false,
     baseSha: undefined,
     gitDeltaBundleBase64: undefined,
+    gitDeltaParentSha: undefined,
+    gitDeltaParentCommitBase64: undefined,
     sandboxToken: TEST_TOKEN,
     gitUserName: 'Kortix Agent',
     gitUserEmail: 'agent@kortix.ai',
@@ -516,11 +518,26 @@ describe('daemon proxy auth gate', () => {
       const scaffoldSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
       git(['clone', '--bare', source, scaffold])
 
+      gitOutput(['commit', '--amend', '--no-edit'], {
+        cwd: source,
+        env: {
+          GIT_AUTHOR_DATE: '2026-01-02T00:00:00Z',
+          GIT_COMMITTER_DATE: '2026-01-02T00:00:00Z',
+        },
+      })
+      const providerParentSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
+      expect(providerParentSha).not.toBe(scaffoldSha)
+      const providerParentCommitBase64 = Buffer.from(execFileSync(
+        'git',
+        ['cat-file', 'commit', providerParentSha],
+        { cwd: source },
+      )).toString('base64')
+
       writeFileSync(join(source, 'README.md'), 'customer project\n')
       git(['add', 'README.md'], source)
       git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'project setup'], source)
       const baseSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
-      git(['bundle', 'create', bundlePath, 'refs/heads/main', `^${scaffoldSha}`], source)
+      git(['bundle', 'create', bundlePath, 'refs/heads/main', `^${providerParentSha}`], source)
 
       __setScaffoldRepoPathForTests(scaffold)
       globalThis.fetch = (async (url: string | URL | Request) => {
@@ -542,6 +559,8 @@ describe('daemon proxy auth gate', () => {
         sessionFresh: true,
         baseSha,
         gitDeltaBundleBase64: readFileSync(bundlePath).toString('base64'),
+        gitDeltaParentSha: providerParentSha,
+        gitDeltaParentCommitBase64: providerParentCommitBase64,
       }))
 
       expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(0)

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -518,7 +518,11 @@ describe('daemon proxy auth gate', () => {
       const scaffoldSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
       git(['clone', '--bare', source, scaffold])
 
-      gitOutput(['commit', '--amend', '--no-edit'], {
+      gitOutput([
+        '-c', 'user.email=noreply@kortix.ai',
+        '-c', 'user.name=Kortix',
+        'commit', '--amend', '--no-edit',
+      ], {
         cwd: source,
         env: {
           GIT_AUTHOR_DATE: '2026-01-02T00:00:00Z',

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -574,7 +574,7 @@ describe('daemon proxy auth gate', () => {
     }
   })
 
-  it('falls back to the authenticated fetch when a delta bundle is invalid', async () => {
+  it('falls back to the authenticated fetch when the parent commit payload is forged', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-invalid-delta-bundle-'))
     const originalFetch = globalThis.fetch
     const requests: string[] = []
@@ -582,16 +582,19 @@ describe('daemon proxy auth gate', () => {
       const source = join(root, 'source')
       const scaffold = join(root, 'scaffold.git')
       const target = join(root, 'workspace')
+      const bundlePath = join(root, 'delta.bundle')
       mkdirSync(source)
       git(['init', '-b', 'main'], source)
       writeFileSync(join(source, 'README.md'), 'generic scaffold\n')
       git(['add', 'README.md'], source)
       git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'scaffold'], source)
+      const scaffoldSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
       git(['clone', '--bare', source, scaffold])
       writeFileSync(join(source, 'README.md'), 'remote truth\n')
       git(['add', 'README.md'], source)
       git(['-c', 'user.email=noreply@kortix.ai', '-c', 'user.name=Kortix', 'commit', '-m', 'project setup'], source)
       const baseSha = gitOutput(['-C', source, 'rev-parse', 'HEAD'])
+      git(['bundle', 'create', bundlePath, 'refs/heads/main', `^${scaffoldSha}`], source)
 
       __setScaffoldRepoPathForTests(scaffold)
       globalThis.fetch = (async (url: string | URL | Request) => {
@@ -612,7 +615,9 @@ describe('daemon proxy auth gate', () => {
         branchName: 'session-fresh',
         sessionFresh: true,
         baseSha,
-        gitDeltaBundleBase64: Buffer.from('not a git bundle').toString('base64'),
+        gitDeltaBundleBase64: readFileSync(bundlePath).toString('base64'),
+        gitDeltaParentSha: scaffoldSha,
+        gitDeltaParentCommitBase64: Buffer.from('forged parent commit').toString('base64'),
       }))
 
       expect(requests.filter((url) => url.includes('/git/clone-credential'))).toHaveLength(1)

--- a/apps/kortix-sandbox-agent-server/src/config.ts
+++ b/apps/kortix-sandbox-agent-server/src/config.ts
@@ -57,6 +57,8 @@ const Schema = z.object({
   KORTIX_SESSION_FRESH: z.string().optional(),
   KORTIX_BASE_SHA: z.string().optional(),
   KORTIX_GIT_DELTA_BUNDLE_BASE64: z.string().optional(),
+  KORTIX_GIT_DELTA_PARENT_SHA: z.string().optional(),
+  KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64: z.string().optional(),
   // The sandbox credential. KORTIX_SANDBOX_TOKEN is canonical; KORTIX_TOKEN is
   // the legacy alias (resolved with a fallback below).
   KORTIX_SANDBOX_TOKEN: z.string().optional(),
@@ -122,6 +124,8 @@ export type Config = {
   sessionFresh: boolean
   baseSha: string | undefined
   gitDeltaBundleBase64?: string
+  gitDeltaParentSha?: string
+  gitDeltaParentCommitBase64?: string
   /** The sandbox credential (HMAC key + sandbox-identity route bearer). NOT the
    *  session/user token — see the module doc. */
   sandboxToken: string | undefined
@@ -157,6 +161,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     KORTIX_SESSION_FRESH: env.KORTIX_SESSION_FRESH,
     KORTIX_BASE_SHA: env.KORTIX_BASE_SHA,
     KORTIX_GIT_DELTA_BUNDLE_BASE64: env.KORTIX_GIT_DELTA_BUNDLE_BASE64,
+    KORTIX_GIT_DELTA_PARENT_SHA: env.KORTIX_GIT_DELTA_PARENT_SHA,
+    KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64: env.KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64,
     KORTIX_SANDBOX_TOKEN: env.KORTIX_SANDBOX_TOKEN,
     KORTIX_TOKEN: env.KORTIX_TOKEN,
     KORTIX_GIT_USER_NAME: env.KORTIX_GIT_USER_NAME,
@@ -187,6 +193,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
     sessionFresh: parsed.KORTIX_SESSION_FRESH === '1',
     baseSha: parsed.KORTIX_BASE_SHA,
     gitDeltaBundleBase64: parsed.KORTIX_GIT_DELTA_BUNDLE_BASE64,
+    gitDeltaParentSha: parsed.KORTIX_GIT_DELTA_PARENT_SHA,
+    gitDeltaParentCommitBase64: parsed.KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64,
     // Canonical name wins; fall back to the legacy alias so daemons running in
     // older-API sandboxes (which only inject KORTIX_TOKEN) still resolve it.
     sandboxToken: parsed.KORTIX_SANDBOX_TOKEN ?? parsed.KORTIX_TOKEN,

--- a/apps/kortix-sandbox-agent-server/src/git.ts
+++ b/apps/kortix-sandbox-agent-server/src/git.ts
@@ -995,7 +995,14 @@ async function tryScaffoldDeltaFetch(
       cfg.sessionFresh &&
       cfg.baseSha &&
       cfg.gitDeltaBundleBase64 &&
-      await applyFastBootDeltaBundle(tmp, base, cfg.baseSha, cfg.gitDeltaBundleBase64)
+      await applyFastBootDeltaBundle(
+        tmp,
+        base,
+        cfg.baseSha,
+        cfg.gitDeltaBundleBase64,
+        cfg.gitDeltaParentSha,
+        cfg.gitDeltaParentCommitBase64,
+      )
     ) {
       await swapStageIntoTarget(tmp, target)
       logger.info('[git] repo materialized via scaffold (zero-network: API delta bundle)', {
@@ -1034,11 +1041,14 @@ async function applyFastBootDeltaBundle(
   base: string,
   baseSha: string,
   bundleBase64: string,
+  parentSha?: string,
+  parentCommitBase64?: string,
 ): Promise<boolean> {
   if (!/^[0-9a-f]{40}$/i.test(baseSha)) return false
   if (
     bundleBase64.length === 0 ||
     bundleBase64.length > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES ||
+    bundleBase64.length + (parentCommitBase64?.length ?? 0) > MAX_FAST_BOOT_GIT_BUNDLE_BASE64_BYTES ||
     bundleBase64.length % 4 !== 0 ||
     !/^[A-Za-z0-9+/]+={0,2}$/.test(bundleBase64)
   ) return false
@@ -1046,7 +1056,34 @@ async function applyFastBootDeltaBundle(
   const bytes = Buffer.from(bundleBase64, 'base64')
   if (bytes.toString('base64') !== bundleBase64) return false
   const bundlePath = join(repoPath, '.kortix-fast-boot.bundle')
+  const parentCommitPath = join(repoPath, '.kortix-fast-boot-parent.commit')
   try {
+    if (parentSha || parentCommitBase64) {
+      if (
+        !parentSha ||
+        !/^[0-9a-f]{40}$/i.test(parentSha) ||
+        !parentCommitBase64 ||
+        parentCommitBase64.length % 4 !== 0 ||
+        !/^[A-Za-z0-9+/]+={0,2}$/.test(parentCommitBase64)
+      ) {
+        throw new Error('incomplete or malformed parent commit payload')
+      }
+      const parentBytes = Buffer.from(parentCommitBase64, 'base64')
+      if (parentBytes.toString('base64') !== parentCommitBase64) {
+        throw new Error('non-canonical parent commit payload')
+      }
+      await writeFile(parentCommitPath, parentBytes, { mode: 0o600 })
+      const importedParent = await execGit([
+        '-C', repoPath, 'hash-object', '-t', 'commit', '-w', parentCommitPath,
+      ])
+      if (importedParent.code !== 0 || importedParent.stdout.trim() !== parentSha) {
+        throw new Error('parent commit payload does not match the expected SHA')
+      }
+      const parentTree = await execGit(['-C', repoPath, 'cat-file', '-e', `${parentSha}^{tree}`])
+      if (parentTree.code !== 0) {
+        throw new Error('parent commit tree is not present in the baked scaffold')
+      }
+    }
     await writeFile(bundlePath, bytes, { mode: 0o600 })
     const verified = await execGit(['-C', repoPath, 'bundle', 'verify', bundlePath])
     if (verified.code !== 0) throw new Error(`bundle verify: ${verified.stderr}`)
@@ -1064,6 +1101,7 @@ async function applyFastBootDeltaBundle(
     return false
   } finally {
     await rm(bundlePath, { force: true }).catch(() => {})
+    await rm(parentCommitPath, { force: true }).catch(() => {})
   }
 }
 

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -30,6 +30,9 @@ branch workspace:
   within its existing two-second deadline
 - `KORTIX_GIT_DELTA_BUNDLE_BASE64=<bounded exact commit bundle>` when the base
   tip is one commit above its parent and the encoded bundle is at most 24 KiB
+- `KORTIX_GIT_DELTA_PARENT_SHA=<bundle prerequisite commit>` and
+  `KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64=<raw prerequisite commit>` when the
+  storage provider rewrites the scaffold commit metadata
 
 After a managed project seed completes, the API stores the verified bundle in
 `projects.metadata.git.fast_boot`. A later session validates the cached SHA
@@ -39,6 +42,11 @@ network fallback.
 
 The cache is available to every API instance. The project serializer removes
 the internal `fast_boot` field from provision, list, and detail responses.
+
+The provider-specific parent payload makes the thin bundle portable across
+identical scaffold trees with different commit metadata. The bundle and parent
+payload share the existing 24 KiB limit. Cache version 2 invalidates earlier
+entries that do not contain the parent payload.
 
 The daemon uses the hints as follows:
 
@@ -52,7 +60,9 @@ The daemon uses the hints as follows:
 - Restarted sessions keep the existing remote-branch fetch behavior.
 
 The bundle is transported with the sandbox creation environment. The daemon
-validates its encoding, size, prerequisite commit, and resulting SHA. Any
+recomputes the parent commit SHA before it writes the object. It also verifies
+that the parent tree already exists in the baked scaffold. The daemon then
+validates the bundle, imports it, and verifies the resulting base SHA. Any
 validation failure uses the authenticated fetch path.
 
 This design creates no sandbox pool. It requires no schema migration. It changes
@@ -61,7 +71,7 @@ no Git history or push behavior.
 ## Rollback
 
 Set `KORTIX_FAST_COLD_BOOT_ENABLED=false` and redeploy the API. The API then
-omits all three hints, and the daemon uses the previous network path.
+omits all fast-boot Git hints, and the daemon uses the previous network path.
 
 ## Verification
 


### PR DESCRIPTION
## Problem

PR #6668 exposed a provider mismatch in the zero-network Git path. The baked scaffold and provider seed have the same tree but different parent commit SHAs. Git bundle verification rejects the thin bundle and falls back to a network fetch.

The deployed five-session sample measured repository materialization at 6,451 ms p50 and runtime readiness at 24,962 ms p50.

## Change

- Package the exact raw prerequisite commit with the existing thin bundle.
- Verify the parent SHA and require its tree to exist in the baked scaffold.
- Keep the combined payload within the existing 24 KiB limit.
- Bump the durable cache version so old incomplete hints cannot load.
- Transport the parent payload only when KORTIX_FAST_COLD_BOOT_ENABLED is enabled.
- Preserve authenticated network fetch as the validation fallback.
- Document the provider-portable bundle contract.

This creates no warm sandbox pool. KORTIX_FAST_COLD_BOOT_ENABLED remains the single rollback switch.

## Verification

- Daemon: 676 pass, 0 fail, 1,550 expectations.
- Daemon typecheck: pass.
- Daemon Linux binary build: pass, 95,627,392 bytes.
- Shared sandbox tests: 70 pass, 0 fail.
- API focused tests: 126 pass, 0 fail, 613 expectations.
- API typecheck: pass.
- Provider mismatch regression: zero credential requests and repository materialization in about 116 ms.
- Forged parent payload: rejected, then authenticated network fallback returns remote truth.