### PR TITLE
fix(secrets): relay substitutes handles in Authorization/Cookie (egress works for Bearer auth)

### DIFF
--- a/apps/api/src/projects/secret-capabilities.test.ts
+++ b/apps/api/src/projects/secret-capabilities.test.ts
@@ -224,13 +224,18 @@ describe('buildSecretCapabilities describes egress-enforced delivery', () => {
     const json = JSON.stringify(built());
     expect(json).not.toContain(NEVER_LEAKS);
     expect(json).not.toContain('{{secret}}');
-    expect(json).not.toContain('Bearer');
-    // The legacy injection slot is an implementation detail of the relay; an
-    // agent that can read the shape of the header starts assembling one.
-    expect(json).not.toContain('authorization');
     // `bindingAlias` in ../secrets/network-boundary.ts derives a stable
     // attachment name from the secret id. The guest must not see that either.
     expect(json).not.toContain(row.secretId.replace(/-/g, ''));
+    // The network CAPABILITY object reveals no injection header shape — an agent
+    // that could read where a credential auto-attaches would start assembling
+    // one. Scoped to the capabilities: the usage NOTES do name
+    // `Authorization: Bearer $VAR` as generic guidance (that is where an agent
+    // SHOULD put the handle), which carries no per-secret config.
+    const capabilities = JSON.stringify(built().capabilities);
+    expect(capabilities).not.toContain('Bearer');
+    expect(capabilities).not.toContain('authorization');
+    expect(capabilities).not.toContain('{{secret}}');
   });
 
   test('states the handle, the substitution, the [REDACTED] echo and the fallback', () => {

--- a/apps/api/src/projects/secret-capabilities.ts
+++ b/apps/api/src/projects/secret-capabilities.ts
@@ -65,13 +65,14 @@ export type SecretCapability =
  * capabilities.
  */
 export const NETWORK_BOUNDARY_NOTES: readonly string[] = [
-  'Use the environment variable exactly as you would use the real credential: put it in the header, query string or body your client already builds.',
+  'Use the environment variable exactly as you would use the real credential: put it in the header, query string or body your client already builds. `Authorization: Bearer $VAR`, `Cookie: session=$VAR`, an `X-Api-Key` header, a query parameter and a JSON/form body field all work — Kortix substitutes the handle wherever it appears.',
   'The variable holds a HANDLE, not the value. Kortix swaps the handle for the real credential outside the sandbox.',
   'The value is not in this sandbox: no environment variable, no file, no alias. Do not search for it and do not ask the user for it.',
+  'Send the handle as-is. Do NOT base64-encode it yourself first — for example HTTP Basic auth (`curl -u $VAR:` / `Authorization: Basic <base64>`) hides the handle inside a base64 blob Kortix cannot find, so the swap does not happen. Put the handle in a Bearer/token header, a query parameter or a body field instead.',
   'The swap happens only on the `hosts` this capability lists, over HTTPS. Sent anywhere else the handle arrives as a literal string and the request fails.',
   'If a response reflects the credential straight back, Kortix scrubs the obvious copies to `[REDACTED]`. This is best-effort reflection-scrubbing, not proof of success: a `[REDACTED]` is a hint the substitution ran, not a guarantee, and a host can still transform the value past the scrub.',
   'An empty reply or a connection error on a listed host is a REAL failure. Do not read it as the substitution working.',
-  'Requests to a listed host are relayed through Kortix, so responses are not streamed: no SSE, no websockets, and large bodies are capped.',
+  'Requests to a listed host are relayed through Kortix, so responses are not streamed: no SSE, no websockets, and large bodies are capped (1 MiB request, 5 MiB response).',
   'A listed host that answers 401 means the swap did not happen. Report that; do not invent a credential.',
   'If a request cannot be relayed, run `kortix secrets call <identifier> <https-url> [options]` — the explicit door to the same hosts and the same policy.',
 ]

--- a/apps/api/src/secrets/http-broker.test.ts
+++ b/apps/api/src/secrets/http-broker.test.ts
@@ -51,15 +51,33 @@ describe('prepareSecretBrokerRequest', () => {
     }
   });
 
-  test('rejects non-HTTPS URLs, URL credentials, and managed caller headers', () => {
+  test('rejects non-HTTPS URLs, URL credentials, and framing caller headers', () => {
     for (const input of [
       request({ url: 'http://api.example.com/v1/messages' }),
       request({ url: 'https://user:pass@api.example.com/v1/messages' }),
-      request({ headers: { authorization: 'caller-value' } }),
+      // Only true framing / hop-by-hop headers are rejected. `authorization` and
+      // `cookie` are NOT here — they are substitution surfaces (see the
+      // substitution suite). `host` is managed by the broker.
       request({ headers: { host: 'attacker.example' } }),
+      request({ headers: { 'transfer-encoding': 'chunked' } }),
     ]) {
       expect(() => prepareSecretBrokerRequest(policy(), SECRET, input)).toThrow(SecretBrokerError);
     }
+  });
+
+  test('a caller authorization/cookie header is accepted (not rejected)', () => {
+    // The pre-substitution broker rejected these outright (59c1f74bf8). They are
+    // the credential-carrying headers the agent must be able to send a HANDLE in,
+    // so they pass sanitizeHeaders now. With the default policy's inject slot the
+    // route's own value still overwrites `authorization`; without a slot the
+    // caller's header rides through and substitution handles the handle.
+    expect(() =>
+      prepareSecretBrokerRequest(
+        hostsOnlyPolicy(),
+        SECRET,
+        request({ headers: { authorization: 'Bearer plain', cookie: 'session=plain' } }),
+      ),
+    ).not.toThrow();
   });
 
   test('injects query and nested JSON fields without accepting prototype paths', () => {
@@ -294,6 +312,27 @@ describe('prepareSecretBrokerRequest substitution', () => {
     // The relay is fully buffered, so the framing it states must be the framing
     // it sends — the substituted body is longer than the one that arrived.
     expect(prepared.headers['content-length']).toBe(String(prepared.body!.byteLength));
+    expect(prepared.substituted).toEqual(['PRIMARY']);
+  });
+
+  test('substitutes a handle in the Authorization and Cookie headers', () => {
+    // The reliability fix: `Authorization: Bearer <handle>` is the single most
+    // common way an agent authenticates, and `cookie` is the other credential
+    // header. Both were dropped before, so the request left carrying nothing.
+    const prepared = prepareSecretBrokerRequest(
+      hostsOnlyPolicy(),
+      SECRET,
+      request({
+        headers: {
+          authorization: `Bearer ${HANDLE}`,
+          cookie: `session=${HANDLE}; other=keep`,
+        },
+      }),
+      [substitution({ policy: hostsOnlyPolicy() })],
+    );
+
+    expect(prepared.headers.authorization).toBe(`Bearer ${SECRET}`);
+    expect(prepared.headers.cookie).toBe(`session=${SECRET}; other=keep`);
     expect(prepared.substituted).toEqual(['PRIMARY']);
   });
 

--- a/apps/api/src/secrets/http-broker.ts
+++ b/apps/api/src/secrets/http-broker.ts
@@ -15,11 +15,25 @@ const MAX_REDIRECTS = 3;
 const REQUEST_TIMEOUT_MS = 30_000;
 const REDACTED = Buffer.from('[REDACTED]');
 
+// FRAMING / hop-by-hop headers only. These are rejected with a 400 because the
+// broker manages them itself (it sets `host` and `content-length`, forces
+// `accept-encoding: identity`) or because they describe THIS connection, not the
+// upstream one (`connection`, `keep-alive`, `te`, `trailer`, `transfer-encoding`,
+// `upgrade`, `proxy-*`). A caller must not set them.
+//
+// `authorization` and `cookie` are DELIBERATELY NOT here. They are the two
+// credential-carrying request headers, and the whole substitution feature exists
+// so an agent can put a HANDLE where it would put the real credential — i.e.
+// `Authorization: Bearer <handle>`, the single most common auth pattern. The
+// substitution pass below replaces the handle with the real value inside these
+// headers; blocking them (as the pre-substitution broker did, 59c1f74bf8) left
+// the new substitution-only default with no working path to Bearer/token/cookie
+// auth. A legacy `inject` slot that names one of them still overwrites it, so the
+// old broker behaviour is unchanged. The shim keeps an identical copy of this
+// set (`blocked-headers.test.ts` pins the two together).
 const BLOCKED_REQUEST_HEADERS = new Set([
-  'authorization',
   'connection',
   'content-length',
-  'cookie',
   'host',
   'keep-alive',
   'proxy-authenticate',

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.test.ts
@@ -42,4 +42,14 @@ describe('shim/broker blocked-header agreement', () => {
     expect(BLOCKED_REQUEST_HEADERS.has('accept-encoding')).toBe(false)
     expect(brokerBlockedHeaders().has('accept-encoding')).toBe(false)
   })
+
+  // The credential-carrying headers must NOT be blocked: they are the
+  // substitution surfaces (`Authorization: Bearer <handle>`, `Cookie: …=<handle>`).
+  // Blocking them left the substitution-only default with no working Bearer path.
+  test('neither list blocks authorization or cookie', () => {
+    for (const header of ['authorization', 'cookie']) {
+      expect(BLOCKED_REQUEST_HEADERS.has(header)).toBe(false)
+      expect(brokerBlockedHeaders().has(header)).toBe(false)
+    }
+  })
 })

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
@@ -177,11 +177,22 @@ describe('headers the broker would reject or that would defeat redaction', () =>
     expect(headers['accept-encoding']).toBe('identity')
   })
 
+  // authorization and cookie are the credential-carrying headers: an agent puts
+  // a HANDLE in them and the broker substitutes it server-side, so the shim must
+  // FORWARD them. Dropping them (as before) left a Bearer/cookie request carrying
+  // nothing, and the upstream answered 401.
   test.each([
-    ['cookie', 'Cookie: sid=abc'],
-    ['authorization', 'Authorization: Bearer guess'],
+    ['authorization', 'Authorization: Bearer guess', 'Bearer guess'],
+    ['cookie', 'Cookie: sid=abc', 'sid=abc'],
+  ])('%s is forwarded so the broker can substitute a handle in it', async (name, line, value) => {
+    const headers = await relayedHeaders(`${line}\r\n`)
+    expect(headers[name]).toBe(value)
+  })
+
+  test.each([
     ['te', 'TE: trailers'],
-  ])('%s is dropped, because the broker 400s on it rather than stripping it', async (name, line) => {
+    ['keep-alive', 'Keep-Alive: timeout=5'],
+  ])('%s is dropped, because the broker manages or 400s it', async (name, line) => {
     const headers = await relayedHeaders(`${line}\r\n`)
     expect(headers[name]).toBeUndefined()
   })

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/shim.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/shim.ts
@@ -66,23 +66,26 @@ export interface EgressShimOptions {
 const BROKER_TIMEOUT_MS = 30_000
 
 /**
- * Headers the broker REJECTS with a 400 rather than stripping
- * (apps/api/src/secrets/http-broker.ts BLOCKED_REQUEST_HEADERS).
+ * FRAMING / hop-by-hop headers the broker REJECTS with a 400
+ * (apps/api/src/secrets/http-broker.ts BLOCKED_REQUEST_HEADERS). The shim drops
+ * them before relaying so an ordinary request does not turn into
+ * `400 request header is managed by Kortix: <name>`.
  *
- * Mirrored here so the shim drops them before relaying. Forwarding them turns
- * an ordinary request into `400 request header is managed by Kortix: cookie` —
- * and a cookie-bearing client, or any `curl -H 'Authorization: ...'`, is an
- * entirely reasonable thing for an agent to run.
+ * `authorization` and `cookie` are DELIBERATELY NOT dropped. They are the
+ * credential-carrying headers, and the whole point of this mode is that the
+ * agent puts a HANDLE where it would put the real credential — `curl -H
+ * 'Authorization: Bearer <handle>'`. Dropping them here stripped the handle
+ * before the broker could substitute it, so a Bearer/token/cookie request left
+ * carrying nothing and the upstream answered 401. They are forwarded now; the
+ * broker swaps the handle for the real value server-side.
  *
  * Kept as a literal copy rather than an import: this binary must not drag
  * apps/api's http-broker (and its DB and config dependencies) into the sandbox.
  * The `blocked-headers` test asserts the two lists still agree.
  */
 export const BLOCKED_REQUEST_HEADERS = new Set([
-  'authorization',
   'connection',
   'content-length',
-  'cookie',
   'host',
   'keep-alive',
   'proxy-authenticate',

--- a/apps/web/content/docs/project/secrets.mdx
+++ b/apps/web/content/docs/project/secrets.mdx
@@ -103,8 +103,22 @@ returns `403` `feature_disabled`.
 
 The sandbox receives an environment variable whose value is a **handle**, not
 the credential. The agent uses that variable exactly as it would use the real
-key — in a header, a query string, or a body. On the way out, Kortix replaces
-the handle with the real value, but only for requests to hosts you approved.
+key — in a header, a query string, or a body. `Authorization: Bearer $VAR`,
+`Cookie: …=$VAR`, an `X-Api-Key` header, a query parameter, and a JSON or form
+body field all work: Kortix finds the handle wherever it appears (raw,
+URL-encoded, standalone base64, or JSON-escaped) and swaps in the real value.
+On the way out, Kortix replaces the handle with the real value, but only for
+requests to hosts you approved.
+
+<Callout type="warn" title="Send the handle as-is — do not base64 it yourself">
+One thing does not work: hiding the handle inside a base64 blob you build
+yourself, which is what **HTTP Basic auth** does (`curl -u $VAR:` →
+`Authorization: Basic <base64>`). Kortix cannot find a handle that is embedded,
+unaligned, inside base64 you encoded, so the swap never happens and the upstream
+answers `401`. Put the handle in a Bearer/token header, a query parameter, or a
+body field instead. If the API only supports Basic auth, use **environment**
+exposure for that secret.
+</Callout>
 
 ```text
 agent's ordinary HTTP client


### PR DESCRIPTION
## Why

The egress-enforced relay swaps a handle for the real value on approved hosts — but it could not do it in the ONE place agents put a credential most: the **Authorization header**. `authorization` and `cookie` sat in `BLOCKED_REQUEST_HEADERS` (a leftover from the pre-substitution broker, `59c1f74bf8`), so the in-guest shim **dropped** them and the broker **400'd** them. A `curl -H 'Authorization: Bearer $VAR'` — exactly what agents are told to run — left carrying nothing, and the upstream answered `401`. Egress-enforced was effectively non-functional for Bearer/token auth (Stripe, OpenAI, Anthropic, GitHub, most REST APIs).

## What

`authorization` and `cookie` are the **credential-carrying** request headers, not framing headers. They are removed from the blocked set (broker + the shim's mirror copy), so the existing substitution pass replaces the handle inside them, in every representation (raw, URL-encoded, standalone base64, JSON-escaped). Only true framing / hop-by-hop headers stay managed. A legacy `inject` slot that names one of them still overwrites it, so the old broker behaviour is unchanged. The `blocked-headers` agreement test keeps the two lists pinned together.

## Verification

**Real host, real HTTPS** (`postman-echo.com`), through the real substitution engine:

| Handle placement | Result |
|---|---|
| `Authorization: Bearer <handle>` | host received the real value → echoed → **`Bearer [REDACTED]`** ✅ |
| `X-Api-Key: <handle>` | substituted → `[REDACTED]` ✅ |
| `?key=<handle>` | substituted → `[REDACTED]` ✅ |
| handle in the echo | **gone** (substituted away) ✅ |
| raw value past redaction | **never leaked** ✅ |

Before the fix, `Authorization` would have thrown `400`. Unit: broker `32/0`, shim + agreement `45/0`, capabilities + broker-route + network-boundary + strategy-route all green. Daemon `tsc` clean.

## Known limitation (documented in the agent notes + `secrets.mdx`)

The handle must appear as **recoverable bytes**. Do NOT base64 it yourself — so HTTP **Basic auth** (`curl -u $VAR:` → `Authorization: Basic <base64>`) hides the handle inside an unaligned base64 blob and is unsupported. Use a Bearer/token header, a query param, a body field, or `environment` exposure for Basic-only APIs.

Egress-enforced remains behind the experimental `secrets_egress` flag (#6677).