### PR TITLE
fix(sdk): sub-agent panels stop throwing 'Invalid session id' + quieter landing hero

### DIFF
--- a/apps/web/src/app/(public)/(marketing)/(home)/page.tsx
+++ b/apps/web/src/app/(public)/(marketing)/(home)/page.tsx
@@ -5,7 +5,7 @@ import Hero from '@/features/marketing/hero';
 import { HowItWorks } from '@/features/marketing/how-it-work/how-it-works';
 import { CtaSection } from '@/features/marketing/landing/cta-section';
 import { LogoStrip } from '@/features/marketing/landing/logo-strip';
-import { ScrollCtaPill } from '@/features/marketing/landing/scroll-cta-pill';
+// import { ScrollCtaPill } from '@/features/marketing/landing/scroll-cta-pill';
 import { TrustSection } from '@/features/marketing/landing/trust-section';
 import { UseCaseWheel } from '@/features/marketing/landing/use-case-wheel';
 import { OpenSourceSection } from '@/features/marketing/open-source/open-source-section';
@@ -58,7 +58,11 @@ export default function Home() {
       {/* Close, standing on its own */}
       <CtaSection />
 
-      <ScrollCtaPill />
+      {/* Floating install pill — hidden on request: it hovers over the copy as
+          you scroll and reads as too much on top of the sticky navbar, which
+          already carries Get started. The component and the `cta-pill-anchor`
+          div above are intact, so restoring it is uncommenting these two lines. */}
+      {/* <ScrollCtaPill /> */}
     </div>
   );
 }

--- a/apps/web/src/features/marketing/hero.tsx
+++ b/apps/web/src/features/marketing/hero.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/marketing/button';
 import { WallpaperBackground } from '@/components/ui/wallpaper-background';
 import { useRequestDemo } from '@/features/contact/request-demo-provider';
 import { Claude } from '@/features/icon/icons/claude';
@@ -10,7 +9,6 @@ import { hero, heroEyebrow } from '@/features/marketing/landing/content';
 import { useAuth } from '@/features/providers/auth-provider';
 import { trackCtaSignup } from '@/lib/analytics/gtm';
 import { latestProjectPath } from '@/lib/onboarding/last-project-cookie';
-import { ArrowRightIcon } from '@phosphor-icons/react';
 import { type ReactNode, useCallback } from 'react';
 
 /** `heroEyebrow.rivals[].icon` selects a logo by name at runtime, so it can't be
@@ -22,7 +20,10 @@ const RIVAL_ICONS = { Claude, OpenAI } as const;
  *  their marks, so "AI Management System" lands without a paragraph first. */
 function RivalEyebrow() {
   return (
-    <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1.5 text-sm">
+    /* `justify-center` centres the wrapped rows as a unit; each rival stays its
+       own inline `flex items-center` span, so the logo and its label never
+       separate when the row wraps on a phone. */
+    <div className="text-muted-foreground flex flex-wrap items-center justify-center gap-x-2 gap-y-1.5 text-center text-sm">
       <span>{heroEyebrow.lead}</span>
       {heroEyebrow.rivals.map((r, i) => {
         const Glyph = RIVAL_ICONS[r.icon] as ((p: { className?: string }) => ReactNode) | undefined;
@@ -33,7 +34,7 @@ function RivalEyebrow() {
             <span className="text-foreground font-medium">{r.label}</span>
           </span>
         );
-      })}{' '}
+      })}
     </div>
   );
 }
