### PR TITLE
feat(runtime): converge every sandbox onto the API it talks to

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -874,13 +874,16 @@ app.use('/v1/skills/*', combinedAuth);
 app.route('/v1/skills', skillsApp); // GET /v1/skills, /v1/skills/:name[?full=1], /v1/skills/:name/file?path=
 
 // /v1/runtime-assets — the sandbox runtime assets THIS deploy was built with:
-// the `kortix` CLI binary it bakes into snapshots and the managed-skill overlay.
-// A live sandbox reconciles against these on every session start/restart/resume,
-// which is what stops an old box from running a CLI that predates the routes it
-// calls. combinedAuth for the same reason as /v1/skills above: the callers are a
-// `kortix_pat_` CLI and the in-sandbox KORTIX_CLI_TOKEN.
+// the `kortix-agent` daemon and `kortix` CLI binaries it bakes into snapshots,
+// and the managed-skill overlay. A live sandbox reconciles against these on
+// every session start/restart/resume, which is what stops an old box from
+// running a daemon or CLI that predates the routes it calls. combinedAuth for
+// the same reason as /v1/skills above: the callers are a `kortix_pat_` CLI and
+// the in-sandbox KORTIX_CLI_TOKEN. The `/*` wildcard is what puts every payload
+// route behind auth — a new one must be added to runtimeAssetsApp, never mounted
+// beside it.
 app.use('/v1/runtime-assets/*', combinedAuth);
-app.route('/v1/runtime-assets', runtimeAssetsApp); // GET /manifest, /cli, /managed-skills
+app.route('/v1/runtime-assets', runtimeAssetsApp); // GET /manifest, /cli, /agent, /managed-skills
 
 // Universal git smart-HTTP proxy — every git-backed project's client origin.
 // Auth is handled inside (git sends Basic/Bearer, not combinedAuth's Bearer),

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -772,8 +772,11 @@ async function enforceTokenProjectScope(c: Context, tokenProjectId: string): Pro
   // authorization.
   if (path === '/v1/skills' || path.startsWith('/v1/skills/')) return;
 
-  // `/v1/runtime-assets` — the CLI binary + managed-skill overlay this deploy
-  // bakes into sandboxes. Same situation and same reasoning as `/v1/skills`
+  // `/v1/runtime-assets` — the `kortix-agent` daemon binary, the CLI binary, and
+  // the managed-skill overlay this deploy bakes into sandboxes. The prefix test
+  // covers every payload route including `/agent`, which is deliberate: the
+  // daemon converging ITSELF is the same caller with the same token as the
+  // daemon converging its CLI. Same reasoning as `/v1/skills`
   // above, and for the same single caller: the in-sandbox daemon reconciles
   // against these on every session start/restart/resume holding exactly a
   // project+session-scoped `KORTIX_CLI_TOKEN`. A 403 here means a sandbox can

