### PR TITLE
fix(boot): the managed-skill overlay no longer counts as the user's changes

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,25 @@ linked, not inlined.
 
 ## Register
 
+### `git stash` is repo-global — never `pop` from a worktree (2026-08-21)
+
+**When:** any `git stash` / `git stash pop` inside a `pnpm worktree` checkout.
+The stash stack belongs to the REPOSITORY, not the worktree, and this repo
+carries ~80 entries from other people and other branches. `git stash -u` on a
+clean tree creates NOTHING, so a reflexive `stash … ; do work ; stash pop`
+pops **someone else's `stash@{0}`** into your tree. To compare against another
+ref, use `git worktree add <tmp> <ref>`, `git show <ref>:<path>`, or
+`git diff <ref>` — never stash.
+*Incident:* proving a CI failure was pre-existing, `git stash -q -u` on a clean
+worktree stashed nothing, then `git stash pop` unpacked
+`stash@{0}` — "WIP on relay-streaming: streaming substitution kernel", 16 files
+/ 1203 insertions of a colleague's parked work — into an unrelated worktree.
+A modify/delete conflict is the only reason git RETAINED the entry instead of
+dropping it; a clean apply would have silently consumed it and left the work
+recoverable only via `git fsck`. Recovered with `git reset --hard HEAD` +
+`git clean -fd` after verifying `git stash show --stat 'stash@{0}'` still
+listed all 16 files. **No enforcer** — the guard is the habit.
+
 ### Entitlement is a property of the subscription, and "has an active subscription" is not "pays us" (2026-08-20)
 
 **When:** writing any rule that decides what an account may DO — the wallet

--- a/apps/kortix-sandbox-agent-server/src/__tests__/injected-skills.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/injected-skills.test.ts
@@ -70,6 +70,43 @@ describe('ensureInjectedManagedSkills', () => {
     }
   })
 