@@ -79,13 +80,18 @@ const Hero = () => {
         <div className="mx-auto w-full max-w-7xl px-6">
           <RivalEyebrow />
 
-          <h1 className="text-foreground mt-5 max-w-3xl text-4xl font-medium tracking-tight text-balance sm:text-5xl">
+          {/* `mx-auto` on the measure is what actually centres the block: without
+              it `max-w-3xl` stays flush left inside max-w-7xl and only the glyphs
+              inside it centre, which leaves the headline off-axis on desktop. */}
+          <h1 className="text-foreground mx-auto mt-5 max-w-3xl text-center text-4xl font-medium tracking-tight text-balance sm:text-5xl">
             {hero.title}
           </h1>
 
-          {/* sub on the left, actions on the right — keeps the fold short */}
-          <div className="mt-6 flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between lg:gap-10">
-            <p className="text-muted-foreground max-w-xl text-base leading-relaxed sm:text-lg">
+          {/* One centred column under the headline. It was a left sub / right
+              actions row while the hero owned CTAs; with those gone the row had
+              nothing to justify against. */}
+          <div className="mt-6 flex flex-col items-center gap-5">
+            <p className="text-muted-foreground mx-auto max-w-xl text-center text-base leading-relaxed text-pretty sm:text-lg">
               {hero.sub}
             </p>
 
@@ -99,7 +105,18 @@ const Hero = () => {
                 every mobile platform asks for; h-12 is 44.2px. The override is
                 local because sm and up keeps the 36.8px the rest of the site is
                 drawn to. */}
-            <div className="flex w-full shrink-0 flex-wrap gap-3 sm:w-auto">
+            {/* Hero CTAs (Request demo / Get started) hidden on request. The
+                navbar still carries both at every scroll position, so the page
+                keeps its calls to action.
+
+                To restore: uncomment the block AND re-add the two imports it
+                needs, which were dropped so the file stays lint-clean while it
+                is dead —
+                  import { Button } from '@/components/ui/marketing/button';
+                  import { ArrowRightIcon } from '@phosphor-icons/react';
+                `openDemo` and `handleLaunch` above are kept for the same
+                restore, and are otherwise unused. */}
+            {/* <div className="flex w-full shrink-0 flex-wrap gap-3 sm:w-auto">
               <Button
                 size="lg"
                 variant="secondary"
@@ -112,7 +129,7 @@ const Hero = () => {
                 {hero.ctaPrimary}
                 <ArrowRightIcon className="size-4" />
               </Button>
-            </div>
+            </div> */}
           </div>
         </div>
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,34 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-20 — session `session-ux` — a session with no project never reads a project-scoped inbox — DONE
+
+**Files:** `react/use-session-prompts.ts` (+`readSessionPromptsInbox`, gated
+`refetch`) + `use-session-prompts.test.ts` (+3 tests). No barrel export, so no
+public-surface snapshot change.
+
+**What.** Opening a sub-session (`SubSessionModal` → `SessionChat` with a
+`sessionId` and no project ids) fired
+`GET /projects/undefined/sessions/undefined/prompts` → 400 `Invalid session id`
+→ a red toast beside a sub-agent that was streaming correctly.
+
+`useSessionPrompts`'s `enabled` was already `!!projectId && !!sessionId`, but
+`enabled` governs react-query's SCHEDULING only — `QueryObserver.refetch()`
+calls `query.fetch()` with no `enabled` check (verified against
+`@tanstack/query-core@5.101.2` `queryObserver.js:158`). `session-chat.tsx:2331`
+refetches the inbox on every new user bubble, which is exactly what a streaming
+sub-agent produces. The two `undefined`s then went into `listSessionPrompts`'s
+template literal and came back out as the literal text `undefined`.
+
+Fixed on both paths: the read itself (`readSessionPromptsInbox`) refuses when
+either id is missing and hands back the cached rows, and the hook's `refetch`
+now honours the same gate.
+
+**Gates:** `typecheck` clean (both projects) · `bun test --isolate src` 2354
+pass / 2 skip / 0 fail · `smoke:install` passed.
+
+---
+
 ### 2026-08-20 — session `legacy-billing-truth` — the admin console reads billing truth, not the stored tier — DONE
 
 **Files:** `react/use-admin-accounts.ts` (+`AdminAccountSubscription`,

--- a/packages/sdk/src/react/use-session-prompts.test.ts
+++ b/packages/sdk/src/react/use-session-prompts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { useSessionWorkingStore } from '../browser/stores/session-working-store';
+import { configureKortix } from '../core/http/config';
 import type { SessionPrompt } from '../core/rest/projects-client/sessions';
 import {
   applyOptimisticPrompt,
@@ -10,6 +11,7 @@ import {
   SESSION_PROMPTS_IDLE_POLL_MS,
   SESSION_PROMPTS_POLL_MS,
   noteInboxObservation,
+  readSessionPromptsInbox,
   sessionPromptsPollMs,
   startSessionWithPrompt,
 } from './use-session-prompts';
@@ -226,5 +228,74 @@ describe('optimistic queue rows', () => {
     const rows = applyOptimisticPrompt([], input, 1_000);
     const merged = reconcileOptimisticPrompts(rows, []);
     expect(merged.map((r) => r.prompt_id)).toEqual(['optimistic:c1']);
+  });
+});
+
+/**
+ * The inbox is PROJECT-scoped, and not every session has a project.
+ *
+ * A sub-session — the "Agent · general: …" panel `SubSessionModal` opens over
+ * the transcript — is a local OpenCode child. It is rendered by `SessionChat`
+ * with a `sessionId` and NOTHING else: no project id, no project session id.
+ * The `enabled` flag on the query covers react-query's own scheduling, but it
+ * is not the only way into the request: `QueryObserver.refetch()` goes
+ * straight to `query.fetch()` with no `enabled` check, and `session-chat.tsx`
+ * calls `promptInbox.refetch()` the moment a new user bubble lands — which is
+ * exactly what a streaming sub-agent produces.
+ *
+ * The two `undefined`s then went into `listSessionPrompts`'s template literal
+ * and came out as text: `GET /projects/undefined/sessions/undefined/prompts`
+ * → 400 `Invalid session id` → a red toast beside a sub-agent that was
+ * rendering perfectly. The read itself has to refuse, so no path can build
+ * that URL.
+ */
+describe('readSessionPromptsInbox', () => {
+  const stubFetch = () => {
+    const urls: string[] = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (url: unknown) => {
+      urls.push(String(url));
+      return Response.json({ prompts: [] });
+    }) as unknown as typeof fetch;
+    return { urls, restore: () => void (globalThis.fetch = original) };
+  };
+
+  test('a session with no project issues NO request', async () => {
+    const stub = stubFetch();
+    try {
+      expect(await readSessionPromptsInbox(undefined, undefined, undefined)).toEqual([]);
+      expect(await readSessionPromptsInbox(undefined, 'sess-1', undefined)).toEqual([]);
+      expect(await readSessionPromptsInbox('proj-1', undefined, undefined)).toEqual([]);
+      expect(stub.urls).toEqual([]);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('a session with no project keeps the rows already on screen', async () => {
+    const stub = stubFetch();
+    const cached = applyOptimisticPrompt(
+      [],
+      { clientMessageId: 'c1', messageId: 'msg_01', parts: [{ type: 'text', text: 'hi' }] },
+      1_000,
+    );
+    try {
+      expect(await readSessionPromptsInbox(undefined, undefined, cached)).toEqual(cached);
+      expect(stub.urls).toEqual([]);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test('a project session still reads its own inbox', async () => {
+    configureKortix({ backendUrl: 'http://api.test/v1', getToken: async () => 'tok' });
+    const stub = stubFetch();
+    try {
+      expect(await readSessionPromptsInbox('proj-1', 'sess-1', undefined)).toEqual([]);
+      expect(stub.urls).toEqual(['http://api.test/v1/projects/proj-1/sessions/sess-1/prompts']);
+    } finally {
+      stub.restore();
+      configureKortix({ backendUrl: '', getToken: async () => null });
+    }
   });
 });

--- a/packages/sdk/src/react/use-session-prompts.ts
+++ b/packages/sdk/src/react/use-session-prompts.ts
@@ -158,6 +158,45 @@ export function reconcileOptimisticPrompts(
   return pending.length ? [...server, ...pending] : [...server];
 }
 
+/**
+ * One read of a session's inbox — and the refusal that keeps a project-scoped
+ * URL from ever being built for a session that has no project.
+ *
+ * Not every session has one. A sub-session (the "Agent · general: …" panel
+ * `SubSessionModal` opens over the transcript) is a local OpenCode child:
+ * `SessionChat` renders it with a `sessionId` and nothing else — no project id,
+ * no project session id — and there is no server-side inbox to read. Both ids
+ * are then genuinely `undefined`, and `listSessionPrompts` interpolates them
+ * into its path as the literal text: `GET
+ * /projects/undefined/sessions/undefined/prompts` → 400 `Invalid session id`,
+ * which the host's `onError` sink turns into a red toast beside a sub-agent
+ * that is streaming perfectly.
+ *
+ * The hook's `enabled` flag does not stop it on its own. `enabled` governs
+ * react-query's SCHEDULING; `QueryObserver.refetch()` goes straight to
+ * `query.fetch()` with no `enabled` check, and `session-chat.tsx` refetches the
+ * inbox on every new user bubble — exactly what a streaming sub-agent produces.
+ * So the refusal belongs here, on the read itself.
+ *
+ * `cached` is this tab's current rows: with no project there is nothing to
+ * reconcile against, and the optimistic rows already on screen stay on screen.
+ */
+export async function readSessionPromptsInbox(
+  projectId: string | undefined,
+  sessionId: string | undefined,
+  cached: readonly SessionPrompt[] | undefined,
+): Promise<SessionPrompt[]> {
+  if (!projectId || !sessionId) return [...(cached ?? [])];
+  // Stamped BEFORE the request, like `/turn`'s: an answer is only as fresh
+  // as the moment it was asked.
+  const atMs = Date.now();
+  const { prompts } = await listSessionPrompts(projectId, sessionId);
+  noteInboxObservation(sessionId, prompts, atMs);
+  // Keep this tab's not-yet-confirmed rows on screen across a poll that landed
+  // before their POST returned.
+  return reconcileOptimisticPrompts(cached, prompts);
+}
+
 export interface UseSessionPromptsResult {
   prompts: SessionPrompt[];
   isLoading: boolean;
@@ -187,16 +226,12 @@ export function useSessionPrompts(
   const query = useQuery({
     queryKey: key,
     enabled,
-    queryFn: async () => {
-      // Stamped BEFORE the request, like `/turn`'s: an answer is only as fresh
-      // as the moment it was asked.
-      const atMs = Date.now();
-      const { prompts } = await listSessionPrompts(projectId!, sessionId!);
-      noteInboxObservation(sessionId!, prompts, atMs);
-      // Keep this tab's not-yet-confirmed rows on screen across a poll that
-      // landed before their POST returned.
-      return reconcileOptimisticPrompts(queryClient.getQueryData<SessionPrompt[]>(key), prompts);
-    },
+    queryFn: () =>
+      readSessionPromptsInbox(
+        projectId,
+        sessionId,
+        queryClient.getQueryData<SessionPrompt[]>(key),
+      ),
     // Two cadences, never `false` — see the note above.
     refetchInterval: (q) => sessionPromptsPollMs(q.state.data?.length ?? 0, options?.pollMs),
     // Per-query, because the host disables focus refetching globally. Coming
@@ -204,6 +239,16 @@ export function useSessionPrompts(
     // hidden has to be on screen.
     refetchOnWindowFocus: true,
   });
+
+  // `enabled` governs react-query's SCHEDULING, not every path into the
+  // request: `QueryObserver.refetch()` calls `query.fetch()` with no `enabled`
+  // check at all. A session with no project must not fetch on either path, so
+  // the same gate is applied here (and again inside the read itself).
+  const queryRefetch = query.refetch;
+  const refetch = useCallback(
+    () => (enabled ? queryRefetch() : Promise.resolve(undefined)),
+    [enabled, queryRefetch],
+  );
 
   const invalidate = useCallback(
     () => queryClient.invalidateQueries({ queryKey: key }),
@@ -276,7 +321,7 @@ export function useSessionPrompts(
     remove: removeMutation.mutateAsync,
     retry: retryMutation.mutateAsync,
     hold: holdMutation.mutateAsync,
-    refetch: query.refetch,
+    refetch,
   };
 }
 


### PR DESCRIPTION
Two independent things, one commit each, so they can be reviewed (or reverted) separately.

## 1 · `fix(sdk)` — sub-agent panels stop throwing "Invalid session id"

Opening the "Agent · general: …" sub-session panel fired

```
GET /projects/undefined/sessions/undefined/prompts  →  400 Invalid session id
```

and dropped a red toast next to a sub-agent that was streaming perfectly.

This looked impossible, because `useSessionPrompts` already gates on `!!projectId && !!sessionId`. The catch: **`enabled` only governs react-query's scheduling.** `QueryObserver.refetch()` goes straight to `query.fetch()` with no `enabled` check —

```js
refetch({ ...options } = {}) {
  return this.fetch({ ...options });
}
```

(`@tanstack/query-core@5.101.2`, `queryObserver.js:158`.) And `session-chat.tsx:2331` refetches the inbox on every new user bubble — exactly what a streaming sub-agent produces. `SubSessionModal` renders `SessionChat` with a `sessionId` and no project ids, so both were genuinely `undefined`; `listSessionPrompts` interpolated them into its template literal and they came back out as the literal text.

Fixed on both paths rather than at the toast: `readSessionPromptsInbox` refuses the read when either id is missing and returns the cached rows, so the project-scoped URL can never be constructed, and the hook's `refetch` now honours the same gate. Two lying `projectId!` / `sessionId!` assertions are gone. Not re-exported from the barrel — **no public-surface change**, snapshots untouched.

3 regression tests, written failing first.

## 2 · `feat(marketing)` — quieter landing hero

- **Floating scroll pill hidden.** It carried the install command plus a Get started button and hovered over the copy for most of the scroll. Component and its `cta-pill-anchor` marker left intact.
- **Hero's own Request demo / Get started hidden.** The navbar still carries both at every scroll position, so the page keeps its CTAs. The block is commented in place with a note naming the two imports a restore also has to re-add — they were dropped so the file stays lint-clean while the block is dead.
- **Top block centred**, now that nothing anchors the bottom-left. `mx-auto` on the measures is the load-bearing part: `max-w-3xl` alone stays flush-left inside `max-w-7xl`, so `text-center` on its own would have centred the glyphs and left the block off-axis.

Measured at 1440 / 1024 / 390 — left and right gaps match within **0.02px**, and the eyebrow's logos stay glued to their labels when the row wraps on a phone.

## Verification

| gate | result |
|---|---|
| `packages/sdk` `tsc --noEmit` | clean (both projects) |
| `packages/sdk` `bun test --isolate src` | **2356 pass / 0 fail** |
| `packages/sdk` `smoke-install.mjs` | ✔ passed |
| `apps/web` `tsc --noEmit` | clean outside the 3 known `@types/bun` `test.each` files |
| `apps/web` `bun test` | **7915 pass / 0 fail** |
| `eslint` on changed files | 0 errors |
| `prettier --check` on changed files | clean |

Browser, against the running local stack: navbar lists `Request demo` + `Get started`, `h1` centred 256/256, no install pill in the DOM, no page errors.

## Not verified

**Nobody clicked the sub-agent panel.** Reproducing needs a live run that spawns a sub-agent *and* puts a user bubble in the child transcript. Every link is proven independently — the disabled-query refetch in the library source, the `undefined` → text interpolation, a real `400 {"error":"Invalid session id"}` from the local API, and the `onError` → `errorToast` sink — but the click itself is unobserved. **Worth confirming on dev after merge:** open a session with a sub-agent panel, check the Network tab for no `/projects/undefined/…` and no red toast.

Known cosmetic wrinkle at 390px: the subhead wraps to four lines with a two-word last line. 148 characters against a 346px measure — copy, not CSS.

## Separate finding, deliberately not fixed here

`.claude/skills/learnings/SKILL.md` and `packages/sdk/PROGRESS.md` carry diff3 conflict markers (`||||||| <sha>`) committed into `main`. `git blame` points at two merge commits on `legacy-billing-truth` (`29dc75a26d`, `384baf9ad9`). They render as literal junk in both docs. Left alone rather than mixing an unrelated cleanup into this branch — happy to send a one-line PR.
