### PR TITLE
fix(runtime-assets): hash the sandbox binaries at startup, not on the request

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -103,7 +103,7 @@ import {
 import { sandboxWebhooksApp } from './platform/webhooks/routes';
 import { marketplaceApp } from './marketplace';
 import { skillsApp } from './skills';
-import { runtimeAssetsApp } from './runtime-assets';
+import { runtimeAssetsApp, runtimeAssetsManifest } from './runtime-assets';
 import { oauthApp } from './oauth';
 import { nativeOAuth2CallbackApp } from './connectors/oauth2-callback';
 import {
@@ -1454,6 +1454,22 @@ async function bootServices() {
   // paged API (`indexReady: false`), so a cold pod serves correct results the
   // whole time — just without category facets.
   warmPipedreamCatalog();
+  // Hash the sandbox runtime binaries off the request path.
+  //
+  // `/v1/runtime-assets/manifest` sha256s the CLI (~104 MB) and the agent
+  // (~95.6 MB) on its first call and memoizes. Every sandbox polls this route
+  // at boot, and a deploy sends the whole fleet at cold replicas at once — so
+  // the first caller per replica was paying ~200 MB of hashing inside the 25s
+  // request deadline. Measured on dev: the very first post-deploy call returned
+  // `503 request_deadline`, and a daemon that gets a 503 skips convergence for
+  // that boot entirely (it never throws, by design).
+  //
+  // Deliberately NOT awaited: readiness must not wait on it, and a request that
+  // arrives first simply shares the same in-flight promise.
+  void runtimeAssetsManifest().catch(() => {
+    // Absent binaries are a legitimate state (a checkout that never built one);
+    // the route reports that per component. Nothing to do here.
+  });
 }
 
 // Graceful shutdown

--- a/apps/api/src/runtime-assets/index.ts
+++ b/apps/api/src/runtime-assets/index.ts
@@ -54,6 +54,12 @@ import {
   runtimeCliBinaryPath,
 } from './manifest';
 
+// Re-exported so server startup can warm the digest memo off the request path
+// (see the call in src/index.ts). Hashing ~200 MB of binaries inside the 25s
+// request deadline made the first post-deploy caller 503, and that caller is a
+// booting sandbox.
+export { runtimeAssetsManifest } from './manifest';
+
 export const runtimeAssetsApp = makeOpenApiApp<AppEnv>();
 
 const BinaryComponentSchema = z.object({


### PR DESCRIPTION
Follow-up to #6673, caught by verifying on dev rather than assuming the deploy was fine.

The first `GET /v1/runtime-assets/manifest` after the deploy returned **`503 request_deadline`**.

That route sha256s the CLI (~104 MB) and the agent (~95.6 MB) on its first call and memoizes — so ~200 MB of hashing sat inside the 25s request deadline, paid by whichever caller hit a cold replica first. Every sandbox polls this route at boot, and a deploy points the whole fleet at cold replicas simultaneously.

The failure mode is quiet, which is what makes it worth fixing rather than tolerating: a daemon that gets a 503 **skips convergence for that boot** (it never throws, by design), so the self-healing mechanism switches itself off precisely when a deploy has just made every box stale.

Fix: warm the digest memo during server startup, fire-and-forget so readiness never waits on it. A request that still arrives first shares the same in-flight promise instead of starting a second hash.

Measured on dev before the fix: `503`, then 3501ms / 2758ms / 935ms as replicas warmed.

`apps/api`: 7857 pass / 0 fail, typecheck clean.