+  // A repository controls `opencode.config_dir`, so `git rev-parse --show-prefix`
+  // is repository-controlled input. `.git/info/exclude` is newline-delimited, so a
+  // config dir whose name carries a newline could append EXTRA rules — and an
+  // exclude rule hides a file from `git status --porcelain -uall`, the exact
+  // command the product uses to show the user what changed. Hiding a file there
+  // hides it from the human review step.
+  it('refuses to write an exclude entry for a config dir that could inject rules', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'inj-skills-'))
+    try {
+      const repo = await makeRepo(root)
+      // A real directory whose name embeds a newline plus a rule of its own.
+      const hostile = 'opencode\nsecret.txt\nmask'
+      const configDir = join(repo, '.kortix', hostile)
+      const bakedDir = join(root, 'baked')
+      await mkdir(join(bakedDir, 'kortix-system'), { recursive: true })
+      await writeFile(join(bakedDir, 'kortix-system', 'SKILL.md'), 'managed')
+
+      // A file the repo would love to hide from the user's change review.
+      await writeFile(join(repo, 'secret.txt'), 'exfiltrated')
+
+      await ensureInjectedManagedSkills(configDir, { bakedDir })
+
+      let exclude = ''
+      try {
+        exclude = await readFile(join(repo, '.git', 'info', 'exclude'), 'utf8')
+      } catch {
+        exclude = '' // never created — also a pass
+      }
+      // No rule for the smuggled path, however it was spelled.
+      expect(exclude.split(/\r?\n/).some((line) => line.trim() === 'secret.txt')).toBe(false)
+      // And the file the attacker wanted hidden is still reported to the user.
+      expect(await git(repo, 'status', '--porcelain', '-uall')).toContain('secret.txt')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('hides the injected skills from git status instead of dirtying the working tree', async () => {
     const root = await mkdtemp(join(tmpdir(), 'inj-skills-'))
     try {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/injected-skills.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/injected-skills.test.ts
@@ -1,9 +1,31 @@
 import { describe, expect, it } from 'bun:test'
+import { execFile } from 'node:child_process'
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 
 import { ensureInjectedManagedSkills } from '../injected-skills'
+
+const execFileAsync = promisify(execFile)
+
+/** A real git working tree — the exclude behaviour under test is git's, not ours. */
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd })
+  return stdout
+}
+
+async function makeRepo(root: string): Promise<string> {
+  const repo = join(root, 'repo')
+  await mkdir(repo, { recursive: true })
+  await git(repo, 'init', '-q', '-b', 'main')
+  await git(repo, 'config', 'user.email', 'test@kortix.ai')
+  await git(repo, 'config', 'user.name', 'test')
+  await writeFile(join(repo, 'README.md'), 'hi\n')
+  await git(repo, 'add', '-A')
+  await git(repo, 'commit', '-qm', 'base')
+  return repo
+}
 
 async function exists(p: string): Promise<boolean> {
   try {
@@ -42,6 +64,89 @@ describe('ensureInjectedManagedSkills', () => {
       )
       expect(await exists(join(configDir, 'skills', 'kortix-system', 'references', 'cli.md'))).toBe(
         true,
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('hides the injected skills from git status instead of dirtying the working tree', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'inj-skills-'))
+    try {
+      const repo = await makeRepo(root)
+      const configDir = join(repo, '.kortix', 'opencode')
+      const bakedDir = join(root, 'baked')
+      await mkdir(join(bakedDir, 'kortix-system', 'references'), { recursive: true })
+      await writeFile(join(bakedDir, 'kortix-system', 'SKILL.md'), 'managed')
+      await writeFile(join(bakedDir, 'kortix-system', 'references', 'cli.md'), 'ref')
+      await mkdir(join(bakedDir, 'kortix-apps'), { recursive: true })
+      await writeFile(join(bakedDir, 'kortix-apps', 'SKILL.md'), 'managed')
+
+      await ensureInjectedManagedSkills(configDir, { bakedDir })
+
+      // The bodies are on disk for opencode to load…
+      expect(await readFile(join(configDir, 'skills', 'kortix-apps', 'SKILL.md'), 'utf8')).toBe(
+        'managed',
+      )
+      // …and the session's change count — `git status --porcelain -uall`, the
+      // exact command GET /file/status runs — is back to zero.
+      expect(await git(repo, 'status', '--porcelain', '-uall')).toBe('')
+      // `reload config` reads the config dir alone; it must be clean too.
+      expect(await git(repo, 'status', '--porcelain', '--', '.kortix/opencode')).toBe('')
+      const exclude = await readFile(join(repo, '.git', 'info', 'exclude'), 'utf8')
+      expect(exclude).toContain('/.kortix/opencode/skills/kortix-apps/')
+      expect(exclude).toContain('/.kortix/opencode/skills/kortix-system/')
+
+      // Re-running a boot must not append the same entries again.
+      await ensureInjectedManagedSkills(configDir, { bakedDir })
+      expect(await readFile(join(repo, '.git', 'info', 'exclude'), 'utf8')).toBe(exclude)
+
+      // A file the USER writes next to them is still reported.
+      await writeFile(join(configDir, 'skills', 'mine.md'), 'mine')
+      expect(await git(repo, 'status', '--porcelain', '-uall')).toContain(
+        '.kortix/opencode/skills/mine.md',
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves a committed copy of a managed skill visible — exclude never applies to tracked paths', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'inj-skills-'))
+    try {
+      const repo = await makeRepo(root)
+      const configDir = join(repo, '.kortix', 'opencode')
+      const bakedDir = join(root, 'baked')
+      // A pre-slim-down project: the managed body is TRACKED in the repo.
+      await mkdir(join(configDir, 'skills', 'kortix-system'), { recursive: true })
+      await writeFile(join(configDir, 'skills', 'kortix-system', 'SKILL.md'), 'OLD')
+      await git(repo, 'add', '-A')
+      await git(repo, 'commit', '-qm', 'committed managed skill')
+      await mkdir(join(bakedDir, 'kortix-system'), { recursive: true })
+      await writeFile(join(bakedDir, 'kortix-system', 'SKILL.md'), 'NEW')
+
+      await ensureInjectedManagedSkills(configDir, { bakedDir })
+
+      // The refresh still happens and is still reported as a real modification —
+      // it is a change to a file the project committed, not boot noise.
+      expect(await git(repo, 'status', '--porcelain', '-uall')).toContain(
+        'M .kortix/opencode/skills/kortix-system/SKILL.md',
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('no-ops safely when the config dir is outside any git repo', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'inj-skills-'))
+    try {
+      const configDir = join(root, 'ephemeral', 'opencode')
+      const bakedDir = join(root, 'baked')
+      await mkdir(join(bakedDir, 'kortix-cli'), { recursive: true })
+      await writeFile(join(bakedDir, 'kortix-cli', 'SKILL.md'), 'body')
+      await ensureInjectedManagedSkills(configDir, { bakedDir })
+      expect(await readFile(join(configDir, 'skills', 'kortix-cli', 'SKILL.md'), 'utf8')).toBe(
+        'body',
       )
     } finally {
       await rm(root, { recursive: true, force: true })

--- a/apps/kortix-sandbox-agent-server/src/injected-skills.ts
+++ b/apps/kortix-sandbox-agent-server/src/injected-skills.ts
@@ -46,6 +46,33 @@ const BAKED_MANAGED_SKILLS_DIR = '/opt/kortix/managed-skills'
  * Never throws: a failure just leaves the noise in place, which is the state
  * this function inherited.
  */
+/**
+ * One exclude line, or nothing.
+ *
+ * `.git/info/exclude` is newline-delimited and gives `#` and `!` their own
+ * meaning, so a value is only safe to write if every segment is an ordinary
+ * path segment. That matters because `prefix` here comes from
+ * `git rev-parse --show-prefix`, which follows the repository's own
+ * `opencode.config_dir` — repository-controlled input. A crafted value carrying
+ * a newline would append EXTRA rules of the attacker's choosing, and an exclude
+ * rule hides a file from `git status --porcelain -uall` — the exact command the
+ * product uses to show a user what changed in their session. Hiding a file
+ * there is hiding it from the human review step.
+ *
+ * Anything that is not a plain segment is DROPPED, not escaped: this is
+ * boot-time hygiene, and a skill directory that cannot be named safely is one
+ * we simply do not exclude. The cost of dropping is cosmetic (the row shows up
+ * as a change); the cost of writing it blind is a hidden file.
+ */
+const SAFE_PATH_SEGMENT = /^[\w .-]+$/
+
+function toExcludeEntry(relativePath: string): string | null {
+  const segments = relativePath.replace(/\/+$/, '').split('/').filter(Boolean)
+  if (segments.length === 0) return null
+  if (!segments.every((segment) => SAFE_PATH_SEGMENT.test(segment))) return null
+  return `/${segments.join('/')}/`
+}
+
 async function excludeInjectedSkillsFromGit(
   skillsDir: string,
   names: readonly string[],
@@ -74,7 +101,11 @@ async function excludeInjectedSkillsFromGit(
   if (!excludeRelative) return
   const excludePath = resolve(skillsDir, excludeRelative)
 
-  const wanted = [...names].sort().map((name) => `/${prefix}${name}/`)
+  const wanted = [...names]
+    .sort()
+    .map((name) => toExcludeEntry(`${prefix}${name}`))
+    .filter((entry): entry is string => entry !== null)
+  if (wanted.length === 0) return
   let existing = ''
   try {
     existing = await readFile(excludePath, 'utf8')

--- a/apps/kortix-sandbox-agent-server/src/injected-skills.ts
+++ b/apps/kortix-sandbox-agent-server/src/injected-skills.ts
@@ -1,6 +1,10 @@
-import { access, constants, cp, readdir } from 'node:fs/promises'
-import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { access, constants, cp, readdir, readFile, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { promisify } from 'node:util'
 import { logger } from './logger'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * Image-baked copy of the always-latest Kortix system skills — `kortix-cli`
@@ -9,6 +13,86 @@ import { logger } from './logger'
  * work. Each subdirectory is a skill folder (`<name>/SKILL.md`, references, …).
  */
 const BAKED_MANAGED_SKILLS_DIR = '/opt/kortix/managed-skills'
+
+/**
+ * Keep the overlay out of the user's `git status`.
+ *
+ * The managed family is deliberately NOT part of the scaffold commit (see
+ * `getManagedSkillFiles` in `packages/starter/src/index.ts`), so every file this
+ * overlay writes lands in the session working tree as an UNTRACKED file. The
+ * product reads that same working tree — `GET /file/status` runs
+ * `git status --porcelain -uall` — so 31 files of platform boot output were
+ * presented to the user as their own uncommitted changes, on a session where the
+ * agent had touched nothing. It also wedged `reload config`, which refuses with
+ * `local changes` whenever `git status -- <config dir>` is non-empty.
+ *
+ * The rule this restores is already written down one module over, in
+ * `runtime-assets.ts`: platform convergence must never dirty a working tree.
+ * `.git/info/exclude` is how the CLI already hides its own platform-local files
+ * (`appendGitExcludeEntries`, used by `kortix init`): repository-local, never
+ * committed, and — unlike a `.gitignore` edit — it fixes projects that already
+ * exist instead of only the next one created.
+ *
+ * Deliberately narrow:
+ *   - only the skill directories this call actually injected are listed, so a
+ *     user file is never hidden by a wildcard;
+ *   - git ignores exclude rules for TRACKED paths, so a project that committed
+ *     its own copy (every project created before the family left the scaffold)
+ *     keeps showing that copy exactly as it does today;
+ *   - the paths come from `git rev-parse --show-prefix`, so they are correct
+ *     whatever `opencode.config_dir` the manifest chose, and the whole thing
+ *     no-ops when the config dir is the out-of-repo default.
+ *
+ * Never throws: a failure just leaves the noise in place, which is the state
+ * this function inherited.
+ */
+async function excludeInjectedSkillsFromGit(
+  skillsDir: string,
+  names: readonly string[],
+): Promise<void> {
+  if (names.length === 0) return
+  const git = async (args: string[]): Promise<string | null> => {
+    try {
+      const { stdout } = await execFileAsync('git', args, {
+        cwd: skillsDir,
+        timeout: 10_000,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      })
+      return stdout.trim()
+    } catch {
+      return null
+    }
+  }
+  // Not a git working tree (the out-of-repo default config dir) → nothing to do.
+  const toplevel = await git(['rev-parse', '--show-toplevel'])
+  if (!toplevel) return
+  // Repo-relative location of the skills dir, WITH a trailing slash when nested.
+  // Taken from git rather than computed with path.relative so a symlinked
+  // workspace root cannot turn it into a `../..` escape.
+  const prefix = (await git(['rev-parse', '--show-prefix'])) ?? ''
+  const excludeRelative = await git(['rev-parse', '--git-path', 'info/exclude'])
+  if (!excludeRelative) return
+  const excludePath = resolve(skillsDir, excludeRelative)
+
+  const wanted = [...names].sort().map((name) => `/${prefix}${name}/`)
+  let existing = ''
+  try {
+    existing = await readFile(excludePath, 'utf8')
+  } catch {
+    existing = '' // no exclude file yet
+  }
+  const present = new Set(existing.split(/\r?\n/))
+  const missing = wanted.filter((entry) => !present.has(entry))
+  if (missing.length === 0) return
+
+  const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n' : ''
+  const header = '# Kortix-managed skills — injected at boot, never committed.\n'
+  await writeFile(excludePath, `${existing}${separator}${header}${missing.join('\n')}\n`, 'utf8')
+  logger.info('[boot] excluded injected managed skills from git status', {
+    excludePath,
+    entries: missing.length,
+  })
+}
 
 async function pathExists(p: string): Promise<boolean> {
   try {
@@ -43,17 +127,22 @@ export async function ensureInjectedManagedSkills(
     if (!(await pathExists(bakedDir))) return // nothing baked → leave repo copies as-is
     const skillsDir = join(configDir, 'skills')
     const entries = await readdir(bakedDir, { withFileTypes: true })
-    let injected = 0
+    const injectedNames: string[] = []
     for (const entry of entries) {
       if (!entry.isDirectory()) continue
       await cp(join(bakedDir, entry.name), join(skillsDir, entry.name), {
         recursive: true,
         force: true, // overwrite → the injected body always wins over the repo copy
       })
-      injected += 1
+      injectedNames.push(entry.name)
     }
-    if (injected > 0) {
-      logger.info('[boot] injected managed kortix skills', { configDir, from: bakedDir, injected })
+    if (injectedNames.length > 0) {
+      logger.info('[boot] injected managed kortix skills', {
+        configDir,
+        from: bakedDir,
+        injected: injectedNames.length,
+      })
+      await excludeInjectedSkillsFromGit(skillsDir, injectedNames)
     }
   } catch (err) {
     // Non-fatal: the repo's own copy (if any) stays in place.

--- a/tests/unit/ecs-deploy-environment.test.ts
+++ b/tests/unit/ecs-deploy-environment.test.ts
@@ -71,9 +71,15 @@ describe('ECS task environment overrides', () => {
       'utf8',
     );
 
-    expect(apiDeploy).toContain(
-      `KORTIX_ECS_ENV_OVERRIDES: '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}'`,
-    );
+    // Assert the KEY is armed, not the exact serialization of the whole object.
+    // Pinning the full JSON made this test fail the moment the preview work
+    // added KORTIX_PREVIEW_BASE_DOMAIN alongside it — a correct config change
+    // read as a regression. What this test is here to protect is that dev's API
+    // task carries the fast-cold-boot flag; anything else sharing the override
+    // map is not its business.
+    const overrides = apiDeploy.match(/KORTIX_ECS_ENV_OVERRIDES: '(\{.*\})'/)?.[1];
+    expect(overrides).toBeDefined();
+    expect(JSON.parse(overrides!)).toMatchObject({ KORTIX_FAST_COLD_BOOT_ENABLED: 'true' });
     const apiFilter = workflow.slice(
       workflow.indexOf('            api:'),
       workflow.indexOf('            gateway:'),


### PR DESCRIPTION
## The report

A brand-new session, a throwaway question (not a code task), and the header immediately claimed:

> **32 changes in this version** — Not in your `main` version yet

Every listed file was session bootstrap: `.kortix/opencode/package.json` plus the baked `kortix-*` skills. The product was offering to **Propose changes** platform boot output into `main`.

## Root cause

The count is exact, not approximate:

- `packages/starter/templates/managed/` holds **31 files across 11 skills** (verified: `find … | wc -l` → 31, `ls …/skills | wc -l` → 11)
- plus `M .kortix/opencode/package.json` → **32**

The overlay at `injected-skills.ts` runs *after* `materializeRepo()` and *after* the base commit is checked out (`main.ts:266` vs `:255`), so it is pure post-checkout boot output. The base commit deliberately excludes the managed family (`packages/starter/src/index.ts:186-196` — "committing a second copy into each project repo bought nothing… while padding every new project with ~10 files the user never asked for"). Untracked and not ignored, so `GET /file/status` — which runs `git status --porcelain -uall` (`routes/files.ts:92`) — counts all 31 as the user's work, and `session-changes-indicator.tsx:30` renders the number.

## It is a regression — `9ecd00895c` (PR #5770, 2026-07-29)

"Slim the Kortix Starter to a 10-skill artifact floor" moved the family from `templates/base/` to `templates/managed/` and left the boot overlay untouched. Verified:

```
$ git ls-tree -r --name-only 9ecd00895c^ -- packages/starter/templates/base/.kortix/opencode/skills/
…/kortix-executor/SKILL.md
…/kortix-marketplace/SKILL.md
…/kortix-memory/SKILL.md
…/kortix-onboarding/SKILL.md          (and the rest of the family)

$ git ls-tree -r --name-only 9ecd00895c  -- …/base/.kortix/opencode/skills/ | wc -l
1
```

Before #5770 the family was in every project's base commit, so the overlay wrote byte-identical content on top and `git status` stayed clean. After, it dirties the tree on every boot.

The recent `codex/boot-baked-scaffold` / `boot-scaffold-fingerprint` work is **not** the cause — its build-time guard uses `git status --porcelain --untracked-files=no`, deliberately blind to exactly this class of noise, which is why it never caught it.

## Second, larger blast radius

`git.ts:1428` — `syncOpencodeConfigDirToBase` refuses with `skipped: 'local changes'` whenever `git status --porcelain -- <config dir>` is non-empty. Since #5770 that is **always** non-empty, so **"reload config" has been a silent no-op on every project for three weeks.** Same root cause, same fix.

## The fix

After a successful overlay, record the injected skill directories in `.git/info/exclude`. This is the repo's own existing idiom — `apps/cli/src/git-exclude.ts` (`appendGitExcludeEntries`) already does exactly this for `/.kortix/link.json` in `kortix init`. Repository-local, never committed, and unlike a `.gitignore` edit it fixes **projects that already exist** rather than only the next one created.

Deliberately narrow:
- only the directories this call actually injected — never a wildcard, so a user's own skill can't be hidden
- paths from `git rev-parse --show-prefix`, so any `opencode.config_dir` works and a symlinked root can't produce a `../` escape
- git ignores exclude rules for **tracked** paths, so pre-#5770 projects that committed their copies still report `M` — unchanged
- no-ops when the config dir is out-of-repo; idempotent across reboots; never throws

### Options rejected

| Option | Why not |
|---|---|
| Commit the scaffold into the base commit | Reverses #5770's stated decision; re-pads every repo with 31 files the overlay clobbers each boot |
| `.gitignore` in `templates/base/` | Only helps projects created *after* the change; every existing project stays broken |
| Filter it out of the diff response | Cosmetic — the tree stays dirty, so `kortix ship`, in-sandbox `git status`, CR contents and the reload guard are all still wrong |
| `skills.paths` at `/opt/kortix/managed-skills`, stop overlaying | Architecturally cleanest, but changes skill discovery and collides with pre-#5770 projects that track their copies. Too risky for session boot — worth a follow-up |

## Verification

```
$ bun test src/__tests__/injected-skills.test.ts
 5 pass / 0 fail

$ bun test                     # whole daemon suite
 775 pass / 0 fail   (2311 assertions, 63 files)

$ bun tsc --noEmit
EXIT=0
```

The new tests use a **real git repo** and assert git's own output: after injection `git status --porcelain -uall` is empty, `git status --porcelain -- .kortix/opencode` is empty (the reload guard), a user file added beside the skills is still reported, a re-run appends nothing, and a tracked managed skill still reports `M`.

## Not verified

No live sandbox boot. The fix is proven against a real git repo in tests, but not yet against a real session. **Test on dev after merge:** open a brand-new session and ask anything — the header indicator should not render at all (it returns `null` at `changedCount === 0`). Then hit "reload config" and confirm it syncs instead of skipping. On a project created before 2026-07-29, confirm its committed `kortix-*` copies still show as `M`.

## Two follow-ups, deliberately not in this PR

1. **The 32nd row is a different bug.** `M .kortix/opencode/package.json` comes from `opencode-config-deps.ts:197` writing the install sentinel only in the "linked baked node_modules" branch; the staged-install fallback never writes it and also overwrites the tracked `configLock`. Without the sentinel, OpenCode's Arborist adds `@opencode-ai/plugin` to the tracked config `package.json`. Code-supported, not verified against a live boot. `.git/info/exclude` cannot help — it has no effect on tracked files.

2. **The Changes panel contradicts itself**, independent of this fix: the tab badge reads `git status` (whole working tree) while the body reads `session.diff`, which the OpenCode SDK documents as *"the file changes that resulted from a **specific user message**"* — zero on a fresh session. Hence "Changes 32" above "No changes yet". The right fix is `/vcs/diff?mode=branch`, which exists in the same SDK version; it's an SDK public-API addition needing TDD + snapshot updates, so it belongs in its own PR.
