### PR TITLE
fix(boot): invalidate stale scaffold images

### DIFF
--- a/apps/api/src/projects/git/fast-boot-bundle.test.ts
+++ b/apps/api/src/projects/git/fast-boot-bundle.test.ts
@@ -133,55 +133,6 @@ describe('buildSingleParentDeltaBundle', () => {
     }
   });
 
-  test('imports when the provider parent tree differs from the image-baked scaffold', async () => {
-    const root = mkdtempSync(join(tmpdir(), 'kortix-portable-fast-boot-bundle-'));
-    try {
-      const bakedSource = join(root, 'baked-source');
-      const providerSource = join(root, 'provider-source');
-      const scaffoldRepo = join(root, 'scaffold.git');
-      const checkout = join(root, 'checkout');
-      mkdirSync(bakedSource);
-      mkdirSync(providerSource);
-
-      const identity = {
-        GIT_AUTHOR_NAME: 'Kortix',
-        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
-        GIT_COMMITTER_NAME: 'Kortix',
-        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
-      };
-      git(['init', '-b', 'main'], bakedSource);
-      writeFileSync(join(bakedSource, 'README.md'), 'image scaffold\n');
-      git(['add', 'README.md'], bakedSource);
-      git(['commit', '-m', 'chore: scaffold Kortix project'], bakedSource, identity);
-      git(['clone', '--bare', bakedSource, scaffoldRepo], root);
-
-      git(['init', '-b', 'main'], providerSource);
-      writeFileSync(join(providerSource, 'README.md'), 'newer provider scaffold\n');
-      writeFileSync(join(providerSource, 'package.json'), '{}\n');
-      git(['add', '-A'], providerSource);
-      git(['commit', '-m', 'chore: scaffold Kortix project'], providerSource, identity);
-      writeFileSync(join(providerSource, 'README.md'), 'customer project\n');
-      git(['add', 'README.md'], providerSource);
-      git(['commit', '-m', 'chore: project setup'], providerSource, identity);
-      const baseSha = git(['rev-parse', 'HEAD'], providerSource);
-
-      const bundle = await buildSingleParentDeltaBundle(providerSource, 'main');
-      expect(bundle?.baseSha).toBe(baseSha);
-
-      git(['clone', '-q', scaffoldRepo, checkout], root);
-      const bundlePath = join(root, 'portable.bundle');
-      writeFileSync(bundlePath, Buffer.from(bundle!.bundleBase64, 'base64'));
-      git(['bundle', 'verify', bundlePath], checkout);
-      git(['bundle', 'unbundle', bundlePath], checkout);
-      git(['checkout', '-q', '-B', 'main', baseSha], checkout);
-
-      expect(readFileSync(join(checkout, 'README.md'), 'utf8')).toBe('customer project\n');
-      expect(readFileSync(join(checkout, 'package.json'), 'utf8')).toBe('{}\n');
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-
   test('keeps the current managed starter delta below the sandbox env limit', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-starter-fast-boot-bundle-'));
     try {

--- a/apps/api/src/projects/git/fast-boot-bundle.test.ts
+++ b/apps/api/src/projects/git/fast-boot-bundle.test.ts
@@ -133,6 +133,55 @@ describe('buildSingleParentDeltaBundle', () => {
     }
   });
 
+  test('imports when the provider parent tree differs from the image-baked scaffold', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'kortix-portable-fast-boot-bundle-'));
+    try {
+      const bakedSource = join(root, 'baked-source');
+      const providerSource = join(root, 'provider-source');
+      const scaffoldRepo = join(root, 'scaffold.git');
+      const checkout = join(root, 'checkout');
+      mkdirSync(bakedSource);
+      mkdirSync(providerSource);
+
+      const identity = {
+        GIT_AUTHOR_NAME: 'Kortix',
+        GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+        GIT_COMMITTER_NAME: 'Kortix',
+        GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+      };
+      git(['init', '-b', 'main'], bakedSource);
+      writeFileSync(join(bakedSource, 'README.md'), 'image scaffold\n');
+      git(['add', 'README.md'], bakedSource);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], bakedSource, identity);
+      git(['clone', '--bare', bakedSource, scaffoldRepo], root);
+
+      git(['init', '-b', 'main'], providerSource);
+      writeFileSync(join(providerSource, 'README.md'), 'newer provider scaffold\n');
+      writeFileSync(join(providerSource, 'package.json'), '{}\n');
+      git(['add', '-A'], providerSource);
+      git(['commit', '-m', 'chore: scaffold Kortix project'], providerSource, identity);
+      writeFileSync(join(providerSource, 'README.md'), 'customer project\n');
+      git(['add', 'README.md'], providerSource);
+      git(['commit', '-m', 'chore: project setup'], providerSource, identity);
+      const baseSha = git(['rev-parse', 'HEAD'], providerSource);
+
+      const bundle = await buildSingleParentDeltaBundle(providerSource, 'main');
+      expect(bundle?.baseSha).toBe(baseSha);
+
+      git(['clone', '-q', scaffoldRepo, checkout], root);
+      const bundlePath = join(root, 'portable.bundle');
+      writeFileSync(bundlePath, Buffer.from(bundle!.bundleBase64, 'base64'));
+      git(['bundle', 'verify', bundlePath], checkout);
+      git(['bundle', 'unbundle', bundlePath], checkout);
+      git(['checkout', '-q', '-B', 'main', baseSha], checkout);
+
+      expect(readFileSync(join(checkout, 'README.md'), 'utf8')).toBe('customer project\n');
+      expect(readFileSync(join(checkout, 'package.json'), 'utf8')).toBe('{}\n');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('keeps the current managed starter delta below the sandbox env limit', async () => {
     const root = mkdtempSync(join(tmpdir(), 'kortix-starter-fast-boot-bundle-'));
     try {

--- a/apps/api/src/snapshots/__tests__/scaffold-fingerprint-closure.test.ts
+++ b/apps/api/src/snapshots/__tests__/scaffold-fingerprint-closure.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+
+const templatesSource = readFileSync(join(import.meta.dir, '..', 'templates.ts'), 'utf8');
+
+describe('standard snapshot scaffold fingerprint closure', () => {
+  test('treats the complete starter package as non-agent runtime content', () => {
+    const start = templatesSource.indexOf('const NON_AGENT_RUNTIME_ARTIFACTS = [');
+    const end = templatesSource.indexOf('];', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const artifacts = templatesSource.slice(start, end);
+    expect(artifacts).toContain("label: 'kortix-starter'");
+    expect(artifacts).toContain('path: STARTER_ROOT');
+    expect(artifacts).toContain('excludeNames: FINGERPRINT_EXCLUDES');
+  });
+});

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -87,10 +87,15 @@ const SLACK_CLI_SRC_PATH = process.env.KORTIX_SNAPSHOT_SLACK_CLI_PATH
 // This closure is asserted complete by snapshots/__tests__/cli-connector-closure
 // .test.ts, which re-derives it from the `kortix connectors` entrypoints and fails
 // if a new import escapes the hashed set — so scoping can never silently ship a
-// stale in-sandbox connector. packages/starter (scaffolding) and packages/
-// manifest-schema (only reached by laptop-side `ship`/`validate`) are likewise
-// never in the sandbox and are deliberately not fingerprinted.
+// stale in-sandbox connector. packages/manifest-schema is only reached by
+// laptop-side `ship`/`validate` and is deliberately not fingerprinted.
 const CLI_ROOT = resolve(REPO_ROOT, 'apps/cli');
+// The standard image bakes the canonical starter repository at
+// /opt/kortix/scaffold.git. A starter change must invalidate the non-agent
+// fingerprint. Otherwise the agent-swap path can copy a new agent onto an old
+// image while preserving a stale scaffold, which makes every fresh session
+// reject its local Git bundle and fall back to the network clone.
+const STARTER_ROOT = resolve(REPO_ROOT, 'packages/starter');
 const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'] as const;
 
 // Bump when the rendered Kortix Dockerfile layer changes (the Dockerfile text
@@ -911,6 +916,7 @@ const NON_AGENT_RUNTIME_ARTIFACTS = [
   { label: 'kortix-opencode-warmup', path: OPENCODE_WARMUP_PATH },
   { label: 'kortix-machine-doc', path: MACHINE_DOC_PATH },
   { label: 'kortix-slack-cli', path: SLACK_CLI_SRC_PATH, excludeNames: FINGERPRINT_EXCLUDES },
+  { label: 'kortix-starter', path: STARTER_ROOT, excludeNames: FINGERPRINT_EXCLUDES },
   // Only the in-sandbox `kortix connectors` closure (NOT the whole apps/cli/src) —
   // see CLI_CONNECTOR_RUNTIME_FILES in @kortix/shared. This artifact set also
   // includes @kortix/sdk because the compiled CLI owns the Connector client.
@@ -980,7 +986,7 @@ export async function currentRuntimeArtifactFingerprint(): Promise<string> {
 /**
  * Fingerprint of the runtime layer EXCLUDING the kortix-agent binary. Changes iff
  * a NON-agent runtime input moved — opencode/entrypoint/CLI/slack-cli/SDK/
- * manifest-schema source, or the layer/browser/sandbox version constants. The
+ * starter source, or the layer/browser/sandbox version constants. The
  * agent-swap fast path is sound ONLY when this is byte-identical between the
  * predecessor and the new identity (i.e. the agent binary is the SOLE runtime
  * delta). Folded into the template's swapKey so the builder can compare against the


### PR DESCRIPTION
## Problem

The standard sandbox image bakes the canonical starter repository at /opt/kortix/scaffold.git. The non-agent snapshot fingerprint excluded packages/starter. An agent-only deployment could therefore use the agent-swap path and retain an old scaffold. Fresh sessions then rejected the local Git bundle and spent 5-10 seconds cloning over the network.

## Change

- Include the complete packages/starter tree in the standard non-agent runtime fingerprint.
- Exclude generated dependency and build directories from the digest.
- Add a regression guard for the fingerprint closure.
- Keep the existing KORTIX_FAST_COLD_BOOT_ENABLED rollback switch.

This changes no session API contract and creates no warm sandbox pool.

## Verification

- bun test apps/api/src/snapshots/__tests__/scaffold-fingerprint-closure.test.ts apps/api/src/projects/git/fast-boot-bundle.test.ts: 4 pass, 0 fail.
- bun test packages/starter/src: 75 pass, 0 fail.
- bun apps/api/node_modules/typescript/bin/tsc -p apps/api/tsconfig.json --noEmit: exit 0.

The dev deployment benchmark will run after merge because it must build a new content-addressed standard image.