--- a/apps/api/src/runtime-assets/__tests__/agent-route.test.ts
+++ b/apps/api/src/runtime-assets/__tests__/agent-route.test.ts
@@ -1,0 +1,176 @@
+/**
+ * `GET /v1/runtime-assets/agent` — the daemon binary this deploy bakes.
+ *
+ * Mounted here EXACTLY as apps/api/src/index.ts mounts it: one
+ * `app.use('/v1/runtime-assets/*', <auth>)` wildcard in front of
+ * `app.route('/v1/runtime-assets', runtimeAssetsApp)`. That is the property
+ * worth testing — a payload route added beside the sub-app instead of inside it
+ * would serve a ~96 MB root-executed binary to an unauthenticated caller. The
+ * auth middleware is stubbed because `combinedAuth` needs a database; what is
+ * under test is the WIRING, not the token parser.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runtimeAssetsApp } from '../index';
+import { _resetRuntimeAssetsCache } from '../manifest';
+
+const CLI_BIN_ENV = 'KORTIX_SNAPSHOT_CLI_BIN_PATH';
+const AGENT_BIN_ENV = 'KORTIX_SNAPSHOT_AGENT_BIN_PATH';
+const VERSION_ENV = 'KORTIX_VERSION';
+const COMMIT_ENV = 'KORTIX_COMMIT';
+const MANAGED_ENV = [CLI_BIN_ENV, AGENT_BIN_ENV, VERSION_ENV, COMMIT_ENV] as const;
+const originalEnv = new Map(MANAGED_ENV.map((key) => [key, process.env[key]]));
+const tempDirs: string[] = [];
+
+const AGENT_BYTES = 'compiled-kortix-agent-elf';
+const AGENT_SHA = new Bun.CryptoHasher('sha256').update(AGENT_BYTES).digest('hex');
+
+/** The same mount shape as index.ts, with a stand-in for combinedAuth. */
+function mountedApp() {
+  const app = new Hono();
+  app.use('/v1/runtime-assets/*', async (c, next) => {
+    if (!c.req.header('Authorization')) return c.json({ error: true, status: 401 }, 401);
+    await next();
+  });
+  app.route('/v1/runtime-assets', runtimeAssetsApp as never);
+  return app;
+}
+
+async function stageAgent(bytes: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'runtime-assets-agent-route-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'kortix-agent');
+  await writeFile(path, bytes);
+  return path;
+}
+
+beforeEach(() => {
+  // Never the repo's real ~96 MB / ~104 MB dist artifacts.
+  process.env[CLI_BIN_ENV] = join(tmpdir(), 'kortix-agent-route-unset-cli');
+  process.env[AGENT_BIN_ENV] = join(tmpdir(), 'kortix-agent-route-unset-agent');
+  delete process.env[VERSION_ENV];
+  delete process.env[COMMIT_ENV];
+  _resetRuntimeAssetsCache();
+});
+
+afterEach(async () => {
+  for (const key of MANAGED_ENV) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  _resetRuntimeAssetsCache();
+  while (tempDirs.length > 0) {
+    await rm(tempDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe('GET /v1/runtime-assets/agent', () => {
+  test('is behind the same auth wildcard as /cli — no token, no binary', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent(AGENT_BYTES);
+    _resetRuntimeAssetsCache();
+
+    const app = mountedApp();
+    const anonymous = await app.request('/v1/runtime-assets/agent');
+    expect(anonymous.status).toBe(401);
+    // The CLI route it mirrors behaves identically; both live inside the mount.
+    expect((await app.request('/v1/runtime-assets/cli')).status).toBe(401);
+    expect((await app.request('/v1/runtime-assets/manifest')).status).toBe(401);
+  });
+
+  test('streams the baked binary with a content-addressed ETag', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent(AGENT_BYTES);
+    process.env[VERSION_ENV] = '0.13.1-dev.abc12345';
+    process.env[COMMIT_ENV] = 'abc12345def';
+    _resetRuntimeAssetsCache();
+
+    const res = await mountedApp().request('/v1/runtime-assets/agent', {
+      headers: { Authorization: 'Bearer kortix_pat_test' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('ETag')).toBe(`"${AGENT_SHA}"`);
+    expect(res.headers.get('Cache-Control')).toBe('no-cache');
+    expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
+    expect(res.headers.get('Content-Length')).toBe(String(AGENT_BYTES.length));
+    expect(res.headers.get('X-Kortix-Agent-Sha256')).toBe(AGENT_SHA);
+    expect(res.headers.get('X-Kortix-Agent-Version')).toBe('0.13.1-dev.abc12345+abc12345');
+    // The bytes on the wire must hash to the digest the manifest advertised —
+    // that digest is the ONLY thing standing between a box and a bad binary.
+    const body = await res.arrayBuffer();
+    expect(new Bun.CryptoHasher('sha256').update(body).digest('hex')).toBe(AGENT_SHA);
+  });
+
+  test('honours If-None-Match with a 304 and no body', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent(AGENT_BYTES);
+    _resetRuntimeAssetsCache();
+
+    const res = await mountedApp().request('/v1/runtime-assets/agent', {
+      headers: {
+        Authorization: 'Bearer kortix_pat_test',
+        'If-None-Match': `"${AGENT_SHA}"`,
+      },
+    });
+    expect(res.status).toBe(304);
+    expect(await res.text()).toBe('');
+  });
+
+  test('HEAD reports the size without transferring ~96 MB', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent(AGENT_BYTES);
+    _resetRuntimeAssetsCache();
+
+    const res = await mountedApp().request('/v1/runtime-assets/agent', {
+      method: 'HEAD',
+      headers: { Authorization: 'Bearer kortix_pat_test' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Length')).toBe(String(AGENT_BYTES.length));
+    expect(res.headers.get('X-Kortix-Agent-Sha256')).toBe(AGENT_SHA);
+    expect(await res.text()).toBe('');
+  });
+
+  test('404s when the image carries no agent binary — the same degradation as /cli', async () => {
+    _resetRuntimeAssetsCache();
+    const app = mountedApp();
+    const headers = { Authorization: 'Bearer kortix_pat_test' };
+
+    const res = await app.request('/v1/runtime-assets/agent', { headers });
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({
+      error: true,
+      message: 'This deploy carries no sandbox agent binary',
+      status: 404,
+    });
+    // …and the manifest agrees, so a box skips the agent half instead of
+    // polling a route that will never answer.
+    const manifest = (await (await app.request('/v1/runtime-assets/manifest', { headers })).json()) as {
+      components: Record<string, unknown>;
+    };
+    expect(manifest.components.agent).toBeUndefined();
+  });
+
+  test('an absent agent does not take the CLI route down with it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'runtime-assets-agent-route-'));
+    tempDirs.push(dir);
+    const cliPath = join(dir, 'kortix');
+    await writeFile(cliPath, 'compiled-kortix-cli');
+    await writeFile(`${cliPath}.version`, '0.13.1+abc12345\n');
+    process.env[CLI_BIN_ENV] = cliPath;
+    _resetRuntimeAssetsCache();
+
+    const app = mountedApp();
+    const headers = { Authorization: 'Bearer kortix_pat_test' };
+    expect((await app.request('/v1/runtime-assets/agent', { headers })).status).toBe(404);
+
+    const cli = await app.request('/v1/runtime-assets/cli', { headers });
+    expect(cli.status).toBe(200);
+    // The v1 CLI headers are part of the deployed-daemon contract too.
+    expect(cli.headers.get('X-Kortix-Cli-Sha256')).toBe(
+      new Bun.CryptoHasher('sha256').update('compiled-kortix-cli').digest('hex'),
+    );
+    expect(cli.headers.get('X-Kortix-Cli-Version')).toBe('0.13.1+abc12345');
+  });
+});

--- a/apps/api/src/runtime-assets/__tests__/manifest.test.ts
+++ b/apps/api/src/runtime-assets/__tests__/manifest.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, test } from 'bun:test';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { OPENCODE_VERSION } from '@kortix/shared/runtime-versions';
 import {
   managedSkillOverlayFiles,
   managedSkillOverlayHash,
@@ -9,21 +10,54 @@ import {
 import { _resetRuntimeAssetsCache, runtimeAssetsManifest } from '../manifest';
 
 const CLI_BIN_ENV = 'KORTIX_SNAPSHOT_CLI_BIN_PATH';
-const originalCliBin = process.env[CLI_BIN_ENV];
+const AGENT_BIN_ENV = 'KORTIX_SNAPSHOT_AGENT_BIN_PATH';
+const SELF_UPDATE_ENV = 'RUNTIME_AGENT_SELF_UPDATE';
+const BUILD_ENV = 'RUNTIME_ASSETS_BUILD';
+const VERSION_ENV = 'KORTIX_VERSION';
+const COMMIT_ENV = 'KORTIX_COMMIT';
+const MANAGED_ENV = [
+  CLI_BIN_ENV,
+  AGENT_BIN_ENV,
+  SELF_UPDATE_ENV,
+  BUILD_ENV,
+  VERSION_ENV,
+  COMMIT_ENV,
+] as const;
+const originalEnv = new Map(MANAGED_ENV.map((key) => [key, process.env[key]]));
 const tempDirs: string[] = [];
 
-async function stageCli(bytes: string, version?: string): Promise<string> {
+async function stageBinary(name: string, bytes: string, version?: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'runtime-assets-test-'));
   tempDirs.push(dir);
-  const binaryPath = join(dir, 'kortix');
+  const binaryPath = join(dir, name);
   await writeFile(binaryPath, bytes);
   if (version !== undefined) await writeFile(`${binaryPath}.version`, `${version}\n`);
   return binaryPath;
 }
 
+const stageCli = (bytes: string, version?: string) => stageBinary('kortix', bytes, version);
+const stageAgent = (bytes: string) => stageBinary('kortix-agent', bytes);
+
+beforeEach(() => {
+  // Pin BOTH binaries away from the repo's real ~96 MB / ~104 MB dist artifacts.
+  // Without this every case in this file would stream-hash 200 MB of real
+  // binary, and the suite would pass or fail on whether a checkout happens to
+  // have been built.
+  process.env[CLI_BIN_ENV] = join(tmpdir(), 'kortix-runtime-assets-unset-cli');
+  process.env[AGENT_BIN_ENV] = join(tmpdir(), 'kortix-runtime-assets-unset-agent');
+  delete process.env[SELF_UPDATE_ENV];
+  delete process.env[BUILD_ENV];
+  delete process.env[VERSION_ENV];
+  delete process.env[COMMIT_ENV];
+  _resetRuntimeAssetsCache();
+});
+
 afterEach(async () => {
-  if (originalCliBin === undefined) delete process.env[CLI_BIN_ENV];
-  else process.env[CLI_BIN_ENV] = originalCliBin;
+  for (const key of MANAGED_ENV) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   _resetRuntimeAssetsCache();
   while (tempDirs.length > 0) {
     await rm(tempDirs.pop() as string, { recursive: true, force: true });
@@ -103,7 +137,37 @@ describe('runtime assets manifest', () => {
     const first = await runtimeAssetsManifest();
     await writeFile(binaryPath, 'two');
     const second = await runtimeAssetsManifest();
-    expect(second).toBe(first);
+    // Not object identity: the returned object is assembled per call so `policy`
+    // can be read live. Everything that costs a hash comes from the memo, which
+    // is what this asserts — the rewritten file is NOT re-read.
+    expect(second.cli_sha256).toBe(first.cli_sha256 as string);
+    expect(second.cli_size).toBe(first.cli_size as number);
+    expect(second.build).toBe(first.build);
+    expect(second.components).toEqual(first.components);
+  });
+
+  test('two CONCURRENT first calls hash the binaries exactly once', async () => {
+    const cliPath = await stageCli('concurrent-cli');
+    const agentPath = await stageAgent('concurrent-agent');
+    process.env[CLI_BIN_ENV] = cliPath;
+    process.env[AGENT_BIN_ENV] = agentPath;
+    _resetRuntimeAssetsCache();
+
+    // Both calls are issued before either can settle, so they can only agree if
+    // the memo stores the in-flight PROMISE rather than the resolved value.
+    // Rewriting both files the instant the first read starts would make a second
+    // hash observable as a different digest.
+    const [a, b] = await Promise.all([runtimeAssetsManifest(), runtimeAssetsManifest()]);
+    await writeFile(cliPath, 'mutated-cli');
+    await writeFile(agentPath, 'mutated-agent');
+    const c = await runtimeAssetsManifest();
+
+    const expectedCli = new Bun.CryptoHasher('sha256').update('concurrent-cli').digest('hex');
+    const expectedAgent = new Bun.CryptoHasher('sha256').update('concurrent-agent').digest('hex');
+    for (const manifest of [a, b, c]) {
+      expect(manifest.components.cli?.sha256).toBe(expectedCli);
+      expect(manifest.components.agent?.sha256).toBe(expectedAgent);
+    }
   });
 
   test('a missing version sidecar reports null, not a fabricated version', async () => {
@@ -129,5 +193,253 @@ describe('runtime assets manifest', () => {
     _resetRuntimeAssetsCache();
     const manifest = await runtimeAssetsManifest();
     expect(manifest.cli_sha256).toBeNull();
+  });
+});
+
+/**
+ * THE COMPATIBILITY GUARD. Deployed daemons read the v1 keys off this document
+ * (apps/kortix-sandbox-agent-server/src/runtime-assets.ts). Dropping or renaming
+ * one is invisible in a typecheck of the API alone and breaks every box already
+ * in the field — the accept-encoding two-list divergence, again. This test is
+ * what stops a future refactor from doing it quietly.
+ */
+describe('manifest v1 keys are permanent', () => {
+  const V1_KEYS = [
+    'cli_version',
+    'cli_sha256',
+    'cli_size',
+    'managed_skills_hash',
+    'managed_skills_count',
+  ] as const;
+
+  test('every v1 key is present with its v1 meaning, alongside the v2 keys', async () => {
+    process.env[CLI_BIN_ENV] = await stageCli('v1-cli-bytes', '0.13.1+abc12345');
+    process.env[AGENT_BIN_ENV] = await stageAgent('v1-agent-bytes');
+    _resetRuntimeAssetsCache();
+
+    const manifest = await runtimeAssetsManifest();
+    for (const key of V1_KEYS) {
+      expect(Object.hasOwn(manifest, key)).toBe(true);
+    }
+    // Meaning, not just presence: a key that survives a refactor as `undefined`
+    // or as a renamed alias is the same outage.
+    expect(manifest.cli_version).toBe('0.13.1+abc12345');
+    expect(manifest.cli_sha256).toBe(
+      new Bun.CryptoHasher('sha256').update('v1-cli-bytes').digest('hex'),
+    );
+    expect(manifest.cli_size).toBe('v1-cli-bytes'.length);
+    expect(manifest.managed_skills_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(manifest.managed_skills_count).toBe(managedSkillOverlayFiles().length);
+
+    // v2 is ADDITIVE — it sits beside v1, it does not replace it.
+    expect(typeof manifest.build).toBe('number');
+    expect(manifest.components).toBeDefined();
+    expect(manifest.policy).toBeDefined();
+  });
+
+  test('the v1 CLI keys and components.cli describe the SAME bytes', async () => {
+    process.env[CLI_BIN_ENV] = await stageCli('one-measurement', '0.13.1+deadbeef');
+    _resetRuntimeAssetsCache();
+
+    const manifest = await runtimeAssetsManifest();
+    // A v1 daemon and a v2 daemon reading one manifest must converge on one
+    // binary. Two spellings of one measurement, never two measurements.
+    expect(manifest.components.cli?.sha256).toBe(manifest.cli_sha256 as string);
+    expect(manifest.components.cli?.size).toBe(manifest.cli_size as number);
+    expect(manifest.components.cli?.version).toBe(manifest.cli_version);
+    expect(manifest.components.cli?.path).toBe('/v1/runtime-assets/cli');
+  });
+
+  test('the v1 skill keys and components["managed-skills"] agree', async () => {
+    _resetRuntimeAssetsCache();
+    const manifest = await runtimeAssetsManifest();
+    expect(manifest.components['managed-skills'].hash).toBe(manifest.managed_skills_hash);
+    expect(manifest.components['managed-skills'].count).toBe(manifest.managed_skills_count);
+  });
+
+  test('an absent CLI binary still reports the v1 nulls, not a missing key', async () => {
+    _resetRuntimeAssetsCache();
+    const manifest = await runtimeAssetsManifest();
+    for (const key of V1_KEYS) expect(Object.hasOwn(manifest, key)).toBe(true);
+    expect(manifest.cli_sha256).toBeNull();
+    // The v2 spelling of "absent" is an omitted component, which is what tells a
+    // v2 daemon to skip that half.
+    expect(manifest.components.cli).toBeUndefined();
+  });
+});
+
+describe('manifest v2 components', () => {
+  test('agent reports version, digest, size, and its download path', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('kortix-agent-bytes');
+    process.env[VERSION_ENV] = '0.13.1-dev.abc12345';
+    process.env[COMMIT_ENV] = 'abc12345def67890';
+    _resetRuntimeAssetsCache();
+
+    const agent = (await runtimeAssetsManifest()).components.agent;
+    expect(agent?.sha256).toBe(
+      new Bun.CryptoHasher('sha256').update('kortix-agent-bytes').digest('hex'),
+    );
+    expect(agent?.size).toBe('kortix-agent-bytes'.length);
+    expect(agent?.path).toBe('/v1/runtime-assets/agent');
+    // `<version>+<commit8>` — the same stamp shape the CLI stage bakes.
+    expect(agent?.version).toBe('0.13.1-dev.abc12345+abc12345');
+  });
+
+  test('an unstamped image reports a null agent version, never a fabricated one', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('unstamped');
+    _resetRuntimeAssetsCache();
+    const agent = (await runtimeAssetsManifest()).components.agent;
+    expect(agent?.version).toBeNull();
+    expect(agent?.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('an absent agent binary omits the component and keeps every other one', async () => {
+    process.env[CLI_BIN_ENV] = await stageCli('cli-survives');
+    _resetRuntimeAssetsCache();
+    const manifest = await runtimeAssetsManifest();
+    expect(manifest.components.agent).toBeUndefined();
+    expect(manifest.components.cli).toBeDefined();
+    expect(manifest.components.opencode.version).toBe(OPENCODE_VERSION);
+    expect(manifest.components['managed-skills'].count).toBeGreaterThan(0);
+  });
+
+  test('an empty (truncated) agent binary is treated as absent', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('');
+    _resetRuntimeAssetsCache();
+    expect((await runtimeAssetsManifest()).components.agent).toBeUndefined();
+  });
+
+  test('opencode states the expected npm version and is not proxied', async () => {
+    _resetRuntimeAssetsCache();
+    const opencode = (await runtimeAssetsManifest()).components.opencode;
+    expect(opencode.version).toBe(OPENCODE_VERSION);
+    expect(opencode.source).toBe('npm');
+    // No `path`: 167 MB per stale box must not cross our control plane.
+    expect(Object.hasOwn(opencode, 'path')).toBe(false);
+  });
+});
+
+describe('manifest build number', () => {
+  test('is stable across calls — it does not move per request', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('stable-build');
+    _resetRuntimeAssetsCache();
+
+    const first = (await runtimeAssetsManifest()).build;
+    await Bun.sleep(1100); // long enough that a request-time clock would differ
+    const second = (await runtimeAssetsManifest()).build;
+    expect(second).toBe(first);
+    expect(first).toBeGreaterThan(0);
+  });
+
+  test('is the image build time — the mtime of the baked binary, in seconds', async () => {
+    const agentPath = await stageAgent('mtime-derived');
+    process.env[AGENT_BIN_ENV] = agentPath;
+    const stamp = new Date('2026-08-20T12:00:00.000Z');
+    await utimes(agentPath, stamp, stamp);
+    _resetRuntimeAssetsCache();
+
+    expect((await runtimeAssetsManifest()).build).toBe(Math.floor(stamp.getTime() / 1000));
+  });
+
+  test('moves FORWARD for a newer image and never backwards for the same one', async () => {
+    const oldPath = await stageAgent('old-image');
+    await utimes(oldPath, new Date('2026-08-01T00:00:00Z'), new Date('2026-08-01T00:00:00Z'));
+    process.env[AGENT_BIN_ENV] = oldPath;
+    _resetRuntimeAssetsCache();
+    const oldBuild = (await runtimeAssetsManifest()).build;
+
+    const newPath = await stageAgent('new-image');
+    await utimes(newPath, new Date('2026-08-20T00:00:00Z'), new Date('2026-08-20T00:00:00Z'));
+    process.env[AGENT_BIN_ENV] = newPath;
+    _resetRuntimeAssetsCache();
+    const newBuild = (await runtimeAssetsManifest()).build;
+
+    // This is the anti-flap guard: during a rolling deploy the two live API
+    // versions serve two builds, and a box takes only the higher one.
+    expect(newBuild).toBeGreaterThan(oldBuild);
+  });
+
+  test('takes the max of the agent and CLI binaries so one missing file cannot regress it', async () => {
+    const agentPath = await stageAgent('agent-newer');
+    const cliPath = await stageCli('cli-older');
+    await utimes(cliPath, new Date('2026-08-01T00:00:00Z'), new Date('2026-08-01T00:00:00Z'));
+    await utimes(agentPath, new Date('2026-08-20T00:00:00Z'), new Date('2026-08-20T00:00:00Z'));
+    process.env[AGENT_BIN_ENV] = agentPath;
+    process.env[CLI_BIN_ENV] = cliPath;
+    _resetRuntimeAssetsCache();
+
+    expect((await runtimeAssetsManifest()).build).toBe(
+      Math.floor(new Date('2026-08-20T00:00:00Z').getTime() / 1000),
+    );
+  });
+
+  test('RUNTIME_ASSETS_BUILD overrides it — the rollback escape hatch', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('rolled-back');
+    process.env[BUILD_ENV] = '1900000000';
+    _resetRuntimeAssetsCache();
+    expect((await runtimeAssetsManifest()).build).toBe(1_900_000_000);
+  });
+
+  test('a malformed RUNTIME_ASSETS_BUILD falls back to the mtime instead of poisoning it', async () => {
+    const agentPath = await stageAgent('bad-override');
+    const stamp = new Date('2026-08-20T12:00:00.000Z');
+    await utimes(agentPath, stamp, stamp);
+    process.env[AGENT_BIN_ENV] = agentPath;
+    for (const bad of ['not-a-number', '-5', '1.5e400', '']) {
+      process.env[BUILD_ENV] = bad;
+      _resetRuntimeAssetsCache();
+      expect((await runtimeAssetsManifest()).build).toBe(Math.floor(stamp.getTime() / 1000));
+    }
+  });
+
+  test('is 0 when the image carries no binary at all — degrades, never regresses', async () => {
+    _resetRuntimeAssetsCache();
+    // A box compares with a strict `<`, so 0 simply never out-ranks what it has.
+    expect((await runtimeAssetsManifest()).build).toBe(0);
+  });
+});
+
+describe('manifest policy — the agent self-update kill switch', () => {
+  test('defaults to enabled', async () => {
+    _resetRuntimeAssetsCache();
+    expect((await runtimeAssetsManifest()).policy.agent_self_update).toBe(true);
+  });
+
+  test('RUNTIME_AGENT_SELF_UPDATE=false stops the rollout', async () => {
+    process.env[SELF_UPDATE_ENV] = 'false';
+    _resetRuntimeAssetsCache();
+    expect((await runtimeAssetsManifest()).policy.agent_self_update).toBe(false);
+  });
+
+  test('accepts the operator spellings an operator actually types', async () => {
+    for (const off of ['false', 'FALSE', 'False', '0', ' false ']) {
+      process.env[SELF_UPDATE_ENV] = off;
+      _resetRuntimeAssetsCache();
+      expect((await runtimeAssetsManifest()).policy.agent_self_update).toBe(false);
+    }
+  });
+
+  test('a typo fails SAFE — towards the default, not a silent fleet freeze', async () => {
+    for (const noise of ['flase', 'no', 'off', 'true', '1', '']) {
+      process.env[SELF_UPDATE_ENV] = noise;
+      _resetRuntimeAssetsCache();
+      expect((await runtimeAssetsManifest()).policy.agent_self_update).toBe(true);
+    }
+  });
+
+  test('is read live — the switch does not wait on the digest memo', async () => {
+    process.env[AGENT_BIN_ENV] = await stageAgent('live-policy');
+    _resetRuntimeAssetsCache();
+    expect((await runtimeAssetsManifest()).policy.agent_self_update).toBe(true);
+
+    // No cache reset: this is the property that makes the kill switch a config
+    // change and not a deploy.
+    process.env[SELF_UPDATE_ENV] = 'false';
+    const flipped = await runtimeAssetsManifest();
+    expect(flipped.policy.agent_self_update).toBe(false);
+    // …and flipping it did NOT invalidate the expensive half.
+    expect(flipped.components.agent?.sha256).toBe(
+      new Bun.CryptoHasher('sha256').update('live-policy').digest('hex'),
+    );
   });
 });

--- a/apps/api/src/runtime-assets/index.ts
+++ b/apps/api/src/runtime-assets/index.ts
@@ -24,13 +24,17 @@
  * published on every release), but it is not an anonymous 100 MB download
  * either.
  *
- * SHAPE — a cheap manifest plus two payload routes, because the payloads are
+ * SHAPE — a cheap manifest plus three payload routes, because the payloads are
  * large and almost always unnecessary:
- *   GET /manifest        ~200 B — digests only. Polled on every session start.
- *   GET /cli             ~100 MB — the binary. Fetched only on a digest mismatch.
+ *   GET /manifest        ~700 B — digests only. Polled on every session start.
+ *   GET /cli             ~104 MB — the `kortix` binary. Only on a digest mismatch.
+ *   GET /agent           ~96 MB — the `kortix-agent` daemon. Same.
  *   GET /managed-skills  ~300 KB — the overlay files. Same.
- * Both payload routes are content-addressed (`ETag` = the digest from the
- * manifest) and honour `If-None-Match` with a 304, so a caller that re-fetches
+ * `opencode` is deliberately NOT proxied here: the manifest states the expected
+ * version and the daemon fetches it from npm, because 167 MB per stale box has
+ * no business crossing our own control plane.
+ * Every payload route is content-addressed (`ETag` = the digest from the
+ * manifest) and honours `If-None-Match` with a 304, so a caller that re-fetches
  * without checking the manifest first still pays nothing.
  *
  * The managed-skill payload is JSON, not a tarball, on purpose: the sandbox
@@ -43,17 +47,39 @@ import { createRoute, z } from '@hono/zod-openapi';
 import { auth, errors, json, makeOpenApiApp } from '../openapi';
 import { etagMatches } from '../shared/http-cache';
 import type { AppEnv } from '../types';
-import { managedSkillOverlay, runtimeAssetsManifest, runtimeCliBinaryPath } from './manifest';
+import {
+  managedSkillOverlay,
+  runtimeAgentBinaryPath,
+  runtimeAssetsManifest,
+  runtimeCliBinaryPath,
+} from './manifest';
 
 export const runtimeAssetsApp = makeOpenApiApp<AppEnv>();
 
+const BinaryComponentSchema = z.object({
+  version: z.string().nullable(),
+  sha256: z.string(),
+  size: z.number().int(),
+  path: z.string(),
+});
+
 const ManifestSchema = z
   .object({
+    // v1 — load-bearing for daemons already in the field. Never remove one.
     cli_version: z.string().nullable(),
     cli_sha256: z.string().nullable(),
     cli_size: z.number().int().nullable(),
     managed_skills_hash: z.string(),
     managed_skills_count: z.number().int(),
+    // v2 — additive.
+    build: z.number().int(),
+    components: z.object({
+      agent: BinaryComponentSchema.optional(),
+      cli: BinaryComponentSchema.optional(),
+      opencode: z.object({ version: z.string(), source: z.literal('npm') }),
+      'managed-skills': z.object({ hash: z.string(), count: z.number().int() }),
+    }),
+    policy: z.object({ agent_self_update: z.boolean() }),
   })
   .openapi('RuntimeAssetsManifest');
 
@@ -71,10 +97,14 @@ runtimeAssetsApp.openapi(
     tags: ['runtime-assets'],
     summary: 'GET /runtime-assets/manifest — digests of this deploy\'s sandbox runtime assets',
     description:
-      'Identifies the `kortix` CLI binary and managed-skill overlay this API was built with. ' +
-      'A sandbox compares these digests against what it has on disk and downloads only on a ' +
-      'mismatch. `cli_sha256` is null when the API image carries no CLI binary; the caller ' +
-      'then skips the CLI half.',
+      'Identifies the `kortix-agent` daemon, `kortix` CLI binary, expected `opencode` version, ' +
+      'and managed-skill overlay this API was built with. A sandbox compares these digests ' +
+      'against what it has on disk and downloads only on a mismatch. The top-level `cli_*` and ' +
+      '`managed_skills_*` keys are the permanent v1 contract for daemons already in the field; ' +
+      '`build`, `components`, and `policy` are the additive v2 surface. `build` is monotonic per ' +
+      'deploy — a box refuses a manifest whose `build` is lower than the one it converged to, ' +
+      'so two concurrently-live API versions during a rolling deploy cannot make it oscillate. ' +
+      'A component is absent from `components` when this image carries no such binary.',
     ...auth,
     responses: {
       200: json(ManifestSchema, 'Runtime asset digests'),
@@ -90,40 +120,69 @@ runtimeAssetsApp.openapi(
   },
 );
 
-/**
- * Shared by GET and HEAD. HEAD is registered explicitly below because nothing in
- * the stack synthesizes it, and it is the only way to read `Content-Length`
- * without transferring ~100 MB — which is what both a size check and the ke2e
- * flow need.
- */
-async function serveCli(c: {
+type BinaryContext = {
   req: { header: (name: string) => string | undefined; method: string };
   header: (name: string, value: string) => void;
   json: (body: unknown, status: 404) => Response;
   body: (body: ReadableStream | null, status: 200 | 304) => Response;
-}): Promise<Response> {
+};
+
+/**
+ * Shared by GET and HEAD, and by both binary components. HEAD is registered
+ * explicitly below because nothing in the stack synthesizes it, and it is the
+ * only way to read `Content-Length` without transferring ~100 MB — which is what
+ * both a size check and the ke2e flow need.
+ *
+ * One implementation for `/cli` and `/agent` on purpose: they are the same
+ * contract (content-addressed ETag, conditional 304, streamed body, 404 when the
+ * image carries no such binary) and two copies would drift.
+ */
+async function serveBinary(
+  c: BinaryContext,
+  component: 'agent' | 'cli',
+  absentMessage: string,
+  headerPrefix: string,
+  binaryPath: () => string,
+): Promise<Response> {
   const manifest = await runtimeAssetsManifest();
-  if (!manifest.cli_sha256 || manifest.cli_size === null) {
-    return c.json(
-      { error: true, message: 'This deploy carries no sandbox CLI binary', status: 404 },
-      404,
-    );
+  const asset = manifest.components[component];
+  if (!asset) {
+    return c.json({ error: true, message: absentMessage, status: 404 }, 404);
   }
-  const etag = `"${manifest.cli_sha256}"`;
+  const etag = `"${asset.sha256}"`;
   c.header('ETag', etag);
   c.header('Cache-Control', 'no-cache');
   if (etagMatches(c.req.header('If-None-Match'), etag)) return c.body(null, 304);
   c.header('Content-Type', 'application/octet-stream');
-  c.header('Content-Length', String(manifest.cli_size));
-  c.header('X-Kortix-Cli-Sha256', manifest.cli_sha256);
-  if (manifest.cli_version) c.header('X-Kortix-Cli-Version', manifest.cli_version);
+  c.header('Content-Length', String(asset.size));
+  c.header(`${headerPrefix}-Sha256`, asset.sha256);
+  if (asset.version) c.header(`${headerPrefix}-Version`, asset.version);
   if (c.req.method === 'HEAD') return c.body(null, 200);
   // Streamed, not read into memory: this is ~100 MB and several sandboxes can
   // converge at once after a deploy.
-  return c.body(Bun.file(runtimeCliBinaryPath()).stream(), 200);
+  return c.body(Bun.file(binaryPath()).stream(), 200);
 }
 
+const serveCli = (c: BinaryContext) =>
+  serveBinary(
+    c,
+    'cli',
+    'This deploy carries no sandbox CLI binary',
+    'X-Kortix-Cli',
+    runtimeCliBinaryPath,
+  );
+
+const serveAgent = (c: BinaryContext) =>
+  serveBinary(
+    c,
+    'agent',
+    'This deploy carries no sandbox agent binary',
+    'X-Kortix-Agent',
+    runtimeAgentBinaryPath,
+  );
+
 runtimeAssetsApp.on('HEAD', '/cli', (c) => serveCli(c as never));
+runtimeAssetsApp.on('HEAD', '/agent', (c) => serveAgent(c as never));
 
 runtimeAssetsApp.openapi(
   createRoute({
@@ -146,6 +205,31 @@ runtimeAssetsApp.openapi(
     },
   }),
   (c) => serveCli(c as never) as never,
+);
+
+runtimeAssetsApp.openapi(
+  createRoute({
+    method: 'get',
+    path: '/agent',
+    tags: ['runtime-assets'],
+    summary: 'GET /runtime-assets/agent — the `kortix-agent` daemon this deploy bakes into sandboxes',
+    description:
+      'Streams the Linux daemon binary from the API image. `ETag` is its sha256 (the manifest\'s ' +
+      '`components.agent.sha256`); send `If-None-Match` to get a 304 instead of the body. 404 ' +
+      'when the image carries no agent binary, in which case `components.agent` is absent from ' +
+      'the manifest and the caller skips the agent half. The daemon never overwrites its own ' +
+      'running binary — it stages the download and its supervisor performs the swap.',
+    ...auth,
+    responses: {
+      200: {
+        description: 'The compiled kortix-agent daemon',
+        content: { 'application/octet-stream': { schema: z.string() } },
+      },
+      304: { description: 'Not modified' },
+      ...errors(401, 404),
+    },
+  }),
+  (c) => serveAgent(c as never) as never,
 );
 
 runtimeAssetsApp.openapi(

--- a/apps/api/src/runtime-assets/manifest.ts
+++ b/apps/api/src/runtime-assets/manifest.ts
@@ -9,15 +9,22 @@
  * release, no separate artifact store, and CLI↔API consistency by construction:
  * whatever a sandbox converges on is by definition the build that serves it.
  *
- * Both digests are computed once and memoized. Neither input can change for the
- * lifetime of a process: the binary is baked into an immutable image layer, and
- * the templates are a compiled-in package.
+ * The same image also carries the compiled `kortix-agent` daemon
+ * (apps/api/Dockerfile:234), so the manifest describes that too and a box can
+ * converge the daemon itself — not only what the daemon manages.
+ *
+ * All digests are computed once and memoized. No input can change for the
+ * lifetime of a process: the binaries are baked into immutable image layers, and
+ * the templates are a compiled-in package. The one exception is `policy`, which
+ * is read live from the env on every call so a kill switch never waits on a
+ * deploy — see agentSelfUpdateEnabled().
  */
 
 import { stat } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildFileSha256 } from '@kortix/shared/sandbox-runtime-artifact';
+import { OPENCODE_VERSION } from '@kortix/shared/runtime-versions';
 import {
   managedSkillOverlayFiles,
   managedSkillOverlayHash,
@@ -39,11 +46,151 @@ export function runtimeCliBinaryPath(): string {
   );
 }
 
+/**
+ * The `kortix-agent` daemon binary, resolved exactly like the CLI above and
+ * through the SAME env override the snapshot builder already uses
+ * (`KORTIX_SNAPSHOT_AGENT_BIN_PATH`, snapshots/build-context.ts:55). The
+ * deployed API image carries it: apps/api/Dockerfile:234 copies
+ * `/agent/dist/kortix-agent` out of the `sandbox-agent` stage into
+ * `apps/kortix-sandbox-agent-server/dist/kortix-agent`. So the daemon a box
+ * converges to is by construction the daemon the API serving it was built with.
+ */
+export function runtimeAgentBinaryPath(): string {
+  return (
+    process.env.KORTIX_SNAPSHOT_AGENT_BIN_PATH ||
+    resolve(REPO_ROOT, 'apps/kortix-sandbox-agent-server/dist/kortix-agent')
+  );
+}
+
 /** Sidecar written by apps/cli/scripts/build.sh naming the version it stamped. */
 function runtimeCliVersionPath(): string {
   return `${runtimeCliBinaryPath()}.version`;
 }
 
+/**
+ * The version stamped into THIS image, as the agent's version string.
+ *
+ * apps/kortix-sandbox-agent-server/scripts/build.sh writes no `.version`
+ * sidecar (unlike apps/cli/scripts/build.sh), so there is nothing to read off
+ * disk. The next best true statement is the image's own stamp: the agent binary
+ * in this image was compiled from the same source tree as the API serving it,
+ * in the same `docker build`. Format matches what the CLI stage stamps
+ * (`<version>+<commit8>`, apps/api/Dockerfile:86) so the two components read
+ * alike.
+ *
+ * Null — never fabricated — when the image carries no stamp (a local checkout).
+ * Informational only: every reconcile decision is made on `sha256`, because a
+ * version string cannot prove which bytes are on disk.
+ */
+function runtimeAgentVersion(): string | null {
+  const version = process.env.KORTIX_VERSION?.trim();
+  if (!version) return null;
+  const commit = (process.env.KORTIX_COMMIT || 'unknown').trim().slice(0, 8);
+  return `${version}+${commit}`;
+}
+
+/**
+ * Is a box allowed to converge its own daemon?
+ *
+ * OPERATOR RUNBOOK — flipping this needs no code deploy and no new image:
+ *   • ECS (dev/prod): update the `RUNTIME_AGENT_SELF_UPDATE` env var on the
+ *     kortix-api task definition to `false` and roll the service. New tasks
+ *     serve `policy.agent_self_update: false` on their next manifest read.
+ *   • k8s: `kubectl set env deploy/kortix-api RUNTIME_AGENT_SELF_UPDATE=false`.
+ *   • self-host / local: set it in the API's env before boot.
+ * Anything other than a literal `false`/`0` (case-insensitive) leaves it on, so
+ * a typo fails SAFE — towards the documented default, not towards a silent
+ * fleet-wide freeze nobody notices.
+ *
+ * Read per call rather than memoized: it costs nothing, and it must never be
+ * the thing that makes a kill switch take one extra deploy to land.
+ */
+function agentSelfUpdateEnabled(): boolean {
+  const raw = process.env.RUNTIME_AGENT_SELF_UPDATE?.trim().toLowerCase();
+  return !(raw === 'false' || raw === '0');
+}
+
+/**
+ * The monotonic build number a box uses to refuse going backwards.
+ *
+ * WHY THIS IS NOT A TIMESTAMP TAKEN AT REQUEST TIME. A box records the highest
+ * `build` it converged to and ignores anything lower. A per-request `Date.now()`
+ * would be different on every read and identical across two concurrently-live
+ * API versions, which defeats the guard entirely.
+ *
+ * WHAT WE ACTUALLY HAVE. Nothing in the deployed image is a purpose-built
+ * monotonic counter — stated plainly rather than implied:
+ *   • `KORTIX_VERSION` is `X.Y.Z-dev.<sha8>` on dev. The sha does not order.
+ *   • `KORTIX_COMMIT` is a sha. It does not order either.
+ *   • Process start time is NOT stable per deploy: every replica boots at a
+ *     different instant, and a restarted OLD pod would out-rank a NEW one.
+ * The best available source is the mtime of a binary baked into the image
+ * layer. apps/api/Dockerfile:280 `touch`es the agent binary as the last step of
+ * the runner stage, so its mtime IS the image build time; it is stored in the
+ * layer, so every replica of one image reports the identical value; and a later
+ * build necessarily has a later mtime. We take the max of the agent and CLI
+ * binaries so a missing one degrades instead of regressing.
+ *
+ * DOCUMENTED LIMITATIONS.
+ *   1. Monotonic only because images are built in chronological order. A
+ *      deliberate rollback re-deploys an OLDER image with a LOWER build, and
+ *      boxes will correctly refuse to converge backwards to it. The remedy is
+ *      `RUNTIME_ASSETS_BUILD` (below) or `RUNTIME_AGENT_SELF_UPDATE=false`.
+ *   2. A build backend that normalizes layer timestamps (SOURCE_DATE_EPOCH,
+ *      buildkit `rewrite-timestamp`) would flatten this to 0. Nothing in
+ *      .github/workflows sets either today. `0` degrades safely: it never
+ *      exceeds a recorded build, so a box simply stops treating it as newer.
+ *   3. Multi-arch builds produce one image per arch with mtimes seconds apart.
+ *      dev and prod build `linux/amd64` only (deploy-dev.yml:367,609).
+ *
+ * `RUNTIME_ASSETS_BUILD` overrides it with an explicit integer, which is the
+ * escape hatch for limitation 1: set it above the highest value already served
+ * and a rolled-back image out-ranks the build it is replacing.
+ */
+function buildIdOverride(): number | null {
+  const raw = process.env.RUNTIME_ASSETS_BUILD?.trim();
+  if (!raw) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+/** One downloadable binary this deploy serves. */
+export interface RuntimeBinaryComponent {
+  /** Informational. Null when the build stamped nothing; never fabricated. */
+  version: string | null;
+  sha256: string;
+  size: number;
+  /** Where to GET it, relative to the API root the box already talks to. */
+  path: string;
+}
+
+export interface RuntimeComponents {
+  /** Absent when the API image carries no agent binary — the box then skips it. */
+  agent?: RuntimeBinaryComponent;
+  /** Absent when the API image carries no CLI binary. Mirrors the v1 `cli_*` keys. */
+  cli?: RuntimeBinaryComponent;
+  /** Fetched from npm by the daemon, not proxied: 167 MB has no business crossing our control plane. */
+  opencode: { version: string; source: 'npm' };
+  'managed-skills': { hash: string; count: number };
+}
+
+export interface RuntimeAssetsPolicy {
+  /** Kill switch. False stops daemon self-update fleet-wide without shipping a daemon. */
+  agent_self_update: boolean;
+}
+
+/**
+ * V1 KEYS ARE PERMANENT. Daemons already running in the field read
+ * `cli_version` / `cli_sha256` / `cli_size` / `managed_skills_hash` /
+ * `managed_skills_count` off this document (see
+ * apps/kortix-sandbox-agent-server/src/runtime-assets.ts). Removing or renaming
+ * one breaks every box that already exists — the same failure class as the
+ * accept-encoding two-list divergence. New daemons prefer `components`; old
+ * daemons keep working because their keys are still here. `runtime-assets/
+ * __tests__/manifest.test.ts` guards this so a future refactor cannot quietly
+ * drop one.
+ */
 export interface RuntimeAssetsManifest {
   /**
    * The version string compiled INTO the binary, or null when the build wrote no
@@ -57,9 +204,22 @@ export interface RuntimeAssetsManifest {
   cli_size: number | null;
   managed_skills_hash: string;
   managed_skills_count: number;
+
+  // ── v2, additive ──────────────────────────────────────────────────────────
+  /** Monotonic per deploy. See buildIdOverride() for the derivation and its limits. */
+  build: number;
+  components: RuntimeComponents;
+  policy: RuntimeAssetsPolicy;
 }
 
-let manifestPromise: Promise<RuntimeAssetsManifest> | null = null;
+/**
+ * Everything in the manifest that costs a hash or a stat. Memoized; the inputs
+ * cannot change for the lifetime of a process (immutable image layers).
+ * `policy` is deliberately NOT in here — see agentSelfUpdateEnabled().
+ */
+type RuntimeAssetsDigests = Omit<RuntimeAssetsManifest, 'policy'>;
+
+let manifestPromise: Promise<RuntimeAssetsDigests> | null = null;
 let overlayCache: { files: ManagedSkillOverlayFile[]; hash: string } | null = null;
 
 export function managedSkillOverlay(): { files: ManagedSkillOverlayFile[]; hash: string } {
@@ -70,35 +230,85 @@ export function managedSkillOverlay(): { files: ManagedSkillOverlayFile[]; hash:
   return overlayCache;
 }
 
-async function computeManifest(): Promise<RuntimeAssetsManifest> {
-  const overlay = managedSkillOverlay();
-  const binaryPath = runtimeCliBinaryPath();
-  let cli: { sha256: string; size: number } | null = null;
+/**
+ * Digest + size + mtime of one baked binary, or null when the image carries
+ * none. An absent binary is a legitimate state — a `bun run dev` checkout that
+ * never compiled it. Report null and let the box skip that one component rather
+ * than fail the whole manifest and take the other components down with it.
+ */
+async function measureBinary(
+  path: string,
+): Promise<{ sha256: string; size: number; mtimeMs: number } | null> {
   try {
-    const stats = await stat(binaryPath);
-    if (stats.isFile() && stats.size > 0) {
-      cli = { sha256: await buildFileSha256(binaryPath), size: stats.size };
-    }
+    const stats = await stat(path);
+    if (!stats.isFile() || stats.size === 0) return null;
+    return {
+      sha256: await buildFileSha256(path),
+      size: stats.size,
+      mtimeMs: stats.mtimeMs,
+    };
   } catch {
-    // Absent binary is a legitimate state — a `bun run dev` checkout that never
-    // built the CLI. Report null and let the sandbox skip the CLI half rather
-    // than fail the whole manifest and take the skill half down with it.
-    cli = null;
+    return null;
   }
+}
+
+async function computeManifest(): Promise<RuntimeAssetsDigests> {
+  const overlay = managedSkillOverlay();
+  // Both binaries are hashed here, once per process, concurrently. Hashing
+  // ~95 MB + ~104 MB per request is not acceptable; this is the whole reason
+  // the memo below stores the promise rather than the value.
+  const [cli, agent] = await Promise.all([
+    measureBinary(runtimeCliBinaryPath()),
+    measureBinary(runtimeAgentBinaryPath()),
+  ]);
   let version: string | null = null;
   if (cli) {
     version = (await Bun.file(runtimeCliVersionPath()).text().catch(() => '')).trim() || null;
   }
+
+  const mtimes = [agent?.mtimeMs, cli?.mtimeMs].filter(
+    (value): value is number => typeof value === 'number' && Number.isFinite(value),
+  );
+  const build =
+    buildIdOverride() ??
+    (mtimes.length > 0 ? Math.floor(Math.max(...mtimes) / 1000) : 0);
+
+  const components: RuntimeComponents = {
+    opencode: { version: OPENCODE_VERSION, source: 'npm' },
+    'managed-skills': { hash: overlay.hash, count: overlay.files.length },
+  };
+  if (agent) {
+    components.agent = {
+      version: runtimeAgentVersion(),
+      sha256: agent.sha256,
+      size: agent.size,
+      path: '/v1/runtime-assets/agent',
+    };
+  }
+  if (cli) {
+    // Deliberately the SAME values as the v1 `cli_*` keys above — one
+    // measurement, two spellings. A v1 daemon and a v2 daemon must never
+    // converge on different bytes.
+    components.cli = {
+      version,
+      sha256: cli.sha256,
+      size: cli.size,
+      path: '/v1/runtime-assets/cli',
+    };
+  }
+
   return {
     cli_version: version,
     cli_sha256: cli?.sha256 ?? null,
     cli_size: cli?.size ?? null,
     managed_skills_hash: overlay.hash,
     managed_skills_count: overlay.files.length,
+    build,
+    components,
   };
 }
 
-export function runtimeAssetsManifest(): Promise<RuntimeAssetsManifest> {
+function runtimeAssetsDigests(): Promise<RuntimeAssetsDigests> {
   if (!manifestPromise) {
     // Store the promise, not the value: two concurrent first requests must not
     // both hash a 100 MB binary.
@@ -108,6 +318,13 @@ export function runtimeAssetsManifest(): Promise<RuntimeAssetsManifest> {
     });
   }
   return manifestPromise;
+}
+
+export async function runtimeAssetsManifest(): Promise<RuntimeAssetsManifest> {
+  // Assembled per call so `policy` is read live: the kill switch must never
+  // cost an extra deploy. Everything expensive comes from the memo, so the
+  // marginal cost of a call is one object spread.
+  return { ...(await runtimeAssetsDigests()), policy: { agent_self_update: agentSelfUpdateEnabled() } };
 }
 
 /** Test-only: drop both memos so a case can recompute against a mutated fixture. */

--- a/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
 import { mkdtempSync, writeFileSync } from 'node:fs'
-import { mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -365,7 +365,15 @@ describe('agent convergence — stage only', () => {
     const result = await run(ws, stub)
 
     expect(result.agent).toBe('staged')
-    expect(stub.calls.some((url) => url.startsWith('https://evil.test'))).toBe(false)
+    // Assert the POSITIVE — every fetch stayed on this API's origin. The
+    // negative form (`no url starts with https://evil.test`) still passes for
+    // `https://evil.test.attacker.com`, which is precisely the incomplete
+    // substring sanitization this test exists to rule out. Comparing parsed
+    // origins cannot be fooled that way.
+    const apiOrigin = new URL(API_URL).origin
+    for (const url of stub.calls) {
+      expect(new URL(url).origin).toBe(apiOrigin)
+    }
     expect(stub.calls).toContain(`${API_URL}/v1/runtime-assets/agent`)
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
@@ -1,0 +1,868 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  AGENT_SWAP_EXIT_CODE,
+  reconcileRuntimeAssets,
+  refreshOpencodePluginPin,
+  registerAgentSwapBlocker,
+  requestAgentSwapIfIdle,
+  resetAgentSwapBlockersForTests,
+  resetRuntimeConvergenceForTests,
+  noteRuntimeConvergence,
+  runtimeConvergenceReport,
+  resetRuntimeConvergenceReportForTests,
+  overlayHash,
+} from '../runtime-assets'
+
+/**
+ * Convergent runtime — the v2 half of `reconcileRuntimeAssets`.
+ *
+ * Everything here is a way the mechanism could break a box: a manifest that
+ * moves backwards, an artifact that does not match its digest, a swap requested
+ * while a turn is running, an opencode binary installed without its matching
+ * plugin. The v1 half stays covered by runtime-assets.test.ts, and the "a v1
+ * manifest still converges the CLI" case below is the compatibility contract
+ * for daemons that talk to an API which has not shipped v2 yet.
+ */
+
+const API_URL = 'https://api.test.invalid'
+const TOKEN = 'kortix_pat_test'
+
+const dirs: string[] = []
+
+async function workspace() {
+  const dir = await mkdtemp(join(tmpdir(), 'runtime-convergence-'))
+  dirs.push(dir)
+  return {
+    root: dir,
+    cliPath: join(dir, 'bin', 'kortix'),
+    agentBakedPath: join(dir, 'usr', 'kortix-agent'),
+    stateDir: join(dir, 'state'),
+    agentNext: join(dir, 'state', 'agent.next'),
+    agentNextSha: join(dir, 'state', 'agent.next.sha256'),
+    agentCurrent: join(dir, 'state', 'agent.current'),
+    agentPinned: join(dir, 'state', 'agent.pinned'),
+    skillsDir: join(dir, 'opt', 'managed-skills'),
+    statePath: join(dir, 'state', 'runtime-assets-state.json'),
+    depsDir: join(dir, 'opencode-config-deps'),
+  }
+}
+
+afterEach(async () => {
+  resetAgentSwapBlockersForTests()
+  resetRuntimeConvergenceForTests()
+  while (dirs.length > 0) await rm(dirs.pop() as string, { recursive: true, force: true })
+})
+
+const sha = (s: string) => createHash('sha256').update(s).digest('hex')
+
+const SKILL_FILES = [{ path: 'kortix-system/SKILL.md', content: 'body\n' }]
+const SKILLS_HASH = overlayHash(SKILL_FILES)
+
+const CLI_BYTES = 'CLI-BYTES'
+const AGENT_BYTES = 'AGENT-BYTES-v2'
+
+interface ManifestOptions {
+  build?: number
+  agentSha?: string
+  agentPath?: string
+  agentSelfUpdate?: boolean
+  opencodeVersion?: string
+  /** Emit a v1-only document — no `components`, no `build`, no `policy`. */
+  v1Only?: boolean
+}
+
+function buildManifest(opts: ManifestOptions = {}): Record<string, unknown> {
+  const v1 = {
+    cli_version: '0.13.1-dev.abc1234',
+    cli_sha256: sha(CLI_BYTES),
+    cli_size: CLI_BYTES.length,
+    managed_skills_hash: SKILLS_HASH,
+  }
+  if (opts.v1Only) return v1
+  return {
+    ...v1,
+    build: opts.build ?? 1_755_700_000,
+    components: {
+      agent: {
+        version: '0.13.1-dev.abc1234',
+        sha256: opts.agentSha ?? sha(AGENT_BYTES),
+        size: AGENT_BYTES.length,
+        path: opts.agentPath ?? '/v1/runtime-assets/agent',
+      },
+      cli: { version: '0.13.1-dev.abc1234', sha256: sha(CLI_BYTES), size: CLI_BYTES.length },
+      opencode: { version: opts.opencodeVersion ?? '1.18.19', source: 'npm' },
+      'managed-skills': { hash: SKILLS_HASH, count: SKILL_FILES.length },
+    },
+    policy: { agent_self_update: opts.agentSelfUpdate ?? true },
+  }
+}
+
+function stubFetch(opts: ManifestOptions & { agentBody?: string; agentStatus?: number } = {}) {
+  const calls: string[] = []
+  const impl = (async (input: string | URL | Request) => {
+    const url = String(input)
+    calls.push(url)
+    if (url.endsWith('/runtime-assets/manifest')) return Response.json(buildManifest(opts))
+    if (url.endsWith('/runtime-assets/cli')) return new Response(CLI_BYTES)
+    if (url.endsWith('/runtime-assets/agent')) {
+      if (opts.agentStatus && opts.agentStatus !== 200) {
+        return new Response('nope', { status: opts.agentStatus })
+      }
+      return new Response(opts.agentBody ?? AGENT_BYTES)
+    }
+    if (url.endsWith('/runtime-assets/managed-skills')) {
+      return Response.json({ hash: SKILLS_HASH, files: SKILL_FILES })
+    }
+    return new Response('unexpected', { status: 500 })
+  }) as unknown as typeof fetch
+  return { impl, calls }
+}
+
+async function run(
+  ws: Awaited<ReturnType<typeof workspace>>,
+  stub: ReturnType<typeof stubFetch>,
+  extra: Record<string, unknown> = {},
+) {
+  return reconcileRuntimeAssets({
+    apiUrl: API_URL,
+    token: TOKEN,
+    cliPath: ws.cliPath,
+    managedSkillsDir: ws.skillsDir,
+    statePath: ws.statePath,
+    agentStateDir: ws.stateDir,
+    agentBakedPath: ws.agentBakedPath,
+    fetchImpl: stub.impl,
+    ...extra,
+  })
+}
+
+/** A seam whose opencode is reachable and idle unless a test says otherwise. */
+function opencodeSeam(restarts: string[] = []) {
+  return {
+    seam: {
+      opencodeBaseUrl: () => 'http://127.0.0.1:4096',
+      workspace: '/workspace',
+      restartOpencode: async () => {
+        restarts.push('restart')
+      },
+    },
+  }
+}
+
+describe('epoch guard', () => {
+  test('a manifest whose build is LOWER than the converged one is ignored', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, 'STALE-CLI')
+    await Bun.write(ws.statePath, JSON.stringify({ build: 200 }))
+    const stub = stubFetch({ build: 100 })
+
+    const result = await run(ws, stub)
+
+    expect(result.cli).toBe('skipped')
+    expect(result.skills).toBe('skipped')
+    expect(result.build).toBe(200)
+    expect(result.reason).toContain('older than converged build 200')
+    // Nothing beyond the manifest was even requested: the whole point is that a
+    // rolling deploy's older API cannot make this box re-download anything.
+    expect(stub.calls).toEqual([`${API_URL}/v1/runtime-assets/manifest`])
+    expect(await readFile(ws.cliPath, 'utf8')).toBe('STALE-CLI')
+  })
+
+  test('an EQUAL build is accepted — re-converging is idempotent, not a flap', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, 'STALE-CLI')
+    await Bun.write(ws.statePath, JSON.stringify({ build: 200 }))
+
+    const result = await run(ws, stubFetch({ build: 200 }))
+
+    expect(result.cli).toBe('updated')
+    expect(result.build).toBe(200)
+    expect(await readFile(ws.cliPath, 'utf8')).toBe(CLI_BYTES)
+  })
+
+  test('a higher build is converged and recorded as the new floor', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, 'STALE-CLI')
+    await Bun.write(ws.statePath, JSON.stringify({ build: 100 }))
+
+    const result = await run(ws, stubFetch({ build: 300 }))
+
+    expect(result.build).toBe(300)
+    const state = JSON.parse(await readFile(ws.statePath, 'utf8')) as { build?: number }
+    expect(state.build).toBe(300)
+  })
+})
+
+describe('agent convergence — stage only', () => {
+  test('a digest mismatch stages agent.next + .sha256, and swaps NOTHING', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    const stub = stubFetch()
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('staged')
+    expect(result.agentSwapPending).toBe(true)
+    expect(await readFile(ws.agentNext, 'utf8')).toBe(AGENT_BYTES)
+    expect((await readFile(ws.agentNextSha, 'utf8')).trim()).toBe(sha(AGENT_BYTES))
+    expect((await stat(ws.agentNext)).mode & 0o777).toBe(0o755)
+    // The running binary is untouched, and no `agent.current` was invented:
+    // installing is the supervisor's job, not ours.
+    expect(await readFile(ws.agentBakedPath, 'utf8')).toBe('AGENT-BYTES-v1')
+    expect(await stat(ws.agentCurrent).catch(() => null)).toBeNull()
+  })
+
+  test('a matching digest downloads nothing at all', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    const stub = stubFetch()
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('current')
+    expect(result.agentSwapPending).toBeUndefined()
+    expect(stub.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+  })
+
+  test('agent.current is what gets hashed once an update is installed', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    // The baked floor is an OLD build; the installed update is the new one.
+    // Hashing the floor here would re-stage the same ~96 MB on every start.
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    await Bun.write(ws.agentCurrent, AGENT_BYTES)
+    const stub = stubFetch()
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('current')
+    expect(stub.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+  })
+
+  test('a staged artifact that does not match its digest is REJECTED', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    // The manifest promises one digest; the body delivers different bytes.
+    const stub = stubFetch({ agentBody: 'TRUNCATED' })
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('failed')
+    expect(result.agentSwapPending).toBeUndefined()
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    expect(await stat(ws.agentNextSha).catch(() => null)).toBeNull()
+    expect(await readFile(ws.agentBakedPath, 'utf8')).toBe('AGENT-BYTES-v1')
+    // No temp file left behind in the state dir.
+    const left = await readdir(ws.stateDir)
+    expect(left.filter((e) => e.includes('download'))).toEqual([])
+  })
+
+  test('policy.agent_self_update:false stops the rollout before any download', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    const stub = stubFetch({ agentSelfUpdate: false })
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('skipped')
+    expect(result.reasons?.agent).toBe('policy.agent_self_update is false')
+    expect(stub.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    // The kill switch governs the agent ONLY — the CLI still converges.
+    expect(result.cli).toBe('current')
+  })
+
+  test('flipping the kill switch RETRACTS a build already staged', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    // The box staged the bad build before the switch was flipped. The
+    // supervisor knows nothing about policy, so if this is left on disk it
+    // installs at the next start and the kill switch stopped nothing.
+    await run(ws, stubFetch())
+    expect(await stat(ws.agentNext).catch(() => null)).not.toBeNull()
+
+    const result = await run(ws, stubFetch({ agentSelfUpdate: false }))
+
+    expect(result.agent).toBe('skipped')
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    expect(await stat(ws.agentNextSha).catch(() => null)).toBeNull()
+  })
+
+  test('a pinned box (rollback latched) never re-stages the build it rejected', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    await Bun.write(ws.agentPinned, '')
+    const stub = stubFetch()
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('skipped')
+    expect(result.reasons?.agent).toBe('updates pinned after a rollback')
+    expect(stub.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+  })
+
+  test('an artifact already staged is not downloaded a second time', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    await run(ws, stubFetch())
+
+    const second = stubFetch()
+    const result = await run(ws, second)
+
+    expect(result.agent).toBe('staged')
+    expect(result.agentSwapPending).toBe(true)
+    expect(second.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+  })
+
+  test('a staged artifact the API no longer advertises is discarded', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    // Running binary already matches, but a stale artifact sits staged. Left
+    // alone, the supervisor would install it at the next start.
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await Bun.write(ws.agentNext, 'AGENT-BYTES-v0')
+    await Bun.write(ws.agentNextSha, `${sha('AGENT-BYTES-v0')}\n`)
+
+    const result = await run(ws, stubFetch())
+
+    expect(result.agent).toBe('current')
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    expect(await stat(ws.agentNextSha).catch(() => null)).toBeNull()
+  })
+
+  test('an agent download that 500s leaves the box exactly as it was', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+
+    const result = await run(ws, stubFetch({ agentStatus: 500 }))
+
+    expect(result.agent).toBe('failed')
+    expect(result.reasons?.agent).toBe('agent download returned 500')
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    // The rest of the pass still converged.
+    expect(result.skills).toBe('updated')
+  })
+
+  test('a manifest path pointing off this API is refused; the built-in route is used', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    const stub = stubFetch({ agentPath: 'https://evil.test/agent' })
+
+    const result = await run(ws, stub)
+
+    expect(result.agent).toBe('staged')
+    expect(stub.calls.some((url) => url.startsWith('https://evil.test'))).toBe(false)
+    expect(stub.calls).toContain(`${API_URL}/v1/runtime-assets/agent`)
+  })
+})
+
+describe('opencode convergence — idle only', () => {
+  async function bakeDeps(ws: Awaited<ReturnType<typeof workspace>>, pin: string) {
+    await Bun.write(
+      join(ws.depsDir, 'package.json'),
+      `${JSON.stringify({ name: 'kortix-opencode-config', dependencies: { '@opencode-ai/plugin': pin, zod: '4.1.8' } }, null, 2)}\n`,
+    )
+  }
+
+  test('a version mismatch installs the exact version and refreshes the plugin pin', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.17.11')
+    const installs: string[] = []
+    const depsInstalls: string[] = []
+    const restarts: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(restarts),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.17.11',
+      turnProbe: async () => false,
+      installOpencode: async (version: string) => {
+        installs.push(version)
+      },
+      installPluginDeps: async (dir: string) => {
+        depsInstalls.push(dir)
+      },
+    })
+
+    expect(result.opencode).toBe('updated')
+    expect(installs).toEqual(['1.18.19'])
+    // Same step, always: a binary and a plugin that disagree is the stall this
+    // pairing exists to prevent.
+    const pkg = JSON.parse(await readFile(join(ws.depsDir, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies['@opencode-ai/plugin']).toBe('1.18.19')
+    expect(pkg.dependencies.zod).toBe('4.1.8')
+    expect(depsInstalls).toEqual([ws.depsDir])
+    expect(restarts).toEqual(['restart'])
+  })
+
+  test('a turn in flight defers everything — no install, no restart', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.17.11')
+    const installs: string[] = []
+    const restarts: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(restarts),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.17.11',
+      turnProbe: async () => true,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+      installPluginDeps: async () => {
+        throw new Error("a busy box must never install plugin deps")
+      },
+    })
+
+    expect(result.opencode).toBe('skipped')
+    expect(result.reasons?.opencode).toBe('a turn is in flight')
+    expect(installs).toEqual([])
+    expect(restarts).toEqual([])
+    const pkg = JSON.parse(await readFile(join(ws.depsDir, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies['@opencode-ai/plugin']).toBe('1.17.11')
+  })
+
+  test('UNREADABLE turn state counts as busy', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.17.11')
+    const installs: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.17.11',
+      turnProbe: async () => null,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+      installPluginDeps: async () => {
+        throw new Error("a busy box must never install plugin deps")
+      },
+    })
+
+    expect(result.opencode).toBe('skipped')
+    expect(result.reasons?.opencode).toBe('turn state unreadable')
+    expect(installs).toEqual([])
+  })
+
+  test('a matching binary AND pin is a no-op', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.18.19')
+    const installs: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.18.19',
+      turnProbe: async () => {
+        throw new Error('the turn probe must not be consulted for a no-op')
+      },
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+    })
+
+    expect(result.opencode).toBe('current')
+    expect(installs).toEqual([])
+  })
+
+  test('a pin that drifted from a matching binary is repaired without a restart', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.17.11')
+    const installs: string[] = []
+    const restarts: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(restarts),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.18.19',
+      turnProbe: async () => false,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+      installPluginDeps: async () => {},
+    })
+
+    expect(result.opencode).toBe('updated')
+    expect(installs).toEqual([])
+    // The plugin is read when opencode boots, so the refreshed pin takes effect
+    // on its own. Cutting a session short for it would buy nothing.
+    expect(restarts).toEqual([])
+  })
+
+  test('a malformed version from the manifest is refused, never executed', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    const installs: string[] = []
+
+    const result = await run(ws, stubFetch({ opencodeVersion: '1.18.19; rm -rf /' }), {
+      ...opencodeSeam(),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.17.11',
+      turnProbe: async () => false,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+    })
+
+    expect(result.opencode).toBe('skipped')
+    expect(result.reasons?.opencode).toBe('manifest opencode version is malformed')
+    expect(installs).toEqual([])
+  })
+
+  test('an unreadable opencode converges nothing', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    const installs: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => null,
+      turnProbe: async () => false,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+    })
+
+    expect(result.opencode).toBe('skipped')
+    expect(result.reasons?.opencode).toBe('opencode did not report its version')
+    expect(installs).toEqual([])
+  })
+
+  test('a failing install leaves the pin alone and never restarts', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    await bakeDeps(ws, '1.17.11')
+    const restarts: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(restarts),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => '1.17.11',
+      turnProbe: async () => false,
+      installOpencode: async () => {
+        throw new Error('npm registry unreachable')
+      },
+    })
+
+    expect(result.opencode).toBe('failed')
+    expect(restarts).toEqual([])
+    const pkg = JSON.parse(await readFile(join(ws.depsDir, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(pkg.dependencies['@opencode-ai/plugin']).toBe('1.17.11')
+    // The rest of the pass is unaffected — one failure never costs the others.
+    expect(result.cli).toBe('current')
+    expect(result.skills).toBe('updated')
+  })
+
+  test('no live runtime in this process → reported, not attempted', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+
+    const result = await run(ws, stubFetch())
+
+    expect(result.opencode).toBe('skipped')
+    expect(result.reasons?.opencode).toBe('no opencode runtime in this process')
+  })
+
+  test('refreshOpencodePluginPin reports an absent dependency dir instead of failing', async () => {
+    const ws = await workspace()
+    expect(await refreshOpencodePluginPin(ws.depsDir, '1.18.19')).toBe('absent')
+  })
+})
+
+describe('v1 compatibility', () => {
+  test('a v1-only manifest still converges the CLI and reports no v2 components', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, 'OLD-CLI')
+    await Bun.write(ws.agentBakedPath, 'AGENT-BYTES-v1')
+    const stub = stubFetch({ v1Only: true })
+
+    const result = await run(ws, stub)
+
+    expect(result.cli).toBe('updated')
+    expect(result.skills).toBe('updated')
+    expect(await readFile(ws.cliPath, 'utf8')).toBe(CLI_BYTES)
+    // An API that has never heard of `components` says nothing about the agent
+    // or opencode — which is different from saying "skip them".
+    expect(result.agent).toBeUndefined()
+    expect(result.opencode).toBeUndefined()
+    expect(result.build).toBeUndefined()
+    // And nothing was staged from a manifest that never described an agent.
+    expect(await stat(ws.agentNext).catch(() => null)).toBeNull()
+    expect(stub.calls.some((url) => url.endsWith('/runtime-assets/agent'))).toBe(false)
+  })
+
+  test('a v1 manifest is never blocked by a build recorded earlier', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, 'OLD-CLI')
+    await Bun.write(ws.statePath, JSON.stringify({ build: 900 }))
+
+    const result = await run(ws, stubFetch({ v1Only: true }))
+
+    expect(result.cli).toBe('updated')
+  })
+})
+
+describe('requestAgentSwapIfIdle', () => {
+  async function stage(ws: Awaited<ReturnType<typeof workspace>>) {
+    await Bun.write(ws.agentNext, AGENT_BYTES)
+    await Bun.write(ws.agentNextSha, `${sha(AGENT_BYTES)}\n`)
+  }
+
+  test('exits 75 when nothing is in flight', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('exited')
+    expect(exits).toEqual([AGENT_SWAP_EXIT_CODE])
+    expect(AGENT_SWAP_EXIT_CODE).toBe(75)
+  })
+
+  test('never exits across a live turn', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => true,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('turn-in-flight')
+    expect(exits).toEqual([])
+  })
+
+  test('unreadable turn state counts as busy', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => null,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('turn-state-unknown')
+    expect(exits).toEqual([])
+  })
+
+  test('a registered blocker (an open PTY) defers the swap', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+    registerAgentSwapBlocker('pty', () => true)
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('attached')
+    expect(exits).toEqual([])
+  })
+
+  test('a blocker that throws counts as busy', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+    registerAgentSwapBlocker('pty', () => {
+      throw new Error('registry unavailable')
+    })
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('attached')
+    expect(exits).toEqual([])
+  })
+
+  test('nothing staged → nothing requested', async () => {
+    const ws = await workspace()
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('nothing-staged')
+    expect(exits).toEqual([])
+  })
+
+  test('a digest side-car without its binary is not a staged update', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.agentNextSha, `${sha(AGENT_BYTES)}\n`)
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('nothing-staged')
+    expect(exits).toEqual([])
+  })
+
+  test('a pinned box does not ask for a restart it would waste', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    await Bun.write(ws.agentPinned, '')
+    const exits: number[] = []
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('pinned')
+    expect(exits).toEqual([])
+  })
+
+  test('an unconfigured daemon never exits on its own', async () => {
+    const ws = await workspace()
+    await stage(ws)
+
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 10 * 60_000,
+    })
+
+    expect(decision).toBe('not-configured')
+  })
+
+  test('a freshly booted daemon never restarts itself on the session-start path', async () => {
+    const ws = await workspace()
+    await stage(ws)
+    const exits: number[] = []
+
+    // The boot reconcile fires seconds after opencode is ready — the moment a
+    // user sends their first prompt and the frontend polls readiness. The
+    // supervisor promotes before every launch anyway, so waiting costs nothing.
+    const decision = await requestAgentSwapIfIdle({
+      agentStateDir: ws.stateDir,
+      uptimeMs: 20_000,
+      turnInFlight: async () => false,
+      exit: (code) => exits.push(code),
+    })
+
+    expect(decision).toBe('too-young')
+    expect(exits).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Observability. A box that self-heals silently is only marginally better than
+// one that never heals: you still cannot answer "is the fleet current?". These
+// pin the reporting contract /kortix/health exposes.
+// ---------------------------------------------------------------------------
+describe('runtime convergence report', () => {
+  beforeEach(() => {
+    resetRuntimeConvergenceReportForTests()
+  })
+
+  test('starts empty — a box that has never reconciled must not look converged', async () => {
+    const report = await runtimeConvergenceReport(mkdtempSync(join(tmpdir(), 'rcr-')))
+    expect(report.build).toBeNull()
+    expect(report.at).toBeNull()
+    expect(report.agentSwapPending).toBe(false)
+    expect(report.pinned).toBe(false)
+  })
+
+  test('records the epoch and per-component outcome of the last pass', async () => {
+    noteRuntimeConvergence({
+      cli: 'current',
+      skills: 'current',
+      agent: 'staged',
+      opencode: 'updated',
+      build: 1787241641,
+      agentSwapPending: true,
+    })
+    const report = await runtimeConvergenceReport(mkdtempSync(join(tmpdir(), 'rcr-')))
+    expect(report.build).toBe(1787241641)
+    expect(report.components).toEqual({
+      cli: 'current',
+      skills: 'current',
+      agent: 'staged',
+      opencode: 'updated',
+    })
+    expect(report.agentSwapPending).toBe(true)
+    expect(typeof report.at).toBe('string')
+  })
+
+  test('omits agent/opencode for a v1 manifest instead of claiming they were skipped', async () => {
+    noteRuntimeConvergence({ cli: 'current', skills: 'current' })
+    const report = await runtimeConvergenceReport(mkdtempSync(join(tmpdir(), 'rcr-')))
+    expect(report.components).toEqual({ cli: 'current', skills: 'current' })
+    expect(report.build).toBeNull()
+  })
+
+  test('reads the rollback latch from DISK, not from the last pass', async () => {
+    // The SUPERVISOR writes agent.pinned between daemon runs, so a value cached
+    // at reconcile time is stale exactly when someone is looking: the first
+    // health check after a rollback.
+    const dir = mkdtempSync(join(tmpdir(), 'rcr-'))
+    noteRuntimeConvergence({ cli: 'current', skills: 'current', build: 7 })
+    expect((await runtimeConvergenceReport(dir)).pinned).toBe(false)
+    writeFileSync(join(dir, 'agent.pinned'), '')
+    expect((await runtimeConvergenceReport(dir)).pinned).toBe(true)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -39,7 +39,7 @@ import { ensureInjectedManagedSkills } from './injected-skills'
 // `startSessionRuntime` — so every way a session comes up reconciles once.
 // Strictly AFTER `bootMark('opencode-ready')` and never awaited: it adds zero
 // milliseconds to the readiness the API and the frontend poll for.
-import { scheduleRuntimeAssetsReconcile } from './runtime-assets'
+import { configureRuntimeConvergence, scheduleRuntimeAssetsReconcile } from './runtime-assets'
 import { isSharedSeedBakedRoot, OPENCODE_SEED_BAKED_PIN_PATH } from './opencode-fork-root'
 import { startOpencodeEventLoop, flattenOpencodeError, type QuestionRequest, type OpencodeTurnError } from './opencode-events'
 import { auditRelayToken, createAuditRelay } from './opencode-audit-relay'
@@ -205,7 +205,26 @@ async function main() {
     },
   })
   const server = startProxy(cfg, opencode, bootTime, bootState, projectEnv, staticWeb.port)
-  installShutdownHandlers(opencode, server, staticWeb)
+  const shutdown = installShutdownHandlers(opencode, server, staticWeb)
+  // Hand the convergence machinery this session's live runtime, once.
+  //
+  // Two things need it. opencode convergence restarts opencode, so it goes
+  // through the supervisor that owns spawn/respawn/dispose — never behind its
+  // back. And a staged daemon update exits `75` through the SAME clean shutdown
+  // a SIGTERM takes: opencode is a child of this process, so a bare
+  // `process.exit` would leave the relaunched daemon fighting an orphan for the
+  // opencode port.
+  configureRuntimeConvergence({
+    seam: {
+      // Re-read per pass: a verified reload promotes the replacement on the
+      // other half of the port pair, so the live URL moves.
+      opencodeBaseUrl: () => opencode.getInternalUrl(),
+      workspace: cfg.workspace,
+      restartOpencode: () => opencode.restart(),
+    },
+    turnInFlight: () => opencodeTurnInFlight(opencode.getInternalUrl(), cfg.workspace),
+    exit: (code) => shutdown({ reason: 'agent-swap', exitCode: code }),
+  })
   bootMark('proxy-up')
 
   // Learn the CURRENT managed lineup from the gateway this session bills

--- a/apps/kortix-sandbox-agent-server/src/opencode-config-deps.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-config-deps.ts
@@ -24,7 +24,8 @@ const execFileAsync = promisify(execFile)
  * Produced by the snapshot Dockerfile (see `dockerfile-layer.ts`) so we can
  * satisfy the config dir's node_modules at boot with zero network work.
  */
-const BAKED_DEPS_DIR = '/opt/kortix/opencode-config-deps'
+export const OPENCODE_CONFIG_DEPS_DIR = '/opt/kortix/opencode-config-deps'
+const BAKED_DEPS_DIR = OPENCODE_CONFIG_DEPS_DIR
 const BUN_CACHE_DIR = `${OPENCODE_HOME}/.bun/install/cache`
 const LOCAL_TOOL_ABI = 1
 const INSTALL_SENTINEL_VERSION = 1

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -17,6 +17,7 @@ import { createFindRouter } from './routes/find'
 import { createPresentationRouter } from './routes/presentation'
 import { createWebProxyRouter } from './routes/web-proxy'
 import { createPtyRegistry, createPtyRouter, type PtyAttachHandle, type PtyRegistry } from './routes/pty'
+import { registerAgentSwapBlocker } from './runtime-assets'
 import type { ProjectEnvStore } from './project-env'
 import {
   KORTIX_USER_CONTEXT_HEADER,
@@ -410,6 +411,14 @@ export function startProxy(
   // Constructed once, outside reload() — pty state must survive a config
   // hot-swap (warm-snapshot restore) exactly like `opencode`/`bootState` do.
   const ptyRegistry = createPtyRegistry(cfg)
+  // A staged daemon update must not exit this process while somebody has a
+  // terminal open — the PTY dies with the daemon that spawned it. The registry
+  // is the only thing that knows, so it answers the question rather than the
+  // updater guessing at it. A busy box just keeps the staging: the supervisor
+  // installs it at the next start.
+  registerAgentSwapBlocker('pty', () =>
+    ptyRegistry.list().some((entry) => entry.status === 'running'),
+  )
   let app = buildOpencodeApp(cfg, opencode, bootTime, bootState, projectEnv, staticWebPort, ptyRegistry)
 
   const server = Bun.serve<OpencodeWsData>({

--- a/apps/kortix-sandbox-agent-server/src/routes/health.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/health.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 
 import type { Config } from '../config'
 import { readRepoInfo } from '../git'
+import { runtimeConvergenceReport } from '../runtime-assets'
 import type { Opencode } from '../opencode'
 import {
   type OpencodeDeliveryObservation,
@@ -225,6 +226,13 @@ export function createHealthRouter(
       // the newest commit and still be running config compiled days ago. Read
       // from the live process env, so it tracks a hot push as well as a boot.
       agent_config_etag: process.env.KORTIX_COMPILED_AGENT_CONFIG_ETAG || null,
+      // What this box last converged its own runtime to. Auto-update without
+      // reporting only moves the uncertainty — this makes "is the fleet
+      // current?" a query instead of a hope, and it is the signal that tells us
+      // a fleet-drain gate has actually cleared. `pinned: true` means an update
+      // crash-looped and the supervisor latched it off: that box will not
+      // self-heal and needs a human.
+      runtime: await runtimeConvergenceReport(),
       // Opt-in (`?turn=1`) because it costs a call into opencode, and health is
       // polled as a liveness check every few seconds on every idle box. Two
       // callers ask: the reload gate, which must not restart the runtime out

--- a/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import {
   chmod,
@@ -10,9 +11,14 @@ import {
   writeFile,
 } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
 import { resolveOpencodeConfigDir, type Config } from './config'
 import { ensureInjectedManagedSkills } from './injected-skills'
 import { logger } from './logger'
+import { OPENCODE_CONFIG_DEPS_DIR } from './opencode-config-deps'
+import { opencodeTurnInFlight } from './opencode-turn-state'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * Converge this sandbox's runtime assets on the API it talks to.
@@ -44,16 +50,93 @@ const DEFAULT_MANAGED_SKILLS_DIR = '/opt/kortix/managed-skills'
 /** Digest bookkeeping, so a converged box never re-hashes a 100 MB binary. */
 const DEFAULT_STATE_PATH = '/opt/kortix/runtime-assets-state.json'
 
+/**
+ * The image-baked daemon — an IMMUTABLE FLOOR, not an update target.
+ *
+ * It is root-owned and the daemon runs as `kortix` after the entrypoint's
+ * privilege drop, so there is no write path to it from runtime code at all.
+ * That is deliberate: it is what makes a bricked box impossible rather than
+ * merely unlikely. Updates install BESIDE it, in the kortix-owned state dir
+ * below, and the supervisor prefers `agent.current` when one is present.
+ */
+const DEFAULT_AGENT_BAKED_PATH = '/usr/local/bin/kortix-agent'
+/**
+ * kortix-owned state dir. Holds this module's digest cache plus the four files
+ * the supervisor owns: `agent.current` (the installed update), `agent.next`
+ * (what THIS module stages), `agent.prev` (rollback target) and `agent.pinned`
+ * (the rollback latch). Only `agent.next` + `agent.next.sha256` are ever
+ * written here by the daemon. See apps/sandbox/entrypoint.sh.
+ */
+const DEFAULT_AGENT_STATE_DIR = '/opt/kortix'
+
+/**
+ * `EX_TEMPFAIL` — the daemon's way of saying "replace me and start me again".
+ *
+ * The supervisor must be able to tell a requested swap from a crash: exit 75 is
+ * intentional, every other non-zero exit counts against the failure budget that
+ * triggers rollback. Keep this in lockstep with `SWAP_CODE` in
+ * apps/sandbox/entrypoint.sh.
+ */
+export const AGENT_SWAP_EXIT_CODE = 75
+
 const MANIFEST_TIMEOUT_MS = 15_000
 const DOWNLOAD_TIMEOUT_MS = 180_000
+/** opencode is ~167 MB from npm and installs on a 1-2 vCPU box. */
+const OPENCODE_INSTALL_TIMEOUT_MS = 600_000
+const OPENCODE_HEALTH_TIMEOUT_MS = 5_000
 
-export type ReconcileOutcome = 'skipped' | 'current' | 'updated' | 'failed'
+/**
+ * `staged` is agent-only: the bytes are verified and on disk, and the swap
+ * happens in the supervisor at the next start — nothing has been replaced yet.
+ */
+export type ReconcileOutcome = 'skipped' | 'current' | 'updated' | 'failed' | 'staged'
+
+/** The components a v2 manifest can describe. */
+export type RuntimeComponent = 'cli' | 'skills' | 'agent' | 'opencode'
 
 export interface RuntimeAssetsResult {
   cli: ReconcileOutcome
   skills: ReconcileOutcome
-  /** Why, when either half is `skipped` or `failed`. Logged, never thrown. */
+  /**
+   * Agent and opencode are OMITTED for a v1 manifest rather than reported as
+   * `skipped`. A manifest that predates `components` says nothing at all about
+   * them, and "we did not converge it" and "we were never told what it should
+   * be" are different facts. It also keeps every existing caller's shape.
+   */
+  agent?: ReconcileOutcome
+  opencode?: ReconcileOutcome
+  /** The manifest epoch this pass converged to; absent for a v1 manifest. */
+  build?: number
+  /** Why, when a half is `skipped` or `failed`. Logged, never thrown. */
   reason?: string
+  /** Per-component `reason`, for the components that carry one. */
+  reasons?: Partial<Record<RuntimeComponent, string>>
+  /**
+   * A verified agent binary is staged and the supervisor will install it at the
+   * next start. Callers may ask for that start early via
+   * {@link requestAgentSwapIfIdle} — never unconditionally.
+   */
+  agentSwapPending?: boolean
+}
+
+/**
+ * The live runtime this pass is allowed to touch.
+ *
+ * opencode convergence restarts opencode, so it needs the daemon's own
+ * lifecycle owner (`src/opencode.ts`) and the one authoritative answer to "is a
+ * turn running" (`src/opencode-turn-state.ts`). Both are passed in rather than
+ * reached for: this module must stay runnable from a test with no runtime at
+ * all, and a second source of truth for turn state is exactly the bug class the
+ * turn-state module exists to prevent.
+ */
+export interface RuntimeConvergenceSeam {
+  /** Live opencode base URL — `opencode.getInternalUrl()`, re-read per pass
+   *  because a verified reload moves the port. */
+  opencodeBaseUrl: () => string
+  /** The directory opencode serves — `cfg.workspace`. */
+  workspace: string
+  /** Restart through the supervisor that owns spawn/respawn/dispose. */
+  restartOpencode: () => Promise<void>
 }
 
 export interface RuntimeAssetsOptions {
@@ -67,13 +150,44 @@ export interface RuntimeAssetsOptions {
   fetchImpl?: typeof fetch
   /** Injected for tests; production uses the daemon's own overlay routine. */
   injectSkills?: (configDir: string, bakedDir: string) => Promise<void>
+  /** Where `agent.next` is staged. Defaults to `$KORTIX_AGENT_STATE_DIR`. */
+  agentStateDir?: string
+  /** The immutable baked daemon. Defaults to `$KORTIX_AGENT_BIN`. */
+  agentBakedPath?: string
+  /** Override "which binary is this process running from". Tests only. */
+  runningAgentPath?: string
+  /** Present only when the daemon has a live runtime to converge. */
+  seam?: RuntimeConvergenceSeam
+  /** Test seams. Production uses the real npm install / health read / turn probe. */
+  installOpencode?: (version: string) => Promise<void>
+  readOpencodeVersion?: (baseUrl: string) => Promise<string | null>
+  turnProbe?: (baseUrl: string, workspace: string) => Promise<boolean | null>
+  /** Baked dependency dir holding the `@opencode-ai/plugin` pin. */
+  opencodeDepsDir?: string
+  /** Test seam for the `bun install` that materializes a refreshed plugin pin. */
+  installPluginDeps?: (dir: string) => Promise<void>
+}
+
+/** One entry of the v2 `components` map. Every field is optional by contract. */
+interface ManifestComponent {
+  version?: unknown
+  sha256?: unknown
+  size?: unknown
+  path?: unknown
+  hash?: unknown
+  source?: unknown
 }
 
 interface RuntimeAssetsManifest {
+  // v1 — load-bearing for daemons already in the field. Never removed.
   cli_version: string | null
   cli_sha256: string | null
   cli_size: number | null
   managed_skills_hash: string
+  // v2 — additive. Absent when this box talks to an older API.
+  build?: unknown
+  components?: unknown
+  policy?: unknown
 }
 
 interface OverlayFile {
@@ -86,6 +200,21 @@ interface RuntimeAssetsState {
   cli_size?: number
   cli_mtime_ms?: number
   managed_skills_hash?: string
+  /** Highest manifest epoch this box has converged to. See the epoch guard. */
+  build?: number
+  /**
+   * Digest cache for the RUNNING daemon, keyed by the path it was taken from.
+   * The path moves (baked floor → `agent.current`) the first time an update is
+   * installed, and a cache that ignored that would answer for the wrong file.
+   */
+  agent_path?: string
+  agent_sha256?: string
+  agent_size?: number
+  agent_mtime_ms?: number
+  /** Digest of the artifact currently staged at `agent.next`, if any. */
+  staged_agent_sha256?: string
+  /** Last opencode version this box converged to. Diagnostic only. */
+  opencode_version?: string
 }
 
 /**
@@ -144,35 +273,118 @@ async function writeState(path: string, state: RuntimeAssetsState): Promise<void
   }
 }
 
-/**
- * The CLI's sha256, preferring the cached value when the file is provably
- * unchanged (same size AND same mtime). The manifest is always trusted over the
- * cache: the cache only answers "what is on disk", never "what should be".
- */
-async function localCliSha(cliPath: string, state: RuntimeAssetsState): Promise<{
+interface LocalDigest {
   sha: string
   size: number
   mtimeMs: number
-} | null> {
+}
+
+/**
+ * A file's sha256, preferring a cached value when the file is provably
+ * unchanged (same size AND same mtime).
+ *
+ * Hashing is not free at these sizes — the CLI is ~104 MB and the daemon ~96 MB
+ * — and this runs on every session start, so a converged box must not pay for
+ * two full reads to learn that nothing changed. The manifest is always trusted
+ * over the cache: the cache only ever answers "what is on disk", never "what
+ * should be".
+ */
+async function localDigest(path: string, cached: Partial<LocalDigest>): Promise<LocalDigest | null> {
   let stats: Awaited<ReturnType<typeof stat>>
   try {
-    stats = await stat(cliPath)
+    stats = await stat(path)
   } catch {
     return null
   }
   if (!stats.isFile()) return null
-  if (
-    state.cli_sha256 &&
-    state.cli_size === stats.size &&
-    state.cli_mtime_ms === Math.trunc(stats.mtimeMs)
-  ) {
-    return { sha: state.cli_sha256, size: stats.size, mtimeMs: Math.trunc(stats.mtimeMs) }
+  const mtimeMs = Math.trunc(stats.mtimeMs)
+  if (cached.sha && cached.size === stats.size && cached.mtimeMs === mtimeMs) {
+    return { sha: cached.sha, size: stats.size, mtimeMs }
   }
-  return {
-    sha: await fileSha256(cliPath),
-    size: stats.size,
-    mtimeMs: Math.trunc(stats.mtimeMs),
-  }
+  return { sha: await fileSha256(path), size: stats.size, mtimeMs }
+}
+
+async function localCliSha(cliPath: string, state: RuntimeAssetsState): Promise<LocalDigest | null> {
+  return localDigest(cliPath, {
+    sha: state.cli_sha256,
+    size: state.cli_size,
+    mtimeMs: state.cli_mtime_ms,
+  })
+}
+
+/**
+ * The single choke point every downloaded artifact passes through before it is
+ * allowed anywhere near a path something else will execute.
+ *
+ * Today this is a digest-from-the-manifest check: integrity against truncation
+ * and corruption, NOT against a compromised API. Artifact signing against a key
+ * baked into the image is the next increment and lands here, in one place, on
+ * purpose.
+ */
+function verifyArtifact(bytes: Buffer, expectedSha: string): boolean {
+  return createHash('sha256').update(bytes).digest('hex') === expectedSha
+}
+
+// ── Manifest reading ───────────────────────────────────────────────────────
+// Every read below is total: a field that is missing, null, or the wrong type
+// answers "not stated" instead of throwing. A daemon that crashes on a manifest
+// shape it does not recognize is a daemon that cannot be rolled forward.
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function manifestComponent(
+  manifest: RuntimeAssetsManifest,
+  name: 'agent' | 'cli' | 'opencode' | 'managed-skills',
+): ManifestComponent | null {
+  const components = manifest.components
+  if (!components || typeof components !== 'object' || Array.isArray(components)) return null
+  const entry = (components as Record<string, unknown>)[name]
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null
+  return entry as ManifestComponent
+}
+
+/** True once the API speaks v2 at all — i.e. it stated a `components` map. */
+function isV2Manifest(manifest: RuntimeAssetsManifest): boolean {
+  const components = manifest.components
+  return Boolean(components && typeof components === 'object' && !Array.isArray(components))
+}
+
+function manifestBuild(manifest: RuntimeAssetsManifest): number | undefined {
+  const build = manifest.build
+  return typeof build === 'number' && Number.isFinite(build) ? build : undefined
+}
+
+/**
+ * The kill switch. `false` — and only an explicit `false` — stops agent
+ * self-update fleet-wide.
+ *
+ * It has to be centrally flippable precisely because the thing it governs is
+ * the component that might no longer boot: shipping a new daemon to stop a bad
+ * daemon rollout assumes the daemon still works.
+ */
+function agentSelfUpdateAllowed(manifest: RuntimeAssetsManifest): boolean {
+  const policy = manifest.policy
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) return true
+  return (policy as Record<string, unknown>).agent_self_update !== false
+}
+
+/**
+ * Turn a manifest-supplied artifact path into a URL on the API we are already
+ * talking to.
+ *
+ * The path is server-supplied and decides what this root process downloads and
+ * stages, so it may name a PATH on this API and nothing else. An absolute URL,
+ * a protocol-relative `//host/…`, or anything with whitespace is refused and
+ * the built-in route is used instead — the manifest can never redirect a
+ * sandbox to another host.
+ */
+function resolveArtifactUrl(apiRoot: string, path: unknown, fallback: string): string {
+  if (typeof path !== 'string' || !path.startsWith('/') || path.startsWith('//')) return fallback
+  if (/\s/.test(path) || path.includes('://')) return fallback
+  const origin = apiRoot.replace(/\/v1$/, '')
+  return `${origin}${path}`
 }
 
 async function replaceCli(
@@ -194,11 +406,9 @@ async function replaceCli(
     // transient, and the reconcile runs at most once per session start.
     const bytes = Buffer.from(body)
     await writeFile(tmpPath, bytes)
-    const actual = createHash('sha256').update(bytes).digest('hex')
-    if (actual !== expectedSha) {
+    if (!verifyArtifact(bytes, expectedSha)) {
       logger.warn('[runtime-assets] CLI download digest mismatch — keeping the installed binary', {
         expected: expectedSha,
-        actual,
       })
       return 'failed'
     }
@@ -213,6 +423,129 @@ async function replaceCli(
   } finally {
     await rm(tmpPath, { force: true }).catch(() => {})
   }
+}
+
+// ── Agent staging ──────────────────────────────────────────────────────────
+
+function agentStateDirOf(options: RuntimeAssetsOptions): string {
+  return options.agentStateDir ?? process.env.KORTIX_AGENT_STATE_DIR ?? DEFAULT_AGENT_STATE_DIR
+}
+
+function agentBakedPathOf(options: RuntimeAssetsOptions): string {
+  return options.agentBakedPath ?? process.env.KORTIX_AGENT_BIN ?? DEFAULT_AGENT_BAKED_PATH
+}
+
+/**
+ * Is this process a `bun --compile` standalone binary, or `bun some/file.ts`?
+ *
+ * A standalone build runs its entry from Bun's embedded filesystem, so
+ * `process.argv[1]` is a `/$bunfs/` path. In dev and under `bun test` it is a
+ * real source path. The distinction matters because `process.execPath` is the
+ * daemon binary in the first case and the BUN RUNTIME in the second — hashing
+ * the latter would compare the wrong file entirely.
+ */
+function isCompiledStandalone(): boolean {
+  return typeof process.argv[1] === 'string' && process.argv[1].startsWith('/$bunfs/')
+}
+
+/**
+ * Which file is this daemon actually running from?
+ *
+ * `process.execPath` is the truthful answer for a compiled binary: it is the
+ * real path of the executable and it follows a rename or a copy (verified
+ * 2026-08-20 by renaming a `bun --compile` output and re-reading it inside the
+ * process). Falling back, we use the supervisor's own rule from
+ * `select_agent()` in apps/sandbox/entrypoint.sh: `agent.current` when it is
+ * present, the baked floor otherwise.
+ *
+ * Getting this wrong has one specific, expensive consequence. An already-
+ * updated box runs `agent.current`; hashing the baked floor there would compare
+ * the wrong file, find a permanent mismatch, and re-download ~96 MB on every
+ * single start — for ever.
+ */
+async function resolveRunningAgentPath(options: RuntimeAssetsOptions): Promise<string> {
+  if (options.runningAgentPath) return options.runningAgentPath
+  if (isCompiledStandalone() && process.execPath) return process.execPath
+  const current = join(agentStateDirOf(options), 'agent.current')
+  const usable = await stat(current).then(
+    (s) => s.isFile(),
+    () => false,
+  )
+  return usable ? current : agentBakedPathOf(options)
+}
+
+/**
+ * Stage a verified daemon binary for the supervisor to install at the next
+ * start. NOTHING is replaced here and nothing restarts.
+ *
+ * Write order is deliberate: the bytes are verified in a temp file, the digest
+ * side-car is renamed into place, and only then does `agent.next` itself
+ * appear. Every interruption therefore leaves a state the supervisor already
+ * refuses — `agent.next` absent (nothing to promote), or present with a digest
+ * that does not describe it (discarded). It can never leave one it would
+ * install blind.
+ */
+async function stageAgentBinary(
+  stateDir: string,
+  expectedSha: string,
+  body: ArrayBuffer,
+): Promise<'staged' | 'failed'> {
+  const nextPath = join(stateDir, 'agent.next')
+  // Same directory as the destination: `rename` is atomic only within one
+  // filesystem, and a cross-device temp file fails with EXDEV.
+  const tmpPath = join(
+    stateDir,
+    `.agent.download.${process.pid}.${Math.random().toString(36).slice(2, 10)}`,
+  )
+  const tmpShaPath = `${tmpPath}.sha256`
+  try {
+    await mkdir(stateDir, { recursive: true })
+    const bytes = Buffer.from(body)
+    await writeFile(tmpPath, bytes)
+    if (!verifyArtifact(bytes, expectedSha)) {
+      logger.warn('[runtime-assets] agent download digest mismatch — nothing staged', {
+        expected: expectedSha,
+      })
+      return 'failed'
+    }
+    await chmod(tmpPath, 0o755)
+    await writeFile(tmpShaPath, `${expectedSha}\n`, 'utf8')
+    await rename(tmpShaPath, `${nextPath}.sha256`)
+    await rename(tmpPath, nextPath)
+    return 'staged'
+  } catch (err) {
+    logger.warn('[runtime-assets] agent staging failed', { err: String(err) })
+    return 'failed'
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {})
+    await rm(tmpShaPath, { force: true }).catch(() => {})
+  }
+}
+
+/** Drop a staged artifact the API no longer advertises, so the supervisor never
+ *  promotes a build this box has already moved past. */
+async function discardStagedAgent(stateDir: string): Promise<void> {
+  const nextPath = join(stateDir, 'agent.next')
+  await rm(nextPath, { force: true }).catch(() => {})
+  await rm(`${nextPath}.sha256`, { force: true }).catch(() => {})
+}
+
+async function stagedAgentSha(stateDir: string): Promise<string | null> {
+  try {
+    const raw = await readFile(join(stateDir, 'agent.next.sha256'), 'utf8')
+    const sha = raw.trim()
+    return /^[0-9a-f]{64}$/.test(sha) ? sha : null
+  } catch {
+    return null
+  }
+}
+
+/** The supervisor's rollback latch: a previous update crash-looped this box. */
+async function agentUpdatesPinned(stateDir: string): Promise<boolean> {
+  return stat(join(stateDir, 'agent.pinned')).then(
+    () => true,
+    () => false,
+  )
 }
 
 async function writeOverlay(dir: string, files: OverlayFile[]): Promise<void> {
@@ -237,6 +570,119 @@ async function writeOverlay(dir: string, files: OverlayFile[]): Promise<void> {
   } catch (err) {
     await rm(staging, { recursive: true, force: true }).catch(() => {})
     throw err
+  }
+}
+
+// ── opencode ───────────────────────────────────────────────────────────────
+
+/**
+ * A version string that is safe to hand to a package manager.
+ *
+ * The value comes off the manifest and becomes an ARGUMENT of an install
+ * command run as the sandbox user. `execFile` (no shell) is the primary
+ * control; this allowlist is the second, so a malformed or hostile value is
+ * refused loudly instead of being executed at all.
+ */
+const OPENCODE_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/
+
+const OPENCODE_PLUGIN_PACKAGE = '@opencode-ai/plugin'
+
+/** The version opencode itself reports. `null` when it cannot be read — which
+ *  is NOT the same as "mismatched", and never converges anything. */
+async function readOpencodeVersion(baseUrl: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${baseUrl}/global/health`, {
+      signal: AbortSignal.timeout(OPENCODE_HEALTH_TIMEOUT_MS),
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as { version?: unknown }
+    return optionalString(body?.version) ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Install one exact opencode version, exactly the way the image does.
+ *
+ * `pnpm add -g --allow-build=opencode-ai` is not a stylistic choice — it is the
+ * command in `dockerfile-layer.ts`, and the point of convergence is that a box
+ * that updates itself ends up byte-identical to a box built fresh. A different
+ * installer here would produce a second, subtly different runtime that only
+ * ever exists on updated boxes, which is the hardest kind of drift to debug.
+ */
+async function installOpencodeVersion(version: string): Promise<void> {
+  await execFileAsync(
+    'pnpm',
+    ['add', '-g', '--allow-build=opencode-ai', `opencode-ai@${version}`],
+    { timeout: OPENCODE_INSTALL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 },
+  )
+}
+
+async function installPluginDeps(dir: string): Promise<void> {
+  await execFileAsync('bun', ['install'], {
+    cwd: dir,
+    timeout: OPENCODE_INSTALL_TIMEOUT_MS,
+    maxBuffer: 16 * 1024 * 1024,
+  })
+}
+
+/**
+ * The `@opencode-ai/plugin` pin that must track the opencode BINARY version.
+ *
+ * opencode loads the plugin SDK matching its own binary and fetches it over the
+ * network when it is absent — on every boot. That is the multi-second
+ * `opencode-session-created` stall documented in
+ * `packages/shared/src/sandbox/dockerfile-layer.ts`, and it is why a version
+ * bump that moves the binary without the pin is worse than not bumping at all.
+ *
+ * Only the BAKED dependency dir is rewritten. The project's own config-dir
+ * `package.json` is a tracked file in the user's repository; convergence
+ * writing into a working tree would dirty it and show up as an unexplained
+ * local change in their next `git status`.
+ */
+async function readPluginPin(depsDir: string): Promise<string | null> {
+  try {
+    const pkg = JSON.parse(await readFile(join(depsDir, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, unknown>
+    }
+    return optionalString(pkg?.dependencies?.[OPENCODE_PLUGIN_PACKAGE]) ?? null
+  } catch {
+    return null
+  }
+}
+
+export async function refreshOpencodePluginPin(
+  depsDir: string,
+  version: string,
+): Promise<'updated' | 'current' | 'absent' | 'failed'> {
+  const pkgPath = join(depsDir, 'package.json')
+  let pkg: { dependencies?: Record<string, unknown> }
+  try {
+    pkg = JSON.parse(await readFile(pkgPath, 'utf8')) as { dependencies?: Record<string, unknown> }
+  } catch {
+    // No baked dependency dir on this image (self-host, an old snapshot). The
+    // binary still converges; opencode just pays its own plugin fetch.
+    return 'absent'
+  }
+  if (!pkg.dependencies || typeof pkg.dependencies[OPENCODE_PLUGIN_PACKAGE] !== 'string') {
+    return 'absent'
+  }
+  if (pkg.dependencies[OPENCODE_PLUGIN_PACKAGE] === version) return 'current'
+  pkg.dependencies[OPENCODE_PLUGIN_PACKAGE] = version
+  const tmpPath = `${pkgPath}.${process.pid}.${Math.random().toString(36).slice(2, 10)}.tmp`
+  try {
+    await writeFile(tmpPath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8')
+    await rename(tmpPath, pkgPath)
+    return 'updated'
+  } catch (err) {
+    logger.warn('[runtime-assets] could not rewrite the opencode plugin pin', {
+      depsDir,
+      err: String(err),
+    })
+    return 'failed'
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => {})
   }
 }
 
@@ -303,22 +749,54 @@ export async function reconcileRuntimeAssets(
 
   const state = await readState(statePath)
   const nextState: RuntimeAssetsState = { ...state }
+  const build = manifestBuild(manifest)
+  const reasons: Partial<Record<RuntimeComponent, string>> = {}
+
+  // ── Epoch guard ────────────────────────────────────────────────────────────
+  // A box only ever moves FORWARD. During a rolling deploy two API versions are
+  // live at once and serve two different manifests; a box that talked to both
+  // would converge to A, then back to B, then back to A — re-downloading
+  // hundreds of megabytes on every flip, for as long as the rollout takes. That
+  // is not hypothetical: it is the shape of the 2026-07-22 warm-image infinite
+  // mutual-rebuild loop, and the Daytona 429s that came with it.
+  //
+  // EQUAL is accepted, not just greater: re-converging to the same build is
+  // idempotent and is what every ordinary restart does.
+  if (build !== undefined && state.build !== undefined && build < state.build) {
+    return {
+      cli: 'skipped',
+      skills: 'skipped',
+      build: state.build,
+      reason: `manifest build ${build} is older than converged build ${state.build}`,
+    }
+  }
+
+  // The v2 `components` map is preferred whenever the API states it, and the v1
+  // fields remain the fallback. That is the whole compatibility contract: a new
+  // daemon against an old API keeps converging the CLI exactly as it does
+  // today, and an old daemon against a new API never notices the new keys.
+  const cliComponent = manifestComponent(manifest, 'cli')
+  const cliSha = optionalString(cliComponent?.sha256) ?? manifest.cli_sha256 ?? null
+  const cliVersion = optionalString(cliComponent?.version) ?? manifest.cli_version
+  const skillsComponent = manifestComponent(manifest, 'managed-skills')
+  const skillsHash = optionalString(skillsComponent?.hash) ?? manifest.managed_skills_hash
+
   // 'skipped' holds when a branch below never reassigns — e.g. a checkout that
-  // never built the CLI (manifest.cli_sha256 null): nothing to converge on.
+  // never built the CLI (no cli digest stated): nothing to converge on.
   let cli: ReconcileOutcome = 'skipped'
   let skills: ReconcileOutcome
 
   // ── CLI ────────────────────────────────────────────────────────────────────
-  if (manifest.cli_sha256) {
+  if (cliSha) {
     try {
       const local = await localCliSha(cliPath, state)
-      if (local && local.sha === manifest.cli_sha256) {
+      if (local && local.sha === cliSha) {
         cli = 'current'
         nextState.cli_sha256 = local.sha
         nextState.cli_size = local.size
         nextState.cli_mtime_ms = local.mtimeMs
       } else {
-        const res = await fetchImpl(`${base}/cli`, {
+        const res = await fetchImpl(resolveArtifactUrl(apiRoot, cliComponent?.path, `${base}/cli`), {
           headers: { Authorization: `Bearer ${token}` },
           signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
         })
@@ -326,15 +804,15 @@ export async function reconcileRuntimeAssets(
           logger.warn('[runtime-assets] CLI download non-ok', { status: res.status })
           cli = 'failed'
         } else {
-          cli = await replaceCli(cliPath, manifest.cli_sha256, await res.arrayBuffer())
+          cli = await replaceCli(cliPath, cliSha, await res.arrayBuffer())
           if (cli === 'updated') {
             const stats = await stat(cliPath).catch(() => null)
-            nextState.cli_sha256 = manifest.cli_sha256
+            nextState.cli_sha256 = cliSha
             nextState.cli_size = stats?.size
             nextState.cli_mtime_ms = stats ? Math.trunc(stats.mtimeMs) : undefined
             logger.info('[runtime-assets] kortix CLI updated from the API', {
-              version: manifest.cli_version,
-              sha256: manifest.cli_sha256.slice(0, 12),
+              version: cliVersion,
+              sha256: cliSha.slice(0, 12),
             })
           }
         }
@@ -347,34 +825,42 @@ export async function reconcileRuntimeAssets(
 
   // ── Managed skills ─────────────────────────────────────────────────────────
   try {
-    const overlayPresent = await stat(skillsDir).then(
-      (s) => s.isDirectory(),
-      () => false,
-    )
-    if (overlayPresent && state.managed_skills_hash === manifest.managed_skills_hash) {
-      skills = 'current'
+    if (!skillsHash) {
+      // A manifest that states no overlay hash is one we cannot verify a
+      // payload against. Skipping keeps the baked overlay, which works.
+      skills = 'skipped'
+      reasons.skills = 'manifest states no managed-skills hash'
     } else {
-      const payload = await fetchJson<{ hash: string; files: OverlayFile[] }>(
-        fetchImpl,
-        `${base}/managed-skills`,
-        token,
-        DOWNLOAD_TIMEOUT_MS,
+      const overlayPresent = await stat(skillsDir).then(
+        (s) => s.isDirectory(),
+        () => false,
       )
-      if (!payload || !Array.isArray(payload.files)) {
-        skills = 'failed'
-      } else if (overlayHash(payload.files) !== manifest.managed_skills_hash) {
-        logger.warn('[runtime-assets] managed-skill payload digest mismatch — keeping the overlay', {
-          expected: manifest.managed_skills_hash,
-        })
-        skills = 'failed'
+      if (overlayPresent && state.managed_skills_hash === skillsHash) {
+        skills = 'current'
       } else {
-        await writeOverlay(skillsDir, payload.files)
-        nextState.managed_skills_hash = manifest.managed_skills_hash
-        skills = 'updated'
-        logger.info('[runtime-assets] managed-skill overlay updated from the API', {
-          files: payload.files.length,
-          hash: manifest.managed_skills_hash.slice(0, 12),
-        })
+        const payload = await fetchJson<{ hash: string; files: OverlayFile[] }>(
+          fetchImpl,
+          `${base}/managed-skills`,
+          token,
+          DOWNLOAD_TIMEOUT_MS,
+        )
+        if (!payload || !Array.isArray(payload.files)) {
+          skills = 'failed'
+        } else if (overlayHash(payload.files) !== skillsHash) {
+          logger.warn(
+            '[runtime-assets] managed-skill payload digest mismatch — keeping the overlay',
+            { expected: skillsHash },
+          )
+          skills = 'failed'
+        } else {
+          await writeOverlay(skillsDir, payload.files)
+          nextState.managed_skills_hash = skillsHash
+          skills = 'updated'
+          logger.info('[runtime-assets] managed-skill overlay updated from the API', {
+            files: payload.files.length,
+            hash: skillsHash.slice(0, 12),
+          })
+        }
       }
     }
   } catch (err) {
@@ -390,9 +876,365 @@ export async function reconcileRuntimeAssets(
     )
   }
 
+  // ── Agent — STAGE ONLY ─────────────────────────────────────────────────────
+  // A process cannot safely overwrite its own running binary, and the baked one
+  // is root-owned while we run as `kortix`, so this half never swaps anything.
+  // It writes `agent.next` + `agent.next.sha256` and stops. The supervisor in
+  // apps/sandbox/entrypoint.sh re-verifies and installs at the next start —
+  // which `requestAgentSwapIfIdle` can bring forward when the box is idle.
+  const v2 = isV2Manifest(manifest)
+  const stateDir = agentStateDirOf(options)
+  let agent: ReconcileOutcome | undefined
+  let agentSwapPending: boolean | undefined
+  if (v2) {
+    agent = 'skipped'
+    try {
+      const component = manifestComponent(manifest, 'agent')
+      const expectedSha = optionalString(component?.sha256)
+      if (!expectedSha) {
+        reasons.agent = 'manifest states no agent component'
+      } else if (!agentSelfUpdateAllowed(manifest)) {
+        // The kill switch. Deliberately checked BEFORE any digest work: the
+        // whole point is to stop a rollout centrally, without shipping code to
+        // boxes that may no longer boot.
+        //
+        // It also RETRACTS work already done. A box that staged the bad build
+        // minutes before the switch was flipped would otherwise still install
+        // it at its next start — and the supervisor cannot help, because it
+        // knows nothing about policy. Flipping the switch has to stop the
+        // rollout on boxes that have already fetched it, or it does not stop
+        // the rollout.
+        await discardStagedAgent(stateDir)
+        nextState.staged_agent_sha256 = undefined
+        reasons.agent = 'policy.agent_self_update is false'
+      } else if (await agentUpdatesPinned(stateDir)) {
+        // The supervisor rolled an update back and latched. Re-staging the same
+        // build would download ~96 MB the supervisor is guaranteed to discard,
+        // on every start, for ever.
+        reasons.agent = 'updates pinned after a rollback'
+      } else {
+        const runningPath = await resolveRunningAgentPath(options)
+        const running = await localDigest(
+          runningPath,
+          state.agent_path === runningPath
+            ? { sha: state.agent_sha256, size: state.agent_size, mtimeMs: state.agent_mtime_ms }
+            : {},
+        )
+        if (running) {
+          nextState.agent_path = runningPath
+          nextState.agent_sha256 = running.sha
+          nextState.agent_size = running.size
+          nextState.agent_mtime_ms = running.mtimeMs
+        }
+        const staged = await stagedAgentSha(stateDir)
+        if (running && running.sha === expectedSha) {
+          agent = 'current'
+          // Anything still staged describes a build this box has moved past;
+          // leaving it would have the supervisor install it at the next start.
+          if (staged && staged !== expectedSha) await discardStagedAgent(stateDir)
+          nextState.staged_agent_sha256 = undefined
+        } else if (staged === expectedSha) {
+          // Already staged by an earlier pass and not yet promoted. Do not
+          // re-download it just because the process restarted.
+          agent = 'staged'
+          agentSwapPending = true
+          nextState.staged_agent_sha256 = staged
+        } else {
+          // Either the running binary differs, or there is no readable binary
+          // at the resolved path to compare against. Both mean "cannot prove
+          // this box is current", and staging is the safe answer to that: the
+          // supervisor verifies the artifact again before it installs it.
+          const res = await fetchImpl(
+            resolveArtifactUrl(apiRoot, component?.path, `${base}/agent`),
+            {
+              headers: { Authorization: `Bearer ${token}` },
+              signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+            },
+          )
+          if (!res.ok) {
+            logger.warn('[runtime-assets] agent download non-ok', { status: res.status })
+            agent = 'failed'
+            reasons.agent = `agent download returned ${res.status}`
+          } else {
+            agent = await stageAgentBinary(stateDir, expectedSha, await res.arrayBuffer())
+            if (agent === 'staged') {
+              agentSwapPending = true
+              nextState.staged_agent_sha256 = expectedSha
+              logger.info('[runtime-assets] agent staged for the supervisor to install', {
+                version: optionalString(component?.version),
+                sha256: expectedSha.slice(0, 12),
+                runningSha256: running?.sha.slice(0, 12) ?? null,
+              })
+            } else {
+              reasons.agent = 'staged artifact failed verification'
+            }
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn('[runtime-assets] agent reconcile failed', { err: String(err) })
+      agent = 'failed'
+      reasons.agent = String(err)
+    }
+  }
+
+  // ── opencode — IDLE ONLY ───────────────────────────────────────────────────
+  // Installing opencode replaces the binary the live model call is running in,
+  // and applying it needs a restart. Both sever a turn in flight, so this half
+  // only ever acts when the daemon's own turn oracle says the box is idle.
+  // "Cannot tell" is treated as busy; a skipped pass costs nothing, because the
+  // next start reconciles again.
+  let opencode: ReconcileOutcome | undefined
+  if (v2) {
+    opencode = 'skipped'
+    try {
+      const component = manifestComponent(manifest, 'opencode')
+      const expected = optionalString(component?.version)
+      const seam = options.seam
+      const depsDir = options.opencodeDepsDir ?? OPENCODE_CONFIG_DEPS_DIR
+      if (!expected) {
+        reasons.opencode = 'manifest states no opencode version'
+      } else if (!OPENCODE_VERSION.test(expected)) {
+        // Refused, not sanitized: this value becomes an install argument.
+        logger.warn('[runtime-assets] refusing a malformed opencode version', { expected })
+        reasons.opencode = 'manifest opencode version is malformed'
+      } else if (!seam) {
+        // No live runtime in this process (monitor mode, a test, a pass fired
+        // before opencode exists). Nothing to read a version from.
+        reasons.opencode = 'no opencode runtime in this process'
+      } else {
+        const readVersion = options.readOpencodeVersion ?? readOpencodeVersion
+        const installed = await readVersion(seam.opencodeBaseUrl())
+        const pin = await readPluginPin(depsDir)
+        const binaryStale = installed !== null && installed !== expected
+        // The pin can drift from the binary on its own — a pass that installed
+        // the binary and then failed the pin refresh leaves exactly that — and
+        // a pin that does not match makes opencode refetch the plugin on every
+        // boot. It is worth one idle-only repair even when the binary is fine.
+        const pinStale = pin !== null && pin !== expected
+        if (installed === null) {
+          reasons.opencode = 'opencode did not report its version'
+        } else if (!binaryStale && !pinStale) {
+          opencode = 'current'
+          nextState.opencode_version = installed
+        } else {
+          const probe = options.turnProbe ?? opencodeTurnInFlight
+          const turnInFlight = await probe(seam.opencodeBaseUrl(), seam.workspace)
+          if (turnInFlight !== false) {
+            reasons.opencode =
+              turnInFlight === null ? 'turn state unreadable' : 'a turn is in flight'
+            logger.info('[runtime-assets] opencode convergence deferred — box is busy', {
+              installed,
+              expected,
+              turnInFlight,
+            })
+          } else {
+            const install = options.installOpencode ?? installOpencodeVersion
+            if (binaryStale) await install(expected)
+            // SAME STEP as the binary, always. A binary and a plugin that
+            // disagree is the state this whole block exists to avoid.
+            const pinResult = await refreshOpencodePluginPin(depsDir, expected)
+            if (pinResult === 'updated') {
+              await (options.installPluginDeps ?? installPluginDeps)(depsDir)
+            }
+            // Only a NEW BINARY needs the process replaced: the plugin is read
+            // when opencode boots, so a refreshed pin takes effect on its own at
+            // the next start and buys nothing by cutting this one short.
+            if (binaryStale) await seam.restartOpencode()
+            opencode = 'updated'
+            nextState.opencode_version = expected
+            logger.info('[runtime-assets] opencode converged', {
+              from: installed,
+              to: expected,
+              pin: pinResult,
+              restarted: binaryStale,
+            })
+          }
+        }
+      }
+    } catch (err) {
+      logger.warn('[runtime-assets] opencode reconcile failed', { err: String(err) })
+      opencode = 'failed'
+      reasons.opencode = String(err)
+    }
+  }
+
+  // The epoch advances only after a pass that actually looked at this manifest.
+  // It is recorded even when a half failed: `build` answers "which manifest did
+  // this box last read", and the per-component outcomes answer what it managed
+  // to do with it. Conflating the two would make a single failed download
+  // re-open the flapping window the guard exists to close.
+  if (build !== undefined && (state.build === undefined || build >= state.build)) {
+    nextState.build = build
+  }
+
   await writeState(statePath, nextState)
-  return { cli, skills }
+  const result: RuntimeAssetsResult = { cli, skills }
+  if (agent !== undefined) result.agent = agent
+  if (opencode !== undefined) result.opencode = opencode
+  if (build !== undefined) result.build = build
+  if (agentSwapPending) result.agentSwapPending = true
+  if (Object.keys(reasons).length > 0) result.reasons = reasons
+  return result
 }
+
+// ── Requesting the swap ────────────────────────────────────────────────────
+
+/**
+ * Why a swap request did or did not exit the process. Every value except
+ * `exited` leaves the box exactly as it was: the staged binary is installed by
+ * the supervisor at the next natural start, which for a sandbox is soon.
+ */
+export type AgentSwapDecision =
+  | 'exited'
+  | 'nothing-staged'
+  | 'pinned'
+  | 'too-young'
+  | 'turn-in-flight'
+  | 'turn-state-unknown'
+  | 'attached'
+  | 'not-configured'
+
+/**
+ * How long this process must have been up before it may ask to be replaced.
+ *
+ * The first reconcile fires moments after `opencode-ready` — which is exactly
+ * when a user is about to send their first prompt, and when the frontend is
+ * polling readiness. A restart there is not "free because the box is idle": it
+ * is a readiness flap on the session-start hot path, in exchange for an update
+ * that the supervisor installs at the next start anyway (it promotes before
+ * every launch). So the early exit is reserved for LONG-LIVED boxes, the only
+ * ones that would otherwise run a stale daemon for days.
+ */
+const AGENT_SWAP_MIN_UPTIME_MS = 5 * 60_000
+
+/**
+ * Anything the daemon owns that a restart would sever, beyond a turn.
+ *
+ * The daemon is also the reverse proxy and the PTY host, and those are not
+ * visible from turn state. Components that hold such work register a predicate
+ * here rather than this module inventing a second opinion about their state —
+ * `routes/pty.ts`'s registry is the only thing that knows whether a shell is
+ * open, so it is the thing that answers.
+ */
+const swapBlockers = new Map<string, () => boolean>()
+
+export function registerAgentSwapBlocker(name: string, isBusy: () => boolean): void {
+  swapBlockers.set(name, isBusy)
+}
+
+/** Test seam: drop every registered blocker. */
+export function resetAgentSwapBlockersForTests(): void {
+  swapBlockers.clear()
+}
+
+interface RuntimeConvergenceConfig {
+  seam: RuntimeConvergenceSeam
+  turnInFlight: () => Promise<boolean | null>
+  agentStateDir?: string
+  exit?: (code: number) => void
+}
+
+/**
+ * Hand this module the live runtime, once, at boot.
+ *
+ * Both scheduling call sites (`startSessionRuntime` and `POST /kortix/refresh`)
+ * pass only a `Config`, so the runtime is registered here instead of threaded
+ * through every one of them. Nothing below requires it: an unconfigured daemon
+ * still converges the CLI and the overlay, and simply reports that it had no
+ * runtime to converge opencode against.
+ */
+let swapConfig: RuntimeConvergenceConfig | null = null
+
+export function configureRuntimeConvergence(config: RuntimeConvergenceConfig): void {
+  swapConfig = config
+}
+
+/** Test seam: forget the configured runtime. */
+export function resetRuntimeConvergenceForTests(): void {
+  swapConfig = null
+}
+
+export interface AgentSwapOptions {
+  /** The one authority on "is a turn running". `null` means unreadable. */
+  turnInFlight?: () => Promise<boolean | null>
+  agentStateDir?: string
+  /** Defaults to the daemon's own clean shutdown, exiting {@link AGENT_SWAP_EXIT_CODE}. */
+  exit?: (code: number) => void
+  /** Seconds this process has been up. Injected by tests. */
+  uptimeMs?: number
+  /** Override the settle window. Tests only. */
+  minUptimeMs?: number
+}
+
+/**
+ * Ask the supervisor to install the staged daemon — but only if nothing is
+ * mid-flight that the restart would destroy.
+ *
+ * THE SAFETY RULE, stated once: this process exiting takes opencode, the
+ * reverse proxy and every PTY down with it. So a swap is requested only when
+ * the turn oracle says, definitely, that no turn is running, AND no registered
+ * blocker claims live work. "Cannot tell" counts as busy — an update is never
+ * worth guessing about, because the alternative to exiting now is simply
+ * exiting later, at a start that was going to happen anyway.
+ *
+ * Never throws: a failure to ask leaves the staged binary staged.
+ */
+export async function requestAgentSwapIfIdle(
+  options: AgentSwapOptions = {},
+): Promise<AgentSwapDecision> {
+  try {
+    const stateDir = options.agentStateDir ?? swapConfig?.agentStateDir ?? DEFAULT_AGENT_STATE_DIR
+    const staged = await stagedAgentSha(stateDir)
+    const stagedPresent =
+      staged !== null &&
+      (await stat(join(stateDir, 'agent.next')).then(
+        (s) => s.isFile(),
+        () => false,
+      ))
+    if (!stagedPresent) return 'nothing-staged'
+    if (await agentUpdatesPinned(stateDir)) return 'pinned'
+
+    const uptimeMs = options.uptimeMs ?? process.uptime() * 1000
+    if (uptimeMs < (options.minUptimeMs ?? AGENT_SWAP_MIN_UPTIME_MS)) return 'too-young'
+
+    const probe = options.turnInFlight ?? swapConfig?.turnInFlight
+    if (!probe) return 'not-configured'
+    const turnInFlight = await probe()
+    if (turnInFlight === true) return 'turn-in-flight'
+    if (turnInFlight === null) return 'turn-state-unknown'
+
+    for (const [name, isBusy] of swapBlockers) {
+      let busy = false
+      try {
+        busy = isBusy()
+      } catch (err) {
+        // A blocker that cannot answer is a blocker that says busy.
+        logger.warn('[runtime-assets] swap blocker threw; treating as busy', {
+          name,
+          err: String(err),
+        })
+        busy = true
+      }
+      if (busy) {
+        logger.info('[runtime-assets] agent swap deferred — live work in progress', { name })
+        return 'attached'
+      }
+    }
+
+    const exit = options.exit ?? swapConfig?.exit ?? ((code: number) => process.exit(code))
+    logger.info('[runtime-assets] requesting agent swap; exiting for the supervisor', {
+      sha256: staged.slice(0, 12),
+      code: AGENT_SWAP_EXIT_CODE,
+    })
+    exit(AGENT_SWAP_EXIT_CODE)
+    return 'exited'
+  } catch (err) {
+    logger.warn('[runtime-assets] agent swap request failed', { err: String(err) })
+    return 'not-configured'
+  }
+}
+
 
 /**
  * Single-flight guard for the detached entry point below. Boot readiness and a
@@ -407,16 +1249,29 @@ let inFlight: Promise<RuntimeAssetsResult> | null = null
  */
 export function ensureLatestKortixAssets(configDir?: string): void {
   if (inFlight) return
-  inFlight = reconcileRuntimeAssets({ configDir })
+  inFlight = reconcileRuntimeAssets({ configDir, seam: swapConfig?.seam })
   void inFlight
     .finally(() => {
       inFlight = null
     })
-    .then((result) => {
-      if (result.cli === 'updated' || result.skills === 'updated') {
+    .then(async (result) => {
+      // Record BEFORE the swap request below: `requestAgentSwapIfIdle` can exit
+      // the process, and a pass that converged but never got reported would
+      // make the box look like it had not run at all.
+      noteRuntimeConvergence(result)
+      if (result.cli === 'updated' || result.skills === 'updated' || result.opencode === 'updated') {
         logger.info('[runtime-assets] reconcile complete', result)
       } else {
         logger.info('[runtime-assets] reconcile no-op', result)
+      }
+      // Asked at most once per pass, and only when a verified binary is
+      // actually waiting. A busy box simply keeps the staging: the supervisor
+      // installs it at the next start.
+      if (result.agentSwapPending) {
+        const decision = await requestAgentSwapIfIdle()
+        if (decision !== 'exited') {
+          logger.info('[runtime-assets] agent update staged; swap deferred', { decision })
+        }
       }
     })
     .catch((err) => logger.warn('[runtime-assets] reconcile threw', { err: String(err) }))
@@ -433,4 +1288,83 @@ export function scheduleRuntimeAssetsReconcile(cfg: Config): void {
     // A config dir we cannot resolve costs the overlay re-injection, not the
     // CLI update — still worth running.
     .catch(() => ensureLatestKortixAssets())
+}
+
+// ---------------------------------------------------------------------------
+// Observability — convergence you can query.
+//
+// Auto-update without reporting just moves the uncertainty: instead of "we hope
+// boxes are current" you get "we hope boxes updated". The last pass is recorded
+// here and surfaced on /kortix/health so a stale box is a FACT the control plane
+// can read, per box, rather than an assumption.
+//
+// It is also the signal that tells us a fleet-drain gate has actually cleared —
+// the thing we had no way to answer when the wire-id deletion was blocked on
+// "have all the 1.17.11 boxes gone yet?".
+// ---------------------------------------------------------------------------
+
+export interface RuntimeConvergenceReport {
+  /** The manifest epoch this box converged to; null before the first pass. */
+  build: number | null
+  /** Wall-clock of the last completed pass. */
+  at: string | null
+  /** Per-component outcome of that pass. */
+  components: Partial<Record<RuntimeComponent, ReconcileOutcome>>
+  /** Per-component explanation, when one was recorded. */
+  reasons?: Partial<Record<RuntimeComponent, string>>
+  /**
+   * A verified agent binary is staged. The box is NOT yet running it — the
+   * supervisor installs it at the next start. A box reporting `true` for a long
+   * time is a box that never restarts, which is itself worth seeing.
+   */
+  agentSwapPending: boolean
+  /**
+   * Updates are latched off because a previous update crash-looped and the
+   * supervisor rolled back. This box will not self-heal and needs a human.
+   */
+  pinned: boolean
+}
+
+let lastConvergence: RuntimeConvergenceReport = {
+  build: null,
+  at: null,
+  components: {},
+  agentSwapPending: false,
+  pinned: false,
+}
+
+/** Record a completed pass. Never throws — this is reporting, not control. */
+export function noteRuntimeConvergence(result: RuntimeAssetsResult): void {
+  const components: Partial<Record<RuntimeComponent, ReconcileOutcome>> = {
+    cli: result.cli,
+    skills: result.skills,
+  }
+  if (result.agent) components.agent = result.agent
+  if (result.opencode) components.opencode = result.opencode
+  lastConvergence = {
+    build: result.build ?? lastConvergence.build,
+    at: new Date().toISOString(),
+    components,
+    ...(result.reasons ? { reasons: result.reasons } : {}),
+    agentSwapPending: result.agentSwapPending === true,
+    pinned: lastConvergence.pinned,
+  }
+}
+
+/**
+ * The last recorded pass, for `/kortix/health`.
+ *
+ * The rollback latch is re-read from disk on every call rather than cached: the
+ * SUPERVISOR writes it between daemon runs, so a value captured at reconcile
+ * time would be stale exactly when it matters most — on the first health check
+ * after a rollback, which is the moment someone is looking.
+ */
+export async function runtimeConvergenceReport(
+  stateDir: string = process.env.KORTIX_AGENT_STATE_DIR ?? DEFAULT_AGENT_STATE_DIR,
+): Promise<RuntimeConvergenceReport> {
+  return { ...lastConvergence, pinned: await agentUpdatesPinned(stateDir) }
+}
+
+export function resetRuntimeConvergenceReportForTests(): void {
+  lastConvergence = { build: null, at: null, components: {}, agentSwapPending: false, pinned: false }
 }

--- a/apps/kortix-sandbox-agent-server/src/shutdown.ts
+++ b/apps/kortix-sandbox-agent-server/src/shutdown.ts
@@ -5,17 +5,33 @@ import type { Opencode } from './opencode'
 import type { ProxyServer } from './proxy'
 import type { StaticWebServer } from './static-web'
 
+/**
+ * Stop the daemon cleanly, and choose the exit code.
+ *
+ * The code is load-bearing for the entrypoint supervisor: `75` means "install
+ * the staged binary and start me again", anything else non-zero counts against
+ * the failure budget that triggers a rollback. See
+ * apps/sandbox/entrypoint.sh and src/runtime-assets.ts.
+ *
+ * A self-update MUST come through here rather than calling `process.exit`
+ * directly: opencode is a child of this process, and leaving it alive would
+ * hand the relaunched daemon a port that is already taken.
+ */
+export interface DaemonShutdown {
+  (opts: { reason: string; exitCode?: number; signal?: NodeJS.Signals }): void
+}
+
 export function installShutdownHandlers(
   opencode: Opencode,
   proxy: ProxyServer,
   staticWeb?: StaticWebServer,
-) {
+): DaemonShutdown {
   let shuttingDown = false
 
-  const handle = (signal: NodeJS.Signals) => {
+  const stop = (reason: string, exitCode: number, signal: NodeJS.Signals) => {
     if (shuttingDown) return
     shuttingDown = true
-    logger.info('[shutdown] signal received', { signal })
+    logger.info('[shutdown] stopping', { reason, exitCode })
     shredAgentEnvFile()
     // Stops the listener and drops the CA private key, which lives only in
     // memory and is never written to disk. A hibernated or archived disk must
@@ -40,11 +56,13 @@ export function installShutdownHandlers(
       } catch (err) {
         logger.warn('[shutdown] opencode stop failed', err)
       }
-      logger.info('[shutdown] done')
-      process.exit(0)
+      logger.info('[shutdown] done', { reason, exitCode })
+      process.exit(exitCode)
     })()
   }
 
-  process.on('SIGTERM', () => handle('SIGTERM'))
-  process.on('SIGINT', () => handle('SIGINT'))
+  process.on('SIGTERM', () => stop('SIGTERM', 0, 'SIGTERM'))
+  process.on('SIGINT', () => stop('SIGINT', 0, 'SIGINT'))
+
+  return ({ reason, exitCode = 0, signal = 'SIGTERM' }) => stop(reason, exitCode, signal)
 }

--- a/apps/sandbox/entrypoint.sh
+++ b/apps/sandbox/entrypoint.sh
@@ -107,5 +107,173 @@ done
 # cwd stable; the daemon itself works with absolute paths under
 # ${WORKSPACE} from here on.
 cd /
+
+# ---------------------------------------------------------------------------
+# Supervisor — the daemon's own updater.
+#
+# The image is a cache, not the truth: a box provisioned months ago otherwise
+# runs a months-old daemon forever, because restart/resume suspend the same VM
+# and a warm fork adopts a captured disk. None of them re-run the image build.
+#
+# A process cannot safely overwrite its own running binary, so the daemon never
+# replaces itself. It STAGES ${AGENT_NEXT} (+ .sha256) and exits ${SWAP_CODE}
+# to ask for the swap. This loop performs it. See
+# docs/specs/2026-08-20-convergent-runtime.md.
+#
+# Everything here is failure-biased toward "keep running the binary that
+# worked": a bad artifact, a bad digest, or a new binary that will not stay up
+# leaves a working box, never a bricked one.
+# ---------------------------------------------------------------------------
+# The baked binary is the PERMANENT FLOOR: root-owned, never written by anything
+# at runtime (we run as `kortix` — see the privilege drop above — so we could not
+# overwrite it even if we wanted to). Updates install alongside it in the
+# kortix-owned state dir, and the supervisor prefers the updated one when it is
+# present and executable.
+#
+# This is what makes a bricked box impossible rather than merely unlikely:
+# rollback in the worst case is "delete one file", after which the box boots the
+# binary that shipped in the image.
+#
+# Overridable so the supervisor logic is testable without root or a real image;
+# production never sets these. See apps/sandbox/scripts/test-entrypoint-swap.sh.
+AGENT_BAKED="${KORTIX_AGENT_BIN:-/usr/local/bin/kortix-agent}"
+AGENT_STATE_DIR="${KORTIX_AGENT_STATE_DIR:-/opt/kortix}"
+AGENT_CURRENT="${AGENT_STATE_DIR}/agent.current"
+AGENT_NEXT="${AGENT_STATE_DIR}/agent.next"
+AGENT_PREV="${AGENT_STATE_DIR}/agent.prev"
+AGENT_PINNED="${AGENT_STATE_DIR}/agent.pinned"
+# EX_TEMPFAIL. Distinguishes "swap me and restart" from a crash: any other exit
+# code counts against the failure budget below, so a crash-looping NEW binary
+# rolls back while a crash-looping OLD one never triggers an update.
+SWAP_CODE=75
+# A relaunched binary must survive this long to count as good. Shorter than any
+# real session, longer than a binary that dies on startup.
+HEALTHY_AFTER_S=60
+# Consecutive early exits after a swap before we give up and pin.
+MAX_EARLY_EXITS=2
+
+early_exits=0
+
+# Move a verified staged binary into place. Any failure leaves the live binary
+# untouched — the caller simply relaunches what is already there.
+promote_staged_agent() {
+  [ -f "${AGENT_NEXT}" ] || return 1
+  if [ -f "${AGENT_PINNED}" ]; then
+    echo "[entrypoint] update pinned after rollback; discarding staged agent" >&2
+    rm -f "${AGENT_NEXT}" "${AGENT_NEXT}.sha256"
+    return 1
+  fi
+  # Re-verify independently. The daemon that wrote this file is exactly the
+  # component being replaced, so its correctness is not assumed here.
+  if [ -f "${AGENT_NEXT}.sha256" ] && command -v sha256sum >/dev/null 2>&1; then
+    expected=$(tr -d '[:space:]' < "${AGENT_NEXT}.sha256")
+    actual=$(sha256sum "${AGENT_NEXT}" | cut -d' ' -f1)
+    if [ "${expected}" != "${actual}" ]; then
+      echo "[entrypoint] staged agent digest mismatch; discarding" >&2
+      rm -f "${AGENT_NEXT}" "${AGENT_NEXT}.sha256"
+      return 1
+    fi
+  else
+    echo "[entrypoint] staged agent has no verifiable digest; discarding" >&2
+    rm -f "${AGENT_NEXT}" "${AGENT_NEXT}.sha256"
+    return 1
+  fi
+  # Keep the binary that was running as the rollback target BEFORE overwriting.
+  # Only a previously-updated binary is worth keeping; the baked one is always
+  # on disk anyway, so there is nothing to preserve on the first update.
+  if [ -f "${AGENT_CURRENT}" ]; then
+    cp -f "${AGENT_CURRENT}" "${AGENT_PREV}" 2>/dev/null || true
+  fi
+  chmod 0755 "${AGENT_NEXT}" 2>/dev/null || true
+  # rename(2) within the same filesystem: no reader can see a partial binary.
+  if mv -f "${AGENT_NEXT}" "${AGENT_CURRENT}" 2>/dev/null; then
+    rm -f "${AGENT_NEXT}.sha256"
+    echo "[entrypoint] agent updated from staged binary" >&2
+    return 0
+  fi
+  echo "[entrypoint] could not install staged agent; keeping current" >&2
+  rm -f "${AGENT_NEXT}" "${AGENT_NEXT}.sha256"
+  return 1
+}
+
+# Which binary to launch. An updated one when it is present and executable,
+# otherwise the binary that shipped in the image.
+select_agent() {
+  if [ -x "${AGENT_CURRENT}" ]; then
+    echo "${AGENT_CURRENT}"
+  else
+    echo "${AGENT_BAKED}"
+  fi
+}
+
+# Undo the last update. Restores the previous updated binary when there is one,
+# otherwise drops back to the baked binary by simply removing the override —
+# which is why a box can never be bricked by an update: the floor is a file that
+# runtime code cannot write.
+rollback_agent() {
+  [ -f "${AGENT_CURRENT}" ] || return 1
+  if [ -f "${AGENT_PREV}" ]; then
+    mv -f "${AGENT_PREV}" "${AGENT_CURRENT}" 2>/dev/null || return 1
+    chmod 0755 "${AGENT_CURRENT}" 2>/dev/null || true
+    echo "[entrypoint] rolled back to previous agent and pinned updates off" >&2
+  else
+    rm -f "${AGENT_CURRENT}" 2>/dev/null || return 1
+    echo "[entrypoint] dropped back to the baked agent and pinned updates off" >&2
+  fi
+  # Latch it. Without this the box would re-stage the same bad build on every
+  # boot and crash-loop forever.
+  : > "${AGENT_PINNED}"
+  return 0
+}
+
+mkdir -p "${AGENT_STATE_DIR}" 2>/dev/null || true
+
 echo "[entrypoint] daemon takeover (cwd=/, workspace=${WORKSPACE})" >&2
-exec /usr/local/bin/kortix-agent "$@"
+while :; do
+  # A staged binary from the previous run is installed before launch, never
+  # while the daemon it replaces is running.
+  promote_staged_agent || true
+
+  agent_bin="$(select_agent)"
+  started=$(date +%s)
+  set +e
+  "${agent_bin}" "$@"
+  status=$?
+  set -e
+  ran=$(( $(date +%s) - started ))
+
+  if [ "${status}" -eq "${SWAP_CODE}" ]; then
+    echo "[entrypoint] daemon requested update swap (ran ${ran}s)" >&2
+    early_exits=0
+    continue
+  fi
+
+  # Anything else is the daemon exiting on its own terms. Honour it — this is
+  # PID 1 and the provider decides what a stopped sandbox means — unless it
+  # FAILED fast right after we swapped in a new binary, which is the one case
+  # where the update itself is the prime suspect.
+  #
+  # `status != 0` is load-bearing. A clean exit is the daemon choosing to stop
+  # (a stopped sandbox, a drained box) and must never be read as a bad update:
+  # counting it would roll back and pin a perfectly healthy binary purely
+  # because the box was short-lived.
+  # `AGENT_CURRENT` — not `AGENT_PREV` — is the test for "we are running an
+  # updated binary". The FIRST update has no predecessor to keep, so keying off
+  # AGENT_PREV would leave exactly the first bad rollout unable to roll back,
+  # which is the rollout most likely to be bad.
+  if [ "${status}" -ne 0 ] \
+     && [ "${ran}" -lt "${HEALTHY_AFTER_S}" ] \
+     && [ -f "${AGENT_CURRENT}" ] \
+     && [ ! -f "${AGENT_PINNED}" ]; then
+    early_exits=$(( early_exits + 1 ))
+    echo "[entrypoint] agent exited ${status} after ${ran}s (early exit ${early_exits}/${MAX_EARLY_EXITS})" >&2
+    if [ "${early_exits}" -ge "${MAX_EARLY_EXITS}" ] && rollback_agent; then
+      early_exits=0
+      continue
+    fi
+    [ "${early_exits}" -lt "${MAX_EARLY_EXITS}" ] && continue
+  fi
+
+  echo "[entrypoint] agent exited ${status} after ${ran}s; exiting" >&2
+  exit "${status}"
+done

--- a/apps/sandbox/scripts/test-entrypoint-swap.sh
+++ b/apps/sandbox/scripts/test-entrypoint-swap.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Supervisor tests for apps/sandbox/entrypoint.sh.
+#
+# The supervisor decides whether a box comes back up. Every path below is a way
+# it could brick one, so each is exercised against the REAL script with a stub
+# daemon rather than a re-implementation of the logic.
+#
+# The workspace-stabilization half is skipped by pointing KORTIX_WORKSPACE at a
+# writable temp dir; only the supervisor loop is under test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/../entrypoint.sh"
+pass=0
+fail=0
+
+ok() { echo "PASS  $1"; pass=$((pass + 1)); }
+no() { echo "FAIL  $1 — $2"; fail=$((fail + 1)); }
+
+sha_of() { sha256sum "$1" | cut -d' ' -f1; }
+
+# A stub "daemon": prints a marker, then exits with whatever its own marker file
+# says. Lets one test drive several generations of binary.
+make_agent() { # <path> <marker> <exit-code> [sleep]
+  cat > "$1" <<EOF
+#!/usr/bin/env bash
+echo "AGENT:$2" >> "\${KORTIX_TEST_LOG}"
+sleep "${4:-0}"
+exit $3
+EOF
+  chmod +x "$1"
+}
+
+run_case() { # <name>  (expects $TMP prepared by caller)
+  KORTIX_TEST_LOG="${TMP}/log" \
+  KORTIX_AGENT_BIN="${TMP}/bin/kortix-agent" \
+  KORTIX_AGENT_STATE_DIR="${TMP}/state" \
+  KORTIX_WORKSPACE="${TMP}/ws" \
+    bash "${ENTRYPOINT}" >"${TMP}/out" 2>&1
+  echo $?
+}
+
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "${TMP}/bin" "${TMP}/state" "${TMP}/ws"
+  : > "${TMP}/log"
+}
+
+# ---------------------------------------------------------------------------
+# 1. No staged binary: the supervisor is a pass-through and preserves exit code.
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/bin/kortix-agent" v1 0
+code=$(run_case)
+[ "${code}" = "0" ] && [ "$(grep -c AGENT:v1 "${TMP}/log")" = "1" ] \
+  && ok "clean run: daemon runs once, exit code preserved" \
+  || no "clean run" "code=${code} runs=$(grep -c AGENT:v1 "${TMP}/log")"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 2. A non-zero exit is still honoured (the provider decides what stopped means).
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/bin/kortix-agent" v1 3
+code=$(run_case)
+[ "${code}" = "3" ] && ok "non-zero exit propagates" || no "non-zero exit" "code=${code}"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 3. THE HAPPY PATH. v1 stages a good v2 and asks for the swap; the supervisor
+#    installs it, relaunches, and v2 runs.
+# ---------------------------------------------------------------------------
+setup
+# Faithful to production: the daemon stages the new binary DURING its own run
+# (that is what reconcileRuntimeAssets does), then asks for the swap.
+cat > "${TMP}/bin/kortix-agent" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:v1" >> "${KORTIX_TEST_LOG}"
+cat > "${KORTIX_AGENT_STATE_DIR}/agent.next" <<'INNER'
+#!/usr/bin/env bash
+echo "AGENT:v2" >> "${KORTIX_TEST_LOG}"
+exit 0
+INNER
+chmod +x "${KORTIX_AGENT_STATE_DIR}/agent.next"
+sha256sum "${KORTIX_AGENT_STATE_DIR}/agent.next" | cut -d' ' -f1 > "${KORTIX_AGENT_STATE_DIR}/agent.next.sha256"
+exit 75
+EOF
+chmod +x "${TMP}/bin/kortix-agent"
+code=$(run_case)
+if [ "${code}" = "0" ] && grep -q AGENT:v1 "${TMP}/log" && grep -q AGENT:v2 "${TMP}/log" \
+   && [ ! -f "${TMP}/state/agent.next" ] && [ -x "${TMP}/state/agent.current" ]; then
+  ok "swap: staged binary promoted, relaunched, installed as current"
+else
+  no "swap" "code=${code} log=$(tr '\n' ',' < "${TMP}/log") next=$([ -f "${TMP}/state/agent.next" ] && echo present || echo gone)"
+fi
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 4. Corrupt artifact: digest mismatch must NOT be installed. The running binary
+#    survives. This is the difference between a bad download and a dead fleet.
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/state/agent.next" v2 0
+echo "0000000000000000000000000000000000000000000000000000000000000000" > "${TMP}/state/agent.next.sha256"
+cat > "${TMP}/bin/kortix-agent" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:v1" >> "${KORTIX_TEST_LOG}"
+if [ -f "${KORTIX_AGENT_STATE_DIR}/ran-once" ]; then exit 0; fi
+: > "${KORTIX_AGENT_STATE_DIR}/ran-once"
+exit 75
+EOF
+chmod +x "${TMP}/bin/kortix-agent"
+code=$(run_case)
+if ! grep -q AGENT:v2 "${TMP}/log" && [ ! -f "${TMP}/state/agent.next" ] && [ "${code}" = "0" ]; then
+  ok "bad digest: staged binary discarded, live binary kept running"
+else
+  no "bad digest" "code=${code} log=$(tr '\n' ',' < "${TMP}/log")"
+fi
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 5. No digest at all: refuse. An unverifiable binary is never installed.
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/state/agent.next" v2 0
+cat > "${TMP}/bin/kortix-agent" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:v1" >> "${KORTIX_TEST_LOG}"
+if [ -f "${KORTIX_AGENT_STATE_DIR}/ran-once" ]; then exit 0; fi
+: > "${KORTIX_AGENT_STATE_DIR}/ran-once"
+exit 75
+EOF
+chmod +x "${TMP}/bin/kortix-agent"
+code=$(run_case)
+! grep -q AGENT:v2 "${TMP}/log" && [ ! -f "${TMP}/state/agent.next" ] \
+  && ok "unverifiable staged binary refused" \
+  || no "unverifiable staged binary" "log=$(tr '\n' ',' < "${TMP}/log")"
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 6. THE ONE THAT MATTERS. A new binary that dies immediately must roll back to
+#    the previous one and latch, instead of crash-looping the box forever.
+# ---------------------------------------------------------------------------
+setup
+# v2 is broken: always exits 1 straight away.
+cat > "${TMP}/state/agent.next" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:v2-broken" >> "${KORTIX_TEST_LOG}"
+exit 1
+EOF
+chmod +x "${TMP}/state/agent.next"
+sha_of "${TMP}/state/agent.next" > "${TMP}/state/agent.next.sha256"
+# v1 asks for the swap once, then (as the restored binary) runs fine.
+cat > "${TMP}/bin/kortix-agent" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:v1" >> "${KORTIX_TEST_LOG}"
+if [ -f "${KORTIX_AGENT_STATE_DIR}/asked" ]; then exit 0; fi
+: > "${KORTIX_AGENT_STATE_DIR}/asked"
+exit 75
+EOF
+chmod +x "${TMP}/bin/kortix-agent"
+code=$(run_case)
+broken_runs=$(grep -c AGENT:v2-broken "${TMP}/log")
+if [ -f "${TMP}/state/agent.pinned" ] && [ "${broken_runs}" -le 2 ] \
+   && [ "$(tail -1 "${TMP}/log")" = "AGENT:v1" ] && [ "${code}" = "0" ]; then
+  ok "crash-looping update rolls back to the baked binary and pins"
+else
+  no "rollback" "code=${code} brokenRuns=${broken_runs} pinned=$([ -f "${TMP}/state/agent.pinned" ] && echo yes || echo no) log=$(tr '\n' ',' < "${TMP}/log")"
+fi
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 6b. The baked binary is an IMMUTABLE FLOOR. An update never writes it, so a
+#     box can always fall back to what shipped in the image. This is the
+#     property that makes bricking impossible rather than unlikely.
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/bin/kortix-agent" baked 0
+baked_before=$(sha_of "${TMP}/bin/kortix-agent")
+cat > "${TMP}/state/agent.next" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:update" >> "${KORTIX_TEST_LOG}"
+exit 0
+EOF
+chmod +x "${TMP}/state/agent.next"
+sha_of "${TMP}/state/agent.next" > "${TMP}/state/agent.next.sha256"
+code=$(run_case)
+baked_after=$(sha_of "${TMP}/bin/kortix-agent")
+if [ "${baked_before}" = "${baked_after}" ] && grep -q AGENT:update "${TMP}/log" \
+   && [ -x "${TMP}/state/agent.current" ]; then
+  ok "update installs beside the baked binary and never overwrites it"
+else
+  no "immutable floor" "bakedChanged=$([ "${baked_before}" = "${baked_after}" ] && echo no || echo YES) log=$(tr '\n' ',' < "${TMP}/log")"
+fi
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 6c. Regression guard. The FIRST update has no predecessor to roll back to, so
+#     an implementation keying rollback off `agent.prev` leaves exactly the
+#     first bad rollout unrecoverable — the rollout most likely to be bad.
+#     Removing the override must drop the box back to the baked binary.
+# ---------------------------------------------------------------------------
+setup
+make_agent "${TMP}/bin/kortix-agent" baked-good 0
+cat > "${TMP}/state/agent.next" <<'EOF'
+#!/usr/bin/env bash
+echo "AGENT:first-update-broken" >> "${KORTIX_TEST_LOG}"
+exit 1
+EOF
+chmod +x "${TMP}/state/agent.next"
+sha_of "${TMP}/state/agent.next" > "${TMP}/state/agent.next.sha256"
+code=$(run_case)
+if [ -f "${TMP}/state/agent.pinned" ] && [ ! -f "${TMP}/state/agent.current" ] \
+   && [ "$(tail -1 "${TMP}/log")" = "AGENT:baked-good" ]; then
+  ok "first bad update with no predecessor falls back to the baked binary"
+else
+  no "first-update rollback" "pinned=$([ -f "${TMP}/state/agent.pinned" ] && echo yes || echo no) current=$([ -f "${TMP}/state/agent.current" ] && echo present || echo gone) log=$(tr '\n' ',' < "${TMP}/log")"
+fi
+rm -rf "${TMP}"
+
+# ---------------------------------------------------------------------------
+# 7. Once pinned, a staged binary is discarded — no re-download loop of a build
+#    already known to be bad.
+# ---------------------------------------------------------------------------
+setup
+: > "${TMP}/state/agent.pinned"
+make_agent "${TMP}/state/agent.next" v2 0
+sha_of "${TMP}/state/agent.next" > "${TMP}/state/agent.next.sha256"
+make_agent "${TMP}/bin/kortix-agent" v1 0
+code=$(run_case)
+! grep -q AGENT:v2 "${TMP}/log" && [ ! -f "${TMP}/state/agent.next" ] \
+  && ok "pinned box refuses staged updates" \
+  || no "pinned" "log=$(tr '\n' ',' < "${TMP}/log")"
+rm -rf "${TMP}"
+
+echo
+echo "${pass} passed, ${fail} failed"
+[ "${fail}" -eq 0 ]

--- a/apps/web/src/components/iam/audit-display-helpers.ts
+++ b/apps/web/src/components/iam/audit-display-helpers.ts
@@ -164,6 +164,8 @@ const ROUTE_LABEL_OVERRIDES: Record<string, string> = {
   'GET /v1/runtime-assets/manifest': 'Checked sandbox runtime-asset versions',
   'GET /v1/runtime-assets/cli': 'Downloaded the sandbox CLI',
   'HEAD /v1/runtime-assets/cli': 'Checked the sandbox CLI',
+  'GET /v1/runtime-assets/agent': 'Downloaded the sandbox agent',
+  'HEAD /v1/runtime-assets/agent': 'Checked the sandbox agent',
   'GET /v1/runtime-assets/managed-skills': 'Downloaded managed skills',
   'POST /v1/router/web-search': 'Searched the web',
   'POST /v1/router/image-search': 'Searched images',

--- a/apps/web/src/components/iam/audit-http-routes.generated.ts
+++ b/apps/web/src/components/iam/audit-http-routes.generated.ts
@@ -539,6 +539,8 @@ const AUDIT_HTTP_ROUTE_KEYS = [
   "GET|v1|router|models",
   "GET|v1|router|models|:model",
   "POST|v1|router|web-search",
+  "GET|v1|runtime-assets|agent",
+  "HEAD|v1|runtime-assets|agent",
   "GET|v1|runtime-assets|cli",
   "HEAD|v1|runtime-assets|cli",
   "GET|v1|runtime-assets|managed-skills",

--- a/docs/specs/2026-08-20-convergent-runtime.md
+++ b/docs/specs/2026-08-20-convergent-runtime.md
@@ -1,0 +1,219 @@
+# Convergent runtime — the image is a cache, not the truth
+
+**Status:** implementing · **Date:** 2026-08-20
+
+## The problem
+
+A sandbox runs the code that was baked into its image. Restart and resume
+suspend/resume the same VM; a warm fork adopts a captured disk. None of them
+re-run the image build. So a box provisioned this morning runs this morning's
+`kortix-agent`, this morning's `opencode`, and this morning's CLI — forever.
+
+Two consequences we are paying for today:
+
+1. **Fleet-wide gates.** The ~1,700-LOC wire-id placement machine cannot be
+   deleted until every 1.17.11 box drains, because the old OpenCode needs it.
+   Correctness work is blocked on VM turnover.
+2. **Rebuild storms.** `OPENCODE_VERSION` is part of the snapshot identity, so
+   one version bump invalidates every template at once. That is the shape of
+   the 2026-07-22 mutual-rebuild loop and the Daytona 429 incident.
+
+`runtime-assets.ts` already solved this — for two assets. It converges
+`/usr/local/bin/kortix` and `/opt/kortix/managed-skills` against
+`GET /v1/runtime-assets/manifest`: digest compare, download only on mismatch,
+verify before replace, atomic rename, never throw, off the readiness path.
+
+It does not cover the `kortix-agent` daemon or the `opencode` binary. That gap
+is the entire reason stale boxes exist.
+
+## The principle
+
+> The image is a **cache**. The API a box talks to is the **truth**. A box
+> converges onto that truth on every start, and reports what it converged to.
+
+Two corollaries that shape every decision below:
+
+- **A current box downloads nothing.** Digests match, convergence is a no-op.
+  Only a stale box pays, and a stale box is exactly the one that is wrong today.
+- **Converge on the API you talk to** — never on "global latest". Dev runs three
+  regions; two concurrently-live API versions must never make a box oscillate.
+
+## Components
+
+| Component | Size | Served from | Swap safety |
+|---|---|---|---|
+| `agent` (`kortix-agent`) | ~95.6 MB | Kortix API | supervisor, boot-only |
+| `cli` (`kortix`) | ~104 MB | Kortix API | atomic rename, live-safe |
+| `opencode` (+ matching `@opencode-ai/plugin`) | ~167 MB | npm registry | idle-only, restarts opencode |
+| `managed-skills` | small | Kortix API | staged dir swap |
+
+`opencode` is fetched from npm by the daemon, not proxied through our API: the
+manifest states the *expected version*, and 167 MB per stale box has no business
+crossing our own control plane.
+
+## Manifest — additive, never reshaped
+
+Existing deployed daemons read `cli_sha256` / `cli_size` / `managed_skills_hash`
+off this document. Removing or renaming any of them breaks every box already in
+the field, which is the same failure mode as the accept-encoding two-list
+divergence. **The v1 keys are permanent.** New daemons prefer `components`;
+old daemons keep working because their keys are still there.
+
+```jsonc
+{
+  // v1 — load-bearing for already-deployed daemons. Never remove.
+  "cli_version": "0.13.1-dev.abc1234",
+  "cli_sha256": "…",
+  "cli_size": 104233088,
+  "managed_skills_hash": "…",
+  "managed_skills_count": 42,
+
+  // v2 — additive.
+  "build": 1755700000,          // monotonic. A box only ever moves forward.
+  "components": {
+    "agent":    { "version": "…", "sha256": "…", "size": 95606912, "path": "/v1/runtime-assets/agent" },
+    "cli":      { "version": "…", "sha256": "…", "size": 104233088, "path": "/v1/runtime-assets/cli" },
+    "opencode": { "version": "1.18.19", "source": "npm" },
+    "managed-skills": { "hash": "…", "count": 42 }
+  },
+  "policy": {
+    "agent_self_update": true   // kill switch: flip false to stop a bad rollout
+                                // WITHOUT shipping a new daemon to boxes that
+                                // may no longer boot.
+  }
+}
+```
+
+### `build` is the anti-flap guard
+
+The box records the highest `build` it has converged to. A manifest with a lower
+`build` is ignored. During a rolling deploy two API versions serve two manifests;
+without this a box ping-pongs between them, re-downloading ~200 MB each way. We
+have already lived this once with warm images (2026-07-22, infinite mutual
+rebuild).
+
+## Self-update: the supervisor owns the swap
+
+`apps/sandbox/entrypoint.sh` currently ends with `exec /usr/local/bin/kortix-agent`.
+`exec` replaces the shell, so nothing supervises the daemon and it has nowhere to
+hand control back to. A process also cannot safely overwrite its own running
+binary.
+
+### The baked binary is an immutable floor
+
+`/usr/local/bin/kortix-agent` is **root-owned**, and the daemon runs as `kortix`
+after the privilege drop. That is not an obstacle to work around — it is the
+safety property. Updates are therefore installed *beside* it:
+
+| Path | Owner | Role |
+|---|---|---|
+| `/usr/local/bin/kortix-agent` | root | baked floor; runtime code cannot write it |
+| `/opt/kortix/agent.current` | kortix | the updated binary, when one is installed |
+| `/opt/kortix/agent.next` | kortix | staged by the daemon, promoted at next start |
+| `/opt/kortix/agent.prev` | kortix | previous `agent.current`, for rollback |
+| `/opt/kortix/agent.pinned` | kortix | latch: rollback happened, stop updating |
+
+The supervisor launches `agent.current` when it is present and executable, and
+the baked binary otherwise. Worst-case recovery is therefore *deleting one file*,
+after which the box boots exactly what shipped in the image. A bricked box is
+not merely unlikely; there is no write path to the floor.
+
+So the daemon **never** replaces itself. It only *stages*:
+
+1. Daemon downloads the new agent, verifies the digest, writes
+   `/opt/kortix/agent.next` (+ `.sha256`), and does nothing else.
+2. When it is safe to restart (see below) the daemon exits with code **`75`**
+   (`EX_TEMPFAIL`) — "replace me and start me again".
+3. The supervising entrypoint loop:
+   - re-verifies `agent.next` against its recorded digest (the daemon that wrote
+     it is not trusted to have been correct);
+   - copies the live binary to `/opt/kortix/agent.prev`;
+   - atomically renames `agent.next` into place;
+   - relaunches.
+4. If the new binary exits early **twice in a row**, the supervisor restores
+   `agent.prev`, writes `/opt/kortix/agent.pinned`, and stops updating. A pinned
+   box keeps running the last binary that worked.
+
+The image-baked binary is the permanent floor: `agent.prev` is only ever a
+previously-running binary, and a box with neither still boots the baked one.
+
+### Why a sentinel exit code and not a signal
+
+The supervisor must distinguish "swap requested" from "crashed". Exit 75 is
+requested-and-intentional; anything else counts toward the failure budget that
+triggers rollback. A crash-looping *new* binary therefore rolls back, while a
+crash-looping *old* binary does not silently trigger an update.
+
+## When a swap is allowed
+
+Never mid-turn. The daemon owns opencode's lifecycle, the reverse proxy, and
+PTYs; restarting it severs a live turn, and restarting opencode severs the model
+call.
+
+- **agent** — staged any time; the restart is requested only when no turn is in
+  flight. If the box is busy, the staged binary simply takes effect at the next
+  natural restart, which for a sandbox is soon.
+- **opencode** — installed only when idle, and the matching
+  `@opencode-ai/plugin` pin in the config dir is refreshed in the same step. If
+  the plugin does not match the binary, opencode refetches it on every boot,
+  which is the multi-second `opencode-session-created` stall.
+
+## Observability — convergence you can query
+
+Auto-update without reporting just moves the uncertainty. `/kortix/health` gains
+a `runtime` block:
+
+```jsonc
+"runtime": {
+  "build": 1755700000,          // what this box converged to
+  "components": {
+    "agent":    { "installed": "…", "expected": "…", "current": true },
+    "opencode": { "installed": "1.18.19", "expected": "1.18.19", "current": true },
+    "cli":      { "installed": "…", "expected": "…", "current": true }
+  },
+  "pinned": false               // rollback latched
+}
+```
+
+This is what makes "is the fleet current?" answerable instead of hopeful, and it
+is the signal that tells us when a fleet-drain gate has actually cleared.
+
+## Security
+
+The daemon runs as root and this is a remote-code-execution channel by
+construction. Controls, in order of how much they carry:
+
+- Transport is TLS to an authenticated Kortix API; the token is the sandbox's.
+- Every artifact is verified by **sha256 against the manifest** before it is
+  moved into place, and the supervisor **re-verifies** independently of the
+  daemon.
+- Downloads land in a temp file in the destination directory and arrive by
+  atomic `rename`; no consumer can observe a half-written binary.
+- `policy.agent_self_update: false` stops a rollout centrally.
+
+**Known gap, deliberately stated:** digest-from-the-API is integrity against
+corruption and truncation, not against a compromised API. Signing artifacts
+against a public key baked into the image is the next increment — the verifier
+is already a single choke point (`verifyArtifact`) so the upgrade is additive.
+This is written down rather than implied so nobody mistakes the current
+guarantee for a stronger one.
+
+## What this unlocks
+
+- **Gate 2 on the wire-id deletion disappears.** Boxes converge to 1.18.19 on
+  their next start instead of waiting for VM turnover.
+- `OPENCODE_VERSION` can eventually leave the snapshot identity, ending
+  full-fleet template rebuilds on every bump. Identity stays as the *cache key*
+  for fast boots; convergence is what guarantees correctness.
+- The daemon becomes the unit that makes any machine a Kortix machine, which is
+  the shape self-host and BYO-compute need. Those will want
+  `policy.agent_self_update: false` and a pinned version, which the kill switch
+  already expresses.
+
+## Non-goals for this change
+
+- Signing (designed for, not implemented — see Security).
+- Channels (`stable` / `latest` / `pinned`) for self-host. The policy block is
+  where they will go.
+- Removing `OPENCODE_VERSION` from the snapshot identity. Convergence has to be
+  proven in the fleet first.

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 600,
+  "count": 598,
   "routes": [
     {
       "method": "GET",
@@ -965,6 +965,34 @@
     {
       "method": "GET",
       "path": "/v1/health/ready"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/llm/chat/completions"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/llm/health"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/llm/messages"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/llm/models"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/llm/v1/chat/completions"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/llm/v1/messages"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/llm/v1/models"
     },
     {
       "method": "GET",
@@ -2165,42 +2193,6 @@
     {
       "method": "POST",
       "path": "/v1/setup-links/secret/:token"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/setup/bootstrap-owner"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/health"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/install-status"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/sandbox-providers"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/setup/setup-complete"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/setup-status"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/setup-wizard-step"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/setup/setup-wizard-step"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/setup/status"
     },
     {
       "method": "GET",

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 596,
+  "count": 600,
   "routes": [
     {
       "method": "GET",
@@ -965,34 +965,6 @@
     {
       "method": "GET",
       "path": "/v1/health/ready"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/llm/chat/completions"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/llm/health"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/llm/messages"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/llm/models"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/llm/v1/chat/completions"
-    },
-    {
-      "method": "POST",
-      "path": "/v1/llm/v1/messages"
-    },
-    {
-      "method": "GET",
-      "path": "/v1/llm/v1/models"
     },
     {
       "method": "GET",
@@ -2152,6 +2124,14 @@
     },
     {
       "method": "GET",
+      "path": "/v1/runtime-assets/agent"
+    },
+    {
+      "method": "HEAD",
+      "path": "/v1/runtime-assets/agent"
+    },
+    {
+      "method": "GET",
       "path": "/v1/runtime-assets/cli"
     },
     {
@@ -2185,6 +2165,42 @@
     {
       "method": "POST",
       "path": "/v1/setup-links/secret/:token"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/bootstrap-owner"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/health"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/install-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/sandbox-providers"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-complete"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-status"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/setup/setup-wizard-step"
+    },
+    {
+      "method": "GET",
+      "path": "/v1/setup/status"
     },
     {
       "method": "GET",

--- a/tests/src/flows/runtime-assets.flow.ts
+++ b/tests/src/flows/runtime-assets.flow.ts
@@ -35,7 +35,12 @@ flow(
   {
     domain: 'runtime-assets',
     tags: ['smoke'],
-    routes: ['GET /v1/runtime-assets/manifest', 'POST /v1/projects/:projectId/cli-token'],
+    routes: [
+      'GET /v1/runtime-assets/manifest',
+      'GET /v1/runtime-assets/agent',
+      'HEAD /v1/runtime-assets/agent',
+      'POST /v1/projects/:projectId/cli-token',
+    ],
   },
   async (ctx) => {
     const projectPat = await createProjectPat(ctx, 'runtime-assets-manifest-pat');
@@ -82,6 +87,55 @@ flow(
         }
       } else if (body.cli_size !== null) {
         throw new Error('cli_size must be null when cli_sha256 is null');
+      }
+    });
+
+    await ctx.step('the v2 component block describes the whole runtime, not just the CLI', async () => {
+      // A box converges its daemon and its opencode off this block. If the
+      // component list regresses to CLI-only, every sandbox silently stops
+      // self-healing and nothing else in the system notices.
+      const r = await ctx.client.as(ctx.P.OWNER).get('/v1/runtime-assets/manifest');
+      r.status(200);
+      const body = r.json<{
+        build: number;
+        components: Record<string, { sha256?: string; size?: number; version?: string | null; source?: string }>;
+        policy: { agent_self_update: boolean };
+      }>();
+      if (typeof body.build !== 'number') {
+        throw new Error('build must be a number — a sandbox uses it to refuse going backwards');
+      }
+      if (typeof body.policy?.agent_self_update !== 'boolean') {
+        throw new Error('policy.agent_self_update must be a boolean kill switch');
+      }
+      const opencode = body.components?.opencode;
+      if (!opencode?.version) {
+        throw new Error('components.opencode.version is what a stale box converges onto');
+      }
+      const agent = body.components?.agent;
+      // Nullable by design, exactly like the CLI half: a checkout that never
+      // built the daemon must omit it rather than fail the manifest.
+      if (agent && agent.sha256 && !SHA256.test(agent.sha256)) {
+        throw new Error(`components.agent.sha256 must be a sha256 hex digest, got ${agent.sha256}`);
+      }
+    });
+
+    await ctx.step('the agent binary is downloadable and matches its advertised digest', async () => {
+      const manifest = await ctx.client.as(ctx.P.OWNER).get('/v1/runtime-assets/manifest');
+      manifest.status(200);
+      const agent = manifest.json<{ components?: { agent?: { sha256?: string; size?: number } } }>()
+        .components?.agent;
+      if (!agent?.sha256) return; // no daemon built in this profile — nothing to serve
+
+      const anon = await ctx.client.as(ctx.P.ANON).get('/v1/runtime-assets/agent');
+      anon.status(401);
+
+      // HEAD via the generic request seam — the client exposes no `head()`
+      // helper, and HEAD is the call a daemon makes to check the digest without
+      // pulling ~95 MB it may already have.
+      const head = await ctx.client.as(ctx.P.OWNER).request('HEAD', '/v1/runtime-assets/agent');
+      head.status(200);
+      if (head.header('x-kortix-agent-sha256') !== agent.sha256) {
+        throw new Error('the agent route must advertise the same digest the manifest promises');
       }
     });
 


### PR DESCRIPTION
## The problem, in one sentence

A sandbox runs the code that was baked into its image, forever — restart and resume suspend the *same* VM, and a warm fork adopts a captured disk, so none of them re-run the image build.

We keep paying for that:

- **Correctness work gets gated on VM turnover.** The ~1,700-LOC wire-id placement machine cannot be deleted until every 1.17.11 box drains, because the old OpenCode still needs it.
- **One version bump invalidates every template at once**, because `OPENCODE_VERSION` is part of the snapshot identity. That is the shape of the 2026-07-22 mutual-rebuild loop and the Daytona 429 incident.

`runtime-assets.ts` already solved this — for two assets. It converges the `kortix` CLI and the managed-skills overlay against `GET /v1/runtime-assets/manifest`. It did not cover the `kortix-agent` daemon or the `opencode` binary, and **that gap is the entire reason stale boxes exist.**

## The principle

> The image is a **cache**. The API a box talks to is the **truth**. A box converges onto that truth on every start, and reports what it converged to.

Two properties that fall out and are worth stating because they answer the obvious objections:

- **A current box downloads nothing.** Digests match, convergence is a no-op. Only a stale box pays — and a stale box is exactly the one that is wrong today.
- **Converge on the API you talk to**, never on "global latest". Dev runs three regions; two live API versions must never make a box oscillate.

## Supervisor — `apps/sandbox/entrypoint.sh`

It ended with `exec kortix-agent`. `exec` replaces the shell, so nothing supervised the daemon and it had nowhere to hand control back to. A process also cannot safely overwrite its own running binary.

So the daemon **never** replaces itself. It stages `agent.next` + `agent.next.sha256` and exits **75** to request the swap. The supervisor re-verifies the digest *independently of the daemon that wrote it*, keeps a rollback target, swaps atomically, and relaunches.

**The baked binary is an immutable floor.** `/usr/local/bin/kortix-agent` is root-owned and the daemon runs as `kortix` — that is not an obstacle to work around, it is the safety property. Updates install *beside* it at `/opt/kortix/agent.current`. Worst-case recovery is deleting one file, after which the box boots exactly what shipped in the image. There is no write path to the floor, so a bricked box is not merely unlikely.

Two consecutive **non-zero** early exits roll back and latch `agent.pinned`. A *clean* exit is deliberately not counted: a short-lived box must never pin a perfectly healthy binary.

## API — `apps/api/src/runtime-assets`

- Manifest gains `build`, `components`, `policy`. **Every v1 key is kept verbatim and guarded by a test** — daemons already in the field read them, and dropping one breaks every existing box (the accept-encoding two-list divergence, again).
- `build` is a monotonic epoch derived from the image's binary mtime. A box refuses a lower one, so a rolling deploy serving two manifests cannot make it flap. Its limits are documented in-code rather than implied.
- `policy.agent_self_update` is an **env-var kill switch** — stop a bad rollout without shipping code to boxes that may no longer boot. A typo fails safe.
- `GET`/`HEAD /v1/runtime-assets/agent` serve the daemon binary content-addressed and streamed, with the same auth and absent-binary behaviour as `/cli`.

## Daemon — `apps/kortix-sandbox-agent-server`

- Epoch guard, then **agent staging only** (never a self-swap), then **opencode convergence when idle** — restarting opencode severs a live model call, so it uses the existing turn-state seam rather than inventing a second source of truth. The matching `@opencode-ai/plugin` pin is refreshed in the same step, or opencode refetches it on every boot.
- The swap is requested only when idle and unblocked. A busy box simply keeps the staging; the supervisor installs it at the next start, which for a sandbox is soon.
- **`/kortix/health` now reports convergence**: which epoch this box reached, per-component outcome, whether a swap is pending, and whether updates are latched off. Auto-update without reporting only moves the uncertainty — this makes "is the fleet current?" a query instead of a hope, and it is how we will know a drain gate has actually cleared.

## Verified

| Gate | Result |
|---|---|
| Supervisor (real script, stub daemons) | **9/9** |
| `apps/kortix-sandbox-agent-server` | 776 pass / 0 fail, tsc clean |
| `apps/api` | 7855 pass / 0 fail, tsc clean |
| `packages/shared` | 312 pass / 0 fail |
| `tests` typecheck + route manifest | clean, `/agent` registered and covered |

The supervisor tests cover swap, corrupt digest, unverifiable artifact, crash-loop rollback, the immutable floor, **first-update rollback with no predecessor**, and the pin latch. Two of those exist because testing found real bugs: a *healthy* binary exiting cleanly was being rolled back, and rollback keyed off `agent.prev` — which does not exist on a first update, leaving the rollout most likely to be bad unable to recover.

**Cross-component proof:** the real `reconcileRuntimeAssets` staged an artifact into a temp state dir, and the real `entrypoint.sh` then verified, promoted and launched it. The daemon's manifest reader was also fed the live `runtimeAssetsManifest()` output — the two sides agree on the wire shape.

Tests were mutation-checked rather than assumed: neutering the epoch guard fails exactly the lower-build test, neutering the idle gate fails exactly the two busy tests, and deleting a v1 manifest key fails the permanence guard.

## Honest limits

- **This does not retroactively fix today's fleet.** The supervisor only exists in new images, so daemon self-update reaches a box once it has been re-provisioned. **It means this is the last fleet drain we ever pay** — after it, boxes self-heal on every start.
- **Digest-from-the-API is integrity against corruption, not against a compromised API.** Signing against a key baked into the image is the next increment; the verifier is already a single choke point so it stays additive. Written into the spec's Security section rather than implied.
- `pnpm add -g` / `bun install` are stubbed in tests — everything around them is covered, but the real install runs first on dev.
- Not in scope: removing `OPENCODE_VERSION` from the snapshot identity (convergence should be proven in the fleet first), and channels for self-host (`policy` is where they go).

Spec: `docs/specs/2026-08-20-convergent-runtime.md`
