### PR TITLE
feat(secrets): stream the relay — no body caps, SSE, truncation sentinel

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -36,13 +36,22 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 # latest compiled Linux binary even though we no longer publish a sandbox image.
 FROM --platform=$BUILDPLATFORM oven/bun:${SANDBOX_AGENT_BUN_VERSION}-slim AS sandbox-agent
 
-WORKDIR /agent
+# The daemon builds STANDALONE (its own package.json + bun.lock, no workspace
+# root), but it shares ONE module with apps/api: the relay wire contract
+# (packages/api-contract/src/secret-relay.ts). That is reached through a tsconfig
+# `paths` mapping rather than a `"workspace:*"` dependency, because a workspace
+# dependency makes `bun install --frozen-lockfile` here fail outright
+# ("Workspace dependency ... not found / Searched in ./*") and NO image can be
+# built. So mirror the repo layout and copy the one package the mapping points
+# at — the same shape apps/sandbox/Dockerfile uses.
+WORKDIR /repo/apps/kortix-sandbox-agent-server
 
 ARG KORTIX_AGENT_BUN_TARGET=bun-linux-x64
 
 COPY apps/kortix-sandbox-agent-server/package.json apps/kortix-sandbox-agent-server/bun.lock ./
 RUN bun install --frozen-lockfile
 
+COPY packages/api-contract /repo/packages/api-contract
 COPY apps/kortix-sandbox-agent-server/ ./
 RUN BUN_COMPILE_TARGET=${KORTIX_AGENT_BUN_TARGET} bash scripts/build.sh
 
@@ -231,7 +240,7 @@ COPY --from=deps /app/packages/registry/tsconfig.json ./packages/registry/tsconf
 # migrate-db job (pnpm migrate, from the checkout) before the new code serves.
 
 # Copy runtime artifacts used by the layered snapshot builder.
-COPY --from=sandbox-agent /agent/dist/kortix-agent ./apps/kortix-sandbox-agent-server/dist/kortix-agent
+COPY --from=sandbox-agent /repo/apps/kortix-sandbox-agent-server/dist/kortix-agent ./apps/kortix-sandbox-agent-server/dist/kortix-agent
 COPY --from=sandbox-cli /cli/apps/cli/dist/kortix ./apps/cli/dist/kortix
 COPY --from=sandbox-cli /cli/apps/cli/dist/kortix.version ./apps/cli/dist/kortix.version
 COPY --from=sandbox-cli /cli/apps/cli/dist/kortix-connectors-runtime.attestation.json ./apps/cli/dist/kortix-connectors-runtime.attestation.json

--- a/apps/api/src/__tests__/unit-project-secret-relay-route.test.ts
+++ b/apps/api/src/__tests__/unit-project-secret-relay-route.test.ts
@@ -1,0 +1,785 @@
+/**
+ * The streaming relay route, black-box over its REAL wire contract.
+ *
+ * What is mocked: the database, project access, secret decryption, audit, and
+ * the upstream transport (`relay-transport.ts`, which has its own tests against
+ * a real TLS socket). What is NOT mocked, deliberately: the relay meta codec,
+ * the whole policy gate (`prepareRelayHead`), the authorization core
+ * (`relay-authorize.ts`), and both substituters. Those are the security
+ * contract — a test that mocked them would be asserting its own fixtures.
+ */
+import { createHash } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  projectSecrets,
+  projectSessionSecretHandles,
+  projectSessions,
+  sessionSandboxes,
+} from '@kortix/db';
+import {
+  decodeRelayStatus,
+  encodeRelayMeta,
+  RELAY_ERROR_HEADER,
+  RELAY_META_HEADER,
+  RELAY_PROBE_HEADER,
+  RELAY_STATUS_HEADER,
+  RELAY_VERSION_HEADER,
+  type SecretRelayMeta,
+} from '@kortix/api-contract/secret-relay';
+import { Hono } from 'hono';
+import { config } from '../config';
+import * as realAccess from '../projects/lib/access';
+import * as realProjectSecrets from '../projects/secrets';
+import { mintHandle } from '../secrets/strategy';
+
+const PROJECT_ID = '33333333-3333-4333-8333-333333333333';
+const ACCOUNT_ID = '44444444-4444-4444-8444-444444444444';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const SESSION_ID = '55555555-5555-4555-8555-555555555555';
+const SECRET_ID = '66666666-6666-4666-8666-666666666666';
+const LOOKUP_ID = 'aaaaaaaaaaaaaaaaaaaa';
+const SECRET_VALUE = 'sk_live_the_real_value';
+
+const POLICY = {
+  backend: 'kortix_fetch' as const,
+  rules: [{ host: 'api.example.com', methods: ['GET', 'POST'], path: '/v1/*' }],
+};
+
+const HANDLE = mintHandle({ lookupId: LOOKUP_ID, prefix: null, rootSecret: config.API_KEY_SECRET });
+
+let authType: 'pat' | 'supabase' = 'pat';
+let tokenProjectId: string | undefined = PROJECT_ID;
+let sessionId: string | undefined = SESSION_ID;
+let agentGrant: Record<string, unknown> | null = {
+  agent: 'default',
+  kortixCli: 'all',
+  connectors: 'all',
+  env: ['PRIMARY'],
+};
+let sessionRow: Record<string, unknown> | null = {
+  sessionId: SESSION_ID,
+  secretsAllowlist: ['PRIMARY'],
+};
+let secretRows: Array<Record<string, unknown>> = [];
+let handleRows: Array<Record<string, unknown>> = [];
+const audits: Array<Record<string, unknown>> = [];
+let sandboxRow: { metadata: Record<string, unknown> } | null = null;
+
+function sharedSecret(overrides: Record<string, unknown> = {}) {
+  return {
+    secretId: SECRET_ID,
+    identifier: 'PRIMARY',
+    ownerUserId: null,
+    valueEnc: 'shared-encrypted-value',
+    active: true,
+    strategy: 'broker',
+    egressPolicy: POLICY,
+    handlePrefix: null,
+    ...overrides,
+  };
+}
+
+function handleFor(overrides: Record<string, unknown> = {}) {
+  return {
+    secretId: SECRET_ID,
+    identifier: 'PRIMARY',
+    lookupId: LOOKUP_ID,
+    handleHash: createHash('sha256').update(HANDLE).digest('hex'),
+    policySnapshot: POLICY,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+const databaseMock = {
+  select: () => ({
+    from: (table: unknown) => ({
+      where: () => {
+        if (table === projectSessions) return { limit: async () => (sessionRow ? [sessionRow] : []) };
+        if (table === sessionSandboxes) {
+          return { limit: async () => (sandboxRow ? [sandboxRow] : []) };
+        }
+        if (table === projectSecrets) return Promise.resolve(secretRows);
+        if (table === projectSessionSecretHandles) return { orderBy: async () => handleRows };
+        throw new Error('unexpected table');
+      },
+    }),
+  }),
+};
+
+mock.module('../shared/db', () => ({ db: databaseMock, hasDatabase: true }));
+mock.module('../projects/lib/access', () => ({
+  ...realAccess,
+  loadProjectForUser: async () => ({
+    row: { accountId: ACCOUNT_ID, projectId: PROJECT_ID },
+    userId: USER_ID,
+  }),
+}));
+mock.module('../projects/secrets', () => ({
+  ...realProjectSecrets,
+  decryptProjectSecret: () => SECRET_VALUE,
+}));
+mock.module('../shared/audit', () => ({
+  recordAuditEvent: async (event: Record<string, unknown>) => {
+    audits.push(event);
+  },
+}));
+
+// ── The upstream, mocked at the transport boundary ─────────────────────────
+interface UpstreamCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  /** Everything the route actually wrote to the upstream. */
+  body: Buffer;
+  /** The chunk sizes, so "did it STREAM" is observable, not assumed. */
+  chunks: number[];
+}
+let upstreamCalls: UpstreamCall[] = [];
+let upstreamStatus = 200;
+let upstreamHeaders: Array<[string, string]> = [['content-type', 'application/json']];
+/** Per-hop scripted responses, for redirect tests. Consumed in order. */
+let upstreamScript: Array<{ status: number; headers: Array<[string, string]> }> = [];
+/** What the upstream writes back, as discrete chunks. */
+let upstreamBody: string[] = ['{"ok":true}'];
+let upstreamDelayMs = 0;
+/** Destroy the upstream body after N pieces, to model a mid-stream death. */
+let upstreamFailAfter: number | null = null;
+
+mock.module('../secrets/relay-transport', () => ({
+  RELAY_CONNECT_TIMEOUT_MS: 10_000,
+  openUpstream: async (
+    head: { url: URL; method: string; headers: Record<string, string> },
+    body: Readable | Buffer | null,
+  ) => {
+    const call: UpstreamCall = {
+      url: head.url.href,
+      method: head.method,
+      headers: head.headers,
+      body: Buffer.alloc(0),
+      chunks: [],
+    };
+    upstreamCalls.push(call);
+    const scripted = upstreamScript.shift();
+    if (Buffer.isBuffer(body)) {
+      call.body = body;
+      call.chunks.push(body.byteLength);
+    } else if (body) {
+      const parts: Buffer[] = [];
+      for await (const chunk of body) {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+        parts.push(buffer);
+        call.chunks.push(buffer.byteLength);
+      }
+      call.body = Buffer.concat(parts);
+    }
+    const out = new Readable({ read() {} });
+    void (async () => {
+      let written = 0;
+      for (const piece of upstreamBody) {
+        if (upstreamDelayMs) await new Promise((r) => setTimeout(r, upstreamDelayMs));
+        out.push(Buffer.from(piece));
+        written += 1;
+        if (upstreamFailAfter !== null && written >= upstreamFailAfter) {
+          // Exactly what relay-transport does on an idle timeout or a blown
+          // response budget: destroy the stream mid-body.
+          //
+          // The delay is not cosmetic. Measured on bun 1.3.14: destroying a
+          // Readable in the SAME tick as the push that preceded it makes
+          // `Readable.toWeb` drop BOTH the data and the error — the consumer
+          // sees a clean, empty stream. Every real destroy site
+          // (`relay-transport.ts` armIdle, the byte-budget check, the
+          // `'error'` handler) runs on a later tick, so this models production
+          // and not that quirk.
+          await new Promise((r) => setTimeout(r, 5));
+          out.destroy(new Error('upstream stream went idle'));
+          return;
+        }
+      }
+      out.push(null);
+    })();
+    return {
+      status: scripted?.status ?? upstreamStatus,
+      rawHeaders: scripted?.headers ?? upstreamHeaders,
+      body: out,
+      destroy: () => out.destroy(),
+    };
+  },
+}));
+
+const { projectsApp } = await import('../projects/lib/app');
+await import('../projects/routes/secret-relay');
+
+function buildApp() {
+  const app = new Hono<{
+    Variables: {
+      userId: string;
+      authType: 'pat' | 'supabase';
+      tokenProjectId?: string;
+      sessionId?: string;
+      agentGrant?: Record<string, unknown> | null;
+    };
+  }>();
+  app.use('*', async (c, next) => {
+    c.set('userId', USER_ID);
+    c.set('authType', authType);
+    if (tokenProjectId) c.set('tokenProjectId', tokenProjectId);
+    if (sessionId) c.set('sessionId', sessionId);
+    c.set('agentGrant', agentGrant);
+    await next();
+  });
+  app.route('/v1/projects', projectsApp);
+  return app;
+}
+
+function meta(overrides: Partial<SecretRelayMeta> = {}): SecretRelayMeta {
+  return {
+    v: 1,
+    url: 'https://api.example.com/v1/messages',
+    method: 'POST',
+    headers: [['content-type', 'application/json']],
+    body: { present: false },
+    ...overrides,
+  } as SecretRelayMeta;
+}
+
+function relay(
+  init: { meta?: SecretRelayMeta | string | null; body?: BodyInit | null; headers?: Record<string, string> } = {},
+) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/octet-stream',
+    [RELAY_VERSION_HEADER]: '1',
+    ...(init.headers ?? {}),
+  };
+  const m = init.meta === undefined ? meta() : init.meta;
+  if (m !== null) headers[RELAY_META_HEADER] = typeof m === 'string' ? m : encodeRelayMeta(m);
+  return buildApp().request(`/v1/projects/${PROJECT_ID}/secrets/PRIMARY/relay`, {
+    method: 'POST',
+    headers,
+    ...(init.body != null ? { body: init.body } : {}),
+  });
+}
+
+beforeEach(() => {
+  authType = 'pat';
+  tokenProjectId = PROJECT_ID;
+  sessionId = SESSION_ID;
+  agentGrant = { agent: 'default', kortixCli: 'all', connectors: 'all', env: ['PRIMARY'] };
+  sessionRow = { sessionId: SESSION_ID, secretsAllowlist: ['PRIMARY'] };
+  secretRows = [sharedSecret()];
+  handleRows = [handleFor()];
+  sandboxRow = null;
+  audits.length = 0;
+  upstreamCalls = [];
+  upstreamStatus = 200;
+  upstreamHeaders = [['content-type', 'application/json']];
+  upstreamBody = ['{"ok":true}'];
+  upstreamDelayMs = 0;
+  upstreamFailAfter = null;
+  upstreamScript = [];
+});
+
+describe('the capability probe', () => {
+  test('answers 204 with the protocol version', async () => {
+    const response = await relay({ meta: null, headers: { [RELAY_PROBE_HEADER]: '1' } });
+    expect(response.status).toBe(204);
+    expect(response.headers.get(RELAY_VERSION_HEADER)).toBe('1');
+  });
+
+  test('costs nothing: it never touches the secret or writes an audit row', async () => {
+    await relay({ meta: null, headers: { [RELAY_PROBE_HEADER]: '1' } });
+    expect(audits).toEqual([]);
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test('still requires the session-scoped agent token', async () => {
+    authType = 'supabase';
+    const response = await relay({ meta: null, headers: { [RELAY_PROBE_HEADER]: '1' } });
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: 'session_agent_token_required' });
+  });
+});
+
+describe('the meta header is validated before anything else happens', () => {
+  test('a missing meta is 400 relay_meta_invalid', async () => {
+    const response = await relay({ meta: null });
+    expect(response.status).toBe(400);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('relay_meta_invalid');
+    expect(await response.json()).toMatchObject({ code: 'relay_meta_invalid' });
+  });
+
+  test('an oversized meta is 400 relay_meta_too_large', async () => {
+    const response = await relay({ meta: 'A'.repeat(70_000) });
+    expect(response.status).toBe(400);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('relay_meta_too_large');
+  });
+
+  test('a malformed meta never reaches the upstream', async () => {
+    await relay({ meta: 'not-base64-json' });
+    expect(upstreamCalls).toEqual([]);
+  });
+});
+
+describe('the relay-200 vs relay-error disambiguation — the load-bearing rule', () => {
+  test('an out-of-policy host is 403 policy_denied with NO status header', async () => {
+    const response = await relay({ meta: meta({ url: 'https://evil.example.com/v1/x' }) });
+    expect(response.status).toBe(403);
+    expect(response.headers.get(RELAY_STATUS_HEADER)).toBeNull();
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('policy_denied');
+    expect(await response.json()).toMatchObject({ code: 'policy_denied' });
+  });
+
+  test('an upstream 429 is relay 200 WITH a status header carrying 429', async () => {
+    // The distinction the legacy JSON envelope preserves and this contract must
+    // not lose: "Kortix denied you" and "Stripe rate-limited you" are different
+    // facts and the agent acts differently on each.
+    upstreamStatus = 429;
+    upstreamHeaders = [
+      ['content-type', 'application/json'],
+      ['retry-after', '5'],
+    ];
+    const response = await relay();
+    expect(response.status).toBe(200);
+    const status = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!);
+    expect(status.status).toBe(429);
+    expect(status.headers).toContainEqual(['retry-after', '5']);
+  });
+
+  test('an upstream 403 is ALSO relay 200 — never mirrored onto our own status', async () => {
+    upstreamStatus = 403;
+    const response = await relay();
+    expect(response.status).toBe(200);
+    expect(decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!).status).toBe(403);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBeNull();
+  });
+});
+
+describe('substitution covers every carrier the guest can use', () => {
+  test('a handle in a request HEADER is replaced with the real value', async () => {
+    await relay({
+      meta: meta({ headers: [['authorization', `Bearer ${HANDLE}`]] }),
+    });
+    expect(upstreamCalls[0]?.headers.authorization).toBe(`Bearer ${SECRET_VALUE}`);
+  });
+
+  test('a handle in the URL QUERY is replaced', async () => {
+    await relay({ meta: meta({ url: `https://api.example.com/v1/m?key=${HANDLE}`, method: 'GET' }) });
+    expect(upstreamCalls[0]?.url).toContain(encodeURIComponent(SECRET_VALUE));
+    expect(upstreamCalls[0]?.url).not.toContain(HANDLE);
+  });
+
+  test('a handle in the request BODY is replaced', async () => {
+    const body = JSON.stringify({ token: HANDLE });
+    await relay({
+      meta: meta({ body: { present: true, length: body.length } }),
+      body,
+    });
+    expect(upstreamCalls[0]?.body.toString()).toBe(JSON.stringify({ token: SECRET_VALUE }));
+  });
+
+  test('a handle SPLIT ACROSS chunk boundaries in a streamed body is still replaced', async () => {
+    // The bug class this whole design exists to prevent. The body is over the
+    // exact-length threshold, so it takes the streaming path, and the handle is
+    // deliberately straddling a chunk edge.
+    const filler = 'x'.repeat(70_000);
+    const text = `${filler}{"token":"${HANDLE}"}`;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const bytes = Buffer.from(text);
+        // Cut INSIDE the handle.
+        const cut = text.indexOf(HANDLE) + 11;
+        controller.enqueue(bytes.subarray(0, cut));
+        controller.enqueue(bytes.subarray(cut));
+        controller.close();
+      },
+    });
+    await relay({
+      meta: meta({ body: { present: true, length: null } }),
+      body: source,
+    });
+    const sent = upstreamCalls[0]!.body.toString();
+    expect(sent).toContain(SECRET_VALUE);
+    expect(sent).not.toContain(HANDLE);
+    expect(upstreamCalls[0]!.chunks.length).toBeGreaterThan(1);
+  });
+
+  test('a handle this session may NOT spend is left alone, not substituted', async () => {
+    agentGrant = { agent: 'default', kortixCli: 'all', connectors: 'all', env: [] };
+    const response = await relay({ meta: meta({ headers: [['authorization', `Bearer ${HANDLE}`]] }) });
+    // The route's own secret is no longer deliverable, so the relay refuses
+    // outright rather than sending a request with a worthless string in it.
+    expect(response.status).toBe(403);
+    expect(upstreamCalls).toEqual([]);
+  });
+});
+
+describe('echo redaction is inline, on BOTH exits', () => {
+  test('a secret echoed in the streamed body comes back [REDACTED]', async () => {
+    upstreamBody = [`{"echo":"${SECRET_VALUE}"}`];
+    const response = await relay();
+    expect(await response.text()).toBe('{"echo":"[REDACTED]"}');
+  });
+
+  test('a secret SPLIT across upstream chunks is still redacted', async () => {
+    const half = Math.floor(SECRET_VALUE.length / 2);
+    upstreamBody = [`{"echo":"${SECRET_VALUE.slice(0, half)}`, `${SECRET_VALUE.slice(half)}"}`];
+    const response = await relay();
+    expect(await response.text()).toBe('{"echo":"[REDACTED]"}');
+  });
+
+  test('a secret echoed in a WHITELISTED response header comes back [REDACTED]', async () => {
+    // The body is not the only exit.
+    upstreamHeaders = [
+      ['content-type', 'application/json'],
+      ['x-request-id', `req_${SECRET_VALUE}`],
+    ];
+    const response = await relay();
+    const status = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!);
+    expect(status.headers).toContainEqual(['x-request-id', 'req_[REDACTED]']);
+  });
+
+  test('response headers outside the whitelist never travel', async () => {
+    upstreamHeaders = [
+      ['content-type', 'application/json'],
+      ['set-cookie', 'session=abc'],
+      ['content-length', '11'],
+      ['transfer-encoding', 'chunked'],
+    ];
+    const response = await relay();
+    const names = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!).headers.map(
+      ([n]) => n,
+    );
+    expect(names).toEqual(['content-type']);
+  });
+
+  // REGRESSION. `prepareRelayHead` forces `accept-encoding: identity` upstream
+  // precisely so the echo scan sees plaintext, but nothing verified the
+  // upstream OBEYED — and `content-encoding` is not in SAFE_RESPONSE_HEADERS,
+  // so a gzip body was piped through a redactor that cannot match compressed
+  // bytes and handed to the guest as undeclared compressed data. With the 5 MiB
+  // response cap gone, the volume of unredacted upstream bytes reachable
+  // through that gap was unbounded. Fail closed instead.
+  test('a compressed upstream body is REFUSED, not relayed unredacted', async () => {
+    upstreamHeaders = [
+      ['content-type', 'application/json'],
+      ['content-encoding', 'gzip'],
+    ];
+    upstreamBody = ['\u001f\u008b compressed bytes'];
+    const response = await relay();
+    expect(response.status).toBe(502);
+    expect(response.headers.get(RELAY_STATUS_HEADER)).toBeNull();
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('upstream_encoding_unsupported');
+  });
+
+  test('an explicit identity content-encoding is fine', async () => {
+    upstreamHeaders = [
+      ['content-type', 'application/json'],
+      ['content-encoding', 'identity'],
+    ];
+    const response = await relay();
+    expect(response.status).toBe(200);
+    expect(response.headers.get(RELAY_STATUS_HEADER)).not.toBeNull();
+  });
+});
+
+describe('framing', () => {
+  test('a small body of known length is sent with an EXACT content-length', async () => {
+    const body = JSON.stringify({ token: HANDLE });
+    await relay({ meta: meta({ body: { present: true, length: body.length } }), body });
+    // Substitution changed the length; the header must state the POST-substitution
+    // size, never the guest's.
+    expect(upstreamCalls[0]?.headers['content-length']).toBe(
+      String(JSON.stringify({ token: SECRET_VALUE }).length),
+    );
+  });
+
+  test('a large body is streamed with NO content-length', async () => {
+    const body = 'y'.repeat(70_000);
+    await relay({ meta: meta({ body: { present: true, length: body.length } }), body });
+    expect(upstreamCalls[0]?.headers['content-length']).toBeUndefined();
+  });
+
+  test('a bodyless request sends no body and no length header', async () => {
+    await relay({ meta: meta({ method: 'GET', body: { present: false } }) });
+    expect(upstreamCalls[0]?.body.byteLength).toBe(0);
+    expect(upstreamCalls[0]?.headers['content-length']).toBeUndefined();
+  });
+
+  test('the guest cannot set framing headers itself', async () => {
+    const response = await relay({
+      meta: meta({ headers: [['transfer-encoding', 'chunked']] }),
+    });
+    expect(response.status).toBe(400);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('invalid_request');
+  });
+
+  test('accept-encoding is forced to identity so an echo cannot hide in gzip', async () => {
+    await relay({ meta: meta({ headers: [['accept-encoding', 'gzip, br']] }) });
+    expect(upstreamCalls[0]?.headers['accept-encoding']).toBe('identity');
+  });
+});
+
+describe('the kill switch', () => {
+  test('with the relay disabled every call is 503 relay_disabled', async () => {
+    const original = config.KORTIX_SECRET_RELAY_STREAM_ENABLED;
+    (config as { KORTIX_SECRET_RELAY_STREAM_ENABLED: boolean }).KORTIX_SECRET_RELAY_STREAM_ENABLED =
+      false;
+    try {
+      const response = await relay();
+      expect(response.status).toBe(503);
+      expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('relay_disabled');
+      expect(await response.json()).toMatchObject({ code: 'relay_disabled' });
+      // And the probe fails too, which is what puts a NEW shim in legacy mode.
+      const probe = await relay({ meta: null, headers: { [RELAY_PROBE_HEADER]: '1' } });
+      expect(probe.status).toBe(503);
+    } finally {
+      (config as { KORTIX_SECRET_RELAY_STREAM_ENABLED: boolean }).KORTIX_SECRET_RELAY_STREAM_ENABLED =
+        original;
+    }
+  });
+});
+
+describe('redirects', () => {
+  test('a 3xx after a secret rode out is refused, as on the buffered path', async () => {
+    upstreamStatus = 302;
+    upstreamHeaders = [['location', 'https://evil.example.com/']];
+    const response = await relay({ meta: meta({ headers: [['authorization', `Bearer ${HANDLE}`]] }) });
+    expect(response.status).toBe(502);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('upstream_failed');
+  });
+
+  test('a replayable 3xx IS followed, and the new host is re-matched', async () => {
+    // The buffered /broker route follows up to 3 redirects when no credential
+    // is on the wire. The relay must not silently lose that for the ordinary
+    // bodyless GET, or a shim in relay mode breaks traffic that worked before.
+    upstreamScript = [
+      { status: 302, headers: [['location', 'https://api.example.com/v1/moved']] },
+      { status: 200, headers: [['content-type', 'application/json']] },
+    ];
+    const response = await relay({ meta: meta({ method: 'GET', body: { present: false } }) });
+    expect(response.status).toBe(200);
+    expect(decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!).status).toBe(200);
+    expect(upstreamCalls).toHaveLength(2);
+    expect(upstreamCalls[1]?.url).toBe('https://api.example.com/v1/moved');
+  });
+
+  test('a redirect to an OFF-POLICY host is refused, not followed', async () => {
+    // The reason the hop loop re-enters the full head gate instead of just
+    // swapping the URL.
+    upstreamScript = [
+      { status: 302, headers: [['location', 'https://evil.example.com/v1/steal']] },
+    ];
+    const response = await relay({ meta: meta({ method: 'GET', body: { present: false } }) });
+    expect(response.status).toBe(403);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('policy_denied');
+    expect(upstreamCalls).toHaveLength(1);
+  });
+
+  test('a redirect LOOP stops at the limit instead of spinning', async () => {
+    upstreamScript = Array.from({ length: 8 }, () => ({
+      status: 302 as const,
+      headers: [['location', 'https://api.example.com/v1/loop']] as Array<[string, string]>,
+    }));
+    const response = await relay({ meta: meta({ method: 'GET', body: { present: false } }) });
+    expect(response.status).toBe(502);
+    expect(upstreamCalls.length).toBeLessThanOrEqual(5);
+  });
+
+  test('a 303 rewrites the follow-up to a bodyless GET', async () => {
+    const body = JSON.stringify({ plain: 'no handle here' });
+    upstreamScript = [
+      { status: 303, headers: [['location', 'https://api.example.com/v1/result']] },
+      { status: 200, headers: [['content-type', 'application/json']] },
+    ];
+    await relay({ meta: meta({ body: { present: true, length: body.length } }), body });
+    expect(upstreamCalls[1]?.method).toBe('GET');
+    expect(upstreamCalls[1]?.body.byteLength).toBe(0);
+    expect(upstreamCalls[1]?.headers['content-length']).toBeUndefined();
+  });
+
+  test('a 3xx on a STREAMED body is refused with redirect_not_replayable', async () => {
+    upstreamStatus = 302;
+    upstreamHeaders = [['location', 'https://api.example.com/v1/other']];
+    const body = 'z'.repeat(70_000);
+    const response = await relay({
+      meta: meta({ body: { present: true, length: body.length } }),
+      body,
+    });
+    expect(response.status).toBe(502);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('redirect_not_replayable');
+  });
+});
+
+describe('the audit trail names the transport', () => {
+  test('a successful relay records requested + completed', async () => {
+    await relay();
+    expect(audits.map((event) => event.action)).toEqual([
+      'secret.broker.requested',
+      'secret.broker.completed',
+    ]);
+    expect(audits[0]?.metadata).toMatchObject({ identifier: 'PRIMARY', transport: 'relay' });
+  });
+
+  test('no audit row ever contains the secret value', async () => {
+    upstreamBody = [`{"echo":"${SECRET_VALUE}"}`];
+    const response = await relay({ meta: meta({ headers: [['authorization', `Bearer ${HANDLE}`]] }) });
+    await response.text();
+    expect(JSON.stringify(audits)).not.toContain(SECRET_VALUE);
+    expect(JSON.stringify(audits)).not.toContain(HANDLE);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// REGRESSIONS — each of these failed before the fix beside it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('the declared body length is never trusted as a size guarantee', () => {
+  // The buffered CASE-3 branch selected itself on `meta.body.length` and then
+  // read the WHOLE body with `new Response(rawBody).arrayBuffer()`. Nothing
+  // compared the declaration against the bytes that actually arrived, and
+  // `KORTIX_RELAY_MAX_REQUEST_BYTES` is enforced by counters inside
+  // `openUpstream`, which run AFTER the buffer is materialised. Measured on bun
+  // 1.3.14: `Bun.serve` applies no `maxRequestBodySize` to a chunked request
+  // body, and this route is exempt from both the request deadline and Bun's
+  // per-request timeout — so `{length: 1}` + a multi-GiB body was an unbounded
+  // allocation with unlimited time, i.e. a one-request OOM of a shared pod.
+  test('a body larger than its declared length is refused with 413, before the upstream', async () => {
+    const body = 'x'.repeat(200_000);
+    const response = await relay({
+      meta: meta({ body: { present: true, length: 1 } }),
+      body,
+    });
+    expect(response.status).toBe(413);
+    expect(response.headers.get(RELAY_ERROR_HEADER)).toBe('relay_request_too_large');
+    expect(upstreamCalls).toEqual([]);
+  });
+
+  test('the refusal is audited as a failure, not silently dropped', async () => {
+    await relay({ meta: meta({ body: { present: true, length: 4 } }), body: 'x'.repeat(9_000) });
+    expect(audits.map((event) => event.action)).toEqual([
+      'secret.broker.requested',
+      'secret.broker.failed',
+    ]);
+    expect(audits[1]?.after).toMatchObject({ reason: 'relay_request_too_large' });
+  });
+
+  test('an honest declaration still takes the buffered exact-length path', async () => {
+    const body = JSON.stringify({ token: HANDLE });
+    const response = await relay({
+      meta: meta({ body: { present: true, length: body.length } }),
+      body,
+    });
+    expect(response.status).toBe(200);
+    expect(upstreamCalls[0]?.body.toString()).toBe(JSON.stringify({ token: SECRET_VALUE }));
+  });
+});
+
+describe('the end-of-stream sentinel — truncation is signalled POSITIVELY', () => {
+  // The route used to claim "a failure after the headers terminates the chunked
+  // response without its final 0\r\n\r\n, so a missing terminator IS the error
+  // signal". Measured false on bun 1.3.14 across four shapes (source Readable
+  // destroyed with an error, controller.error(), pull() throwing, a declared
+  // content-length cut short): Bun ALWAYS writes `0\r\n\r\n` and the client's
+  // fetch resolves cleanly. So the signal is now a random per-response sentinel
+  // appended ONLY on a clean flush.
+  test('a completing relay ends with the sentinel named in the status header', async () => {
+    upstreamBody = ['{"a":1}', '{"b":2}'];
+    const response = await relay({ meta: meta({ eos: true }) });
+    const status = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!);
+    expect(status.eos).toMatch(/^[0-9a-f]{64}$/);
+    const bytes = Buffer.from(await response.arrayBuffer());
+    const sentinel = Buffer.from(status.eos!, 'hex');
+    expect(bytes.subarray(bytes.byteLength - sentinel.byteLength)).toEqual(sentinel);
+    expect(bytes.subarray(0, bytes.byteLength - sentinel.byteLength).toString()).toBe(
+      '{"a":1}{"b":2}',
+    );
+  });
+
+  test('a client that does NOT ask gets no sentinel and no trailing bytes', async () => {
+    // An already-baked daemon would hand the sentinel to the guest as garbage.
+    upstreamBody = ['{"a":1}'];
+    const response = await relay();
+    const status = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!);
+    expect(status.eos).toBeUndefined();
+    expect(await response.text()).toBe('{"a":1}');
+  });
+
+  test('an upstream that dies mid-body omits the sentinel', async () => {
+    upstreamFailAfter = 1;
+    upstreamBody = ['{"partial":'];
+    const response = await relay({ meta: meta({ eos: true }) });
+    const status = decodeRelayStatus(response.headers.get(RELAY_STATUS_HEADER)!);
+    const bytes = Buffer.from(await response.arrayBuffer().catch(() => new ArrayBuffer(0)));
+    const sentinel = Buffer.from(status.eos!, 'hex');
+    expect(bytes.includes(sentinel)).toBe(false);
+  });
+});
+
+describe('the audit trail is truthful about a STREAMED substitution', () => {
+  // `secret.broker.completed` reported `hop.applied`, which only ever fills on
+  // the buffered branch. A handle substituted inside a streamed body produced a
+  // row with NO `substituted` key at all — an operator reconstructing which
+  // credentials left the platform read it as "nothing was spent".
+  test('a streamed body that substitutes is never recorded as substituting nothing', async () => {
+    const body = `${'p'.repeat(70_000)}${HANDLE}${'q'.repeat(10)}`;
+    const response = await relay({
+      meta: meta({ body: { present: true, length: null }, eos: true }),
+      body,
+    });
+    await response.arrayBuffer();
+    expect(upstreamCalls[0]?.body.toString()).toContain(SECRET_VALUE);
+
+    const completed = audits.find((event) => event.action === 'secret.broker.completed');
+    expect(completed?.after).toMatchObject({
+      substitution: 'streamed_superset',
+      substitution_candidates: ['PRIMARY'],
+    });
+
+    // The EXACT set lands on the terminal row, once the body has actually run
+    // through the substituter.
+    const streamed = audits.find((event) => event.action === 'secret.broker.streamed');
+    expect(streamed?.after).toMatchObject({ complete: true, substituted: ['PRIMARY'] });
+  });
+});
+
+describe('a handle presented in a STREAMED body is still classified', () => {
+  // The refusal classifier was fed `bufferedBody`, which is non-null on the
+  // buffered branch ALONE. Both streaming branches left the body unscanned —
+  // and the attacker picks the branch, by declaring `body.length: null` or by
+  // targeting a host for which it holds no admitted handle (which makes the
+  // pass-through branch fire). A live credential-theft probe was therefore
+  // indistinguishable from ordinary traffic in the audit trail, while the same
+  // probe through /broker was recorded. Substitution was fail-closed the whole
+  // time; the forensic line was not.
+  const FORGED = mintHandle({ lookupId: 'bbbbbbbbbbbbbbbbbbbb', prefix: null, rootSecret: 'a-different-root-secret' });
+
+  test('a forged handle in a length-less (streamed) body is audited', async () => {
+    const body = `{"probe":"${FORGED}"}`;
+    const response = await relay({
+      meta: meta({ body: { present: true, length: null } }),
+      body,
+    });
+    await response.arrayBuffer();
+    const refused = audits.find((event) => event.action === 'secret.handle.refused');
+    expect(refused?.after).toMatchObject({
+      surface: 'request_body',
+      refusals: { forged: 1, stolen: 0, host_denied: 0 },
+    });
+  });
+
+  // NOT covered here: the pass-through branch (CASE 2). Reaching it needs an
+  // authorized relay with an EMPTY spendable-handle set, and
+  // `authorizeSecretRelay` refuses that shape with a 409 before the route runs
+  // — so it is not constructible in this harness. The tap is the same helper
+  // with the same callback on both branches.
+  test('an ordinary body writes no refusal row', async () => {
+    const body = JSON.stringify({ hello: 'world' });
+    const response = await relay({
+      meta: meta({ body: { present: true, length: null } }),
+      body,
+    });
+    await response.arrayBuffer();
+    expect(audits.some((event) => event.action === 'secret.handle.refused')).toBe(false);
+  });
+});

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -163,6 +163,39 @@ const envSchema = z.object({
    * off-sandbox token use`.
    */
   KORTIX_SANDBOX_EGRESS_PIN_ENFORCED: optBoolTrue,
+
+  // ── Streaming secret relay (POST /v1/projects/:id/secrets/:id/relay) ──────
+  //
+  // The kill switch. `false` makes /relay answer 503 `relay_disabled` with no
+  // image rebuild; the in-guest shim probes once at construction, so NEW
+  // sessions fall back to the permanent buffered /broker route immediately.
+  // In-flight relay-mode sessions get a 503 per request and the agent retries —
+  // the honest, documented limitation of a construction-time probe. The
+  // alternative (a capability header on every request) costs a round trip per
+  // relayed request and still cannot un-consume a body already streamed.
+  KORTIX_SECRET_RELAY_STREAM_ENABLED: optBoolTrue,
+  /** Websocket relay, gated separately so it can roll out behind the HTTP leg. */
+  KORTIX_RELAY_WS_ENABLED: optBoolTrue,
+  // Byte budgets. These are a RESOURCE guard, not a product limit: 1 GiB is
+  // 1024x the legacy request cap and 205x the response cap — effectively
+  // uncapped for any real API call — but it stops one runaway sandbox.
+  //
+  // They are MANDATORY because Bun applies NO inbound flow control. Measured on
+  // bun 1.3.14: a 200 MiB body into a 50 ms/chunk consumer produced 12 chunks,
+  // one of them 23,003,148 bytes, and +113.6 MiB RSS. Neither documented lever
+  // helps — `getReader({mode:'byob'})` throws (it needs a
+  // ReadableByteStreamController) and `pipeTo` with
+  // `CountQueuingStrategy({highWaterMark:1})` is byte-for-byte identical to
+  // manual reads. The counter in the read loop is the ONLY guard that exists.
+  // 0 = unlimited, for self-host operators who want no ceiling at all.
+  KORTIX_RELAY_MAX_REQUEST_BYTES: optInt(1_073_741_824),
+  KORTIX_RELAY_MAX_RESPONSE_BYTES: optInt(1_073_741_824),
+  // Time to the upstream's RESPONSE HEADERS, not to completion. The legacy
+  // broker's flat 30 s `REQUEST_TIMEOUT_MS` cannot become a total-duration
+  // timeout here or every SSE stream would die at 30 s.
+  KORTIX_RELAY_HEADERS_TIMEOUT_MS: optInt(30_000),
+  // IDLE on the upstream response socket — never a total duration. 0 = off.
+  KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS: optInt(600_000),
   // Kortix-owned session titles: the moment a session's first prompt text is
   // known server-side (at create when it carries one, else on the first HTTP
   // prompt), generate the title ourselves via the internal LLM gateway instead
@@ -960,6 +993,12 @@ export const config = {
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,
   KORTIX_WORKERS_ENABLED: env.KORTIX_WORKERS_ENABLED,
   KORTIX_SANDBOX_EGRESS_PIN_ENFORCED: env.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED,
+  KORTIX_SECRET_RELAY_STREAM_ENABLED: env.KORTIX_SECRET_RELAY_STREAM_ENABLED,
+  KORTIX_RELAY_WS_ENABLED: env.KORTIX_RELAY_WS_ENABLED,
+  KORTIX_RELAY_MAX_REQUEST_BYTES: env.KORTIX_RELAY_MAX_REQUEST_BYTES,
+  KORTIX_RELAY_MAX_RESPONSE_BYTES: env.KORTIX_RELAY_MAX_RESPONSE_BYTES,
+  KORTIX_RELAY_HEADERS_TIMEOUT_MS: env.KORTIX_RELAY_HEADERS_TIMEOUT_MS,
+  KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS: env.KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS,
   SESSION_TITLE_GENERATION_ENABLED: env.SESSION_TITLE_GENERATION_ENABLED,
   KORTIX_TEMPLATES_ENABLED: env.KORTIX_TEMPLATES_ENABLED,
   OPENAPI_PUBLIC_DOCS: env.OPENAPI_PUBLIC_DOCS,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -145,6 +145,16 @@ import {
 import { opsApp } from './ops';
 import { adminApp } from './admin';
 
+/**
+ * The streaming secret relay routes, matched on the raw pathname in
+ * `Bun.serve`'s fetch — before Hono sees the request.
+ *
+ * Covers both `…/relay` and `…/relay/ws-ticket` (and the ws upgrade path when
+ * it lands). These carry SSE and long-lived upstream bodies, so they need the
+ * same `server.timeout(req, 0)` treatment as /v1/p/ and /v1/llm-gateway.
+ */
+const SECRET_RELAY_PATH = /^\/v1\/projects\/[^/]+\/secrets\/[^/]+\/relay(?:\/|$)/;
+
 // ─── Process-level crash guards ───────────────────────────────────────────────
 // A stray rejected promise or throw escaping any fire-and-forget path — the
 // dozens of `void (async …)()` provisioning/sweep ticks and the module-load
@@ -1571,6 +1581,15 @@ export default {
     // the proxy's own upstream timeout decide instead of Bun closing the client
     // socket early with an empty reply.
     if (url.pathname.includes('/v1/p/')) {
+      server.timeout(req, 0);
+    }
+
+    // The secret streaming relay carries SSE and long-lived upstream bodies.
+    // Without this Bun cuts the socket with an empty reply that the LB turns
+    // into a 502 with no CORS headers — the same shape as the gateway
+    // idleTimeout incident. The global `idleTimeout: 0` above is necessary but
+    // not sufficient: `server.timeout(req, …)` is the PER-REQUEST budget.
+    if (SECRET_RELAY_PATH.test(url.pathname)) {
       server.timeout(req, 0);
     }
 

--- a/apps/api/src/middleware/request-deadline.test.ts
+++ b/apps/api/src/middleware/request-deadline.test.ts
@@ -36,3 +36,42 @@ describe('requestDeadline exemptions', () => {
     expect(isExempt(ctx(path))).toBe(true);
   });
 });
+
+/**
+ * The streaming secret relay must NOT be bounded by the 25 s deadline.
+ *
+ * This is one of two edits that are easy to forget and fail almost silently:
+ * without the exemption every relay over 25 s dies with a 503
+ * `request_deadline` (the sibling edit is `server.timeout(req, 0)` in index.ts,
+ * without which Bun cuts the socket with an empty reply the LB turns into a
+ * CORS-less 502). `/v1/projects` is not an exempt PREFIX, so nothing else here
+ * covers these routes.
+ */
+describe('requestDeadline exempts the streaming secret relay', () => {
+  const project = '/v1/projects/00000000-0000-4000-a000-000000000001';
+
+  test.each([
+    `${project}/secrets/STRIPE_KEY/relay`,
+    `${project}/secrets/STRIPE_KEY/relay/ws-ticket`,
+  ])('exempts %s', (path) => {
+    expect(isExempt(ctx(path))).toBe(true);
+  });
+
+  test('still bounds the buffered broker route, which cannot stream', () => {
+    // /broker is capped at 1 MiB / 5 MiB and answers in one shot, so it has no
+    // business outliving the deadline.
+    expect(isExempt(ctx(`${project}/secrets/STRIPE_KEY/broker`))).toBe(false);
+  });
+
+  test('the fragment is specific enough not to catch unrelated routes', () => {
+    // `EXEMPT_FRAGMENTS` matches with `path.includes()`, so a fragment that is
+    // too generic silently un-bounds half the API.
+    for (const path of [
+      `${project}/secrets`,
+      `${project}/sessions`,
+      '/v1/accounts/relayed-billing',
+    ]) {
+      expect(isExempt(ctx(path))).toBe(false);
+    }
+  });
+});

--- a/apps/api/src/middleware/request-deadline.ts
+++ b/apps/api/src/middleware/request-deadline.ts
@@ -104,7 +104,24 @@ const EXEMPT_METHOD_PATHS: Array<{ method: string; path: string }> = [
   { method: 'POST', path: '/v1/projects' }, // create + seed + provision
 ];
 
-const EXEMPT_METHOD_PATH_PATTERNS: Array<{ method: string; path: RegExp }> = [];
+const EXEMPT_METHOD_PATH_PATTERNS: Array<{ method: string; path: RegExp }> = [
+  // The streaming secret relay. An SSE or long-body relay legitimately outlives
+  // any fixed deadline, and `/v1/projects` is not an exempt PREFIX, so without
+  // this every relay over 25s dies with a 503 `request_deadline`.
+  //
+  // A REGEX, not an `EXEMPT_FRAGMENTS` entry: fragments match with
+  // `path.includes()`, so a `/relay` fragment would also un-bound anything
+  // merely CONTAINING that substring (`/v1/accounts/relayed-billing`). An
+  // exemption that is too broad silently removes the guard from routes nobody
+  // meant to exempt, which is worse than not having it.
+  //
+  // The buffered `/broker` sibling is deliberately NOT exempt: it is capped at
+  // 1 MiB / 5 MiB and answers in one shot.
+  { method: 'POST', path: /\/secrets\/[^/]+\/relay$/ },
+  { method: 'POST', path: /\/secrets\/[^/]+\/relay\/ws-ticket$/ },
+  // The ws UPGRADE needs no entry — `isExempt` returns true for any request
+  // carrying `Upgrade: websocket` before it reaches these lists.
+];
 
 export function isExempt(c: Context): boolean {
   // WebSocket upgrade (defensive — these are handled before app.fetch).

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -22,6 +22,7 @@ import './routes/github-repositories';
 import './routes/r2';
 import './routes/r3';
 import './routes/secret-broker';
+import './routes/secret-relay';
 import './routes/setup-links';
 import './routes/r4';
 import './routes/oauth2-connectors';

--- a/apps/api/src/projects/routes/secret-broker.ts
+++ b/apps/api/src/projects/routes/secret-broker.ts
@@ -1,40 +1,19 @@
-import { createHash } from 'node:crypto';
 import {
   SecretBrokerRequestSchema,
   SecretBrokerResponseSchema,
 } from '@kortix/api-contract';
-import {
-  projectSecrets,
-  projectSessionSecretHandles,
-  projectSessions,
-  type SecretEgressPolicy,
-} from '@kortix/db';
 import { createRoute, z } from '@hono/zod-openapi';
-import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm';
 import { getAgentGrant } from '../../iam/agent-scope';
 import { auth, errors, json } from '../../openapi';
-import {
-  executeSecretBrokerRequest,
-  SecretBrokerError,
-  type SecretSubstitution,
-} from '../../secrets/http-broker';
+import { executeSecretBrokerRequest, SecretBrokerError } from '../../secrets/http-broker';
 import {
   classifyPresentedHandles,
   requestSurfaceText,
   summarizeHandleRefusals,
-  type SessionHandleFacts,
 } from '../../secrets/handle-substitution';
-import { networkBoundaryPolicyError } from '../../secrets/network-boundary';
-import {
-  matchRule,
-  mintHandle,
-  parseHandle,
-  resolveSecretDelivery,
-  type OutboundRequestShape,
-} from '../../secrets/strategy';
+import { authorizeSecretRelay } from '../../secrets/relay-authorize';
 import { recordAuditEvent } from '../../shared/audit';
-import { db } from '../../shared/db';
-import { decryptProjectSecret, intersectSecretGrants } from '../secrets';
+import { intersectSecretGrants } from '../secrets';
 import { config } from '../../config';
 import { loadProjectForUser } from '../lib/access';
 import {
@@ -42,128 +21,7 @@ import {
   verifySandboxEgressIp,
 } from '../../platform/services/sandbox-egress-pin';
 import { projectsApp } from '../lib/app';
-import { ACTIVE_SESSION_STATUSES } from '../lib/session-status';
 import { readBody } from '../lib/serializers';
-
-/** One active handle row, as this route reads it. */
-interface LiveSessionHandle {
-  secretId: string;
-  identifier: string;
-  lookupId: string;
-  handleHash: string;
-  policySnapshot: SecretEgressPolicy;
-  expiresAt: Date | null;
-}
-
-/**
- * Turn this session's active handles into the substitution set for ONE request.
- *
- * Two outputs, deliberately separate:
- *
- *  - `substitutions` — the handles that may be spent on this destination, with
- *    their real values. Only these secrets are decrypted; a handle the grant
- *    excludes or the policy does not admit never reaches the decrypt path.
- *  - `facts` — what is known about EVERY active handle, keyed by lookup id, so
- *    a handle that turns up in the request but is not substituted can still be
- *    classified (stolen vs merely out-of-policy) instead of vanishing.
- *
- * The handle string is rebuilt from the stored lookup id and the secret's
- * prefix, then checked against the stored hash: the hash is what the row
- * committed to at mint time, so a prefix edited afterwards produces a handle
- * that no longer matches and is skipped rather than substituted for the wrong
- * bytes. The tag is verified on top of that — this is the ONE place a handle
- * becomes spendable, so it is the place both checks belong.
- */
-async function resolveSpendableHandles(input: {
-  projectId: string;
-  userId: string;
-  sessionId: string;
-  handles: readonly LiveSessionHandle[];
-  effectiveGrantEnv: string[] | 'all' | undefined;
-  shape: OutboundRequestShape;
-}): Promise<{
-  substitutions: SecretSubstitution[];
-  facts: Map<string, SessionHandleFacts>;
-}> {
-  const facts = new Map<string, SessionHandleFacts>();
-  const substitutions: SecretSubstitution[] = [];
-  const identifiers = [...new Set(input.handles.map((row) => row.identifier))];
-  if (identifiers.length === 0) return { substitutions, facts };
-
-  const secretRows = await db
-    .select({
-      secretId: projectSecrets.secretId,
-      identifier: projectSecrets.identifier,
-      ownerUserId: projectSecrets.ownerUserId,
-      valueEnc: projectSecrets.valueEnc,
-      active: projectSecrets.active,
-      strategy: projectSecrets.strategy,
-      handlePrefix: projectSecrets.handlePrefix,
-    })
-    .from(projectSecrets)
-    .where(
-      and(
-        eq(projectSecrets.projectId, input.projectId),
-        eq(projectSecrets.scope, 'runtime'),
-        inArray(projectSecrets.identifier, identifiers),
-        or(isNull(projectSecrets.ownerUserId), eq(projectSecrets.ownerUserId, input.userId)),
-      ),
-    );
-
-  // Same resolution as `listResolvedProjectSecrets`: the SHARED row carries the
-  // policy the handle was minted from, the member's own active row carries the
-  // value that was actually delivered to the sandbox. Substituting the shared
-  // value for a member who overrides it would send the wrong credential.
-  type SecretRow = (typeof secretRows)[number];
-  const byIdentifier = new Map<string, { shared?: SecretRow; personal?: SecretRow }>();
-  for (const row of secretRows) {
-    const slot = byIdentifier.get(row.identifier) ?? {};
-    if (row.ownerUserId === null) slot.shared = row;
-    else if (row.active) slot.personal = row;
-    byIdentifier.set(row.identifier, slot);
-  }
-
-  for (const row of input.handles) {
-    const slot = byIdentifier.get(row.identifier);
-    const shared = slot?.shared;
-    const delivery = shared
-      ? resolveSecretDelivery({
-          identifier: row.identifier,
-          strategy: shared.strategy,
-          agentGrantEnv: input.effectiveGrantEnv ?? null,
-          sessionAllowlist: null,
-          sessionId: input.sessionId,
-        })
-      : null;
-    const spendable =
-      !!shared && shared.secretId === row.secretId && delivery?.emit === 'handle';
-    const hostAdmitted = matchRule(row.policySnapshot, input.shape) !== null;
-    facts.set(row.lookupId, { identifier: row.identifier, spendable, hostAdmitted });
-    if (!spendable || !hostAdmitted || !shared) continue;
-
-    const handle = mintHandle({
-      lookupId: row.lookupId,
-      prefix: shared.handlePrefix,
-      rootSecret: config.API_KEY_SECRET,
-    });
-    if (createHash('sha256').update(handle).digest('hex') !== row.handleHash) {
-      console.warn('[secret-broker] skipped a handle whose stored hash no longer matches', {
-        projectId: input.projectId,
-        sessionId: input.sessionId,
-        identifier: row.identifier,
-      });
-      continue;
-    }
-    if (!parseHandle(handle, config.API_KEY_SECRET).ok) continue;
-    substitutions.push({
-      identifier: row.identifier,
-      handle,
-      value: decryptProjectSecret(input.projectId, (slot?.personal ?? shared).valueEnc),
-      policy: row.policySnapshot,
-    });
-  }
-  return { substitutions, facts };
-}
 
 projectsApp.openapi(
   createRoute({
@@ -238,53 +96,45 @@ projectsApp.openapi(
     const loaded = await loadProjectForUser(c, projectId, 'read');
     if (!loaded) return c.json({ error: 'Not found' }, 404);
 
-    const [session] = await db
-      .select({
-        sessionId: projectSessions.sessionId,
-        secretsAllowlist: projectSessions.secretsAllowlist,
-      })
-      .from(projectSessions)
-      .where(
-        and(
-          eq(projectSessions.sessionId, sessionId),
-          eq(projectSessions.projectId, projectId),
-          eq(projectSessions.accountId, loaded.row.accountId),
-          inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
-        ),
-      )
-      .limit(1);
-    if (!session) {
-      return c.json({ error: 'Active project session not found', code: 'session_not_active' }, 403);
-    }
-
-    const rows = await db
-      .select({
-        secretId: projectSecrets.secretId,
-        ownerUserId: projectSecrets.ownerUserId,
-        valueEnc: projectSecrets.valueEnc,
-        active: projectSecrets.active,
-        strategy: projectSecrets.strategy,
-        egressPolicy: projectSecrets.egressPolicy,
-      })
-      .from(projectSecrets)
-      .where(
-        and(
-          eq(projectSecrets.projectId, projectId),
-          eq(projectSecrets.identifier, identifier),
-          eq(projectSecrets.scope, 'runtime'),
-          or(isNull(projectSecrets.ownerUserId), eq(projectSecrets.ownerUserId, loaded.userId)),
-        ),
-      );
-    const shared = rows.find((row) => row.ownerUserId === null);
-    const personal = rows.find((row) => row.ownerUserId === loaded.userId && row.active);
-    if (!shared) return c.json({ error: 'Not found' }, 404);
-
     let destination: URL;
     try {
       destination = new URL(parsed.data.url);
     } catch {
       return c.json({ error: 'Invalid broker URL', code: 'invalid_request' }, 400);
     }
+    const shape = {
+      host: destination.hostname,
+      method: parsed.data.method,
+      path: destination.pathname,
+    };
+
+    // ONE authorization decision, shared with the streaming relay and the
+    // websocket transports (`secrets/relay-authorize.ts`). Everything this
+    // route used to inline — the active-session query, the shared/personal
+    // secret resolution, the delivery mode, the broker-or-boundary shape, the
+    // live handle rows, the handle policy check, and the spendable set — lives
+    // there now. Nothing about the wire changed: the same codes, the same
+    // statuses, the same audit actions.
+    const authz = await authorizeSecretRelay({
+      projectId,
+      identifier,
+      userId: loaded.userId,
+      accountId: loaded.row.accountId,
+      sessionId,
+      agentGrantEnv: agentGrant.env ?? 'all',
+      shape,
+    });
+
+    // `audit === null` marks the two refusals that happen before the secret row
+    // is known, which record no audit row — preserved exactly.
+    const auditContext = authz.audit;
+    if (!auditContext) {
+      if (authz.ok) throw new Error('unreachable: an authorized relay always has an audit context');
+      return authz.code === 'secret_not_found'
+        ? c.json({ error: authz.message }, 404)
+        : c.json({ error: authz.message, code: authz.code }, 403);
+    }
+
     const auditBase = {
       accountId: loaded.row.accountId,
       projectId,
@@ -293,177 +143,46 @@ projectsApp.openapi(
       actorType: 'agent' as const,
       source: 'agent',
       resourceType: 'project_secret',
-      resourceId: shared.secretId,
+      resourceId: auditContext.secretId,
       metadata: {
         identifier,
         // Derived, not hardcoded: this route now serves the network boundary as
         // well as the HTTP broker, and an audit row that calls every boundary
         // relay `http_broker` would misattribute the delivery mode in the one
         // record anybody reviews after an incident.
-        consumer: shared.strategy === 'egress' ? 'network' : 'http_broker',
-        strategy: shared.strategy,
+        consumer: auditContext.strategy === 'egress' ? 'network' : 'http_broker',
+        strategy: auditContext.strategy,
         host: destination.hostname,
         method: parsed.data.method,
         path: destination.pathname,
       },
     };
 
-    try {
-      const effectiveGrantEnv = intersectSecretGrants(
-        agentGrant.env ?? 'all',
-        session.secretsAllowlist,
-      );
-      const delivery = resolveSecretDelivery({
-        identifier,
-        strategy: shared.strategy,
-        agentGrantEnv: effectiveGrantEnv,
-        sessionAllowlist: null,
-        sessionId,
+    if (!authz.ok) {
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.broker.failed',
+        outcome: authz.status === 403 || authz.status === 409 ? 'denied' : 'failure',
+        httpStatus: authz.status,
+        after: { reason: authz.code },
       });
-      if (delivery.emit !== 'handle') {
-        const reason = delivery.emit === 'nothing' ? delivery.reason : 'strategy_not_brokered';
-        throw new SecretBrokerError(
-          'policy_denied',
-          `secret delivery denied: ${reason}`,
-          403,
-        );
-      }
-      // Two delivery modes reach this engine, and they are the same engine on
-      // purpose:
-      //
-      //  - `broker`/`kortix_fetch` — the agent calls the route itself
-      //    (`kortix secrets call`, the `secret_call` MCP tool).
-      //  - `egress`/`network` — a network-boundary secret on a provider with no
-      //    credential edge of its own. The in-guest shim terminates the guest's
-      //    TLS and relays here, so the credential stays server-side exactly as
-      //    it does for the broker.
-      //
-      // A boundary policy is already a `SecretEgressPolicy` and
-      // `prepareSecretBrokerRequest` reads only `rules` and `inject` — never
-      // `backend` — so it executes unchanged. `networkBoundaryPolicyError` is
-      // re-checked here rather than trusted from save time: the row could have
-      // been written by an older build, and a policy that is not a valid
-      // boundary must not be executed as one.
-      const isBrokerSecret =
-        shared.strategy === 'broker' && shared.egressPolicy?.backend === 'kortix_fetch';
-      const isBoundarySecret =
-        shared.strategy === 'egress' &&
-        !!shared.egressPolicy &&
-        networkBoundaryPolicyError(shared.egressPolicy) === null;
-      if (!isBrokerSecret && !isBoundarySecret) {
-        await recordAuditEvent({
-          ...auditBase,
-          action: 'secret.broker.failed',
-          outcome: 'denied',
-          httpStatus: 409,
-          after: { reason: 'secret_delivery_unavailable' },
-        });
-        return c.json(
-          {
-            error: 'Secret is not configured for the HTTPS broker',
-            code: 'secret_delivery_unavailable',
-          },
-          409,
-        );
-      }
-
-      // Every active handle this SESSION holds, not just the route's own.
-      //
-      // Substitution has to answer two questions the single-secret lookup
-      // cannot: which other handles in this request may be spent here, and —
-      // for the ones that may not — whether they were forged or merely
-      // carried in from somewhere else. Both need the whole set, and one query
-      // is cheaper than one per handle found.
-      const handleRows = await db
-        .select({
-          secretId: projectSessionSecretHandles.secretId,
-          identifier: projectSessionSecretHandles.identifier,
-          lookupId: projectSessionSecretHandles.lookupId,
-          handleHash: projectSessionSecretHandles.handleHash,
-          policySnapshot: projectSessionSecretHandles.policySnapshot,
-          expiresAt: projectSessionSecretHandles.expiresAt,
-        })
-        .from(projectSessionSecretHandles)
-        .where(
-          and(
-            eq(projectSessionSecretHandles.projectId, projectId),
-            eq(projectSessionSecretHandles.sessionId, sessionId),
-            eq(projectSessionSecretHandles.status, 'active'),
-          ),
-        )
-        .orderBy(desc(projectSessionSecretHandles.revision));
-
-      // Highest revision wins per secret: rotation leaves the previous
-      // revision active for an overlap window rather than killing it mid-turn,
-      // and both are spendable — but only the newest is THE handle for the
-      // route's own secret.
-      const liveHandles = handleRows.filter(
-        (row) => row.expiresAt === null || row.expiresAt.getTime() > Date.now(),
+      return c.json(
+        { error: authz.message, code: authz.code },
+        authz.status as 400 | 403 | 409 | 413 | 502 | 504,
       );
-      const handle = liveHandles.find((row) => row.secretId === shared.secretId);
-      // The snapshot must match the delivery mode this request is being served
-      // under. A broker secret's snapshot carries `kortix_fetch`; a boundary
-      // policy carries no backend at all — `networkBoundaryPolicyError` rejects
-      // one that does — so demanding `kortix_fetch` of both would make a
-      // boundary handle permanently invalid.
-      //
-      // Still checked, not skipped: the snapshot is what the request is
-      // executed against, so a row whose policy is neither shape must not be
-      // spent.
-      const handlePolicyValid = handle
-        ? isBoundarySecret
-          ? networkBoundaryPolicyError(handle.policySnapshot) === null
-          : handle.policySnapshot.backend === 'kortix_fetch'
-        : false;
-      // Expiry is already applied — `liveHandles` is the filter — so this is
-      // the presence and policy check only.
-      if (!handle || !handlePolicyValid) {
-        await recordAuditEvent({
-          ...auditBase,
-          action: 'secret.broker.failed',
-          outcome: 'denied',
-          httpStatus: 409,
-          after: { reason: 'session_secret_handle_required' },
-        });
-        return c.json(
-          {
-            error: 'The active session does not have this brokered secret',
-            code: 'session_secret_handle_required',
-          },
-          409,
-        );
-      }
+    }
 
+    try {
       await recordAuditEvent({
         ...auditBase,
         action: 'secret.broker.requested',
         outcome: 'pending',
       });
 
-      // Which of this session's handles may be spent on THIS destination.
-      //
-      // The resolution is the same one the route already applied to its own
-      // secret — the agent grant intersected with the session allowlist, then
-      // the handle's FROZEN policy snapshot matched against the request.
-      // Substitution must never widen who may spend: a handle the sandbox
-      // holds but this agent may not use is left in the request as the
-      // worthless self-describing string it is.
       const requestBody = parsed.data.body_base64
         ? Buffer.from(parsed.data.body_base64, 'base64')
         : null;
-      const shape = {
-        host: destination.hostname,
-        method: parsed.data.method,
-        path: destination.pathname,
-      };
-      const spendable = await resolveSpendableHandles({
-        projectId,
-        userId: loaded.userId,
-        sessionId,
-        handles: liveHandles,
-        effectiveGrantEnv,
-        shape,
-      });
+      const spendable = { substitutions: authz.substitutions, facts: authz.facts };
 
       // Evidence first, on the request as the guest sent it: once substitution
       // has run, an honored handle is gone from the bytes and a refused one is
@@ -489,14 +208,8 @@ projectsApp.openapi(
         });
       }
 
-      // The route's own secret is part of the spendable set — it is one of this
-      // session's handles like any other — so reuse the value that resolution
-      // already produced instead of decrypting the same row twice.
-      const primary = spendable.substitutions.find((entry) => entry.identifier === identifier);
-      const encryptedValue = personal?.valueEnc ?? shared.valueEnc;
-      const secret = primary?.value ?? decryptProjectSecret(projectId, encryptedValue);
       const applied = new Set<string>();
-      const result = await executeSecretBrokerRequest(handle.policySnapshot, secret, parsed.data, {
+      const result = await executeSecretBrokerRequest(authz.policy, authz.secret, parsed.data, {
         substitutions: spendable.substitutions,
         applied,
       });

--- a/apps/api/src/projects/routes/secret-relay.ts
+++ b/apps/api/src/projects/routes/secret-relay.ts
@@ -1,0 +1,974 @@
+/**
+ * `POST /v1/projects/{projectId}/secrets/{identifier}/relay` — the STREAMING
+ * secret relay.
+ *
+ * ## Why this is a new route and not an upgrade of `/broker`
+ *
+ * It had to be. Measured: a `@hono/zod-openapi` route that declares a
+ * `request.body` schema buffers and LOCKS the request body before the handler
+ * runs (`{bodyUsed: true, bodyLocked: true}`). `/broker` validates
+ * `SecretBrokerRequestSchema`, so it can never stream, however it is rewritten.
+ * This route declares NO body schema at all: the body is the guest's body,
+ * verbatim, and everything else rides in `x-kortix-relay-meta`.
+ *
+ * That is also what keeps already-deployed daemons working. `/broker` is not
+ * modified, not capped differently, not deprecated. A sandbox image built today
+ * can be resumed months from now and must still find its transport, so the
+ * buffered route is PERMANENT.
+ *
+ * ## What streams and what does not
+ *
+ * Only the BODY streams. The url, the method and the headers arrive whole, so
+ * every head-side security check runs against complete data in
+ * `prepareRelayHead` — the same function the buffered route uses. This route
+ * adds no policy logic of its own; it adds framing and two substituters.
+ *
+ * ## The one rule a reader must not lose
+ *
+ * `x-kortix-relay-status` PRESENT ⟺ we reached the upstream, and the payload's
+ * `status` is the upstream's. ABSENT ⟺ Kortix itself refused or failed. The
+ * relay's own status is therefore ALWAYS 200 on success, whatever the upstream
+ * said — mirroring the upstream status would make a bare 403 ambiguous between
+ * "policy denied" and "Stripe said 403", which is a distinction the agent needs.
+ */
+import { randomBytes } from 'node:crypto';
+import { Readable } from 'node:stream';
+import { createRoute, z } from '@hono/zod-openapi';
+import {
+  decodeRelayMeta,
+  encodeRelayStatus,
+  RELAY_EOS_BYTES,
+  RELAY_ERROR_HEADER,
+  RELAY_META_HEADER,
+  RELAY_PROBE_HEADER,
+  RELAY_STATUS_HEADER,
+  RELAY_VERSION,
+  RELAY_VERSION_HEADER,
+  RelayCodecError,
+  type SecretRelayMeta,
+} from '@kortix/api-contract/secret-relay';
+import { config } from '../../config';
+import { getAgentGrant } from '../../iam/agent-scope';
+import { auth, errors } from '../../openapi';
+import {
+  assertPolicyAdmitsPath,
+  bodyEncoding,
+  MAX_REDIRECTS,
+  prepareRelayHead,
+  REDACTED,
+  SAFE_RESPONSE_HEADERS,
+  SecretBrokerError,
+  secretRepresentations,
+  substituteBuffer,
+  encodeSecretRepresentation,
+  type PreparedRelayHead,
+  type SecretSubstitution,
+} from '../../secrets/http-broker';
+import {
+  classifyPresentedHandles,
+  requestSurfaceText,
+  summarizeHandleRefusals,
+} from '../../secrets/handle-substitution';
+import { authorizeSecretRelay } from '../../secrets/relay-authorize';
+import { openUpstream } from '../../secrets/relay-transport';
+import { StreamSubstituter, type StreamReplacement } from '../../secrets/stream-substitute';
+import { recordAuditEvent } from '../../shared/audit';
+import { loadProjectForUser } from '../lib/access';
+import {
+  requestEgressIp,
+  verifySandboxEgressIp,
+} from '../../platform/services/sandbox-egress-pin';
+import { projectsApp } from '../lib/app';
+
+/**
+ * The largest guest body still handled with the buffered, EXACT-LENGTH path.
+ *
+ * 64 KiB keeps today's behaviour byte-for-byte for the overwhelmingly common
+ * small JSON POST: an exact `content-length` (which SigV4-style signers and a
+ * few chunked-hostile origins require), a replayable body (so an ordinary
+ * redirect still works), and the full body available to the handle-refusal
+ * classifier. Above it, framing switches to chunked and the body streams.
+ *
+ * Raising this raises memory per in-flight request; it does NOT re-introduce a
+ * cap, because the streaming path above it has none.
+ */
+const RELAY_EXACT_LENGTH_MAX = 65_536;
+
+/**
+ * Read at most `limit` bytes, refusing the instant byte `limit + 1` arrives.
+ *
+ * `new Response(stream).arrayBuffer()` CANNOT be used here. It buffers whatever
+ * the guest actually sends, and the guest's declared `meta.body.length` — the
+ * only reason this branch believes the body is small — is an assertion by the
+ * caller, not a fact. Measured on bun 1.3.14 there is no ambient ceiling to
+ * fall back on either: `Bun.serve` applies no `maxRequestBodySize` to a chunked
+ * (no `content-length`) request body, `index.ts` sets none, and this route is
+ * exempt from both the 25 s request deadline (`request-deadline.ts`) and Bun's
+ * per-request timeout (`server.timeout(req, 0)`). So an unbounded read here has
+ * neither a memory nor a time budget, and one request could OOM the shared API
+ * pod. The counter is the only guard, exactly as on the transport's own loops.
+ */
+async function readAtMost(stream: ReadableStream<Uint8Array>, limit: number): Promise<Buffer> {
+  const reader = stream.getReader();
+  const parts: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value || value.byteLength === 0) continue;
+      total += value.byteLength;
+      if (total > limit) {
+        throw new SecretBrokerError(
+          'relay_request_too_large',
+          `request body exceeds its declared length of ${limit} bytes`,
+          413,
+        );
+      }
+      // COPY: the reader may reuse the backing ArrayBuffer, and this buffer
+      // outlives the read loop. Cheap — this branch is bounded at 64 KiB.
+      parts.push(Buffer.from(value));
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // The stream is already gone; nothing to release.
+    }
+    reader.releaseLock();
+  }
+  return Buffer.concat(parts);
+}
+
+/**
+ * How much of a STREAMED request body is kept for the handle-refusal
+ * classifier.
+ *
+ * 64 KiB, matching the buffered branch's threshold, so the forensic surface is
+ * the same size on every branch. It is a PREFIX and not the whole body on
+ * purpose: the point of this route is that a body has no size ceiling, and a
+ * classifier that had to see all of it would put one back.
+ */
+const RELAY_CLASSIFY_PREFIX_MAX = 65_536;
+
+/**
+ * Tee a bounded PREFIX out of a passing stream, without holding the body.
+ *
+ * The handle-refusal classifier is a detection control: it is what writes the
+ * `secret.handle.refused` audit line when an agent presents a handle it was
+ * never granted. It used to be fed only the URL, the headers, and — on the
+ * buffered branch alone — the body. Both streaming branches left the body
+ * unscanned, and the attacker CHOOSES the branch (declare `length: null`, or
+ * target a host it holds no handle for). A detection control an attacker can
+ * switch off is not a detection control. Substitution stays fail-closed either
+ * way; this restores the forensic line.
+ */
+function tapPrefix(
+  limit: number,
+  onEnd: (prefix: Buffer) => void,
+): TransformStream<Uint8Array, Uint8Array> {
+  const parts: Buffer[] = [];
+  let total = 0;
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      if (total < limit && chunk.byteLength > 0) {
+        const take = Math.min(limit - total, chunk.byteLength);
+        // COPY: this outlives the chunk, whose backing buffer may be reused.
+        parts.push(Buffer.from(chunk.subarray(0, take)));
+        total += take;
+      }
+      controller.enqueue(chunk);
+    },
+    flush() {
+      onEnd(Buffer.concat(parts));
+    },
+  });
+}
+
+/** A refusal that happened BEFORE the upstream response headers arrived. */
+function refuse(c: any, code: string, message: string, status: number) {
+  c.header(RELAY_ERROR_HEADER, code);
+  c.header(RELAY_VERSION_HEADER, String(RELAY_VERSION));
+  return c.json({ error: message, code }, status);
+}
+
+/**
+ * Turn substitutions into stream find/replace pairs.
+ *
+ * The same four representations `substituteBuffer` uses, in the same order, so
+ * the streaming and buffered bodies substitute identically. `primary` resolves
+ * the ambiguity a handle's URL-safe alphabet creates: raw / url / json collapse
+ * to the same bytes, and which one we WRITE BACK depends on the surface.
+ */
+function requestPairs(
+  admitted: readonly SecretSubstitution[],
+  primary: Parameters<typeof secretRepresentations>[1],
+): StreamReplacement[] {
+  const pairs: StreamReplacement[] = [];
+  for (const substitution of admitted) {
+    for (const { encoding, text } of secretRepresentations(substitution.handle, primary)) {
+      pairs.push({
+        needle: Buffer.from(text),
+        replacement: Buffer.from(encodeSecretRepresentation(substitution.value, encoding)),
+        label: substitution.identifier,
+      });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Redaction pairs for the RETURN leg.
+ *
+ * Deliberately built from every value that COULD have ridden out, not only the
+ * ones a substitution actually fired for. On a streamed body the `applied` set
+ * is not final until the stream ends — long after the redactor must be built —
+ * so the choice is between fail-open and a superset. It is a superset: at worst
+ * a value that never left is also scrubbed on the way back, which costs
+ * nothing and cannot leak.
+ */
+function responsePairs(secrets: readonly string[]): StreamReplacement[] {
+  const pairs: StreamReplacement[] = [];
+  const seen = new Set<string>();
+  for (const secret of secrets) {
+    for (const { text } of secretRepresentations(secret)) {
+      if (!text || seen.has(text)) continue;
+      seen.add(text);
+      pairs.push({ needle: Buffer.from(text), replacement: Buffer.from(REDACTED) });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Wrap a substituter as a `TransformStream`.
+ *
+ * `pipeThrough(new TransformStream(...))` rather than a hand-rolled
+ * `new ReadableStream({ start() { …read loop… } })`: the hand-rolled version
+ * reads the source as fast as it can and enqueues without consulting
+ * `desiredSize`, which is the classic backpressure leak. Measured at 256 MiB,
+ * the TransformStream grew the warm heap by 6 MB against the read loop's
+ * 109 MB.
+ */
+function substituteStream(
+  substituter: StreamSubstituter,
+  /**
+   * Appended after the substituter's own tail, on a CLEAN end only.
+   *
+   * This is the end-of-stream sentinel. `flush()` runs only when the writable
+   * side closes normally — measured: when the source errors, `flush()` is never
+   * invoked — so the sentinel is present exactly when the body completed.
+   */
+  tail?: Buffer,
+  /** Runs after a clean flush, with the substituter's final `applied` set. */
+  onComplete?: (applied: readonly string[]) => void,
+): TransformStream<Uint8Array, Uint8Array> {
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      // Zero-copy view: `Buffer.from(uint8array)` would COPY every chunk.
+      const view = Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+      const out = substituter.push(view);
+      if (out.byteLength > 0) controller.enqueue(out);
+    },
+    flush(controller) {
+      const out = substituter.flush();
+      if (out.byteLength > 0) controller.enqueue(out);
+      const applied = substituter.applied;
+      if (tail && tail.byteLength > 0) controller.enqueue(new Uint8Array(tail));
+      // A long-lived relay holds decrypted values for the life of the
+      // connection. Zero them the moment it ends. NOTE: this is not the only
+      // disposal site — `flush()` does not run on an abnormal end, so the route
+      // also disposes on abort and in its catch block.
+      substituter.dispose();
+      onComplete?.(applied);
+    },
+  });
+}
+
+/** The whitelisted response headers, ordered, each echo-redacted. */
+function safeResponseHeaders(
+  rawHeaders: ReadonlyArray<readonly [string, string]>,
+  secrets: readonly string[],
+): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const [name, value] of rawHeaders) {
+    if (!SAFE_RESPONSE_HEADERS.has(name)) continue;
+    let redacted = value;
+    for (const secret of secrets) {
+      for (const { text } of secretRepresentations(secret)) {
+        if (text) redacted = redacted.split(text).join(REDACTED.toString('utf8'));
+      }
+    }
+    out.push([name, redacted]);
+  }
+  return out;
+}
+
+projectsApp.openapi(
+  createRoute({
+    method: 'post',
+    path: '/{projectId}/secrets/{identifier}/relay',
+    tags: ['secrets'],
+    summary: 'Stream one policy-bound HTTPS request without exposing the secret',
+    description:
+      'The streaming sibling of /broker. The request body is the guest body verbatim; ' +
+      'url, method and headers ride in x-kortix-relay-meta. On success the response is ' +
+      'always 200 and the UPSTREAM status rides in x-kortix-relay-status — the presence ' +
+      'of that header is what distinguishes "Kortix refused" from "the upstream refused".',
+    ...auth,
+    request: {
+      // NO body schema, deliberately. A zod request body buffers and LOCKS the
+      // stream before this handler runs — measured — which is exactly why the
+      // buffered /broker route cannot be upgraded in place.
+      params: z.object({ projectId: z.string(), identifier: z.string() }),
+    },
+    responses: {
+      200: {
+        description: 'The upstream was reached. Body streams; status in x-kortix-relay-status.',
+        content: { 'application/octet-stream': { schema: z.any() } },
+      },
+      204: { description: 'Capability probe acknowledged.' },
+      ...errors(400, 403, 404, 409, 413, 502, 503, 504),
+    },
+  }),
+  async (c: any) => {
+    // The kill switch answers FIRST, so flipping it also fails the probe — which
+    // is what puts every newly-constructed shim back on /broker.
+    if (!config.KORTIX_SECRET_RELAY_STREAM_ENABLED) {
+      return refuse(c, 'relay_disabled', 'The streaming secret relay is disabled', 503);
+    }
+
+    const projectId = c.req.param('projectId');
+    const identifier = c.req.param('identifier')?.trim();
+    if (!identifier) {
+      return refuse(c, 'invalid_request', 'Invalid relay request', 400);
+    }
+
+    const agentGrant = getAgentGrant(c);
+    const sessionId = c.get('sessionId');
+    if (
+      c.get('authType') !== 'pat' ||
+      c.get('tokenProjectId') !== projectId ||
+      !sessionId ||
+      !agentGrant
+    ) {
+      c.header(RELAY_ERROR_HEADER, 'session_agent_token_required');
+      return c.json(
+        {
+          error: 'Secret relay requests require a session-scoped agent token',
+          code: 'session_agent_token_required',
+        },
+        403,
+      );
+    }
+
+    // Same egress pin as /broker: this checks WHERE the token is being used
+    // from, not what it is. Unpinned sessions pass — see sandbox-egress-pin.ts.
+    const pin = await verifySandboxEgressIp(sessionId, requestEgressIp(c));
+    if (!pin.ok) {
+      console.warn('[secret-relay] refused an off-sandbox token use', {
+        sessionId,
+        projectId,
+        pinned: pin.pinned,
+        seen: pin.seen,
+        enforced: config.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED,
+      });
+    }
+    if (!pin.ok && config.KORTIX_SANDBOX_EGRESS_PIN_ENFORCED) {
+      c.header(RELAY_ERROR_HEADER, 'sandbox_egress_mismatch');
+      return c.json(
+        {
+          error: 'This session credential may only be used from its own sandbox',
+          code: 'sandbox_egress_mismatch',
+        },
+        403,
+      );
+    }
+
+    const loaded = await loadProjectForUser(c, projectId, 'read');
+    if (!loaded) return c.json({ error: 'Not found' }, 404);
+
+    // ── Capability probe ──────────────────────────────────────────────────
+    //
+    // Answered here: authenticated (so it is not an unauthenticated capability
+    // oracle) but BEFORE the secret is touched, so it costs one round trip per
+    // daemon lifetime and reveals nothing about which secrets exist.
+    if (c.req.header(RELAY_PROBE_HEADER)) {
+      c.header(RELAY_VERSION_HEADER, String(RELAY_VERSION));
+      return c.body(null, 204);
+    }
+
+    let meta: SecretRelayMeta;
+    try {
+      meta = decodeRelayMeta(c.req.header(RELAY_META_HEADER) ?? '');
+    } catch (error) {
+      const code = error instanceof RelayCodecError ? error.code : 'relay_meta_invalid';
+      const message = error instanceof Error ? error.message : 'relay metadata is invalid';
+      return refuse(c, code, message, 400);
+    }
+
+    const destination = new URL(meta.url);
+    const shape = {
+      host: destination.hostname,
+      method: meta.method,
+      path: destination.pathname,
+    };
+
+    const authz = await authorizeSecretRelay({
+      projectId,
+      identifier,
+      userId: loaded.userId,
+      accountId: loaded.row.accountId,
+      sessionId,
+      agentGrantEnv: agentGrant.env ?? 'all',
+      shape,
+    });
+
+    const auditContext = authz.audit;
+    if (!auditContext) {
+      if (authz.ok) throw new Error('unreachable: an authorized relay always has an audit context');
+      c.header(RELAY_ERROR_HEADER, authz.code);
+      return authz.code === 'secret_not_found'
+        ? c.json({ error: authz.message }, 404)
+        : c.json({ error: authz.message, code: authz.code }, 403);
+    }
+
+    const auditBase = {
+      accountId: loaded.row.accountId,
+      projectId,
+      sessionId,
+      actorUserId: loaded.userId,
+      actorType: 'agent' as const,
+      source: 'agent',
+      resourceType: 'project_secret',
+      resourceId: auditContext.secretId,
+      metadata: {
+        identifier,
+        consumer: auditContext.strategy === 'egress' ? 'network' : 'http_broker',
+        strategy: auditContext.strategy,
+        // The one field the buffered route's audit does not carry. An operator
+        // reading these rows after an incident must be able to tell which
+        // transport spent the secret.
+        transport: 'relay',
+        host: destination.hostname,
+        method: meta.method,
+        path: destination.pathname,
+      },
+    };
+
+    if (!authz.ok) {
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.broker.failed',
+        outcome: authz.status === 403 || authz.status === 409 ? 'denied' : 'failure',
+        httpStatus: authz.status,
+        after: { reason: authz.code },
+      });
+      return refuse(c, authz.code, authz.message, authz.status);
+    }
+
+    let head: PreparedRelayHead;
+    try {
+      head = prepareRelayHead(
+        authz.policy,
+        authz.secret,
+        { url: meta.url, method: meta.method, headers: meta.headers },
+        authz.substitutions,
+      );
+    } catch (error) {
+      const brokerError =
+        error instanceof SecretBrokerError
+          ? error
+          : new SecretBrokerError('invalid_request', 'relay request is invalid', 400);
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.broker.failed',
+        outcome: brokerError.status === 403 ? 'denied' : 'failure',
+        httpStatus: brokerError.status,
+        after: { reason: brokerError.code },
+      });
+      return refuse(c, brokerError.code, brokerError.message, brokerError.status);
+    }
+
+    // A legacy `json` body-injection slot needs the whole body parsed as JSON.
+    // Streaming it is not possible without buffering unboundedly, which is the
+    // cap this route exists to remove — so it is refused, by name, rather than
+    // half-served. Substitution-only rows (the default since §6 of the exposure
+    // model) never carry a slot.
+    if (head.bodyInject) {
+      return refuse(
+        c,
+        'invalid_request',
+        'this secret uses a JSON body injection slot, which the streaming relay cannot serve; ' +
+          'the buffered broker route still can',
+        400,
+      );
+    }
+
+    await recordAuditEvent({ ...auditBase, action: 'secret.broker.requested', outcome: 'pending' });
+
+    // ── Framing ───────────────────────────────────────────────────────────
+    const hasBody = meta.body.present;
+    const declaredLength = meta.body.present ? meta.body.length : null;
+    if (!hasBody && (meta.method === 'GET' || meta.method === 'HEAD')) {
+      // nothing to do — the common case
+    }
+    if (hasBody && (meta.method === 'GET' || meta.method === 'HEAD')) {
+      return refuse(c, 'invalid_request', `${meta.method} requests cannot contain a body`, 400);
+    }
+
+    const primaryEncoding = bodyEncoding(head.headers['content-type']);
+    const requestSubstituter = new StreamSubstituter(
+      requestPairs(head.admitted, primaryEncoding),
+    );
+
+    // ── Disposal, tied to REQUEST LIFETIME rather than to a clean flush ────
+    //
+    // `substituteStream`'s `flush()` is the natural place to zero a
+    // substituter's decrypted bytes, but a `TransformStream` flush runs ONLY on
+    // a clean close of the writable side — measured: when the source errors it
+    // is never invoked. So every abnormal end (upstream idle timeout, byte
+    // budget, guest abort, a throw between building a substituter and handing
+    // it to the transport) used to leave the value un-zeroed until GC. These
+    // two hooks close that window; `flush()` still handles the happy path and
+    // `dispose()` is idempotent.
+    const disposables = new Set<StreamSubstituter>([requestSubstituter]);
+    const disposeAll = () => {
+      for (const substituter of disposables) substituter.dispose();
+      disposables.clear();
+    };
+    c.req.raw.signal?.addEventListener('abort', disposeAll, { once: true });
+
+    /**
+     * Classify a streamed body's prefix for presented-but-refused handles.
+     *
+     * Fires when the request body finishes, which is after the head-side
+     * classification below — so it writes its own audit row rather than
+     * amending one. Only refusals are recorded; a handle that WAS admitted is
+     * an ordinary substitution and already audited as such.
+     */
+    const classifyBodyPrefix = (prefix: Buffer) => {
+      if (prefix.byteLength === 0) return;
+      const found = classifyPresentedHandles(
+        requestSurfaceText({ url: '', headers: {}, body: prefix }),
+        authz.facts,
+        config.API_KEY_SECRET,
+      );
+      if (found.length === 0) return;
+      void recordAuditEvent({
+        ...auditBase,
+        action: 'secret.handle.refused',
+        outcome: 'denied',
+        after: {
+          surface: 'request_body',
+          refusals: summarizeHandleRefusals(found),
+          detail: found,
+        },
+      });
+    };
+
+    let upstreamBody: Readable | Buffer | null = null;
+    /** True when the body is gone once written — a redirect cannot replay it. */
+    let bodyWasStreamed = false;
+    /** The buffered body, when small enough to keep for the refusal classifier. */
+    let bufferedBody: Buffer | null = null;
+
+    const rawBody: ReadableStream<Uint8Array> | null = c.req.raw.body ?? null;
+
+    try {
+      if (!hasBody || !rawBody) {
+        upstreamBody = null;
+        requestSubstituter.dispose();
+        disposables.delete(requestSubstituter);
+      } else if (requestSubstituter.isPassThrough && declaredLength !== null) {
+        // CASE 2 — nothing can be substituted here, so the length is PROVABLY
+        // unchanged. Forward it and pipe the bytes through untouched.
+        //
+        // `openUpstream` honours a caller-set `content-length` on a Readable by
+        // NOT adding `transfer-encoding: chunked` and by enforcing the declared
+        // count in its write loop, so this promise is kept on the wire.
+        head.headers['content-length'] = String(declaredLength);
+        upstreamBody = Readable.fromWeb(
+          rawBody.pipeThrough(tapPrefix(RELAY_CLASSIFY_PREFIX_MAX, classifyBodyPrefix)) as never,
+        );
+        bodyWasStreamed = true;
+      } else if (declaredLength !== null && declaredLength <= RELAY_EXACT_LENGTH_MAX) {
+        // CASE 3 — small and of known length. Buffer it (BOUNDED BY THE READ
+        // ITSELF, never by the declaration), substitute with the SAME
+        // whole-buffer routine the legacy path uses, and state the exact
+        // post-substitution length. Byte-for-byte identical to /broker for the
+        // ordinary small JSON POST, and replayable across a redirect.
+        const applied = new Set<string>();
+        const original = await readAtMost(rawBody, declaredLength);
+        const substituted =
+          head.admitted.length > 0
+            ? substituteBuffer(original, head.admitted, primaryEncoding, applied)
+            : original;
+        for (const identifier of applied) head.applied.add(identifier);
+        bufferedBody = original;
+        upstreamBody = substituted;
+        head.headers['content-length'] = String(substituted.byteLength);
+        requestSubstituter.dispose();
+        disposables.delete(requestSubstituter);
+      } else {
+        // CASE 4 — unknown or large. Chunked, streamed through the substituter.
+        //
+        // This is the only chunked-hostile exposure (AWS SigV4 with a handle in
+        // a >64 KiB body). It surfaces as the upstream's own 411, relayed
+        // honestly. Do NOT pre-scan to compute a length — that reintroduces the
+        // cap.
+        // The tap runs BEFORE the substituter, so it sees the guest's ORIGINAL
+        // bytes — handles intact, which is what the classifier looks for.
+        upstreamBody = Readable.fromWeb(
+          rawBody
+            .pipeThrough(tapPrefix(RELAY_CLASSIFY_PREFIX_MAX, classifyBodyPrefix))
+            .pipeThrough(substituteStream(requestSubstituter)) as never,
+        );
+        bodyWasStreamed = true;
+      }
+
+      if (head.admitted.length > 0) {
+        assertPolicyAdmitsPath(authz.policy, head.url, head.method);
+      }
+    } catch (error) {
+      disposeAll();
+      const brokerError =
+        error instanceof SecretBrokerError
+          ? error
+          : new SecretBrokerError('invalid_request', 'relay request is invalid', 400);
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.broker.failed',
+        outcome: brokerError.status === 403 ? 'denied' : 'failure',
+        httpStatus: brokerError.status,
+        after: { reason: brokerError.code },
+      });
+      return refuse(c, brokerError.code, brokerError.message, brokerError.status);
+    }
+
+    // Evidence, on the request as the guest sent it. On a streamed body the
+    // classifier sees the url and the headers but not the body — a refused
+    // handle past the buffered threshold is still NOT substituted (fail-closed
+    // is intact) but loses its forensic line. Bounded, documented degradation.
+    const refusals = classifyPresentedHandles(
+      requestSurfaceText({
+        url: meta.url,
+        headers: Object.fromEntries(meta.headers),
+        body: bufferedBody,
+      }),
+      authz.facts,
+      config.API_KEY_SECRET,
+    );
+    if (refusals.length > 0) {
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.handle.refused',
+        outcome: 'denied',
+        after: { refusals: summarizeHandleRefusals(refusals), detail: refusals },
+      });
+    }
+
+    // Every value that could be echoed back: the route's own secret plus every
+    // handle admitted on this hop.
+    let redactable = [authz.secret, ...head.admitted.map((entry) => entry.value)];
+
+    try {
+      // ── The hop loop ────────────────────────────────────────────────────
+      //
+      // Same shape as `executeSecretBrokerRequest`'s: a redirect re-enters
+      // `prepareRelayHead` against the NEW destination, so the policy, the
+      // per-handle admission, the port pin and the unsafe-target check are all
+      // re-run for the host we are actually about to talk to. A secret whose
+      // policy admits the first host must never ride along to wherever that
+      // host points next.
+      let hop = head;
+      let hopUrl = meta.url;
+      let hopMethod: typeof meta.method = meta.method;
+      let hopBody = upstreamBody;
+
+      for (let redirects = 0; ; redirects += 1) {
+        const upstream = await openUpstream(
+          { url: hop.url, method: hop.method, headers: hop.headers },
+          hopBody,
+          { signal: c.req.raw.signal },
+        );
+
+        if (![301, 302, 303, 307, 308].includes(upstream.status)) {
+          // ── FAIL CLOSED on a compressed body ────────────────────────────
+          //
+          // `prepareRelayHead` forces `accept-encoding: identity` upstream so
+          // the echo scan sees plaintext. Nothing until now verified the
+          // upstream OBEYED, and `content-encoding` is not in
+          // SAFE_RESPONSE_HEADERS — so a gzip body would have been piped
+          // through the redactor (which cannot match compressed bytes) and
+          // handed to the guest as undeclared compressed data carrying the
+          // real credential. Refuse instead of relaying it.
+          const contentEncoding = upstream.rawHeaders
+            .find(([name]) => name === 'content-encoding')?.[1]
+            ?.trim()
+            .toLowerCase();
+          if (contentEncoding && contentEncoding !== 'identity') {
+            upstream.destroy();
+            throw new SecretBrokerError(
+              'upstream_encoding_unsupported',
+              `upstream answered with content-encoding: ${contentEncoding} despite accept-encoding: identity, ` +
+                'so the response cannot be scanned for an echoed secret',
+              502,
+            );
+          }
+
+          const responseSubstituter = new StreamSubstituter(responsePairs(redactable));
+          disposables.add(responseSubstituter);
+          // `flush()` covers the clean end and is the ONLY site allowed to run
+          // on it — disposing there too would zero the needles while the final
+          // tail is still being substituted. The abnormal ends are what leak,
+          // so hook exactly those: an upstream that dies mid-body (idle
+          // timeout, byte budget, socket reset) and a guest that goes away.
+          upstream.body.once('error', disposeAll);
+
+          // The end-of-stream SENTINEL. See RELAY_EOS_BYTES: a missing chunked
+          // terminator is NOT an error signal on bun 1.3.14 (measured — Bun
+          // writes `0\r\n\r\n` even when the source stream is destroyed with an
+          // error, and the client's fetch resolves cleanly), so truncation is
+          // signalled POSITIVELY: these bytes are appended only on a clean
+          // flush, and the shim treats their absence as a failed relay. Minted
+          // per response and unguessable, so no truncation point can forge it.
+          // Only for clients that asked — an older daemon would hand them to
+          // the guest as trailing garbage.
+          const eos = meta.eos === true ? randomBytes(RELAY_EOS_BYTES) : undefined;
+
+          const statusHeader = encodeRelayStatus({
+            v: RELAY_VERSION,
+            status: upstream.status,
+            headers: safeResponseHeaders(upstream.rawHeaders, redactable),
+            ...(eos ? { eos: eos.toString('hex') } : {}),
+          });
+
+          // What was substituted is NOT final yet on a streamed request body —
+          // the substituter is still consuming it. Record the honest superset
+          // and mark it as such, so an operator never reads an EMPTY
+          // `substituted` for a hop that did spend a credential. The exact set
+          // lands in the terminal `secret.broker.streamed` row below.
+          const streamingRequest = bodyWasStreamed && !requestSubstituter.isPassThrough;
+          const substitutedSoFar = new Set([...hop.applied, ...requestSubstituter.applied]);
+          await recordAuditEvent({
+            ...auditBase,
+            action: 'secret.broker.completed',
+            outcome: upstream.status >= 400 ? 'failure' : 'success',
+            after: {
+              upstream_status: upstream.status,
+              ...(substitutedSoFar.size > 0
+                ? { substituted: [...substitutedSoFar].sort() }
+                : {}),
+              ...(streamingRequest
+                ? {
+                    substitution: 'streamed_superset',
+                    substitution_candidates: hop.admitted
+                      .map((entry) => entry.identifier)
+                      .sort(),
+                  }
+                : {}),
+              ...(refusals.length > 0
+                ? { handle_refusals: summarizeHandleRefusals(refusals) }
+                : {}),
+            },
+          });
+
+          // 200 ALWAYS on success. See the status header's own docs for why the
+          // upstream status is not mirrored here.
+          let responseBytes = 0;
+          return new Response(
+            (Readable.toWeb(upstream.body) as unknown as ReadableStream<Uint8Array>)
+              .pipeThrough(
+                new TransformStream<Uint8Array, Uint8Array>({
+                  transform(chunk, controller) {
+                    responseBytes += chunk.byteLength;
+                    controller.enqueue(chunk);
+                  },
+                }),
+              )
+              .pipeThrough(
+                substituteStream(responseSubstituter, eos, () => {
+                  // The relay COMPLETED. Written here and not at header time,
+                  // because at header time neither the request substituter's
+                  // final set nor the fact of completion is known yet.
+                  void recordAuditEvent({
+                    ...auditBase,
+                    action: 'secret.broker.streamed',
+                    outcome: 'success',
+                    after: {
+                      upstream_status: upstream.status,
+                      response_bytes: responseBytes,
+                      complete: true,
+                      ...(requestSubstituter.applied.length > 0 || hop.applied.size > 0
+                        ? {
+                            substituted: [
+                              ...new Set([...hop.applied, ...requestSubstituter.applied]),
+                            ].sort(),
+                          }
+                        : {}),
+                    },
+                  });
+                }),
+              ),
+            {
+              status: 200,
+              headers: {
+                [RELAY_VERSION_HEADER]: String(RELAY_VERSION),
+                [RELAY_STATUS_HEADER]: statusHeader,
+                'content-type': 'application/octet-stream',
+                'cache-control': 'no-store',
+              },
+            },
+          );
+        }
+
+        // ── It redirected ─────────────────────────────────────────────────
+        upstream.destroy();
+
+        // A redirect only matters BEFORE any real credential is on the wire.
+        // Once this hop carried one, the value is already delivered and
+        // following `Location` would carry it — or bytes the upstream reflected
+        // into `Location` — to a host re-gated only by the ROUTE secret's
+        // policy, never by the substituted secret's own. Fail closed, exactly
+        // as the buffered path does.
+        // `requestSubstituter.applied` is what makes this truthful on the
+        // STREAMED path: `hop.applied` only ever fills on the buffered branch,
+        // so without it a secret that rode out inside a streamed body left this
+        // gate reading `size === 0`. It was saved by the separate
+        // `bodyWasStreamed` check below — i.e. by ordering, not by the check
+        // that is meant to enforce the invariant.
+        if (
+          hop.carriesSecret ||
+          hop.applied.size > 0 ||
+          requestSubstituter.applied.length > 0
+        ) {
+          await recordAuditEvent({
+            ...auditBase,
+            action: 'secret.broker.failed',
+            outcome: 'failure',
+            httpStatus: 502,
+            after: { reason: 'upstream_failed' },
+          });
+          return refuse(
+            c,
+            'upstream_failed',
+            'redirect after secret substitution is not followed',
+            502,
+          );
+        }
+
+        // No secret rode out — but the BODY may already be gone. A streamed
+        // request body cannot be replayed onto the next hop, and buffering it
+        // for replay would reintroduce exactly the cap this route removes. The
+        // bounded ≤64 KiB path keeps its bytes, so ordinary redirects still
+        // work; only a genuinely streamed body loses this.
+        if (bodyWasStreamed) {
+          await recordAuditEvent({
+            ...auditBase,
+            action: 'secret.broker.failed',
+            outcome: 'failure',
+            httpStatus: 502,
+            after: { reason: 'redirect_not_replayable' },
+          });
+          return refuse(
+            c,
+            'redirect_not_replayable',
+            'the upstream redirected a streamed request body, which cannot be replayed',
+            502,
+          );
+        }
+
+        const location = upstream.rawHeaders.find(([name]) => name === 'location')?.[1];
+        if (!location) {
+          return refuse(c, 'upstream_failed', 'upstream redirect has no location', 502);
+        }
+        if (redirects >= MAX_REDIRECTS) {
+          return refuse(c, 'upstream_failed', 'upstream redirect limit exceeded', 502);
+        }
+
+        // Same method/body rewrite rule as the buffered path.
+        const nextUrl = new URL(location, hopUrl).href;
+        if (
+          upstream.status === 303 ||
+          ((upstream.status === 301 || upstream.status === 302) && hopMethod === 'POST')
+        ) {
+          hopMethod = 'GET';
+          bufferedBody = null;
+        }
+        hopUrl = nextUrl;
+
+        try {
+          hop = prepareRelayHead(
+            authz.policy,
+            authz.secret,
+            { url: hopUrl, method: hopMethod, headers: meta.headers },
+            authz.substitutions,
+          );
+        } catch (error) {
+          const brokerError =
+            error instanceof SecretBrokerError
+              ? error
+              : new SecretBrokerError('policy_denied', 'redirect target is not admitted', 403);
+          await recordAuditEvent({
+            ...auditBase,
+            action: 'secret.broker.failed',
+            outcome: brokerError.status === 403 ? 'denied' : 'failure',
+            httpStatus: brokerError.status,
+            after: { reason: brokerError.code },
+          });
+          return refuse(c, brokerError.code, brokerError.message, brokerError.status);
+        }
+        if (hop.bodyInject) {
+          return refuse(
+            c,
+            'invalid_request',
+            'this secret uses a JSON body injection slot, which the streaming relay cannot serve',
+            400,
+          );
+        }
+
+        // Re-substitute the ORIGINAL body against THIS hop's admitted set. The
+        // new host can admit a handle the previous one did not, and the buffer
+        // we still hold is pre-substitution precisely because nothing fired on
+        // the hop before.
+        if (bufferedBody === null) {
+          hopBody = null;
+          delete hop.headers['content-length'];
+        } else {
+          const applied = new Set<string>();
+          const substituted =
+            hop.admitted.length > 0
+              ? substituteBuffer(
+                  bufferedBody,
+                  hop.admitted,
+                  bodyEncoding(hop.headers['content-type']),
+                  applied,
+                )
+              : bufferedBody;
+          for (const id of applied) hop.applied.add(id);
+          hopBody = substituted;
+          hop.headers['content-length'] = String(substituted.byteLength);
+        }
+        if (hop.admitted.length > 0) assertPolicyAdmitsPath(authz.policy, hop.url, hop.method);
+        redactable = [authz.secret, ...hop.admitted.map((entry) => entry.value)];
+      }
+    } catch (error) {
+      // Anything that threw between building a substituter and handing it off
+      // leaves decrypted bytes in it. Zero them here rather than waiting for GC.
+      disposeAll();
+      const brokerError =
+        error instanceof SecretBrokerError
+          ? error
+          : new SecretBrokerError('upstream_failed', 'Secret relay request failed', 502);
+      await recordAuditEvent({
+        ...auditBase,
+        action: 'secret.broker.failed',
+        outcome: brokerError.status === 403 ? 'denied' : 'failure',
+        httpStatus: brokerError.status,
+        after: { reason: brokerError.code },
+      });
+      return refuse(c, brokerError.code, brokerError.message, brokerError.status);
+    }
+  },
+);

--- a/apps/api/src/secrets/http-broker.ts
+++ b/apps/api/src/secrets/http-broker.ts
@@ -11,9 +11,9 @@ import { matchRule } from './strategy';
 
 const MAX_REQUEST_BYTES = 1_048_576;
 const MAX_RESPONSE_BYTES = 5_242_880;
-const MAX_REDIRECTS = 3;
+export const MAX_REDIRECTS = 3;
 const REQUEST_TIMEOUT_MS = 30_000;
-const REDACTED = Buffer.from('[REDACTED]');
+export const REDACTED = Buffer.from('[REDACTED]');
 
 // FRAMING / hop-by-hop headers only. These are rejected with a 400 because the
 // broker manages them itself (it sets `host` and `content-length`, forces
@@ -44,7 +44,7 @@ const BLOCKED_REQUEST_HEADERS = new Set([
   'upgrade',
 ]);
 
-const SAFE_RESPONSE_HEADERS = new Set([
+export const SAFE_RESPONSE_HEADERS = new Set([
   'cache-control',
   'content-language',
   'content-type',
@@ -64,12 +64,45 @@ const HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
 export type SecretBrokerErrorCode =
+  // ── The legacy /broker vocabulary. UNCHANGED — a daemon baked into a sandbox
+  //    image months ago still branches on these strings. ────────────────────
   | 'invalid_request'
   | 'policy_denied'
   | 'unsafe_destination'
   | 'upstream_failed'
   | 'upstream_timeout'
-  | 'response_too_large';
+  | 'response_too_large'
+  // ── Streaming relay only. Additive: nothing above changes meaning. ───────
+  /** `x-kortix-relay-meta` is missing, malformed, or out of contract (400). */
+  | 'relay_meta_invalid'
+  /** The encoded meta header exceeds `RELAY_META_MAX_BYTES` (400). */
+  | 'relay_meta_too_large'
+  /** The guest's request body exceeded `KORTIX_RELAY_MAX_REQUEST_BYTES` (413). */
+  | 'relay_request_too_large'
+  /** The upstream response exceeded `KORTIX_RELAY_MAX_RESPONSE_BYTES` (502). */
+  | 'relay_response_too_large'
+  /** `KORTIX_SECRET_RELAY_STREAM_ENABLED=false` — the kill switch (503). */
+  | 'relay_disabled'
+  /** A 3xx arrived after the request body was already streamed (502). */
+  | 'redirect_not_replayable'
+  /** The upstream body failed mid-stream, after the 200 was committed (502). */
+  | 'upstream_stream_failed'
+  /** A websocket upgrade arrived with the WS relay disabled (501). */
+  | 'websocket_relay_unavailable'
+  /**
+   * The upstream answered with a `content-encoding` despite being asked for
+   * `identity`, so the echo scan cannot see plaintext in its body (502).
+   *
+   * FAIL CLOSED. `prepareRelayHead` forces `accept-encoding: identity` on the
+   * upstream leg precisely so `StreamSubstituter` can find and redact a secret
+   * the upstream reflects back (debug/echo endpoints and several error shapes
+   * echo `Authorization` verbatim). A DEFLATE stream does not contain those
+   * bytes, so nothing matches, nothing is redacted, and the guest inflates the
+   * real credential locally — the exact leak the whole design prevents. The
+   * alternative is decompressing server-side, which reintroduces a
+   * decompression-bomb budget on an intentionally uncapped path.
+   */
+  | 'upstream_encoding_unsupported';
 
 export class SecretBrokerError extends Error {
   constructor(
@@ -281,7 +314,7 @@ export interface SecretSubstitution {
  * its secret. `applied` collects the identifiers that actually matched, for the
  * audit record and for response redaction.
  */
-function substituteBuffer(
+export function substituteBuffer(
   source: Buffer,
   substitutions: readonly SecretSubstitution[],
   primary: SecretEncoding,
@@ -312,7 +345,7 @@ function substituteString(
 }
 
 /** Which encoding a body's own content type says its bytes are written in. */
-function bodyEncoding(contentType: string | undefined): SecretEncoding {
+export function bodyEncoding(contentType: string | undefined): SecretEncoding {
   const type = contentType?.split(';')[0]?.trim().toLowerCase() ?? '';
   if (type === 'application/json' || type.endsWith('+json')) return 'json';
   if (type === 'application/x-www-form-urlencoded') return 'url';
@@ -326,7 +359,7 @@ function bodyEncoding(contentType: string | undefined): SecretEncoding {
  * side for the mirror-image reason (an echoed secret cannot be redacted out of
  * gzip); this asserts the request side rather than failing silently.
  */
-function assertIdentityRequestBody(headers: Record<string, string>): void {
+export function assertIdentityRequestBody(headers: Record<string, string>): void {
   const encoding = headers['content-encoding']?.trim().toLowerCase();
   if (encoding && encoding !== 'identity') {
     throw new SecretBrokerError(
@@ -342,12 +375,108 @@ function assertIdentityRequestBody(headers: Record<string, string>): void {
 // half-encoded into a header or path the upstream reads as two requests.
 const UNSAFE_TARGET = /[\s\u0000-\u001f\u007f]/;
 
-export function prepareSecretBrokerRequest(
+/** The non-body half of an outbound request, as BOTH transports supply it. */
+export interface RelayHeadInput {
+  url: string;
+  method: SecretBrokerRequest['method'];
+  /** Ordered `[name, value]` pairs, duplicates allowed — see `foldHeaders`. */
+  headers: Array<[string, string]>;
+}
+
+export interface PreparedRelayHead {
+  url: URL;
+  method: NonNullable<SecretBrokerRequest['method']>;
+  headers: Record<string, string>;
+  /**
+   * The substitutions admitted on THIS hop's destination. The caller feeds
+   * exactly these — never the full set — to the body substituter, so a handle
+   * the policy does not admit here stays the worthless self-describing string
+   * it is.
+   */
+  admitted: SecretSubstitution[];
+  /** Live and MUTABLE: the caller adds body-side hits before reading it. */
+  applied: Set<string>;
+  /** True when the route's own `inject` slot placed the decrypted secret. */
+  injectedRouteSecret: boolean;
+  /**
+   * A legacy `json` body-injection slot, NOT yet applied — the head does not
+   * own the body. The streaming transport refuses it rather than buffering an
+   * unbounded body to satisfy it.
+   */
+  bodyInject: { path: string } | null;
+  /** Head-side snapshot. Recompute after body substitution. */
+  substituted: string[];
+  /** Head-side snapshot. Recompute after body substitution. */
+  carriesSecret: boolean;
+}
+
+/**
+ * Fold an ordered header list into the `Record<string,string>` both the node
+ * transport and the legacy code path want.
+ *
+ * Duplicates are JOINED, not dropped: RFC 7230 §3.2.2 makes a repeated field
+ * equivalent to one comma-joined field, and `cookie` is the documented
+ * exception that joins with `"; "` (RFC 6265 §5.4). Taking the last value —
+ * which is what Bun's own parser does, and the reason the meta ships an ordered
+ * array in the first place — would silently discard a header the guest sent.
+ */
+function foldHeaders(pairs: readonly [string, string][]): Record<string, string> {
+  const folded: Record<string, string> = {};
+  for (const [rawName, value] of pairs) {
+    const name = rawName.trim().toLowerCase();
+    const existing = folded[name];
+    folded[name] = existing === undefined ? value : `${existing}${name === 'cookie' ? '; ' : ', '}${value}`;
+  }
+  return folded;
+}
+
+/**
+ * Re-match the policy against the path that will ACTUALLY be sent.
+ *
+ * Substitution only rewrites bytes where a handle sat, but a handle in the path
+ * means those bytes are part of the request target — so the admitted path and
+ * the sent path can differ. Exported and called by both transports at the same
+ * point in their own sequence, rather than folded into `prepareRelayHead`, so
+ * neither path's error PRECEDENCE moves: the legacy route still reports its
+ * `413 body exceeds 1 MiB after substitution` before this 403, exactly as it
+ * does today.
+ */
+export function assertPolicyAdmitsPath(
+  policy: SecretEgressPolicy,
+  url: URL,
+  method: NonNullable<SecretBrokerRequest['method']>,
+): void {
+  if (!matchRule(policy, { host: url.hostname, method, path: url.pathname })) {
+    throw new SecretBrokerError(
+      'policy_denied',
+      'outbound request does not match the secret policy',
+      403,
+    );
+  }
+}
+
+/**
+ * Every head-side security check, for BOTH transports.
+ *
+ * The url, the method and the headers are never streamed — the legacy route
+ * gets them in its JSON envelope and the streaming route gets them whole in
+ * `x-kortix-relay-meta`. Only the BODY streams. So the entire policy gate lives
+ * here, in one implementation, called from both: https-only, no userinfo, port
+ * pinned to empty-or-443, `matchRule`, header sanitation, forced
+ * `accept-encoding: identity`, the per-hop `admitted` re-filter, header
+ * substitution with its CRLF re-check, path/query substitution, the
+ * unsafe-target check, and the legacy `inject` slot.
+ *
+ * Duplicating any of it per transport is exactly how the accept-encoding
+ * two-list divergence incident happened. That class of bug is not acceptable on
+ * the policy gate, so there is one function and no second copy.
+ */
+export function prepareRelayHead(
   policy: SecretEgressPolicy,
   secret: string,
-  input: SecretBrokerRequest,
+  input: RelayHeadInput,
   substitutions: readonly SecretSubstitution[] = [],
-): PreparedBrokerRequest {
+): PreparedRelayHead {
   let url: URL;
   try {
     url = new URL(input.url);
@@ -374,11 +503,7 @@ export function prepareSecretBrokerRequest(
     throw new SecretBrokerError('policy_denied', 'outbound request does not match the secret policy', 403);
   }
 
-  let body = decodeBody(input.body_base64);
-  if ((method === 'GET' || method === 'HEAD') && body && body.byteLength > 0) {
-    throw new SecretBrokerError('invalid_request', `${method} requests cannot contain a body`, 400);
-  }
-  const headers = sanitizeHeaders(input.headers);
+  const headers = sanitizeHeaders(foldHeaders(input.headers));
   // Force an uncompressed upstream response so echo redaction scans real bytes.
   headers['accept-encoding'] = 'identity';
 
@@ -415,28 +540,6 @@ export function prepareSecretBrokerRequest(
     if (UNSAFE_TARGET.test(`${url.pathname}${url.search}`)) {
       throw new SecretBrokerError('invalid_request', 'substituted request target is invalid', 400);
     }
-
-    if (body && body.byteLength > 0) {
-      body = substituteBuffer(body, admitted, bodyEncoding(headers['content-type']), applied);
-      if (body.byteLength > MAX_REQUEST_BYTES) {
-        throw new SecretBrokerError(
-          'invalid_request',
-          'request body exceeds 1 MiB after substitution',
-          413,
-        );
-      }
-    }
-
-    // Substitution can only rewrite bytes where a handle sat, but a handle in
-    // the path means those bytes are part of the request target. Re-match so
-    // the path actually sent is the path the policy admitted.
-    if (!matchRule(policy, { host: url.hostname, method, path: url.pathname })) {
-      throw new SecretBrokerError(
-        'policy_denied',
-        'outbound request does not match the secret policy',
-        403,
-      );
-    }
   }
 
   // ── Legacy injection ──────────────────────────────────────────────────────
@@ -446,7 +549,7 @@ export function prepareSecretBrokerRequest(
   // §6 of the exposure model) carries no slot and is served purely by the block
   // above — there is nothing to inject and nothing to name.
   const slot = rule.inject ?? policy.inject;
-  const injectedRouteSecret = slot != null;
+  let bodyInject: { path: string } | null = null;
   if (slot) {
     if (slot.kind === 'header') {
       const name = slot.name.trim().toLowerCase();
@@ -457,9 +560,75 @@ export function prepareSecretBrokerRequest(
     } else if (slot.kind === 'query') {
       url.searchParams.set(slot.name, secret);
     } else {
-      body = injectJsonBody(body, slot.path, secret);
-      headers['content-type'] = 'application/json';
+      bodyInject = { path: slot.path };
     }
+  }
+
+  return {
+    url,
+    method,
+    headers,
+    admitted,
+    applied,
+    injectedRouteSecret: slot != null,
+    bodyInject,
+    substituted: [...applied],
+    carriesSecret: applied.size > 0 || slot != null,
+  };
+}
+
+export function prepareSecretBrokerRequest(
+  policy: SecretEgressPolicy,
+  secret: string,
+  input: SecretBrokerRequest,
+  substitutions: readonly SecretSubstitution[] = [],
+): PreparedBrokerRequest {
+  // ORDER MATTERS, and it is the LEGACY order on purpose.
+  //
+  // `/broker` is frozen: a daemon baked into a sandbox image months ago still
+  // branches on its codes. Before the head/body split, `decodeBody` (base64
+  // validation + the 1 MiB 413) and the GET/HEAD-body check ran BEFORE
+  // `sanitizeHeaders`. Running the head first silently changed the answer for a
+  // request that is wrong in two ways at once — e.g. a 2 MiB body plus a
+  // blocked `host` header went from `413 request body exceeds 1 MiB` to
+  // `400 request header is managed by Kortix: host`. Keep the old precedence.
+  let body = decodeBody(input.body_base64);
+  if ((input.method === 'GET' || input.method === 'HEAD') && body && body.byteLength > 0) {
+    throw new SecretBrokerError(
+      'invalid_request',
+      `${input.method} requests cannot contain a body`,
+      400,
+    );
+  }
+
+  // The url/method/header half is the SHARED gate — see `prepareRelayHead`.
+  // Everything below is body handling, which is the only part the two
+  // transports genuinely do differently.
+  const head = prepareRelayHead(
+    policy,
+    secret,
+    { url: input.url, method: input.method, headers: Object.entries(input.headers ?? {}) },
+    substitutions,
+  );
+  const { url, method, headers, admitted, applied } = head;
+
+  if (admitted.length > 0) {
+    if (body && body.byteLength > 0) {
+      body = substituteBuffer(body, admitted, bodyEncoding(headers['content-type']), applied);
+      if (body.byteLength > MAX_REQUEST_BYTES) {
+        throw new SecretBrokerError(
+          'invalid_request',
+          'request body exceeds 1 MiB after substitution',
+          413,
+        );
+      }
+    }
+    assertPolicyAdmitsPath(policy, url, method);
+  }
+
+  if (head.bodyInject) {
+    body = injectJsonBody(body, head.bodyInject.path, secret);
+    headers['content-type'] = 'application/json';
   }
   if (body) headers['content-length'] = String(body.byteLength);
 
@@ -469,11 +638,11 @@ export function prepareSecretBrokerRequest(
     headers,
     body,
     substituted: [...applied],
-    carriesSecret: applied.size > 0 || injectedRouteSecret,
+    carriesSecret: applied.size > 0 || head.injectedRouteSecret,
   };
 }
 
-async function resolvePinnedAddress(url: URL): Promise<{ address: string; family: 4 | 6 }> {
+export async function resolvePinnedAddress(url: URL): Promise<{ address: string; family: 4 | 6 }> {
   if (isIP(url.hostname) !== 0) {
     if (isPrivateIp(url.hostname)) {
       throw new SecretBrokerError('unsafe_destination', 'destination IP is private or reserved', 403);
@@ -605,7 +774,7 @@ export function redactSecretFromResponse(body: Buffer, secret: string): Buffer {
   return result;
 }
 
-function responseHeaders(
+export function responseHeaders(
   headers: Record<string, string | string[] | undefined>,
 ): Record<string, string> {
   const safe: Record<string, string> = {};

--- a/apps/api/src/secrets/relay-authorize.ts
+++ b/apps/api/src/secrets/relay-authorize.ts
@@ -1,0 +1,446 @@
+/**
+ * The CONTEXT-FREE authorization core for spending a secret on an outbound
+ * request — the one decision, shared by every transport.
+ *
+ * Four callers need exactly this verdict and must never disagree about it:
+ *
+ *   1. the legacy JSON-RPC route  `POST …/secrets/{id}/broker`
+ *   2. the streaming relay route  `POST …/secrets/{id}/relay`
+ *   3. the websocket ticket mint  `POST …/secrets/{id}/relay/ws-ticket`
+ *   4. the websocket UPGRADE, which runs in `Bun.serve`'s `fetch` BEFORE
+ *      `app.fetch` and therefore has no Hono `Context` at all
+ *
+ * (4) is why this file exists in this shape. `loadProjectForUser(c, …)` needs a
+ * `Context` and is unreachable from the upgrade handler, so anything that lives
+ * only inside a route handler would have to be RE-IMPLEMENTED there — which is
+ * the exact mechanism by which a security invariant silently drifts (see the
+ * accept-encoding two-list divergence). Everything here takes plain values and
+ * returns a plain verdict: one function, four call sites, zero drift.
+ *
+ * What stays OUTSIDE, deliberately: the PAT/session/agent-grant checks, the
+ * sandbox egress pin, and `loadProjectForUser`. Those are transport-level
+ * authentication and IAM; they run on the ordinary Hono path, and the websocket
+ * upgrade receives their verdict through a signed ticket rather than redoing
+ * them.
+ */
+import { createHash } from 'node:crypto';
+import {
+  projectSecrets,
+  projectSessionSecretHandles,
+  projectSessions,
+  type SecretEgressPolicy,
+} from '@kortix/db';
+import { and, desc, eq, inArray, isNull, or } from 'drizzle-orm';
+import { config } from '../config';
+import { decryptProjectSecret, intersectSecretGrants } from '../projects/secrets';
+import { ACTIVE_SESSION_STATUSES } from '../projects/lib/session-status';
+import { db } from '../shared/db';
+import type { SessionHandleFacts } from './handle-substitution';
+import { SecretBrokerError, type SecretSubstitution } from './http-broker';
+import { networkBoundaryPolicyError } from './network-boundary';
+import {
+  matchRule,
+  mintHandle,
+  parseHandle,
+  resolveSecretDelivery,
+  type OutboundRequestShape,
+} from './strategy';
+
+/** One active handle row, as this module reads it. */
+export interface LiveSessionHandle {
+  secretId: string;
+  identifier: string;
+  lookupId: string;
+  handleHash: string;
+  policySnapshot: SecretEgressPolicy;
+  expiresAt: Date | null;
+}
+
+/**
+ * Turn this session's active handles into the substitution set for ONE request.
+ *
+ * Two outputs, deliberately separate:
+ *
+ *  - `substitutions` — the handles that may be spent on this destination, with
+ *    their real values. Only these secrets are decrypted; a handle the grant
+ *    excludes or the policy does not admit never reaches the decrypt path.
+ *  - `facts` — what is known about EVERY active handle, keyed by lookup id, so
+ *    a handle that turns up in the request but is not substituted can still be
+ *    classified (stolen vs merely out-of-policy) instead of vanishing.
+ *
+ * The handle string is rebuilt from the stored lookup id and the secret's
+ * prefix, then checked against the stored hash: the hash is what the row
+ * committed to at mint time, so a prefix edited afterwards produces a handle
+ * that no longer matches and is skipped rather than substituted for the wrong
+ * bytes. The tag is verified on top of that — this is the ONE place a handle
+ * becomes spendable, so it is the place both checks belong.
+ */
+export async function resolveSpendableHandles(input: {
+  projectId: string;
+  userId: string;
+  sessionId: string;
+  handles: readonly LiveSessionHandle[];
+  effectiveGrantEnv: string[] | 'all' | undefined;
+  shape: OutboundRequestShape;
+}): Promise<{
+  substitutions: SecretSubstitution[];
+  facts: Map<string, SessionHandleFacts>;
+}> {
+  const facts = new Map<string, SessionHandleFacts>();
+  const substitutions: SecretSubstitution[] = [];
+  const identifiers = [...new Set(input.handles.map((row) => row.identifier))];
+  if (identifiers.length === 0) return { substitutions, facts };
+
+  const secretRows = await db
+    .select({
+      secretId: projectSecrets.secretId,
+      identifier: projectSecrets.identifier,
+      ownerUserId: projectSecrets.ownerUserId,
+      valueEnc: projectSecrets.valueEnc,
+      active: projectSecrets.active,
+      strategy: projectSecrets.strategy,
+      handlePrefix: projectSecrets.handlePrefix,
+    })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, input.projectId),
+        eq(projectSecrets.scope, 'runtime'),
+        inArray(projectSecrets.identifier, identifiers),
+        or(isNull(projectSecrets.ownerUserId), eq(projectSecrets.ownerUserId, input.userId)),
+      ),
+    );
+
+  // Same resolution as `listResolvedProjectSecrets`: the SHARED row carries the
+  // policy the handle was minted from, the member's own active row carries the
+  // value that was actually delivered to the sandbox. Substituting the shared
+  // value for a member who overrides it would send the wrong credential.
+  type SecretRow = (typeof secretRows)[number];
+  const byIdentifier = new Map<string, { shared?: SecretRow; personal?: SecretRow }>();
+  for (const row of secretRows) {
+    const slot = byIdentifier.get(row.identifier) ?? {};
+    if (row.ownerUserId === null) slot.shared = row;
+    else if (row.active) slot.personal = row;
+    byIdentifier.set(row.identifier, slot);
+  }
+
+  for (const row of input.handles) {
+    const slot = byIdentifier.get(row.identifier);
+    const shared = slot?.shared;
+    const delivery = shared
+      ? resolveSecretDelivery({
+          identifier: row.identifier,
+          strategy: shared.strategy,
+          agentGrantEnv: input.effectiveGrantEnv ?? null,
+          sessionAllowlist: null,
+          sessionId: input.sessionId,
+        })
+      : null;
+    const spendable =
+      !!shared && shared.secretId === row.secretId && delivery?.emit === 'handle';
+    const hostAdmitted = matchRule(row.policySnapshot, input.shape) !== null;
+    facts.set(row.lookupId, { identifier: row.identifier, spendable, hostAdmitted });
+    if (!spendable || !hostAdmitted || !shared) continue;
+
+    const handle = mintHandle({
+      lookupId: row.lookupId,
+      prefix: shared.handlePrefix,
+      rootSecret: config.API_KEY_SECRET,
+    });
+    if (createHash('sha256').update(handle).digest('hex') !== row.handleHash) {
+      console.warn('[secret-broker] skipped a handle whose stored hash no longer matches', {
+        projectId: input.projectId,
+        sessionId: input.sessionId,
+        identifier: row.identifier,
+      });
+      continue;
+    }
+    if (!parseHandle(handle, config.API_KEY_SECRET).ok) continue;
+    substitutions.push({
+      identifier: row.identifier,
+      handle,
+      value: decryptProjectSecret(input.projectId, (slot?.personal ?? shared).valueEnc),
+      policy: row.policySnapshot,
+    });
+  }
+  return { substitutions, facts };
+}
+
+/** Route-level refusal codes. NOT `SecretBrokerErrorCode` — these predate the
+ *  broker engine and are part of the deployed wire contract unchanged. */
+export type SecretRelayAuthzCode =
+  | 'session_not_active'
+  | 'secret_not_found'
+  | 'secret_delivery_unavailable'
+  | 'session_secret_handle_required'
+  | SecretBrokerError['code'];
+
+/** Enough of the secret row to build an audit record, known before the verdict. */
+export interface SecretRelayAuditContext {
+  secretId: string;
+  strategy: string;
+}
+
+export interface SecretRelayAuthzOk {
+  ok: true;
+  audit: SecretRelayAuditContext;
+  /** The handle's FROZEN policy snapshot — the policy the request executes
+   *  against, never the secret row's current one. */
+  policy: SecretEgressPolicy;
+  /** The decrypted value for the route's OWN secret. */
+  secret: string;
+  substitutions: SecretSubstitution[];
+  facts: Map<string, SessionHandleFacts>;
+  isBoundarySecret: boolean;
+}
+
+export interface SecretRelayAuthzDenied {
+  ok: false;
+  code: SecretRelayAuthzCode;
+  message: string;
+  status: number;
+  /**
+   * Null when the refusal happened before the secret row was known (no
+   * project secret, or no active session). Those two cases record NO audit row
+   * today, and this being null is what preserves that.
+   */
+  audit: SecretRelayAuditContext | null;
+}
+
+export type SecretRelayAuthz = SecretRelayAuthzOk | SecretRelayAuthzDenied;
+
+export interface SecretRelayAuthzInput {
+  projectId: string;
+  identifier: string;
+  /** The resolved caller, from `loadProjectForUser`. */
+  userId: string;
+  accountId: string;
+  sessionId: string;
+  /**
+   * The agent token's `secrets` grant, RAW.
+   *
+   * Intersecting it with the session allowlist happens here rather than in the
+   * caller: the intersection IS part of the decision, and the session row it
+   * needs is already read below. A caller that had to fetch the session itself
+   * to compute the input would be a second place the query — and the grant
+   * semantics — could drift.
+   */
+  agentGrantEnv: string[] | 'all';
+  /** This hop's destination, for the per-handle policy match. */
+  shape: OutboundRequestShape;
+}
+
+/**
+ * May this session spend this secret on this destination, and with what?
+ *
+ * Order is load-bearing and matches the legacy route exactly: active session →
+ * secret rows → delivery mode → broker-or-boundary shape → live handle rows →
+ * handle policy shape → spendable set. Each step's refusal keeps the status
+ * code and the wire `code` the deployed daemon already branches on.
+ */
+export async function authorizeSecretRelay(
+  input: SecretRelayAuthzInput,
+): Promise<SecretRelayAuthz> {
+  const [session] = await db
+    .select({
+      sessionId: projectSessions.sessionId,
+      secretsAllowlist: projectSessions.secretsAllowlist,
+    })
+    .from(projectSessions)
+    .where(
+      and(
+        eq(projectSessions.sessionId, input.sessionId),
+        eq(projectSessions.projectId, input.projectId),
+        eq(projectSessions.accountId, input.accountId),
+        inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
+      ),
+    )
+    .limit(1);
+  if (!session) {
+    return {
+      ok: false,
+      code: 'session_not_active',
+      message: 'Active project session not found',
+      status: 403,
+      audit: null,
+    };
+  }
+
+  const rows = await db
+    .select({
+      secretId: projectSecrets.secretId,
+      ownerUserId: projectSecrets.ownerUserId,
+      valueEnc: projectSecrets.valueEnc,
+      active: projectSecrets.active,
+      strategy: projectSecrets.strategy,
+      egressPolicy: projectSecrets.egressPolicy,
+    })
+    .from(projectSecrets)
+    .where(
+      and(
+        eq(projectSecrets.projectId, input.projectId),
+        eq(projectSecrets.identifier, input.identifier),
+        eq(projectSecrets.scope, 'runtime'),
+        or(isNull(projectSecrets.ownerUserId), eq(projectSecrets.ownerUserId, input.userId)),
+      ),
+    );
+  const shared = rows.find((row) => row.ownerUserId === null);
+  const personal = rows.find((row) => row.ownerUserId === input.userId && row.active);
+  if (!shared) {
+    return { ok: false, code: 'secret_not_found', message: 'Not found', status: 404, audit: null };
+  }
+  const audit: SecretRelayAuditContext = {
+    secretId: shared.secretId,
+    strategy: shared.strategy,
+  };
+
+  const effectiveGrantEnv = intersectSecretGrants(input.agentGrantEnv, session.secretsAllowlist);
+  const delivery = resolveSecretDelivery({
+    identifier: input.identifier,
+    strategy: shared.strategy,
+    agentGrantEnv: effectiveGrantEnv,
+    sessionAllowlist: null,
+    sessionId: input.sessionId,
+  });
+  if (delivery.emit !== 'handle') {
+    const reason = delivery.emit === 'nothing' ? delivery.reason : 'strategy_not_brokered';
+    return {
+      ok: false,
+      code: 'policy_denied',
+      message: `secret delivery denied: ${reason}`,
+      status: 403,
+      audit,
+    };
+  }
+
+  // Two delivery modes reach this engine, and they are the same engine on
+  // purpose:
+  //
+  //  - `broker`/`kortix_fetch` — the agent calls the route itself
+  //    (`kortix secrets call`, the `secret_call` MCP tool).
+  //  - `egress`/`network` — a network-boundary secret on a provider with no
+  //    credential edge of its own. The in-guest shim terminates the guest's
+  //    TLS and relays here, so the credential stays server-side exactly as it
+  //    does for the broker.
+  //
+  // `networkBoundaryPolicyError` is re-checked here rather than trusted from
+  // save time: the row could have been written by an older build, and a policy
+  // that is not a valid boundary must not be executed as one.
+  const isBrokerSecret =
+    shared.strategy === 'broker' && shared.egressPolicy?.backend === 'kortix_fetch';
+  const isBoundarySecret =
+    shared.strategy === 'egress' &&
+    !!shared.egressPolicy &&
+    networkBoundaryPolicyError(shared.egressPolicy) === null;
+  if (!isBrokerSecret && !isBoundarySecret) {
+    return {
+      ok: false,
+      code: 'secret_delivery_unavailable',
+      message: 'Secret is not configured for the HTTPS broker',
+      status: 409,
+      audit,
+    };
+  }
+
+  // Every active handle this SESSION holds, not just the route's own.
+  //
+  // Substitution has to answer two questions the single-secret lookup cannot:
+  // which other handles in this request may be spent here, and — for the ones
+  // that may not — whether they were forged or merely carried in from
+  // somewhere else. Both need the whole set, and one query is cheaper than one
+  // per handle found.
+  const handleRows = await db
+    .select({
+      secretId: projectSessionSecretHandles.secretId,
+      identifier: projectSessionSecretHandles.identifier,
+      lookupId: projectSessionSecretHandles.lookupId,
+      handleHash: projectSessionSecretHandles.handleHash,
+      policySnapshot: projectSessionSecretHandles.policySnapshot,
+      expiresAt: projectSessionSecretHandles.expiresAt,
+    })
+    .from(projectSessionSecretHandles)
+    .where(
+      and(
+        eq(projectSessionSecretHandles.projectId, input.projectId),
+        eq(projectSessionSecretHandles.sessionId, input.sessionId),
+        eq(projectSessionSecretHandles.status, 'active'),
+      ),
+    )
+    .orderBy(desc(projectSessionSecretHandles.revision));
+
+  // Highest revision wins per secret: rotation leaves the previous revision
+  // active for an overlap window rather than killing it mid-turn, and both are
+  // spendable — but only the newest is THE handle for the route's own secret.
+  const liveHandles = handleRows.filter(
+    (row) => row.expiresAt === null || row.expiresAt.getTime() > Date.now(),
+  );
+  const handle = liveHandles.find((row) => row.secretId === shared.secretId);
+  // The snapshot must match the delivery mode this request is being served
+  // under. A broker secret's snapshot carries `kortix_fetch`; a boundary policy
+  // carries no backend at all — `networkBoundaryPolicyError` rejects one that
+  // does — so demanding `kortix_fetch` of both would make a boundary handle
+  // permanently invalid. Still checked, not skipped: the snapshot is what the
+  // request is executed against, so a row whose policy is neither shape must
+  // not be spent.
+  const handlePolicyValid = handle
+    ? isBoundarySecret
+      ? networkBoundaryPolicyError(handle.policySnapshot) === null
+      : handle.policySnapshot.backend === 'kortix_fetch'
+    : false;
+  // Expiry is already applied — `liveHandles` is the filter — so this is the
+  // presence and policy check only.
+  if (!handle || !handlePolicyValid) {
+    return {
+      ok: false,
+      code: 'session_secret_handle_required',
+      message: 'The active session does not have this brokered secret',
+      status: 409,
+      audit,
+    };
+  }
+
+  // Which of this session's handles may be spent on THIS destination.
+  //
+  // The resolution is the same one applied to the route's own secret — the
+  // agent grant intersected with the session allowlist, then the handle's
+  // FROZEN policy snapshot matched against the request. Substitution must never
+  // widen who may spend: a handle the sandbox holds but this agent may not use
+  // is left in the request as the worthless self-describing string it is.
+  const spendable = await resolveSpendableHandles({
+    projectId: input.projectId,
+    userId: input.userId,
+    sessionId: input.sessionId,
+    handles: liveHandles,
+    effectiveGrantEnv,
+    shape: input.shape,
+  });
+
+  // The route's own secret is part of the spendable set — it is one of this
+  // session's handles like any other — so reuse the value that resolution
+  // already produced instead of decrypting the same row twice.
+  const primary = spendable.substitutions.find((entry) => entry.identifier === input.identifier);
+  const secret =
+    primary?.value ??
+    decryptProjectSecret(input.projectId, personal?.valueEnc ?? shared.valueEnc);
+
+  return {
+    ok: true,
+    audit,
+    policy: handle.policySnapshot,
+    secret,
+    substitutions: spendable.substitutions,
+    facts: spendable.facts,
+    isBoundarySecret,
+  };
+}
+
+/** The single refusal that is NOT expressible as a `SecretBrokerError`, mapped
+ *  for callers that want one anyway (the websocket upgrade, which has no JSON
+ *  envelope of its own). */
+export function relayAuthzToBrokerError(denied: SecretRelayAuthzDenied): SecretBrokerError {
+  return new SecretBrokerError(
+    denied.code === 'policy_denied' ? 'policy_denied' : 'invalid_request',
+    denied.message,
+    denied.status,
+  );
+}

--- a/apps/api/src/secrets/relay-transport.test.ts
+++ b/apps/api/src/secrets/relay-transport.test.ts
@@ -1,0 +1,466 @@
+import { spawnSync } from 'node:child_process';
+import { createServer, type Server } from 'node:https';
+import type { AddressInfo } from 'node:net';
+import { Readable } from 'node:stream';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { SecretBrokerError } from './http-broker';
+import { openUpstream, type RelayTransportSeam } from './relay-transport';
+
+/**
+ * A REAL TLS upstream on loopback.
+ *
+ * Every assertion here is black-box against a socket, never against a mocked
+ * transport. The four Bun/Node divergences already living in this feature's
+ * neighbourhood (`emit('connection')` a no-op, SNICallback never firing,
+ * deleting content-length leaving the response held, the inert upgrade socket)
+ * all had one thing in common: they were invisible to an in-process handle
+ * handoff and obvious against a real socket.
+ */
+let server: Server;
+let port = 0;
+let certPem = '';
+let handler: (req: import('node:http').IncomingMessage, res: import('node:http').ServerResponse) => void;
+/** What the upstream actually received, per request. */
+let received: Array<{ chunks: Buffer[]; headers: Record<string, unknown>; url?: string; method?: string }> = [];
+
+function makeCert(): { cert: string; key: string } {
+  const dir = `/tmp/kortix-relay-test-cert`;
+  spawnSync('mkdir', ['-p', dir]);
+  const result = spawnSync(
+    'openssl',
+    [
+      'req', '-x509', '-newkey', 'rsa:2048',
+      '-keyout', `${dir}/key.pem`, '-out', `${dir}/cert.pem`,
+      '-days', '2', '-nodes', '-subj', '/CN=upstream.test',
+      '-addext', 'subjectAltName=DNS:upstream.test',
+    ],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) throw new Error(`openssl failed: ${result.stderr}`);
+  return {
+    cert: require('node:fs').readFileSync(`${dir}/cert.pem`, 'utf8'),
+    key: require('node:fs').readFileSync(`${dir}/key.pem`, 'utf8'),
+  };
+}
+
+beforeAll(async () => {
+  const { cert, key } = makeCert();
+  certPem = cert;
+  server = createServer({ cert, key }, (req, res) => handler(req, res));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  port = (server.address() as AddressInfo).port;
+});
+
+afterAll(() => {
+  server?.close();
+});
+
+/**
+ * The transport pins the RESOLVED IP — that is the DNS-rebinding guard and the
+ * reason this leg uses `node:https` and not `fetch`. Loopback is a private
+ * address, so a test upstream can only be reached through the documented
+ * production-unset seam, which stands in for DNS exactly as `resolvePinnedAddress`
+ * would and leaves every other check (policy, port pin, budgets) live.
+ */
+function seam(): RelayTransportSeam {
+  return {
+    resolveAddress: async () => ({ address: '127.0.0.1', family: 4 as const }),
+    ca: certPem,
+    port,
+  };
+}
+
+function head(path = '/v1/things', method = 'POST') {
+  return {
+    url: new URL(`https://upstream.test${path}`),
+    method: method as 'POST',
+    headers: { 'content-type': 'application/json', 'accept-encoding': 'identity' },
+  };
+}
+
+async function drain(body: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of body) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks);
+}
+
+/** Reset per test: several tests install their own upstream behaviour. */
+beforeEach(() => {
+  received = [];
+  handler = (req, res) => {
+    const entry = {
+      chunks: [] as Buffer[],
+      headers: req.headers as Record<string, unknown>,
+      url: req.url,
+      method: req.method,
+    };
+    received.push(entry);
+    req.on('data', (chunk: Buffer) => entry.chunks.push(chunk));
+    req.on('end', () => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  };
+});
+
+describe('the request leg streams, with real backpressure', () => {
+  test('chunks written incrementally ARRIVE incrementally at the upstream', async () => {
+    received = [];
+    const seen: number[] = [];
+    handler = (req, res) => {
+      req.on('data', (chunk: Buffer) => seen.push(chunk.byteLength));
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end('done');
+      });
+    };
+    // A source that emits three chunks with a gap, so coalescing is visible.
+    const source = new Readable({ read() {} });
+    const upstreamPromise = openUpstream(head(), source, { seam: seam() });
+    for (const text of ['first-', 'second-', 'third']) {
+      source.push(Buffer.from(text));
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    source.push(null);
+    const upstream = await upstreamPromise;
+    expect(await drain(upstream.body)).toEqual(Buffer.from('done'));
+    expect(seen.length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('a streamed body is framed CHUNKED, with no content-length', async () => {
+    received = [];
+    const source = Readable.from([Buffer.from('abc')]);
+    const upstream = await openUpstream(head(), source, { seam: seam() });
+    await drain(upstream.body);
+    expect(received[0]?.headers['transfer-encoding']).toBe('chunked');
+    expect(received[0]?.headers['content-length']).toBeUndefined();
+    expect(Buffer.concat(received[0]!.chunks).toString()).toBe('abc');
+  });
+
+  test('a Buffer body sets an exact content-length', async () => {
+    received = [];
+    const upstream = await openUpstream(head(), Buffer.from('exactly-13-by'), { seam: seam() });
+    await drain(upstream.body);
+    expect(received[0]?.headers['content-length']).toBe('13');
+    expect(received[0]?.headers['transfer-encoding']).toBeUndefined();
+  });
+
+  test('the pinned host header names the POLICY host, not the pinned IP', async () => {
+    // The IP is where we connect; the Host header and the SNI name are what the
+    // upstream and its certificate see. Confusing the two is how IP pinning
+    // usually breaks TLS.
+    received = [];
+    const upstream = await openUpstream(head(), null, { seam: seam() });
+    await drain(upstream.body);
+    expect(received[0]?.headers.host).toBe('upstream.test');
+  });
+});
+
+describe('the response leg streams', () => {
+  test('response chunks reach the reader INCREMENTALLY, not at end-of-body', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      let i = 0;
+      const timer = setInterval(() => {
+        res.write(`data: {"i":${i}}\n\n`);
+        if (++i === 3) {
+          clearInterval(timer);
+          res.end();
+        }
+      }, 30);
+    };
+    const upstream = await openUpstream(head('/sse', 'GET'), null, { seam: seam() });
+    const arrivals: number[] = [];
+    const started = Date.now();
+    for await (const chunk of upstream.body) {
+      void chunk;
+      arrivals.push(Date.now() - started);
+    }
+    // Three separate arrivals means the body was never buffered to completion.
+    expect(arrivals.length).toBeGreaterThanOrEqual(3);
+    expect(arrivals[arrivals.length - 1]! - arrivals[0]!).toBeGreaterThan(20);
+  });
+
+  test('the UPSTREAM status and its ordered headers come back', async () => {
+    handler = (_req, res) => {
+      res.writeHead(429, [
+        'content-type', 'application/json',
+        'retry-after', '5',
+        'x-dup', 'one',
+        'x-dup', 'two',
+      ]);
+      res.end('{}');
+    };
+    const upstream = await openUpstream(head('/rl', 'GET'), null, { seam: seam() });
+    await drain(upstream.body);
+    expect(upstream.status).toBe(429);
+    expect(upstream.rawHeaders).toContainEqual(['retry-after', '5']);
+    expect(upstream.rawHeaders).toContainEqual(['content-type', 'application/json']);
+  });
+
+  test('MEASURED: bun does NOT preserve duplicate non-known RESPONSE headers', async () => {
+    // Pinning what is TRUE rather than what would be nice. Measured on bun
+    // 1.3.14 against a raw-socket upstream emitting two literal `X-Dup:` lines:
+    // `res.rawHeaders` came back holding only the LAST value, while `set-cookie`
+    // (a known header) kept both. So `res.rawHeaders` does NOT give the full
+    // duplicate fidelity node does — the same collapse the REQUEST leg already
+    // suffers, now measured on the response leg too.
+    //
+    // It costs the relay nothing today: every name in SAFE_RESPONSE_HEADERS is
+    // single-valued, and `set-cookie` is deliberately excluded from that list,
+    // so no header that can legitimately repeat ever travels back. This test
+    // exists so the day that whitelist grows a repeatable header, it fails here
+    // instead of silently dropping a value in production.
+    handler = (_req, res) => {
+      res.writeHead(200, ['x-dup', 'one', 'x-dup', 'two']);
+      res.end('{}');
+    };
+    const upstream = await openUpstream(head('/dup', 'GET'), null, { seam: seam() });
+    await drain(upstream.body);
+    const dups = upstream.rawHeaders.filter(([name]) => name === 'x-dup').map(([, v]) => v);
+    expect(dups).toHaveLength(1);
+    expect(dups[0]).toContain('two');
+  });
+});
+
+describe('the byte budgets are the ONLY inbound guard, so they are asserted', () => {
+  test('a request over the budget aborts with relay_request_too_large', async () => {
+    handler = (req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => res.end('ok'));
+      req.on('error', () => {});
+    };
+    const source = new Readable({
+      read() {
+        this.push(Buffer.alloc(4096, 0x61));
+      },
+    });
+    const error = await openUpstream(head(), source, {
+      seam: seam(),
+      maxRequestBytes: 8192,
+    })
+      .then(async (upstream) => {
+        await drain(upstream.body);
+        return null;
+      })
+      .catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('relay_request_too_large');
+    expect((error as SecretBrokerError).status).toBe(413);
+    source.destroy();
+  });
+
+  test('a response over the budget destroys the stream with relay_response_too_large', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200);
+      const timer = setInterval(() => res.write(Buffer.alloc(4096, 0x62)), 1);
+      res.on('close', () => clearInterval(timer));
+    };
+    const upstream = await openUpstream(head('/big', 'GET'), null, {
+      seam: seam(),
+      maxResponseBytes: 8192,
+    });
+    const error = await drain(upstream.body).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('relay_response_too_large');
+    expect((error as SecretBrokerError).status).toBe(502);
+  });
+
+  test('a budget of 0 means unlimited, for self-host operators', async () => {
+    handler = (_req, res) => {
+      res.writeHead(200);
+      res.end(Buffer.alloc(64 * 1024, 0x63));
+    };
+    const upstream = await openUpstream(head('/unlimited', 'GET'), null, {
+      seam: seam(),
+      maxResponseBytes: 0,
+    });
+    expect((await drain(upstream.body)).byteLength).toBe(64 * 1024);
+  });
+});
+
+describe('the SSRF guard is not weakened by streaming', () => {
+  test('a private destination is refused before a single byte leaves', async () => {
+    // No seam: the REAL `resolvePinnedAddress` runs, and 127.0.0.1 is private.
+    const error = await openUpstream(
+      { url: new URL('https://127.0.0.1/v1/x'), method: 'GET', headers: {} },
+      null,
+      {},
+    ).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('unsafe_destination');
+    expect((error as SecretBrokerError).status).toBe(403);
+  });
+});
+
+describe('timeouts bound the HEADERS, never the stream', () => {
+  test('a slow-to-respond upstream times out with upstream_timeout', async () => {
+    handler = (_req, _res) => {
+      /* never responds */
+    };
+    const error = await openUpstream(head('/slow', 'GET'), null, {
+      seam: seam(),
+      headersTimeoutMs: 150,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('upstream_timeout');
+    expect((error as SecretBrokerError).status).toBe(504);
+  });
+
+  test('a stream that outlives the HEADERS timeout is NOT killed', async () => {
+    // The whole point: the legacy flat 30 s `REQUEST_TIMEOUT_MS` would kill
+    // every SSE stream. The headers timeout must stop counting once headers
+    // arrive.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.write('data: 1\n\n');
+      setTimeout(() => {
+        res.write('data: 2\n\n');
+        res.end();
+      }, 300);
+    };
+    const upstream = await openUpstream(head('/long', 'GET'), null, {
+      seam: seam(),
+      headersTimeoutMs: 150,
+    });
+    expect((await drain(upstream.body)).toString()).toBe('data: 1\n\ndata: 2\n\n');
+  });
+});
+
+describe('the caller can abort a live relay', () => {
+  test('aborting the client signal tears the relay body down', async () => {
+    // The relay client went away mid-stream. Without this the upstream socket
+    // keeps draining bytes into a substituter nobody will ever read.
+    handler = (_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.write('start');
+      // Never ends on its own — only the abort can finish this test.
+    };
+    const controller = new AbortController();
+    const upstream = await openUpstream(head('/abort', 'GET'), null, {
+      seam: seam(),
+      signal: controller.signal,
+    });
+    const reading = drain(upstream.body).then(
+      () => 'ended',
+      () => 'errored',
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    controller.abort();
+    // Resolves at all ⟹ the body stream was torn down by the abort. Without the
+    // signal wiring this await never settles and the test times out.
+    expect(['ended', 'errored']).toContain(await reading);
+    expect(upstream.body.destroyed || upstream.body.readableEnded).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// REGRESSIONS — each of these failed before the fix beside it.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('the HEADERS deadline measures SILENCE, not the upload', () => {
+  // `headersTimer` used to be armed the moment the request was created and
+  // cleared only in the `'response'` handler. An upstream does not answer until
+  // it HAS the body, so that made a flat 30 s `KORTIX_RELAY_HEADERS_TIMEOUT_MS`
+  // a TOTAL-DURATION timeout on the upload leg — the exact shape this file's
+  // own doc block says it avoids. It also made
+  // `KORTIX_RELAY_MAX_REQUEST_BYTES` (1 GiB) unreachable on any link slower
+  // than ~286 Mbit/s: the real request cap was "whatever uploads in 30 s".
+  test('a body that takes LONGER than the headers timeout to upload is not killed', async () => {
+    handler = (req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'text/plain' });
+        res.end(String(Buffer.concat(chunks).byteLength));
+      });
+    };
+    // 8 writes × 40 ms = ~320 ms of upload against a 120 ms headers budget.
+    const source = new Readable({ read() {} });
+    void (async () => {
+      for (let i = 0; i < 8; i += 1) {
+        source.push(Buffer.from('0123456789'));
+        await new Promise((r) => setTimeout(r, 40));
+      }
+      source.push(null);
+    })();
+    const upstream = await openUpstream(head('/slow-upload'), source, {
+      seam: seam(),
+      headersTimeoutMs: 120,
+    });
+    expect((await drain(upstream.body)).toString()).toBe('80');
+  });
+
+  test('the deadline still fires when the upstream goes silent AFTER the body', async () => {
+    // The control: arming later must not disable the guard.
+    handler = (req, _res) => {
+      req.resume();
+      /* never responds */
+    };
+    const error = await openUpstream(head('/silent'), Readable.from([Buffer.from('abc')]), {
+      seam: seam(),
+      headersTimeoutMs: 150,
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('upstream_timeout');
+  });
+});
+
+describe('EXACTLY ONE framing header reaches the upstream', () => {
+  // The route's pass-through branch sets `content-length` and documents "the
+  // length is PROVABLY unchanged. Forward it" — then `openUpstream` added
+  // `transfer-encoding: chunked` on top without removing it. Measured on bun
+  // 1.3.14: with both present Bun emits ONLY `Transfer-Encoding: chunked` and
+  // silently drops the `Content-Length`, so the promise was inert and every
+  // pass-through body (a 200-byte JSON POST included) went chunked — which S3
+  // answers with `501 Not Implemented`. Under Node the same code emits BOTH,
+  // which is a request-smuggling primitive.
+  test('a caller-declared content-length is KEPT and chunked is not added', async () => {
+    received = [];
+    const source = Readable.from([Buffer.from('abcde')]);
+    const upstream = await openUpstream(
+      { ...head(), headers: { ...head().headers, 'content-length': '5' } },
+      source,
+      { seam: seam() },
+    );
+    await drain(upstream.body);
+    expect(received[0]?.headers['content-length']).toBe('5');
+    expect(received[0]?.headers['transfer-encoding']).toBeUndefined();
+    expect(Buffer.concat(received[0]!.chunks).toString()).toBe('abcde');
+  });
+
+  test('a stream with NO declared length is chunked and carries no content-length', async () => {
+    received = [];
+    const source = Readable.from([Buffer.from('abc')]);
+    const upstream = await openUpstream(head(), source, { seam: seam() });
+    await drain(upstream.body);
+    expect(received[0]?.headers['transfer-encoding']).toBe('chunked');
+    expect(received[0]?.headers['content-length']).toBeUndefined();
+  });
+
+  test('a stream that OVERRUNS its declared content-length is refused, not sent', async () => {
+    const source = Readable.from([Buffer.from('abcdefghij')]);
+    const error = await openUpstream(
+      { ...head(), headers: { ...head().headers, 'content-length': '5' } },
+      source,
+      { seam: seam() },
+    ).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(error).toBeInstanceOf(SecretBrokerError);
+    expect((error as SecretBrokerError).code).toBe('relay_request_too_large');
+  });
+});

--- a/apps/api/src/secrets/relay-transport.test.ts
+++ b/apps/api/src/secrets/relay-transport.test.ts
@@ -107,24 +107,46 @@ describe('the request leg streams, with real backpressure', () => {
   test('chunks written incrementally ARRIVE incrementally at the upstream', async () => {
     received = [];
     const seen: number[] = [];
+    const body: Buffer[] = [];
+    let signalFirstByte!: () => void;
+    const firstByteSeen = new Promise<void>((resolve) => {
+      signalFirstByte = resolve;
+    });
     handler = (req, res) => {
-      req.on('data', (chunk: Buffer) => seen.push(chunk.byteLength));
+      req.on('data', (chunk: Buffer) => {
+        seen.push(chunk.byteLength);
+        body.push(Buffer.from(chunk));
+        signalFirstByte();
+      });
       req.on('end', () => {
         res.writeHead(200, { 'content-type': 'text/plain' });
         res.end('done');
       });
     };
-    // A source that emits three chunks with a gap, so coalescing is visible.
+    // CAUSAL, not timed. An earlier version pushed three chunks 25ms apart and
+    // asserted three `data` events arrived — which TCP coalescing merges into
+    // one on a loaded runner, so it failed in CI while passing locally. The
+    // property is not "three reads", it is "the upstream saw bytes BEFORE the
+    // request body ended". So the upstream signals its first read, and the test
+    // WAITS for that signal before ending the source: if `openUpstream` buffered
+    // the body to completion the signal could never arrive and this times out.
     const source = new Readable({ read() {} });
     const upstreamPromise = openUpstream(head(), source, { seam: seam() });
-    for (const text of ['first-', 'second-', 'third']) {
-      source.push(Buffer.from(text));
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    source.push(Buffer.from('first-'));
+    await Promise.race([
+      firstByteSeen,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('upstream saw no bytes before the body ended — not streaming')), 5000),
+      ),
+    ]);
+    source.push(Buffer.from('second-'));
     source.push(null);
     const upstream = await upstreamPromise;
     expect(await drain(upstream.body)).toEqual(Buffer.from('done'));
-    expect(seen.length).toBeGreaterThanOrEqual(3);
+    // This handler consumes the request itself, so the bytes land in `body`
+    // rather than in the harness's `received`.
+    expect(Buffer.concat(body).toString()).toBe('first-second-');
+    expect(seen.length).toBeGreaterThanOrEqual(1);
   });
 
   test('a streamed body is framed CHUNKED, with no content-length', async () => {
@@ -158,27 +180,37 @@ describe('the request leg streams, with real backpressure', () => {
 
 describe('the response leg streams', () => {
   test('response chunks reach the reader INCREMENTALLY, not at end-of-body', async () => {
+    // CAUSAL, not timed. The upstream writes ONE event, then waits for the test
+    // to actually read it before writing the last one and ending. If the
+    // response were buffered to completion the reader would never see event 1,
+    // the gate would never open, and this times out — which is exactly the
+    // regression worth catching. Counting arrivals within a time budget is not:
+    // TCP coalescing merges SSE frames on a loaded runner, which is how the
+    // timed version failed in CI while passing locally.
+    let openGate!: () => void;
+    const firstEventRead = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
     handler = (_req, res) => {
       res.writeHead(200, { 'content-type': 'text/event-stream' });
-      let i = 0;
-      const timer = setInterval(() => {
-        res.write(`data: {"i":${i}}\n\n`);
-        if (++i === 3) {
-          clearInterval(timer);
-          res.end();
-        }
-      }, 30);
+      res.write('data: {"i":0}\n\n');
+      void firstEventRead.then(() => {
+        res.write('data: {"i":1}\n\n');
+        res.end();
+      });
     };
     const upstream = await openUpstream(head('/sse', 'GET'), null, { seam: seam() });
-    const arrivals: number[] = [];
-    const started = Date.now();
+    const seenEvents: string[] = [];
+    const deadline = setTimeout(() => {
+      throw new Error('no event reached the reader before end-of-body — not streaming');
+    }, 5000);
     for await (const chunk of upstream.body) {
-      void chunk;
-      arrivals.push(Date.now() - started);
+      seenEvents.push(Buffer.from(chunk).toString());
+      openGate();
     }
-    // Three separate arrivals means the body was never buffered to completion.
-    expect(arrivals.length).toBeGreaterThanOrEqual(3);
-    expect(arrivals[arrivals.length - 1]! - arrivals[0]!).toBeGreaterThan(20);
+    clearTimeout(deadline);
+    expect(seenEvents.join('')).toContain('{"i":0}');
+    expect(seenEvents.join('')).toContain('{"i":1}');
   });
 
   test('the UPSTREAM status and its ordered headers come back', async () => {

--- a/apps/api/src/secrets/relay-transport.ts
+++ b/apps/api/src/secrets/relay-transport.ts
@@ -1,0 +1,396 @@
+/**
+ * The STREAMING upstream leg of the secret relay.
+ *
+ * ## Why `node:https` and not `fetch`
+ *
+ * `fetch()` cannot pin the resolved IP address. IP pinning is what makes the
+ * SSRF guard resistant to DNS rebinding — `resolvePinnedAddress()` resolves the
+ * hostname once, rejects private and reserved addresses, and
+ * `createPinnedRequestOptions()` then connects to THAT address with the
+ * hostname carried only in `servername` (SNI) and the `host` header. With
+ * `fetch` the runtime resolves again, at connect time, and a name that answered
+ * public a millisecond ago can answer `169.254.169.254` now. That invariant is
+ * not negotiable, so this leg keeps the same primitive the buffered broker uses.
+ *
+ * The outbound probe measured node:http/node:https streaming under bun 1.3.14
+ * as fully equivalent to fetch — incremental `req.write()`, chunked
+ * transfer-encoding, incremental response `'data'` events, real TLS — and it
+ * additionally hands back `res.rawHeaders`, which preserves duplicate response
+ * headers that fetch's `Headers` collapses.
+ *
+ * `fetch` remains the right tool for the SHIM → API leg, where there is nothing
+ * to pin.
+ *
+ * ## Timeouts
+ *
+ * The buffered broker's flat 30 s `REQUEST_TIMEOUT_MS` is a TOTAL-duration
+ * timeout. Carried over unchanged it would kill every SSE stream at 30 s, which
+ * is the exact shape of the prior gateway `idleTimeout` incident. So it is split:
+ *
+ *   - CONNECT   — bounded, socket-level.
+ *   - HEADERS   — time until the upstream's response line arrives. Stops
+ *                 counting the moment it does.
+ *   - IDLE      — silence on the response socket, re-armed by every byte.
+ *
+ * There is deliberately NO total-duration timeout. A healthy SSE stream can run
+ * for hours, and a dead one is caught by the idle timer.
+ *
+ * ## Byte budgets
+ *
+ * Enforced by counters INSIDE the read/write loops, because on bun 1.3.14 there
+ * is no other guard: Bun applies no inbound flow control, a BYOB reader throws,
+ * and a `CountQueuingStrategy({highWaterMark:1})` is byte-for-byte identical to
+ * manual reads. See `config.ts` for the measurements.
+ */
+import type { IncomingMessage } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { PassThrough, Readable } from 'node:stream';
+import { config } from '../config';
+import {
+  createPinnedRequestOptions,
+  resolvePinnedAddress,
+  SecretBrokerError,
+} from './http-broker';
+
+/** How long to wait for the TCP+TLS connection itself. */
+export const RELAY_CONNECT_TIMEOUT_MS = 10_000;
+
+/** The head of an outbound request — everything `prepareRelayHead` produced. */
+export interface RelayRequestHead {
+  url: URL;
+  method: string;
+  headers: Record<string, string>;
+}
+
+export interface RelayUpstreamResponse {
+  /** The UPSTREAM's status. The relay's own status is a separate concern. */
+  status: number;
+  /**
+   * Ordered `[name, value]` pairs with DUPLICATES PRESERVED, straight from
+   * `res.rawHeaders`. Names are lowercased; values are verbatim.
+   */
+  rawHeaders: Array<[string, string]>;
+  /** The response body, streaming. Errors with a `SecretBrokerError`. */
+  body: Readable;
+  /** Tear the upstream down — used when the relay's own client goes away. */
+  destroy(): void;
+}
+
+/**
+ * TEST SEAM. Production leaves this unset, and every field exists because a
+ * black-box test needs a real socket rather than a mock.
+ *
+ * It stands in for DNS and the trust store ONLY. The policy match, the port
+ * pin, the header sanitation, the substitution and the byte budgets all stay
+ * live behind it, so a test that uses the seam is still exercising the real
+ * gate.
+ */
+export interface RelayTransportSeam {
+  /** Replaces the DNS resolve + private-IP refusal. */
+  resolveAddress?: (url: URL) => Promise<{ address: string; family: 4 | 6 }>;
+  /** Extra CA for a self-signed loopback upstream. */
+  ca?: string | string[];
+  /** Loopback port, since the production path pins 443. */
+  port?: number;
+}
+
+export interface OpenUpstreamOptions {
+  /** The relay client's own signal (`c.req.raw.signal`) — abort propagates. */
+  signal?: AbortSignal;
+  /** 0 = unlimited. Defaults to `KORTIX_RELAY_MAX_REQUEST_BYTES`. */
+  maxRequestBytes?: number;
+  /** 0 = unlimited. Defaults to `KORTIX_RELAY_MAX_RESPONSE_BYTES`. */
+  maxResponseBytes?: number;
+  /** Defaults to `KORTIX_RELAY_HEADERS_TIMEOUT_MS`. */
+  headersTimeoutMs?: number;
+  /** 0 = off. Defaults to `KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS`. */
+  idleTimeoutMs?: number;
+  connectTimeoutMs?: number;
+  seam?: RelayTransportSeam;
+}
+
+/**
+ * Open the upstream request and resolve as soon as its RESPONSE HEADERS arrive.
+ *
+ * Resolving at headers — not at end-of-body — is what makes the relay a proxy
+ * rather than a buffer: the caller gets `status` + `rawHeaders` immediately, can
+ * commit its own 200, and then pipes `body` through the redaction substituter
+ * while the upstream is still writing.
+ */
+export async function openUpstream(
+  head: RelayRequestHead,
+  body: Readable | Buffer | null,
+  options: OpenUpstreamOptions = {},
+): Promise<RelayUpstreamResponse> {
+  const seam = options.seam ?? {};
+  const maxRequestBytes = options.maxRequestBytes ?? config.KORTIX_RELAY_MAX_REQUEST_BYTES;
+  const maxResponseBytes = options.maxResponseBytes ?? config.KORTIX_RELAY_MAX_RESPONSE_BYTES;
+  const headersTimeoutMs = options.headersTimeoutMs ?? config.KORTIX_RELAY_HEADERS_TIMEOUT_MS;
+  const idleTimeoutMs = options.idleTimeoutMs ?? config.KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS;
+
+  // Resolve and refuse BEFORE a byte leaves. Identical guard to the buffered
+  // broker's — same function, so there is no second implementation to drift.
+  const pinned = await (seam.resolveAddress ?? resolvePinnedAddress)(head.url);
+
+  const requestOptions = createPinnedRequestOptions(
+    { url: head.url, method: head.method as never, headers: head.headers, body: null, substituted: [], carriesSecret: false },
+    pinned,
+  );
+  if (seam.port !== undefined) requestOptions.port = seam.port;
+  if (seam.ca !== undefined) (requestOptions as { ca?: string | string[] }).ca = seam.ca;
+
+  // Framing. The guest's own `content-length` / `transfer-encoding` never reach
+  // here (both are in BLOCKED_REQUEST_HEADERS), so this is the only place the
+  // upstream leg's framing is decided:
+  //   - a Buffer body has a provably exact length → `content-length`
+  //   - a streamed body has none → `transfer-encoding: chunked`
+  // Measured: httpbin's origin, Anthropic, OpenAI, GitHub, Stripe and S3 all
+  // accepted a chunked request (no 411, no 501).
+  //
+  // EXACTLY ONE framing header is emitted. Setting both is a request-smuggling
+  // primitive under Node (which sends both) and a silent broken promise under
+  // Bun 1.3.14 (measured: with both present Bun emits ONLY
+  // `Transfer-Encoding: chunked` and drops the `Content-Length`). The route's
+  // pass-through branch sets `content-length` because on that branch the length
+  // is PROVABLY unchanged — so honour it, and enforce it in the write loop
+  // below rather than letting a mismatch reach the upstream.
+  const headers = { ...(requestOptions.headers as Record<string, string>) };
+  const declaredLength =
+    typeof headers['content-length'] === 'string' && /^\d+$/.test(headers['content-length'])
+      ? Number(headers['content-length'])
+      : null;
+  if (Buffer.isBuffer(body)) {
+    headers['content-length'] = String(body.byteLength);
+    delete headers['transfer-encoding'];
+  } else if (body && declaredLength !== null) {
+    delete headers['transfer-encoding'];
+  } else if (body) {
+    delete headers['content-length'];
+    headers['transfer-encoding'] = 'chunked';
+  }
+  requestOptions.headers = headers;
+
+  return await new Promise<RelayUpstreamResponse>((resolve, reject) => {
+    let settled = false;
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(headersTimer);
+      request.destroy();
+      reject(error);
+    };
+
+    const request = httpsRequest(requestOptions);
+
+    // HEADERS deadline. Armed only once the REQUEST BODY IS FULLY WRITTEN, and
+    // cleared the instant the response line arrives.
+    //
+    // Armed at request creation instead — as it was — this is a TOTAL-DURATION
+    // timeout on the upload leg, which is exactly the shape this file's own doc
+    // block says it avoids: an upstream does not answer until it has the body,
+    // so a 200 MB PUT over a 30 Mbit sandbox link died at 30 s with
+    // `504 upstream_timeout` while bytes were flowing the whole time. It also
+    // made `KORTIX_RELAY_MAX_REQUEST_BYTES` (1 GiB) unreachable on any link
+    // slower than ~286 Mbit/s — the real cap was "whatever uploads in 30 s".
+    // `'finish'` fires on bun 1.3.14 for all three body kinds (null, Buffer,
+    // stream); verified.
+    let headersTimer: ReturnType<typeof setTimeout> | undefined;
+    request.on('finish', () => {
+      if (settled) return;
+      headersTimer = setTimeout(() => {
+        fail(new SecretBrokerError('upstream_timeout', 'upstream request timed out', 504));
+      }, Math.max(1, headersTimeoutMs));
+    });
+
+    request.setTimeout(Math.max(1, options.connectTimeoutMs ?? RELAY_CONNECT_TIMEOUT_MS), () => {
+      // `setTimeout` on a `ClientRequest` is a SOCKET-inactivity timer, so it
+      // is disarmed once the response starts — otherwise it would be a second,
+      // hidden total-duration timeout on the stream.
+      if (settled) return;
+      fail(new SecretBrokerError('upstream_timeout', 'upstream request timed out', 504));
+    });
+
+    request.on('error', (error) => {
+      fail(
+        error instanceof SecretBrokerError
+          ? error
+          : new SecretBrokerError('upstream_failed', 'upstream request failed', 502),
+      );
+    });
+
+    const onAbort = () => {
+      // The relay's client went away. Tear the upstream down rather than
+      // leaving a socket draining bytes nobody will read.
+      request.destroy();
+    };
+    options.signal?.addEventListener('abort', onAbort, { once: true });
+
+    request.on('response', (response: IncomingMessage) => {
+      if (settled) {
+        response.destroy();
+        return;
+      }
+      settled = true;
+      clearTimeout(headersTimer);
+      // Disarm the connect/inactivity timer: from here on, IDLE is the only
+      // time-based control, and it is armed on the response socket below.
+      request.setTimeout(0);
+
+      const out = new PassThrough();
+      let responseBytes = 0;
+      let idleTimer: ReturnType<typeof setTimeout> | undefined;
+      const clearIdle = () => {
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = undefined;
+      };
+      const armIdle = () => {
+        if (idleTimeoutMs <= 0) return;
+        clearIdle();
+        idleTimer = setTimeout(() => {
+          response.destroy();
+          out.destroy(
+            new SecretBrokerError('upstream_timeout', 'upstream stream went idle', 504),
+          );
+        }, idleTimeoutMs);
+      };
+      armIdle();
+
+      response.on('data', (chunk: Buffer) => {
+        armIdle();
+        responseBytes += chunk.byteLength;
+        if (maxResponseBytes > 0 && responseBytes > maxResponseBytes) {
+          clearIdle();
+          response.destroy();
+          out.destroy(
+            new SecretBrokerError(
+              'relay_response_too_large',
+              `upstream response exceeds ${maxResponseBytes} bytes`,
+              502,
+            ),
+          );
+          return;
+        }
+        // Respect the consumer: a false return means the reader is behind, so
+        // stop pulling from the socket until it drains. This is the ONLY real
+        // backpressure in the pipeline.
+        if (!out.write(chunk)) {
+          response.pause();
+          out.once('drain', () => response.resume());
+        }
+      });
+      response.on('end', () => {
+        clearIdle();
+        out.end();
+      });
+      response.on('error', (error) => {
+        clearIdle();
+        out.destroy(
+          error instanceof SecretBrokerError
+            ? error
+            : new SecretBrokerError('upstream_stream_failed', 'upstream stream failed', 502),
+        );
+      });
+      out.on('close', () => {
+        clearIdle();
+        options.signal?.removeEventListener('abort', onAbort);
+        if (!response.readableEnded) response.destroy();
+      });
+
+      const rawHeaders: Array<[string, string]> = [];
+      for (let i = 0; i + 1 < response.rawHeaders.length; i += 2) {
+        rawHeaders.push([response.rawHeaders[i]!.toLowerCase(), response.rawHeaders[i + 1]!]);
+      }
+
+      resolve({
+        status: response.statusCode ?? 502,
+        rawHeaders,
+        body: out,
+        destroy: () => {
+          response.destroy();
+          request.destroy();
+        },
+      });
+    });
+
+    // ── Write the request body, with REAL backpressure ────────────────────
+    if (Buffer.isBuffer(body)) {
+      if (maxRequestBytes > 0 && body.byteLength > maxRequestBytes) {
+        fail(
+          new SecretBrokerError(
+            'relay_request_too_large',
+            `request body exceeds ${maxRequestBytes} bytes`,
+            413,
+          ),
+        );
+        return;
+      }
+      request.write(body);
+      request.end();
+      return;
+    }
+    if (!body) {
+      request.end();
+      return;
+    }
+
+    void (async () => {
+      let requestBytes = 0;
+      try {
+        for await (const chunk of body) {
+          if (settled && request.destroyed) return;
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+          requestBytes += buffer.byteLength;
+          // A caller-declared `content-length` is a promise this leg keeps.
+          // Overrunning it would desynchronise the upstream's framing.
+          if (declaredLength !== null && requestBytes > declaredLength) {
+            fail(
+              new SecretBrokerError(
+                'relay_request_too_large',
+                `request body exceeds its declared length of ${declaredLength} bytes`,
+                413,
+              ),
+            );
+            return;
+          }
+          if (maxRequestBytes > 0 && requestBytes > maxRequestBytes) {
+            fail(
+              new SecretBrokerError(
+                'relay_request_too_large',
+                `request body exceeds ${maxRequestBytes} bytes`,
+                413,
+              ),
+            );
+            return;
+          }
+          // `write()` returning false means the kernel buffer is full. Awaiting
+          // 'drain' is what stops a fast guest from being buffered in this
+          // process — the difference between a proxy and a memory sink.
+          if (!request.write(buffer)) {
+            await new Promise<void>((drained, failed) => {
+              request.once('drain', drained);
+              request.once('error', failed);
+              request.once('close', () => drained());
+            });
+          }
+        }
+        if (declaredLength !== null && requestBytes !== declaredLength) {
+          fail(
+            new SecretBrokerError(
+              'invalid_request',
+              `request body is ${requestBytes} bytes but declared ${declaredLength}`,
+              400,
+            ),
+          );
+          return;
+        }
+        request.end();
+      } catch (error) {
+        fail(
+          error instanceof SecretBrokerError
+            ? error
+            : new SecretBrokerError('upstream_failed', 'request body stream failed', 502),
+        );
+      }
+    })();
+  });
+}

--- a/apps/api/src/secrets/stream-substitute.test.ts
+++ b/apps/api/src/secrets/stream-substitute.test.ts
@@ -97,8 +97,91 @@ describe('StreamSubstituter replaces across chunk boundaries', () => {
     }
     emitted += substituter.flush().byteLength;
     expect(emitted).toBe(big.byteLength);
-    // Bounded by the longest needle — never by the body.
-    expect((substituter as unknown as { window: number }).window).toBe(HANDLE.length);
+    // Bounded by the longest needle — never by the body. Asserted on the REAL
+    // retained buffer rather than a declared window: retention is now decided
+    // per chunk by `cutoffFor`, and the bound it guarantees is strictly tighter
+    // (`longest - 1`, because only a PROPER prefix is ever held back).
+    expect((substituter as unknown as { pending: Buffer }).pending.byteLength).toBeLessThan(
+      Math.max(...pairs.map((p) => p.needle.byteLength)),
+    );
+  });
+});
+
+describe('promptness: bytes that cannot become a needle are emitted IMMEDIATELY', () => {
+  // The regression this whole streaming relay exists to prevent. Blind
+  // `longestNeedle` retention withheld the tail of EVERY chunk until the next
+  // one arrived — measured at 1503 ms of added latency per 29-byte SSE event
+  // for a 53-byte API key, and a whole-stream collapse for a PEM. On a
+  // long-lived SSE stream the final event was withheld until the connection
+  // closed, i.e. indefinitely. A relay that streams bytes but not EVENTS passes
+  // a throughput test and fails every real user.
+  const pairs = [pair(HANDLE, VALUE, 'PRIMARY')];
+
+  test('a complete SSE event is forwarded whole, nothing withheld', () => {
+    const substituter = new StreamSubstituter(pairs);
+    const event = Buffer.from('data: {"delta":"tok"}\n\n');
+    expect(substituter.push(event).byteLength).toBe(event.byteLength);
+    expect((substituter as unknown as { pending: Buffer }).pending.byteLength).toBe(0);
+  });
+
+  test('five events arrive as five emissions, not one', () => {
+    const substituter = new StreamSubstituter(pairs);
+    const emissions: number[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      emissions.push(substituter.push(Buffer.from(`data: {"i":${i}}\n\n`)).byteLength);
+    }
+    expect(emissions.every((n) => n > 0)).toBe(true);
+    // And the last one needed no flush() to escape.
+    expect(substituter.flush().byteLength).toBe(0);
+  });
+
+  test('a 2208-byte PEM needle still does not withhold ordinary bytes', () => {
+    // The pathological profile: window 2208 collapsed all five events into one
+    // emission at end-of-stream. Needle length must not gate promptness.
+    const pem = `-----BEGIN RSA PRIVATE KEY-----\n${'MIIEow'.repeat(300)}\n-----END RSA PRIVATE KEY-----`;
+    const substituter = new StreamSubstituter([pair(pem, '[REDACTED]', 'PEM')]);
+    const event = Buffer.from('data: {"delta":"tok"}\n\n');
+    expect(substituter.push(event).byteLength).toBe(event.byteLength);
+  });
+});
+
+describe('retention still happens exactly when it matters', () => {
+  const pairs = [pair(HANDLE, VALUE, 'PRIMARY')];
+
+  test('a chunk ending in a needle PREFIX emits less than it was given', () => {
+    // The adversarial counterpart of the promptness tests, and the leak a naive
+    // "just flush everything" fix causes: emitting these bytes now ships the
+    // first 11 bytes of the handle to the upstream un-substituted, and the
+    // remainder arrives next and no longer matches.
+    const substituter = new StreamSubstituter(pairs);
+    const chunk = Buffer.from(`noise${HANDLE.slice(0, 11)}`);
+    const emitted = substituter.push(chunk);
+    expect(emitted.byteLength).toBeLessThan(chunk.byteLength);
+    expect(emitted.toString()).toBe('noise');
+    // Feeding the rest completes the match — no split secret reaches the wire.
+    const rest = Buffer.concat([substituter.push(Buffer.from(HANDLE.slice(11))), substituter.flush()]);
+    expect(Buffer.concat([emitted, rest]).toString()).toBe(`noise${VALUE}`);
+  });
+
+  test('retention never exceeds the longest needle minus one', () => {
+    // The memory bound that removes the size caps, asserted against the worst
+    // case: a chunk that IS a maximal proper prefix.
+    const substituter = new StreamSubstituter(pairs);
+    substituter.push(Buffer.from(HANDLE.slice(0, HANDLE.length - 1)));
+    expect((substituter as unknown as { pending: Buffer }).pending.byteLength).toBe(HANDLE.length - 1);
+  });
+
+  test('dispose() zero-fills the needle and replacement bytes', () => {
+    // A long-lived SSE/WS relay holds decrypted secret values for the life of
+    // the connection, not milliseconds. Zeroing on teardown bounds that window.
+    const needle = Buffer.from(HANDLE);
+    const replacement = Buffer.from(VALUE);
+    const substituter = new StreamSubstituter([{ needle, replacement, label: 'PRIMARY' }]);
+    substituter.push(Buffer.from('x'));
+    substituter.flush();
+    substituter.dispose();
+    expect(needle.every((byte) => byte === 0)).toBe(true);
+    expect(replacement.every((byte) => byte === 0)).toBe(true);
   });
 });
 

--- a/apps/api/src/secrets/stream-substitute.test.ts
+++ b/apps/api/src/secrets/stream-substitute.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from 'bun:test';
+import { StreamSubstituter, substituteWholeBuffer, type StreamReplacement } from './stream-substitute';
+
+const HANDLE = 'kortix_brokered__use_kortix_fetch__KXS1abcdefghijklmnopqrstuvwxyz234567ab';
+const VALUE = 'sk_live_the_real_value';
+
+function pair(needle: string, replacement: string, label?: string): StreamReplacement {
+  return { needle: Buffer.from(needle), replacement: Buffer.from(replacement), ...(label ? { label } : {}) };
+}
+
+/** Feed `input` through the substituter in fixed-size chunks. */
+function stream(input: string | Buffer, pairs: StreamReplacement[], chunkSize: number): string {
+  const source = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  const substituter = new StreamSubstituter(pairs);
+  const out: Buffer[] = [];
+  for (let i = 0; i < source.byteLength; i += chunkSize) {
+    out.push(substituter.push(source.subarray(i, i + chunkSize)));
+  }
+  out.push(substituter.flush());
+  return Buffer.concat(out).toString('utf8');
+}
+
+describe('StreamSubstituter replaces across chunk boundaries', () => {
+  const pairs = [pair(HANDLE, VALUE, 'PRIMARY')];
+
+  test('replaces a needle contained in one chunk', () => {
+    expect(stream(`Bearer ${HANDLE}`, pairs, 4096)).toBe(`Bearer ${VALUE}`);
+  });
+
+  test('replaces a needle SPLIT across two chunks — the whole reason this exists', () => {
+    // The exact failure a naive per-chunk replace has: the handle straddles the
+    // boundary, so neither chunk contains it and the upstream gets the handle.
+    const body = `Authorization: Bearer ${HANDLE}\r\n\r\n`;
+    const split = 30; // lands inside the handle
+    expect(split).toBeLessThan(body.indexOf(HANDLE) + HANDLE.length);
+    expect(stream(body, pairs, split)).toBe(`Authorization: Bearer ${VALUE}\r\n\r\n`);
+  });
+
+  test('replaces a needle delivered ONE BYTE AT A TIME', () => {
+    expect(stream(`x${HANDLE}y`, pairs, 1)).toBe(`x${VALUE}y`);
+  });
+
+  test('is correct for EVERY chunk size over the same input', () => {
+    const body = `a${HANDLE}b${HANDLE}c`;
+    const expected = `a${VALUE}b${VALUE}c`;
+    for (let size = 1; size <= body.length + 2; size += 1) {
+      expect(stream(body, pairs, size)).toBe(expected);
+    }
+  });
+
+  test('passes through a stream with no match, unchanged', () => {
+    const body = 'no handles here, just ordinary bytes'.repeat(50);
+    for (const size of [1, 7, 4096]) expect(stream(body, pairs, size)).toBe(body);
+  });
+
+  test('emits a partial needle at end-of-stream as plain data', () => {
+    // Nothing can complete it, so it is data, not a handle.
+    const truncated = HANDLE.slice(0, 20);
+    expect(stream(`tail:${truncated}`, pairs, 3)).toBe(`tail:${truncated}`);
+  });
+
+  test('reports which labels actually matched', () => {
+    const substituter = new StreamSubstituter([pair(HANDLE, VALUE, 'PRIMARY'), pair('other', 'x', 'SECOND')]);
+    substituter.push(Buffer.from(`${HANDLE} and more`));
+    substituter.flush();
+    expect(substituter.applied).toEqual(['PRIMARY']);
+  });
+
+  test('never re-scans replacement bytes', () => {
+    // The replacement itself contains the needle. A second pass would rewrite it
+    // again and again; the consumed-cursor invariant forbids that.
+    const substituter = new StreamSubstituter([pair('AA', 'AAA')]);
+    const out = Buffer.concat([substituter.push(Buffer.from('AA')), substituter.flush()]).toString();
+    expect(out).toBe('AAA');
+  });
+
+  test('a needle that is a prefix of another does not shadow it', () => {
+    const pairs2 = [pair('abc', 'SHORT'), pair('abcdef', 'LONG')];
+    expect(stream('abcdef', pairs2, 1)).toBe('LONG');
+  });
+
+  test('with no pairs it is a zero-copy pass-through', () => {
+    const substituter = new StreamSubstituter([]);
+    expect(substituter.isPassThrough).toBe(true);
+    const chunk = Buffer.from('anything at all');
+    expect(substituter.push(chunk)).toBe(chunk); // same object, no copy
+  });
+
+  test('memory is bounded by the needle, not the body', () => {
+    // The property that removes the size caps: a 5 MiB body with no match must
+    // never retain more than (needleLength - 1) bytes.
+    const substituter = new StreamSubstituter(pairs);
+    const big = Buffer.alloc(5 * 1024 * 1024, 0x61);
+    let emitted = 0;
+    for (let i = 0; i < big.byteLength; i += 64 * 1024) {
+      emitted += substituter.push(big.subarray(i, i + 64 * 1024)).byteLength;
+    }
+    emitted += substituter.flush().byteLength;
+    expect(emitted).toBe(big.byteLength);
+    // Bounded by the longest needle — never by the body.
+    expect((substituter as unknown as { window: number }).window).toBe(HANDLE.length);
+  });
+});
+
+describe('the streaming result is byte-identical to the whole-buffer oracle', () => {
+  const pairs = [pair(HANDLE, VALUE, 'A'), pair('SECOND_NEEDLE_XyZ', 'second-value', 'B')];
+
+  test('fuzz: random bodies × random chunkings agree with the oracle', () => {
+    // "It works at my chunk size" is the bug class this file exists to prevent,
+    // so correctness is asserted against the non-streaming implementation for
+    // many shapes rather than a few hand-picked ones.
+    const alphabet = 'ab \n{}"kortix_KXS1';
+    // Deterministic PRNG: a fuzz that cannot be replayed is not a fuzz.
+    let seed = 0x2f6e2b1;
+    const rand = (n: number) => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed % n;
+    };
+    for (let round = 0; round < 300; round += 1) {
+      let body = '';
+      const length = rand(400);
+      for (let i = 0; i < length; i += 1) {
+        // Sprinkle real needles in, so matches actually happen.
+        if (rand(20) === 0) body += HANDLE;
+        else if (rand(40) === 0) body += 'SECOND_NEEDLE_XyZ';
+        else body += alphabet[rand(alphabet.length)];
+      }
+      const expected = substituteWholeBuffer(Buffer.from(body), pairs).toString('utf8');
+      const chunkSize = 1 + rand(64);
+      expect(stream(body, pairs, chunkSize)).toBe(expected);
+    }
+  });
+
+  test('binary-safe: works on bytes that are not valid UTF-8', () => {
+    const needle = Buffer.from([0x00, 0xff, 0xfe, 0x01]);
+    const replacement = Buffer.from([0x42, 0x42]);
+    const source = Buffer.concat([Buffer.from([0x10, 0x00, 0xff]), needle, Buffer.from([0x99])]);
+    const substituter = new StreamSubstituter([{ needle, replacement }]);
+    const out: Buffer[] = [];
+    for (const byte of source) out.push(substituter.push(Buffer.from([byte])));
+    out.push(substituter.flush());
+    expect(Buffer.concat(out)).toEqual(
+      Buffer.concat([Buffer.from([0x10, 0x00, 0xff]), replacement, Buffer.from([0x99])]),
+    );
+  });
+});

--- a/apps/api/src/secrets/stream-substitute.ts
+++ b/apps/api/src/secrets/stream-substitute.ts
@@ -13,19 +13,56 @@
  *     chunk 2: "ered__KXS1abc...  <rest of body>"
  *
  * A naive per-chunk replace misses that and ships the handle to the upstream.
- * The fix is to withhold, at each step, the last `maxNeedleLength - 1` bytes —
- * the longest tail that could still become a needle — and re-scan them joined to
- * the next chunk. That window is BOUNDED by the longest needle (a handle is ~60
- * bytes), so memory is O(needle), NOT O(body). That bound is the whole point:
- * it is what removes the size caps.
+ * The fix is to withhold the tail that could still become a needle — and only
+ * that tail. Retention is decided by `cutoffFor`: the LEFTMOST position whose
+ * suffix is a PROPER PREFIX of some needle. Everything before it is bytes no
+ * future input can change, so it is emitted now; everything from it is held and
+ * re-scanned joined to the next chunk. Retention is bounded by
+ * `longestNeedle - 1` — a proper prefix is by definition shorter than its needle
+ * — so memory is O(needle), NOT O(body). That bound is what removes the size
+ * caps.
  *
- * Two invariants make this safe to reason about:
+ * ## Why the cutoff is prefix-aware and not a blind window
+ *
+ * The first version of this file retained `longestNeedle` bytes UNCONDITIONALLY.
+ * That is correct but it is not PROMPT, and on a stream promptness IS the
+ * contract. Measured on a 500 ms/event SSE stream: a 53-byte API key (whose
+ * base64 representation makes a 72-byte needle) delayed every 29-byte event by
+ * 1503 ms, because each event's tail sat in the window until the NEXT event
+ * arrived. A 1652-byte PEM (2208-byte needle) collapsed five events into one
+ * emission at 2505 ms. Worse, the final window is released only by `flush()` —
+ * i.e. at connection close — so on a long-lived stream the last event is
+ * withheld indefinitely. A relay that streams bytes but not events passes every
+ * throughput test and fails every real user.
+ *
+ * Prefix-aware retention measures 0.0–0.2 ms of added latency on realistic
+ * traffic, retains 0 bytes when no needle prefix is in flight, and is FASTER
+ * than the blind window on real data (11 ms vs 17 ms per 100 MiB) because
+ * `memchr` skips non-candidates.
+ *
+ * Two rejected alternatives, both unsound, recorded so they are not re-invented:
+ *
+ *  - **A time-based idle flush** of the pending bytes is a secret-DISCLOSURE
+ *    bug. With the upstream stalled mid-secret it emits the secret's PREFIX
+ *    un-redacted; the remainder arrives next and no longer matches, so the
+ *    guest reassembles the complete raw value across two writes with no
+ *    `[REDACTED]` anywhere. Proven by direct experiment.
+ *  - **A `\n\n` delimiter flush** for SSE is unsound in general: a multi-line
+ *    secret (any PEM) contains the delimiter, and it does nothing for NDJSON,
+ *    chunked JSON, or websockets.
+ *
+ * Three invariants make this safe to reason about:
  *
  *  1. **Replacement bytes are never re-scanned.** The retained tail always
  *     starts at or after the end of the last completed replacement, so a secret
  *     value that happens to contain needle-shaped bytes cannot be rewritten a
  *     second time.
- *  2. **The output is byte-identical to the whole-buffer algorithm.** Whatever
+ *  2. **A needle that is a prefix of a longer needle cannot shadow it.** If a
+ *     longer needle also starts at the committed position but is not yet fully
+ *     visible, the suffix from that position IS a proper prefix of it, so the
+ *     cutoff sits at or before it and nothing is committed. One condition
+ *     covers both hazards — the straddle and the shadow.
+ *  3. **The output is byte-identical to the whole-buffer algorithm.** Whatever
  *     the chunking, `push(...)+flush()` concatenated equals replacing over the
  *     joined input. `stream-substitute.test.ts` fuzzes this against the
  *     non-streaming implementation, because "it works on my chunk sizes" is
@@ -44,7 +81,6 @@ export interface StreamReplacement {
 
 export class StreamSubstituter {
   private readonly pairs: StreamReplacement[];
-  private readonly window: number;
   private pending: Buffer = Buffer.alloc(0);
   private readonly hits = new Set<string>();
   private done = false;
@@ -52,13 +88,6 @@ export class StreamSubstituter {
   constructor(pairs: readonly StreamReplacement[]) {
     // A zero-length needle would match everywhere and never advance.
     this.pairs = pairs.filter((pair) => pair.needle.byteLength > 0);
-    // Retain the longest needle's worth of bytes. Not `longest - 1`: a match is
-    // only committed once EVERY needle would be fully visible from its start
-    // position, otherwise a short needle that is a PREFIX of a longer one gets
-    // committed first and shadows it (`abc` firing inside `abcdef`). Retaining
-    // `longest` makes leftmost-longest decidable at commit time. Still O(needle),
-    // not O(body) — which is what removes the size caps.
-    this.window = this.pairs.reduce((max, pair) => Math.max(max, pair.needle.byteLength), 0);
   }
 
   /** Labels whose needle matched at least once so far. */
@@ -81,19 +110,76 @@ export class StreamSubstituter {
     if (this.done) throw new Error('StreamSubstituter: push after flush');
     if (this.pairs.length === 0) return chunk;
     const work = this.pending.byteLength === 0 ? chunk : Buffer.concat([this.pending, chunk]);
-    // Only commit a match whose start position leaves room for the LONGEST
-    // needle, so every candidate is fully visible and leftmost-longest is
-    // decidable. Anything at or past this point waits for more bytes.
-    const safeStart = work.byteLength - this.window;
+    // Everything BEFORE the cutoff is decided: no future byte can extend it into
+    // a needle, and no longer needle can start there and shadow a shorter one,
+    // so leftmost-longest is already decidable there. Commit those matches;
+    // hold the rest.
+    const cutoff = this.cutoffFor(work);
     const { output, consumed } =
-      safeStart >= 0 ? this.replaceComplete(work, safeStart) : { output: Buffer.alloc(0), consumed: 0 };
+      cutoff > 0 ? this.replaceComplete(work, cutoff - 1) : { output: Buffer.alloc(0), consumed: 0 };
     // Everything after the last completed replacement is still original bytes,
-    // so it is safe to re-scan on the next chunk.
-    const keepFrom = Math.max(consumed, Math.max(0, safeStart));
+    // so it is safe to re-scan on the next chunk. `consumed` can run PAST the
+    // cutoff when a committed match spans it — that match won leftmost-longest,
+    // so its bytes are gone and the cutoff no longer applies to them.
+    const keepFrom = Math.max(consumed, cutoff);
     this.pending = work.subarray(keepFrom);
     return output.byteLength === 0 && keepFrom === consumed
       ? Buffer.alloc(0)
       : Buffer.concat([output, work.subarray(consumed, keepFrom)]);
+  }
+
+  /**
+   * The leftmost position `p` where `work[p..]` is a PROPER prefix of some
+   * needle — i.e. the first byte that might still turn out to be the start of a
+   * match — or `work.byteLength` when no such position exists (the common case,
+   * which is why ordinary traffic retains nothing).
+   *
+   * Needles shorter than 2 bytes are skipped: a 1-byte needle has no proper
+   * prefix, so it is always either a complete match or not a match at all.
+   *
+   * `indexOf(needle[0], p)` is Bun/Node's `memchr`, so non-candidate bytes are
+   * skipped at memory bandwidth instead of one comparison per position; only
+   * positions whose byte equals the needle's first byte are ever compared.
+   */
+  private cutoffFor(work: Buffer): number {
+    const length = work.byteLength;
+    let cutoff = length;
+    for (const pair of this.pairs) {
+      const needle = pair.needle;
+      if (needle.byteLength < 2) continue;
+      // A proper prefix has length 1 … needle.byteLength - 1, so no position
+      // earlier than this can produce one.
+      const start = Math.max(0, length - (needle.byteLength - 1));
+      if (start >= cutoff) continue;
+      const first = needle[0]!;
+      for (let i = work.indexOf(first, start); i !== -1 && i < cutoff; i = work.indexOf(first, i + 1)) {
+        // 5-arg order is (target, targetStart, targetEnd, sourceStart, sourceEnd):
+        // compare work[i..length] against needle[0..length - i].
+        if (work.compare(needle, 0, length - i, i, length) === 0) {
+          cutoff = i;
+          break;
+        }
+      }
+    }
+    return cutoff;
+  }
+
+  /**
+   * Zero the needle and replacement bytes.
+   *
+   * Called when a relay ends. On the buffered `/broker` path a decrypted secret
+   * lives for milliseconds; on a streaming SSE or websocket relay the same bytes
+   * sit in this object for the life of the connection — minutes to hours. That
+   * is inherent to a streaming relay (the guest still never sees the value,
+   * which is the invariant that matters), but the window after the connection
+   * closes is not, so it is closed.
+   */
+  dispose(): void {
+    for (const pair of this.pairs) {
+      pair.needle.fill(0);
+      pair.replacement.fill(0);
+    }
+    this.pending = Buffer.alloc(0);
   }
 
   /**

--- a/apps/api/src/secrets/stream-substitute.ts
+++ b/apps/api/src/secrets/stream-substitute.ts
@@ -1,0 +1,169 @@
+/**
+ * Chunk-boundary-safe find/replace over a BYTE STREAM.
+ *
+ * This is the kernel that lets the relay stop being a buffered JSON-RPC and
+ * become a real egress proxy. Today `substituteBuffer` / `redactSecretFromResponse`
+ * (http-broker.ts) call `buffer.indexOf` over a COMPLETE body, which forces the
+ * whole request and the whole response to be held in memory — that is where the
+ * 1 MiB / 5 MiB caps come from, and why nothing can stream.
+ *
+ * The problem a stream adds is that a needle can straddle a chunk boundary:
+ *
+ *     chunk 1: "...Authorization: Bearer kortix_brok"
+ *     chunk 2: "ered__KXS1abc...  <rest of body>"
+ *
+ * A naive per-chunk replace misses that and ships the handle to the upstream.
+ * The fix is to withhold, at each step, the last `maxNeedleLength - 1` bytes —
+ * the longest tail that could still become a needle — and re-scan them joined to
+ * the next chunk. That window is BOUNDED by the longest needle (a handle is ~60
+ * bytes), so memory is O(needle), NOT O(body). That bound is the whole point:
+ * it is what removes the size caps.
+ *
+ * Two invariants make this safe to reason about:
+ *
+ *  1. **Replacement bytes are never re-scanned.** The retained tail always
+ *     starts at or after the end of the last completed replacement, so a secret
+ *     value that happens to contain needle-shaped bytes cannot be rewritten a
+ *     second time.
+ *  2. **The output is byte-identical to the whole-buffer algorithm.** Whatever
+ *     the chunking, `push(...)+flush()` concatenated equals replacing over the
+ *     joined input. `stream-substitute.test.ts` fuzzes this against the
+ *     non-streaming implementation, because "it works on my chunk sizes" is
+ *     exactly the bug class this file exists to prevent.
+ */
+
+export interface StreamReplacement {
+  /** The bytes to find — a handle (request side) or a secret value (response
+   *  side, where the replacement is `[REDACTED]`). */
+  needle: Buffer;
+  replacement: Buffer;
+  /** Reported through `applied` when this pair matches at least once, so the
+   *  caller can audit WHICH secrets rode out on the wire. */
+  label?: string;
+}
+
+export class StreamSubstituter {
+  private readonly pairs: StreamReplacement[];
+  private readonly window: number;
+  private pending: Buffer = Buffer.alloc(0);
+  private readonly hits = new Set<string>();
+  private done = false;
+
+  constructor(pairs: readonly StreamReplacement[]) {
+    // A zero-length needle would match everywhere and never advance.
+    this.pairs = pairs.filter((pair) => pair.needle.byteLength > 0);
+    // Retain the longest needle's worth of bytes. Not `longest - 1`: a match is
+    // only committed once EVERY needle would be fully visible from its start
+    // position, otherwise a short needle that is a PREFIX of a longer one gets
+    // committed first and shadows it (`abc` firing inside `abcdef`). Retaining
+    // `longest` makes leftmost-longest decidable at commit time. Still O(needle),
+    // not O(body) — which is what removes the size caps.
+    this.window = this.pairs.reduce((max, pair) => Math.max(max, pair.needle.byteLength), 0);
+  }
+
+  /** Labels whose needle matched at least once so far. */
+  get applied(): string[] {
+    return [...this.hits];
+  }
+
+  /** True when nothing can ever match, so the caller may skip this stage
+   *  entirely and pipe the socket straight through. */
+  get isPassThrough(): boolean {
+    return this.pairs.length === 0;
+  }
+
+  /**
+   * Feed one chunk. Returns the bytes that are safe to forward NOW — which is
+   * everything except a bounded tail that might still turn out to be the start
+   * of a needle.
+   */
+  push(chunk: Buffer): Buffer {
+    if (this.done) throw new Error('StreamSubstituter: push after flush');
+    if (this.pairs.length === 0) return chunk;
+    const work = this.pending.byteLength === 0 ? chunk : Buffer.concat([this.pending, chunk]);
+    // Only commit a match whose start position leaves room for the LONGEST
+    // needle, so every candidate is fully visible and leftmost-longest is
+    // decidable. Anything at or past this point waits for more bytes.
+    const safeStart = work.byteLength - this.window;
+    const { output, consumed } =
+      safeStart >= 0 ? this.replaceComplete(work, safeStart) : { output: Buffer.alloc(0), consumed: 0 };
+    // Everything after the last completed replacement is still original bytes,
+    // so it is safe to re-scan on the next chunk.
+    const keepFrom = Math.max(consumed, Math.max(0, safeStart));
+    this.pending = work.subarray(keepFrom);
+    return output.byteLength === 0 && keepFrom === consumed
+      ? Buffer.alloc(0)
+      : Buffer.concat([output, work.subarray(consumed, keepFrom)]);
+  }
+
+  /**
+   * No more input. Returns the retained tail — at this point a partial needle is
+   * just data, because nothing can complete it.
+   */
+  flush(): Buffer {
+    if (this.done) return Buffer.alloc(0);
+    this.done = true;
+    if (this.pairs.length === 0 || this.pending.byteLength === 0) {
+      const tail = this.pending;
+      this.pending = Buffer.alloc(0);
+      return tail;
+    }
+    // The tail can still contain a COMPLETE needle when the stream ended
+    // mid-window, so it gets one final pass with NO commit limit — nothing more
+    // is coming, so every match that exists is fully visible.
+    const { output, consumed } = this.replaceComplete(this.pending, this.pending.byteLength);
+    const rest = this.pending.subarray(consumed);
+    this.pending = Buffer.alloc(0);
+    return Buffer.concat([output, rest]);
+  }
+
+  /**
+   * Replace every COMPLETE match starting at or before `maxStart`, leftmost-first.
+   *
+   * Returns the rewritten prefix and how far into `work` it consumed. Bytes
+   * after `consumed` are untouched originals — never replacement output — which
+   * is what makes retaining them for the next chunk safe.
+   */
+  private replaceComplete(work: Buffer, maxStart: number): { output: Buffer; consumed: number } {
+    const chunks: Buffer[] = [];
+    let cursor = 0;
+    for (;;) {
+      let bestIndex = -1;
+      let bestPair: StreamReplacement | null = null;
+      for (const pair of this.pairs) {
+        const index = work.indexOf(pair.needle, cursor);
+        if (index === -1 || index > maxStart) continue;
+        // Leftmost wins; on a tie the longer needle wins so a needle that is a
+        // prefix of another cannot shadow it.
+        if (
+          bestIndex === -1 ||
+          index < bestIndex ||
+          (index === bestIndex && pair.needle.byteLength > (bestPair?.needle.byteLength ?? 0))
+        ) {
+          bestIndex = index;
+          bestPair = pair;
+        }
+      }
+      if (bestIndex === -1 || !bestPair) break;
+      chunks.push(work.subarray(cursor, bestIndex), bestPair.replacement);
+      if (bestPair.label) this.hits.add(bestPair.label);
+      cursor = bestIndex + bestPair.needle.byteLength;
+    }
+    return { output: chunks.length > 0 ? Buffer.concat(chunks) : Buffer.alloc(0), consumed: cursor };
+  }
+}
+
+/**
+ * The whole-buffer equivalent, kept here as the ORACLE the streaming path is
+ * fuzzed against. Callers with a complete buffer should keep using
+ * `http-broker.ts`'s own helpers; this exists so the test can assert the two
+ * agree for every chunking.
+ */
+export function substituteWholeBuffer(
+  source: Buffer,
+  pairs: readonly StreamReplacement[],
+): Buffer {
+  const substituter = new StreamSubstituter(pairs);
+  const head = substituter.push(source);
+  return Buffer.concat([head, substituter.flush()]);
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,21 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["@types/bun"]
+    "types": ["@types/bun"],
+    // `provider-shim-env.test.ts` imports the daemon's egress-shim by relative
+    // path, which pulls the whole daemon tree — including `relay-client.ts` —
+    // into THIS program. That file imports `@kortix/api-contract/secret-relay`,
+    // and resolving it from the daemon's directory depends on where the package
+    // manager happened to put the workspace symlink: a full local install has it
+    // at the repo root, but CI runs `pnpm install --filter "kortix-api..."`,
+    // which never installs the daemon, so nothing resolves by walking up from
+    // `apps/kortix-sandbox-agent-server/` and the typecheck fails there and only
+    // there. A path mapping resolves it from the source tree instead, so this
+    // program no longer cares about the node_modules layout. Mirrors the daemon's
+    // own tsconfig, which maps the same specifier for the same reason.
+    "paths": {
+      "@kortix/api-contract/*": ["../../packages/api-contract/src/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/kortix-sandbox-agent-server/package.json
+++ b/apps/kortix-sandbox-agent-server/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "hono": "^4.12.25",
-    "zod": "^3.23.8",
-    "node-forge": "^1.4.0"
+    "node-forge": "^1.4.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.test.ts
@@ -53,3 +53,132 @@ describe('shim/broker blocked-header agreement', () => {
     }
   })
 })
+
+/**
+ * The same tripwire, extended over the STREAMING relay's control headers.
+ *
+ * The list above is a hand copy with a disk-reading test behind it, because a
+ * copy already drifted and broke production. A base64/JSON codec is far riskier
+ * to duplicate than ten strings, so the relay contract is NOT copied at all:
+ * both sides import `@kortix/api-contract/secret-relay`. These tests assert
+ * that structural fact rather than comparing two copies — if anybody
+ * hand-inlines a header name on either side, this fails.
+ */
+describe('shim/API relay-contract agreement', () => {
+  test('the shim reads the relay header names from the SHARED module', () => {
+    const client = readFileSync(join(import.meta.dir, 'relay-client.ts'), 'utf8')
+    expect(client).toContain("from '@kortix/api-contract/secret-relay'")
+    // No hand-inlined copies of the wire strings anywhere in the client.
+    for (const literal of [
+      "'x-kortix-relay'",
+      "'x-kortix-relay-meta'",
+      "'x-kortix-relay-status'",
+      "'x-kortix-relay-error'",
+      "'x-kortix-relay-probe'",
+    ]) {
+      expect(client).not.toContain(literal)
+    }
+  })
+
+  test('the API route reads them from the SAME shared module', () => {
+    const route = readFileSync(
+      join(import.meta.dir, '../../../api/src/projects/routes/secret-relay.ts'),
+      'utf8',
+    )
+    expect(route).toContain("from '@kortix/api-contract/secret-relay'")
+    for (const literal of [
+      "'x-kortix-relay-meta'",
+      "'x-kortix-relay-status'",
+      "'x-kortix-relay-error'",
+    ]) {
+      expect(route).not.toContain(literal)
+    }
+  })
+
+  test('the shared module is dependency-free, so it fits in the sandbox binary', () => {
+    // `bun build --compile` must pull THIS module and not `index.ts`, not zod,
+    // not anything node-only. A stray import here would drag the whole contract
+    // package into the guest binary.
+    const codec = readFileSync(
+      join(import.meta.dir, '../../../../packages/api-contract/src/secret-relay.ts'),
+      'utf8',
+    )
+    const imports = [...codec.matchAll(/^\s*import .*/gm)].map((m) => m[0])
+    expect(imports).toEqual([])
+  })
+
+  test('the codec constants actually resolve from inside the daemon', async () => {
+    const codec = await import('@kortix/api-contract/secret-relay')
+    expect(codec.RELAY_META_HEADER).toBe('x-kortix-relay-meta')
+    expect(codec.RELAY_STATUS_HEADER).toBe('x-kortix-relay-status')
+    expect(codec.RELAY_ERROR_HEADER).toBe('x-kortix-relay-error')
+    expect(codec.RELAY_PROBE_HEADER).toBe('x-kortix-relay-probe')
+    expect(codec.RELAY_VERSION_HEADER).toBe('x-kortix-relay')
+  })
+})
+
+/**
+ * The daemon builds STANDALONE. That is not an accident and it is not free.
+ *
+ * `apps/sandbox/Dockerfile` copies ONLY this app's `package.json` + `bun.lock`
+ * into the builder stage and runs `bun install --frozen-lockfile`;
+ * `.github/workflows/ci.yml` runs the same command with this directory as its
+ * working directory. Neither has a workspace root. So a `"workspace:*"`
+ * dependency here does not merely go unresolved — it fails the install:
+ *
+ *   error: Workspace dependency "@kortix/api-contract" not found
+ *   Searched in "./*"
+ *   error: @kortix/api-contract@workspace:* failed to resolve
+ *
+ * which reds the `sandbox-agent-build` job AND makes it impossible to build any
+ * sandbox image at all, for this change or any unrelated one. It happened. The
+ * shared relay contract is reached through a tsconfig `paths` mapping instead,
+ * and the Dockerfile mirrors the repo layout so that mapping resolves.
+ */
+describe('the daemon still builds standalone', () => {
+  const appDir = join(import.meta.dir, '../..')
+
+  test('package.json declares NO workspace: dependency', () => {
+    const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    const all = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) }
+    const workspaceDeps = Object.entries(all).filter(([, range]) => range.startsWith('workspace:'))
+    expect(workspaceDeps).toEqual([])
+  })
+
+  test('bun.lock lists exactly the dependencies package.json declares', () => {
+    // `--frozen-lockfile` fails on ANY divergence, so a package.json edit that
+    // forgets the lock is the same outage in a different shape.
+    const pkg = JSON.parse(readFileSync(join(appDir, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+      devDependencies?: Record<string, string>
+    }
+    const lock = readFileSync(join(appDir, 'bun.lock'), 'utf8')
+    const root = lock.match(/"workspaces":\s*\{\s*"":\s*\{([\s\S]*?)\n {4}\},/)?.[1] ?? ''
+    for (const name of Object.keys({ ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) })) {
+      expect(root).toContain(`"${name}"`)
+    }
+  })
+
+  test('the shared contract is reached through a tsconfig path mapping', () => {
+    const tsconfig = readFileSync(join(appDir, 'tsconfig.json'), 'utf8')
+    expect(tsconfig).toContain('"@kortix/api-contract/*"')
+    expect(tsconfig).toContain('../../packages/api-contract/src/*')
+  })
+
+  test('the sandbox Dockerfile copies the package that mapping points at', () => {
+    const dockerfile = readFileSync(join(appDir, '../sandbox/Dockerfile'), 'utf8')
+    const builder = dockerfile.slice(
+      dockerfile.indexOf('AS builder'),
+      dockerfile.indexOf('AS cli-builder'),
+    )
+    expect(builder).toContain('COPY packages/api-contract /repo/packages/api-contract')
+    expect(builder).toContain('WORKDIR /repo/apps/kortix-sandbox-agent-server')
+    // …and the runtime stage must copy the binary from where it now lands.
+    expect(dockerfile).toContain(
+      'COPY --from=builder /repo/apps/kortix-sandbox-agent-server/dist/kortix-agent',
+    )
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/blocked-headers.ts
@@ -1,0 +1,35 @@
+/**
+ * FRAMING / hop-by-hop headers Kortix REJECTS with a 400
+ * (apps/api/src/secrets/http-broker.ts BLOCKED_REQUEST_HEADERS). The shim drops
+ * them before relaying so an ordinary request does not turn into
+ * `400 request header is managed by Kortix: <name>`.
+ *
+ * `authorization` and `cookie` are DELIBERATELY NOT dropped. They are the
+ * credential-carrying headers, and the whole point of this mode is that the
+ * agent puts a HANDLE where it would put the real credential — `curl -H
+ * 'Authorization: Bearer <handle>'`. Dropping them here stripped the handle
+ * before Kortix could substitute it, so a Bearer/token/cookie request left
+ * carrying nothing and the upstream answered 401. They are forwarded; Kortix
+ * swaps the handle for the real value server-side.
+ *
+ * Kept as a literal copy rather than an import: this binary must not drag
+ * apps/api's http-broker (and its DB and config dependencies) into the sandbox.
+ * `blocked-headers.test.ts` reads the broker's real list off disk and asserts
+ * the two still agree — that tripwire exists because this copy already drifted
+ * once and broke every deployed daemon (the accept-encoding incident).
+ *
+ * It lives in its OWN module so both `shim.ts` and `relay-client.ts` can read it
+ * without importing each other.
+ */
+export const BLOCKED_REQUEST_HEADERS = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+])

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/relay-client.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/relay-client.ts
@@ -1,0 +1,427 @@
+/**
+ * The shim's STREAMING transport to Kortix.
+ *
+ * The buffered path (`relayBuffered`, in shim.ts) base64s the whole request
+ * into a JSON envelope and buffers the whole response back. That is where the
+ * 1 MiB / 5 MiB caps come from, and why SSE and websockets are impossible. This
+ * module is the replacement: the guest's body bytes go up the wire verbatim as
+ * `application/octet-stream`, everything else rides in `x-kortix-relay-meta`,
+ * and the response body streams back.
+ *
+ * The credential situation is UNCHANGED and is the whole point: this file, like
+ * the rest of the shim, holds no secret value. It ships a handle; Kortix swaps
+ * it server-side and redacts the echo on the way back.
+ *
+ * ## Why `fetch` here, when the API's upstream leg deliberately does not
+ *
+ * There is nothing to IP-pin on this hop — the destination is Kortix itself, a
+ * name the daemon was configured with. Bun's `fetch` sends a `ReadableStream`
+ * body incrementally with chunked encoding and no content-length (verified:
+ * sender-to-receiver chunk alignment exact), and it is effectively full-duplex
+ * despite the name, so response bytes flow while request bytes are still going
+ * out — which is exactly what makes SSE-over-POST work.
+ *
+ * `duplex: 'half'` is REQUIRED by Node and ignored by Bun. It is always sent:
+ * free portability, and the daemon's tests may run under either.
+ *
+ * ## Why the capability probe runs at construction and not per request
+ *
+ * A streamed body that has already been consumed cannot be replayed onto a
+ * fallback. If the transport choice were made per request, a `/relay` that
+ * turned out to be missing would leave the request unrecoverable. So the shim
+ * asks ONCE, off the request path, and remembers for its process lifetime.
+ * `syncEgressShim` tears the shim down and rebuilds it on a live capability
+ * push, so a re-probe happens naturally there.
+ */
+import { Buffer } from 'node:buffer'
+import zlib from 'node:zlib'
+
+import {
+  decodeRelayStatus,
+  encodeRelayMeta,
+  RELAY_ERROR_HEADER,
+  RELAY_META_HEADER,
+  RELAY_PROBE_HEADER,
+  RELAY_STATUS_HEADER,
+  RELAY_VERSION,
+  RELAY_VERSION_HEADER,
+  type RelayMethod,
+  type SecretRelayMeta,
+} from '@kortix/api-contract/secret-relay'
+
+import { BLOCKED_REQUEST_HEADERS } from './blocked-headers'
+import type { ShimBrokerRule } from './rules'
+
+/** Everything the relay client needs from the shim's options. */
+export interface RelayClientOptions {
+  readonly apiUrl: string
+  readonly projectId: string
+  readonly token: string
+  readonly brokerFetch?: typeof fetch
+}
+
+/** How long the one-shot capability probe may take before we assume legacy. */
+const PROBE_TIMEOUT_MS = 5_000
+
+/**
+ * Stream decompressors for the REQUEST leg.
+ *
+ * `deflate` is deliberately absent. It names two wire formats and clients
+ * disagree about which they send, so the buffered decoder tries zlib and falls
+ * back to raw — a retry that cannot be done on a stream, because the first
+ * bytes are already gone by the time the failure shows. Those requests take the
+ * buffered path and keep today's 1 MiB bomb guard. Named in the error, not
+ * silently degraded.
+ */
+const STREAM_DECODERS: Record<string, () => zlib.Gunzip | zlib.BrotliDecompress> = {
+  gzip: () => zlib.createGunzip(),
+  'x-gzip': () => zlib.createGunzip(),
+  br: () => zlib.createBrotliDecompress(),
+}
+
+export function canStreamDecode(contentEncoding: string): boolean {
+  const steps = contentEncoding
+    .split(',')
+    .map((step) => step.trim().toLowerCase())
+    .filter((step) => step.length > 0 && step !== 'identity')
+  return steps.length > 0 && steps.every((step) => step in STREAM_DECODERS)
+}
+
+function relayUrl(options: RelayClientOptions, identifier: string): string {
+  return (
+    `${options.apiUrl.replace(/\/$/, '')}/projects/${options.projectId}` +
+    `/secrets/${encodeURIComponent(identifier)}/relay`
+  )
+}
+
+/**
+ * Ask Kortix once whether it speaks the streaming relay.
+ *
+ * Anything other than a 204 carrying the protocol header — a 404 from an older
+ * self-hosted API, a 503 `relay_disabled` from the kill switch, a timeout —
+ * means legacy `/broker` for this process's whole life. That is a deliberate
+ * fail-CLOSED-to-the-old-path: the buffered route always works.
+ */
+export async function probeRelay(
+  options: RelayClientOptions,
+  identifier: string,
+): Promise<boolean> {
+  const call = options.brokerFetch ?? fetch
+  try {
+    const response = await call(relayUrl(options, identifier), {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${options.token}`,
+        [RELAY_PROBE_HEADER]: '1',
+        [RELAY_VERSION_HEADER]: String(RELAY_VERSION),
+      },
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+    // Drain, so the connection can be reused rather than left half-read.
+    await response.arrayBuffer().catch(() => undefined)
+    return response.status === 204 && response.headers.get(RELAY_VERSION_HEADER) === '1'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Build the meta header from the guest's request.
+ *
+ * Header ORDER and DUPLICATES are preserved here because this is the last point
+ * at which they still exist: Bun's parser has already collapsed duplicate
+ * non-known headers at the guest edge (no worse than the buffered path, which
+ * dropped every multi-value header outright), and putting the list in the body
+ * of a JSON envelope is what the streaming contract removes. Shipping them as
+ * one opaque field stops a SECOND collapse on the shim → API hop.
+ */
+export function buildRelayMeta(input: {
+  url: string
+  method: string
+  headers: Iterable<[string, string]>
+  bodyLength: number | null
+  hasBody: boolean
+}): SecretRelayMeta {
+  const headers: Array<[string, string]> = []
+  for (const [rawName, value] of input.headers) {
+    const name = rawName.toLowerCase()
+    if (BLOCKED_REQUEST_HEADERS.has(name)) continue
+    // The shim's own framing decision — see below — supersedes whatever the
+    // guest declared, and `content-encoding` is undone on this side.
+    if (name === 'accept-encoding' || name === 'content-encoding') continue
+    headers.push([name, value])
+  }
+  // ALWAYS identity, overriding the guest. A compressed echo cannot be redacted:
+  // the API scans response bytes for the secret, and gzip does not contain them.
+  headers.push(['accept-encoding', 'identity'])
+  return {
+    v: RELAY_VERSION,
+    url: input.url,
+    method: input.method.toUpperCase() as RelayMethod,
+    headers,
+    body: input.hasBody ? { present: true, length: input.bodyLength } : { present: false },
+    // This client strips and verifies the end-of-stream sentinel, so ask for
+    // one. Without it a truncated relay is INVISIBLE: measured on bun 1.3.14,
+    // an errored response body stream still gets a clean `0\r\n\r\n`
+    // terminator and `fetch` resolves normally, so the agent would parse half a
+    // JSON document as the whole answer. See RELAY_EOS_BYTES.
+    eos: true,
+  }
+}
+
+/** The relay refused before reaching the upstream — forwarded to the guest verbatim. */
+export class RelayRefusedError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string | null,
+    readonly payload: string,
+    /**
+     * `true` ⟺ the refusal means "/relay is not available here", not "your
+     * request was denied". The shim reacts by permanently falling back to the
+     * buffered `/broker` transport.
+     */
+    readonly downgrade: boolean = false,
+  ) {
+    super(`kortix relay refused: ${code ?? status}`)
+    this.name = 'RelayRefusedError'
+  }
+}
+
+/**
+ * Does this refusal mean the streaming relay is GONE rather than that the
+ * request was denied?
+ *
+ * The two documented incident levers are `KORTIX_SECRET_RELAY_STREAM_ENABLED=false`
+ * (503 `relay_disabled`) and rolling the API back (404, or 501 from a
+ * self-hosted build). A shim that probed 204 at construction and never revised
+ * the verdict turned BOTH levers into "every boundary-secret sandbox now fails
+ * every egress call until its session restarts", while `/broker` was up and
+ * working the whole time. So the verdict is revisable, in exactly these cases
+ * and no others — a 403 policy denial must never downgrade the transport.
+ */
+function isTransportGone(status: number, code: string | null): boolean {
+  return status === 404 || status === 501 || code === 'relay_disabled'
+}
+
+/**
+ * Relay one guest request through Kortix, streaming both ways.
+ *
+ * Returns the response to hand back to the guest, already reconstructed from
+ * `x-kortix-relay-status`. The body is the relay's body stream — NOT copied,
+ * NOT buffered — so the guest sees each SSE event as it arrives.
+ */
+export async function relayStreaming(
+  options: RelayClientOptions,
+  rule: ShimBrokerRule,
+  host: string,
+  request: Request,
+  /**
+   * Called when the relay body ended WITHOUT its end-of-stream sentinel — i.e.
+   * the guest is about to be handed a truncated response. The shim's only
+   * honest reaction is to destroy the guest's connection, because it cannot
+   * signal truncation through framing either (same Bun behaviour, same
+   * measurement). A clean 200 carrying half an answer is the outcome this
+   * callback exists to prevent.
+   */
+  onTruncated?: () => void,
+): Promise<Response> {
+  const call = options.brokerFetch ?? fetch
+  const contentEncoding = request.headers.get('content-encoding')?.trim() ?? ''
+  const declared = request.headers.get('content-length')
+  const hasBody = request.body !== null && request.method !== 'GET' && request.method !== 'HEAD'
+
+  let body: ReadableStream<Uint8Array> | null = null
+  let bodyLength: number | null = null
+  if (hasBody && request.body) {
+    if (contentEncoding && contentEncoding.toLowerCase() !== 'identity') {
+      // Decompressed length is not knowable without decompressing, so the API
+      // is told `null` and picks chunked framing. Correct, not lossy.
+      body = decompressStream(request.body, contentEncoding)
+      bodyLength = null
+    } else {
+      body = request.body
+      bodyLength = declared !== null && /^\d+$/.test(declared) ? Number(declared) : null
+    }
+  }
+
+  const meta = buildRelayMeta({
+    url: `https://${host}${new URL(request.url).pathname}${new URL(request.url).search}`,
+    method: request.method,
+    headers: request.headers as unknown as Iterable<[string, string]>,
+    bodyLength,
+    hasBody: body !== null,
+  })
+
+  const response = await call(relayUrl(options, rule.identifier), {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${options.token}`,
+      'content-type': 'application/octet-stream',
+      [RELAY_VERSION_HEADER]: String(RELAY_VERSION),
+      [RELAY_META_HEADER]: encodeRelayMeta(meta),
+    },
+    ...(body !== null ? { body, duplex: 'half' } : {}),
+  } as RequestInit)
+
+  const statusHeader = response.headers.get(RELAY_STATUS_HEADER)
+  if (!statusHeader) {
+    // No status header ⟺ Kortix itself refused or failed. Surface its own JSON
+    // envelope verbatim: a denied grant or an out-of-policy host must reach the
+    // agent as THAT, not as a generic proxy error it will waste a turn guessing
+    // about. Exactly what the buffered path already does.
+    const detail = await response.text().catch(() => '')
+    const code = response.headers.get(RELAY_ERROR_HEADER)
+    throw new RelayRefusedError(
+      response.status,
+      code,
+      detail || JSON.stringify({ error: 'kortix relay refused the request' }),
+      isTransportGone(response.status, code),
+    )
+  }
+
+  const status = decodeRelayStatus(statusHeader)
+  const headers = new Headers()
+  for (const [name, value] of status.headers) headers.append(name, value)
+  // NEVER copy a content-length: the body streams, and Bun frames a streamed
+  // `Response` body as chunked automatically. (The buffered path keeps its
+  // explicit content-length line — deleting both headers there leaves the
+  // response held under Bun, already measured; see shim.ts.)
+  let responseBody = response.body
+  if (responseBody && status.eos) {
+    // The cast is a lib difference, not a lie: this file is typechecked by BOTH
+    // the daemon's tsconfig (`lib: ESNext`, where `Uint8Array` defaults to
+    // `Uint8Array<ArrayBufferLike>`) and apps/api's (which resolves it to
+    // `Uint8Array<ArrayBuffer>`). Same bytes, same stream.
+    responseBody = verifyEndOfStream(
+      responseBody as ReadableStream<Uint8Array>,
+      Buffer.from(status.eos, 'hex'),
+      onTruncated,
+    ) as typeof responseBody
+  }
+  return new Response(responseBody, { status: status.status, headers })
+}
+
+/**
+ * Strip and verify the end-of-stream sentinel.
+ *
+ * Holds back the last `RELAY_EOS_BYTES` bytes seen so far and releases them
+ * only once more data proves they were not the tail. On a clean end the held
+ * bytes must equal the sentinel; anything else — a short read, a reset, a
+ * source error — means the relay was truncated, so the held bytes are emitted
+ * (they were real data) and `onTruncated` fires.
+ *
+ * Hand-rolled rather than a `TransformStream` on purpose: a transform's
+ * `flush()` does not run when the source ERRORS, and "the source errored" is
+ * one of the two truncation shapes this has to catch.
+ */
+function verifyEndOfStream(
+  source: ReadableStream<Uint8Array>,
+  sentinel: Buffer,
+  onTruncated?: () => void,
+): ReadableStream<Uint8Array> {
+  const reader = source.getReader()
+  let held = new Uint8Array(0)
+  let finished = false
+  const finish = (controller: ReadableStreamDefaultController<Uint8Array>, clean: boolean) => {
+    if (finished) return
+    finished = true
+    if (!clean) {
+      if (held.byteLength > 0) controller.enqueue(held)
+      held = new Uint8Array(0)
+      onTruncated?.()
+    }
+    controller.close()
+  }
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      for (;;) {
+        let result: { done?: boolean; value?: Uint8Array }
+        try {
+          result = await reader.read()
+        } catch {
+          finish(controller, false)
+          return
+        }
+        if (result.done) {
+          const clean =
+            held.byteLength === sentinel.byteLength && Buffer.from(held).equals(sentinel)
+          finish(controller, clean)
+          return
+        }
+        const chunk = result.value
+        if (!chunk || chunk.byteLength === 0) continue
+        const merged = new Uint8Array(held.byteLength + chunk.byteLength)
+        merged.set(held, 0)
+        merged.set(chunk, held.byteLength)
+        if (merged.byteLength <= sentinel.byteLength) {
+          held = merged
+          continue
+        }
+        const cut = merged.byteLength - sentinel.byteLength
+        // `slice` COPIES: `merged` is handed to the consumer below.
+        held = merged.slice(cut)
+        controller.enqueue(merged.subarray(0, cut))
+        return
+      }
+    },
+    cancel(reason) {
+      return reader.cancel(reason)
+    },
+  })
+}
+
+/**
+ * Undo the guest's `content-encoding` AS A STREAM.
+ *
+ * The mirror of forcing `accept-encoding: identity` on the response leg, and
+ * the same security control: substitution is byte-based and server-side, so a
+ * gzipped body does not contain the handle's bytes and the request would leave
+ * carrying a worthless string.
+ */
+function decompressStream(
+  source: ReadableStream<Uint8Array>,
+  contentEncoding: string,
+): ReadableStream<Uint8Array> {
+  const steps = contentEncoding
+    .split(',')
+    .map((step) => step.trim().toLowerCase())
+    .filter((step) => step.length > 0 && step !== 'identity')
+  let stream = source
+  // Encodings are listed in the order they were applied, so undo them backwards.
+  for (const step of steps.reverse()) {
+    const make = STREAM_DECODERS[step]
+    if (!make) throw new Error(`kortix egress shim: cannot stream-decode '${step}'`)
+    stream = pipeThroughZlib(stream, make())
+  }
+  return stream
+}
+
+function pipeThroughZlib(
+  source: ReadableStream<Uint8Array>,
+  transform: zlib.Gunzip | zlib.BrotliDecompress,
+): ReadableStream<Uint8Array> {
+  const reader = source.getReader()
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      transform.on('data', (chunk: Buffer) => controller.enqueue(new Uint8Array(chunk)))
+      transform.on('end', () => controller.close())
+      transform.on('error', (error) => controller.error(error))
+      void (async () => {
+        try {
+          for (;;) {
+            const { done, value } = await reader.read()
+            if (done) break
+            transform.write(Buffer.from(value))
+          }
+          transform.end()
+        } catch (error) {
+          transform.destroy(error as Error)
+        }
+      })()
+    },
+    cancel(reason) {
+      transform.destroy()
+      return reader.cancel(reason)
+    },
+  })
+}

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/shim.test.ts
@@ -28,6 +28,15 @@ async function startShim(
 ): Promise<{ port: number; calls: Array<{ url: string; init: RequestInit }> }> {
   const calls: Array<{ url: string; init: RequestInit }> = []
   const brokerFetch = (async (url: unknown, init: unknown) => {
+    // The capability probe runs ONCE at construction, before any guest request.
+    // Answering 404 puts this shim on the permanent buffered `/broker`
+    // transport, which is what the tests below assert — the streaming tests
+    // override `brokerFetch` to answer 204 instead. It is not recorded, so
+    // `calls[0]` still means "the first relayed request".
+    if ((init as RequestInit | undefined)?.headers &&
+        'x-kortix-relay-probe' in ((init as RequestInit).headers as Record<string, string>)) {
+      return new Response(null, { status: 404 })
+    }
     calls.push({ url: String(url), init: init as RequestInit })
     return new Response(
       JSON.stringify({
@@ -197,27 +206,40 @@ describe('headers the broker would reject or that would defeat redaction', () =>
     expect(headers[name]).toBeUndefined()
   })
 
-  test('a websocket upgrade is reset, not left hanging', async () => {
-    // The relay is request/response and fully buffered — it cannot carry a
-    // socket. Found while testing header handling: without an explicit
-    // 'upgrade' listener the inner server fires neither 'request' nor anything
-    // else, and the client waits forever with nothing in the log.
+  test('a websocket upgrade gets a real 501, not a socket reset', async () => {
+    // This assertion CHANGED, and the change is the point.
+    //
+    // Before, the inner listener was `https.createServer` and a protocol
+    // upgrade fired 'upgrade', never 'request'. Under Bun the socket handed to
+    // that event is an inert stub — `write()` returns true while dropping the
+    // bytes — so the only honest option was to destroy the connection, and the
+    // client learned nothing. Measured: node v22.22.0 delivers the same bytes
+    // fine; there is no workaround at the node:http layer because there is no
+    // fd to recover.
+    //
+    // The listener is `Bun.serve` now, so the shim can ANSWER. Even with the
+    // websocket relay unavailable, the agent gets a status and a code it can
+    // act on instead of a hang and no log line.
     const errors: string[] = []
     const { port } = await startShim({ onError: (where) => errors.push(where) })
     const { socket } = await connect(port, 'api.example.com:443')
     const tls = await import('node:tls')
-    const outcome = await new Promise<string>((resolve) => {
+    const response = await new Promise<string>((resolve, reject) => {
+      let buffer = ''
       const secured = tls.connect({ socket, servername: 'api.example.com', ca: CA.certPem }, () => {
         secured.write(
           'GET / HTTP/1.1\r\nHost: api.example.com\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n',
         )
       })
-      // Either end is a clean outcome; a TIMEOUT is the bug.
-      secured.once('close', () => resolve('closed'))
-      secured.once('error', () => resolve('closed'))
-      setTimeout(() => resolve('TIMEOUT'), 3000)
+      secured.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8')
+        if (buffer.includes('}')) resolve(buffer)
+      })
+      secured.once('error', reject)
+      setTimeout(() => reject(new Error(`timed out; got ${JSON.stringify(buffer)}`)), 4000)
     })
-    expect(outcome).toBe('closed')
+    expect(response).toContain('501')
+    expect(response).toContain('websocket_relay_unavailable')
     expect(errors).toContain('upgrade')
   })
 
@@ -234,7 +256,9 @@ describe('headers the broker would reject or that would defeat redaction', () =>
     const theirs = [...block.slice(0, block.indexOf(']')).matchAll(/'([a-z-]+)'/g)]
       .map((m) => m[1])
       .sort()
-    const mine = readFileSync(new URL('./shim.ts', import.meta.url), 'utf8')
+    // The literal list lives in its own module now, so `relay-client.ts` can
+    // read the same set without importing `shim.ts` (which imports it).
+    const mine = readFileSync(new URL('./blocked-headers.ts', import.meta.url), 'utf8')
     const mineBlock = mine.slice(mine.indexOf('const BLOCKED_REQUEST_HEADERS'))
     const ours = [...mineBlock.slice(0, mineBlock.indexOf(']')).matchAll(/'([a-z-]+)'/g)]
       .map((m) => m[1])
@@ -554,4 +578,450 @@ describe('the shim fails closed', () => {
     expect(resolveShimConfig(env)).toBeNull()
     expect(shimUnavailableReason(env)).toBeNull()
   })
+})
+
+/**
+ * The STREAMING transport.
+ *
+ * Everything above exercises the permanent buffered `/broker` path, which is
+ * unchanged. These drive the same shim with the capability probe answered
+ * `204`, so it selects `/relay` — and assert the three properties the buffered
+ * path could never have: bytes move incrementally in both directions, a handle
+ * split across a chunk boundary is still substituted, and there is no size cap.
+ */
+describe('the streaming relay transport', () => {
+  const HANDLE = 'kortix_brokered__use_kortix_fetch__KXS1abcdefghijklmnopqrstuvwxyz234567ab'
+  const VALUE = 'sk_live_the_real_value'
+
+  /** A shim whose probe succeeds, with a fake Kortix relay behind it. */
+  async function startStreamingShim(relay: {
+    /** Called with the decoded meta and a reader over the streamed request body. */
+    onRelay: (input: {
+      meta: import('@kortix/api-contract/secret-relay').SecretRelayMeta
+      body: ReadableStream<Uint8Array> | null
+    }) => Promise<Response>
+  }) {
+    const codec = await import('@kortix/api-contract/secret-relay')
+    const brokerFetch = (async (url: unknown, init: unknown) => {
+      const request = init as RequestInit & { headers: Record<string, string> }
+      if ('x-kortix-relay-probe' in request.headers) {
+        return new Response(null, { status: 204, headers: { 'x-kortix-relay': '1' } })
+      }
+      expect(String(url)).toContain('/relay')
+      const meta = codec.decodeRelayMeta(request.headers['x-kortix-relay-meta']!)
+      return await relay.onRelay({
+        meta,
+        body: (request.body as ReadableStream<Uint8Array> | undefined) ?? null,
+      })
+    }) as unknown as typeof fetch
+
+    const server = await createEgressShim({
+      ca: CA,
+      rules: [{ hosts: ['api.example.com'], identifier: 'DEMO_TOKEN' }],
+      apiUrl: 'https://api.kortix.test/v1',
+      projectId: 'proj-1',
+      token: 'kortix_pat_test',
+      brokerFetch,
+    })
+    open.push(server)
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    return { port: (server.address() as net.AddressInfo).port }
+  }
+
+  /** A relay response carrying an upstream status and a streamed body. */
+  async function relayResponse(
+    status: number,
+    headers: Array<[string, string]>,
+    chunks: string[],
+    gapMs = 0,
+  ): Promise<Response> {
+    const codec = await import('@kortix/api-contract/secret-relay')
+    const body = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        for (const chunk of chunks) {
+          if (gapMs) await new Promise((r) => setTimeout(r, gapMs))
+          controller.enqueue(Buffer.from(chunk))
+        }
+        controller.close()
+      },
+    })
+    return new Response(body, {
+      status: 200,
+      headers: {
+        'x-kortix-relay': '1',
+        'x-kortix-relay-status': codec.encodeRelayStatus({ v: 1, status, headers }),
+        'content-type': 'application/octet-stream',
+      },
+    })
+  }
+
+  /** Speak HTTPS through the real CONNECT tunnel and hand back the raw socket. */
+  async function guest(port: number) {
+    const { socket } = await connect(port, 'api.example.com:443')
+    const tls = await import('node:tls')
+    const secured = await new Promise<import('node:tls').TLSSocket>((resolve, reject) => {
+      const s = tls.connect({ socket, servername: 'api.example.com', ca: CA.certPem }, () =>
+        resolve(s),
+      )
+      s.once('error', reject)
+    })
+    return secured
+  }
+
+  test('the probe selects the relay, and the guest request arrives there', async () => {
+    let sawRelay = false
+    const { port } = await startStreamingShim({
+      onRelay: async ({ meta }) => {
+        sawRelay = true
+        expect(meta.url).toBe('https://api.example.com/v1/things?a=1')
+        expect(meta.method).toBe('POST')
+        // The security control that survives every transport.
+        expect(meta.headers).toContainEqual(['accept-encoding', 'identity'])
+        return await relayResponse(200, [['content-type', 'application/json']], ['{"ok":true}'])
+      },
+    })
+    const secured = await guest(port)
+    secured.write(
+      'POST /v1/things?a=1 HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: 2\r\n\r\n{}',
+    )
+    const text = await readUntil(secured, '', '{"ok":true}')
+    expect(sawRelay).toBe(true)
+    expect(text).toContain('200')
+    secured.destroy()
+  })
+
+  test('a handle SPLIT across guest chunk boundaries still reaches Kortix whole', async () => {
+    // The bug class the whole design exists to prevent. The guest writes the
+    // handle in two TCP segments; the relay must see the complete byte string.
+    let received = ''
+    const { port } = await startStreamingShim({
+      onRelay: async ({ body }) => {
+        const parts: string[] = []
+        if (body) {
+          const reader = body.getReader()
+          for (;;) {
+            const { done, value } = await reader.read()
+            if (done) break
+            parts.push(Buffer.from(value).toString('utf8'))
+          }
+        }
+        received = parts.join('')
+        return await relayResponse(200, [['content-type', 'application/json']], ['{"ok":true}'])
+      },
+    })
+    const secured = await guest(port)
+    const payload = `{"token":"${HANDLE}"}`
+    secured.write(
+      `POST /v1/things HTTP/1.1\r\nHost: api.example.com\r\nContent-Length: ${payload.length}\r\n\r\n`,
+    )
+    const cut = payload.indexOf(HANDLE) + 11
+    secured.write(payload.slice(0, cut))
+    await new Promise((r) => setTimeout(r, 60))
+    secured.write(payload.slice(cut))
+    await readUntil(secured, '', '{"ok":true}')
+    expect(received).toBe(payload)
+    expect(received).toContain(HANDLE)
+    secured.destroy()
+  })
+
+  test('SSE events reach the guest ONE AT A TIME, not batched at the end', async () => {
+    // The property a buffered relay can never have, and the reason the
+    // substituter had to become prefix-aware: an event that is complete must
+    // leave now, not when the connection closes.
+    const { port } = await startStreamingShim({
+      onRelay: async () =>
+        await relayResponse(
+          200,
+          [['content-type', 'text/event-stream']],
+          ['data: {"i":0}\n\n', 'data: {"i":1}\n\n', 'data: {"i":2}\n\n'],
+          60,
+        ),
+    })
+    const secured = await guest(port)
+    secured.write('GET /v1/stream HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+    const arrivals: number[] = []
+    const started = Date.now()
+    await new Promise<void>((resolve, reject) => {
+      let buffer = ''
+      secured.on('data', (chunk: Buffer) => {
+        buffer += chunk.toString('utf8')
+        arrivals.push(Date.now() - started)
+        if (buffer.includes('{"i":2}')) resolve()
+      })
+      secured.once('error', reject)
+      setTimeout(() => reject(new Error(`timed out; got ${JSON.stringify(buffer)}`)), 5000)
+    })
+    // Batched delivery would land in one or two reads at the very end.
+    expect(arrivals.length).toBeGreaterThanOrEqual(3)
+    expect(arrivals[arrivals.length - 1]! - arrivals[0]!).toBeGreaterThan(60)
+    secured.destroy()
+  })
+
+  test('a response far past the old 5 MiB cap round-trips byte-exactly', async () => {
+    // The cap that no longer exists. 8 MiB is 1.6x the buffered response
+    // ceiling; the buffered path answered 502 response_too_large here.
+    const size = 8 * 1024 * 1024
+    const { port } = await startStreamingShim({
+      onRelay: async () =>
+        await relayResponse(
+          200,
+          [['content-type', 'application/octet-stream']],
+          Array.from({ length: 8 }, () => 'q'.repeat(1024 * 1024)),
+        ),
+    })
+    const secured = await guest(port)
+    secured.write('GET /v1/big HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+    const total = await new Promise<number>((resolve, reject) => {
+      let headerDone = false
+      let bytes = 0
+      let buffer = Buffer.alloc(0)
+      secured.on('data', (chunk: Buffer) => {
+        if (!headerDone) {
+          buffer = Buffer.concat([buffer, chunk])
+          const sep = buffer.indexOf('\r\n\r\n')
+          if (sep < 0) return
+          headerDone = true
+          bytes += buffer.byteLength - (sep + 4)
+        } else {
+          bytes += chunk.byteLength
+        }
+        if (bytes >= size) resolve(bytes)
+      })
+      secured.once('error', reject)
+      setTimeout(() => reject(new Error(`timed out at ${bytes} of ${size} bytes`)), 20_000)
+    })
+    expect(total).toBeGreaterThanOrEqual(size)
+    secured.destroy()
+  }, 30_000)
+
+  test("Kortix's own refusal reaches the agent verbatim, not as a proxy error", async () => {
+    // No `x-kortix-relay-status` ⟺ Kortix refused. The agent must see the code.
+    const { port } = await startStreamingShim({
+      onRelay: async () =>
+        new Response(
+          JSON.stringify({ error: 'outbound request does not match the secret policy', code: 'policy_denied' }),
+          {
+            status: 403,
+            headers: { 'content-type': 'application/json', 'x-kortix-relay-error': 'policy_denied' },
+          },
+        ),
+    })
+    const secured = await guest(port)
+    secured.write('GET /v1/nope HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+    const text = await readUntil(secured, '', 'policy_denied')
+    expect(text).toContain('403')
+    expect(text).toContain('policy_denied')
+    secured.destroy()
+  })
+
+  test('a failed probe pins the shim to the buffered transport for its lifetime', async () => {
+    // The rollout guarantee: an older self-hosted API answers 404 and the shim
+    // never tries `/relay` again — because a streamed body already consumed
+    // cannot be replayed onto a fallback.
+    const seen: string[] = []
+    const brokerFetch = (async (url: unknown, init: unknown) => {
+      const request = init as RequestInit & { headers: Record<string, string> }
+      seen.push(String(url))
+      if ('x-kortix-relay-probe' in request.headers) return new Response(null, { status: 404 })
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body_base64: Buffer.from('{"ok":true}').toString('base64'),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as unknown as typeof fetch
+    const server = await createEgressShim({
+      ca: CA,
+      rules: [{ hosts: ['api.example.com'], identifier: 'DEMO_TOKEN' }],
+      apiUrl: 'https://api.kortix.test/v1',
+      projectId: 'proj-1',
+      token: 'kortix_pat_test',
+      brokerFetch,
+    })
+    open.push(server)
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    const port = (server.address() as net.AddressInfo).port
+    for (let i = 0; i < 2; i += 1) {
+      const secured = await guest(port)
+      secured.write('GET /v1/things HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+      await readUntil(secured, '', '{"ok":true}')
+      secured.destroy()
+    }
+    expect(seen[0]).toContain('/relay')
+    expect(seen.slice(1).every((url) => url.endsWith('/broker'))).toBe(true)
+    expect(seen).toHaveLength(3)
+  })
+
+  // ═════════════════════════════════════════════════════════════════════════
+  // REGRESSIONS — each of these failed before the fix beside it.
+  // ═════════════════════════════════════════════════════════════════════════
+
+  test('a relay body that ends WITHOUT its sentinel kills the guest connection', async () => {
+    // The relay's whole mid-stream error signal used to rest on "a failure
+    // after the headers terminates the chunked response without its final
+    // 0\r\n\r\n". Measured false on bun 1.3.14: Bun writes the terminator
+    // anyway and the client's fetch resolves cleanly, so a truncated 3 MB JSON
+    // list reached the agent as a complete-looking 200 and it acted on partial
+    // data. Truncation is now signalled positively by a random sentinel, and
+    // its ABSENCE has to reach the guest as a transport error — which, for the
+    // same Bun reason, can only be done by killing the connection.
+    const codec = await import('@kortix/api-contract/secret-relay')
+    const { port } = await startStreamingShim({
+      onRelay: async () => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(Buffer.from('{"partial":'))
+            controller.close() // clean close, sentinel NEVER written
+          },
+        })
+        return new Response(body, {
+          status: 200,
+          headers: {
+            'x-kortix-relay': '1',
+            'x-kortix-relay-status': codec.encodeRelayStatus({
+              v: 1,
+              status: 200,
+              headers: [['content-type', 'application/json']],
+              eos: 'ab'.repeat(codec.RELAY_EOS_BYTES),
+            }),
+            'content-type': 'application/octet-stream',
+          },
+        })
+      },
+    })
+    const secured = await guest(port)
+    const closed = new Promise<string>((resolve) => {
+      secured.once('close', (hadError: boolean) => resolve(hadError ? 'reset' : 'closed'))
+      secured.once('error', () => resolve('reset'))
+      setTimeout(() => resolve('still-open'), 2000)
+    })
+    secured.write('GET /v1/things HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+    expect(await closed).not.toBe('still-open')
+    secured.destroy()
+  })
+
+  test('a relay body WITH its sentinel delivers the payload and strips the sentinel', async () => {
+    const codec = await import('@kortix/api-contract/secret-relay')
+    const eos = 'cd'.repeat(codec.RELAY_EOS_BYTES)
+    const { port } = await startStreamingShim({
+      onRelay: async ({ meta }) => {
+        // The shim must ASK for the sentinel, or an old API never sends one.
+        expect(meta.eos).toBe(true)
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(Buffer.from('{"ok":true}'))
+            controller.enqueue(Buffer.from(eos, 'hex'))
+            controller.close()
+          },
+        })
+        return new Response(body, {
+          status: 200,
+          headers: {
+            'x-kortix-relay': '1',
+            'x-kortix-relay-status': codec.encodeRelayStatus({
+              v: 1,
+              status: 200,
+              headers: [['content-type', 'application/json']],
+              eos,
+            }),
+            'content-type': 'application/octet-stream',
+          },
+        })
+      },
+    })
+    const secured = await guest(port)
+    secured.write('GET /v1/things HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+    const text = await readUntil(secured, '', '{"ok":true}')
+    expect(text).toContain('200')
+    // The sentinel is transport framing, never payload.
+    expect(text).not.toContain(eos)
+    expect(Buffer.from(text, 'utf8').includes(Buffer.from(eos, 'hex'))).toBe(false)
+    secured.destroy()
+  })
+
+  test('a relay that goes AWAY mid-life downgrades to /broker instead of failing forever', async () => {
+    // `relaySupported` was decided once by the construction-time probe and
+    // never revised, so both documented incident levers —
+    // KORTIX_SECRET_RELAY_STREAM_ENABLED=false (503 relay_disabled) and an API
+    // rollback (404) — BROKE every running boundary-secret sandbox instead of
+    // healing it, with /broker up and working the whole time.
+    const seen: string[] = []
+    const brokerFetch = (async (url: unknown, init: unknown) => {
+      const request = init as RequestInit & { headers: Record<string, string> }
+      if ('x-kortix-relay-probe' in request.headers) {
+        seen.push('probe')
+        return new Response(null, { status: 204, headers: { 'x-kortix-relay': '1' } })
+      }
+      seen.push(String(url).endsWith('/broker') ? 'broker' : 'relay')
+      if (!String(url).endsWith('/broker')) {
+        return new Response(
+          JSON.stringify({ error: 'The streaming secret relay is disabled', code: 'relay_disabled' }),
+          {
+            status: 503,
+            headers: { 'content-type': 'application/json', 'x-kortix-relay-error': 'relay_disabled' },
+          },
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body_base64: Buffer.from('{"ok":true}').toString('base64'),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      )
+    }) as unknown as typeof fetch
+    const server = await createEgressShim({
+      ca: CA,
+      rules: [{ hosts: ['api.example.com'], identifier: 'DEMO_TOKEN' }],
+      apiUrl: 'https://api.kortix.test/v1',
+      projectId: 'proj-1',
+      token: 'kortix_pat_test',
+      brokerFetch,
+    })
+    open.push(server)
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    const port = (server.address() as net.AddressInfo).port
+    for (let i = 0; i < 2; i += 1) {
+      const secured = await guest(port)
+      secured.write('GET /v1/things HTTP/1.1\r\nHost: api.example.com\r\n\r\n')
+      // Both calls SUCCEED: the first recovers in-turn (a GET is replayable),
+      // the second never touches /relay again.
+      await readUntil(secured, '', '{"ok":true}')
+      secured.destroy()
+    }
+    expect(seen).toEqual(['probe', 'relay', 'broker', 'broker'])
+  })
+
+  test('construction does NOT block on the capability probe', async () => {
+    // `createEgressShim` was awaited on a 5 s network round trip while
+    // `startProxy()` — the daemon's health listener — had not bound yet, so
+    // every readiness poll hit a closed port and the session sat at "Starting
+    // the agent". The probe now settles off the boot path.
+    let probeStarted = false
+    const brokerFetch = (async (_url: unknown, init: unknown) => {
+      const request = init as RequestInit & { headers: Record<string, string> }
+      if ('x-kortix-relay-probe' in request.headers) {
+        probeStarted = true
+        await new Promise((r) => setTimeout(r, 600))
+        return new Response(null, { status: 204, headers: { 'x-kortix-relay': '1' } })
+      }
+      return new Response(null, { status: 500 })
+    }) as unknown as typeof fetch
+    const started = Date.now()
+    const server = await createEgressShim({
+      ca: CA,
+      rules: [{ hosts: ['api.example.com'], identifier: 'DEMO_TOKEN' }],
+      apiUrl: 'https://api.kortix.test/v1',
+      projectId: 'proj-1',
+      token: 'kortix_pat_test',
+      brokerFetch,
+    })
+    open.push(server)
+    const elapsed = Date.now() - started
+    expect(probeStarted).toBe(true)
+    expect(elapsed).toBeLessThan(300)
+  }, 10_000)
 })

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/shim.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/shim.ts
@@ -40,7 +40,14 @@ import net from 'node:net'
 import type { Duplex } from 'node:stream'
 import zlib from 'node:zlib'
 
+import { BLOCKED_REQUEST_HEADERS } from './blocked-headers'
 import { LeafIssuer, type EphemeralCa } from './ca'
+import {
+  canStreamDecode,
+  probeRelay,
+  relayStreaming,
+  RelayRefusedError,
+} from './relay-client'
 import type { ShimBrokerRule } from './rules'
 
 export interface EgressShimOptions {
@@ -65,36 +72,10 @@ export interface EgressShimOptions {
 
 const BROKER_TIMEOUT_MS = 30_000
 
-/**
- * FRAMING / hop-by-hop headers the broker REJECTS with a 400
- * (apps/api/src/secrets/http-broker.ts BLOCKED_REQUEST_HEADERS). The shim drops
- * them before relaying so an ordinary request does not turn into
- * `400 request header is managed by Kortix: <name>`.
- *
- * `authorization` and `cookie` are DELIBERATELY NOT dropped. They are the
- * credential-carrying headers, and the whole point of this mode is that the
- * agent puts a HANDLE where it would put the real credential — `curl -H
- * 'Authorization: Bearer <handle>'`. Dropping them here stripped the handle
- * before the broker could substitute it, so a Bearer/token/cookie request left
- * carrying nothing and the upstream answered 401. They are forwarded now; the
- * broker swaps the handle for the real value server-side.
- *
- * Kept as a literal copy rather than an import: this binary must not drag
- * apps/api's http-broker (and its DB and config dependencies) into the sandbox.
- * The `blocked-headers` test asserts the two lists still agree.
- */
-export const BLOCKED_REQUEST_HEADERS = new Set([
-  'connection',
-  'content-length',
-  'host',
-  'keep-alive',
-  'proxy-authenticate',
-  'proxy-authorization',
-  'te',
-  'trailer',
-  'transfer-encoding',
-  'upgrade',
-])
+// Re-exported from its own module so `relay-client.ts` can read the same set
+// without importing this file (which imports it). See ./blocked-headers.ts for
+// why the list is a copy and what pins it to the broker's.
+export { BLOCKED_REQUEST_HEADERS } from './blocked-headers'
 
 /**
  * The broker's own request ceiling (`MAX_REQUEST_BYTES`,
@@ -170,35 +151,40 @@ function parseTarget(target: string): { host: string; port: number } | null {
 }
 
 /**
- * Hand the guest's request to Kortix, which holds the credential.
+ * Hand the guest's request to Kortix, which holds the credential — BUFFERED.
  *
- * Deliberately the SAME broker route that `kortix secrets call` and the
- * `secret_call` MCP tool already use, so the shim inherits a path that is
- * shipped, tested and verified live rather than opening a second way to spend a
- * secret. The host/method policy, the injection, and the echo redaction all
- * happen there, server-side.
+ * This is the original transport and it is PERMANENT, not deprecated. The
+ * daemon ships inside the sandbox image and a box booted today can be resumed
+ * months from now, so `/broker` must keep working forever; and a
+ * `content-encoding: deflate` body genuinely needs a buffered retry (its
+ * raw-vs-zlib ambiguity cannot be resolved mid-stream). The construction-time
+ * probe picks the transport; both stay.
+ *
+ * The logic below is unchanged from before the streaming relay existed. Only
+ * the I/O shape moved — from `http.IncomingMessage`/`ServerResponse` to
+ * `Request`/`Response` — because the inner listener is now `Bun.serve` (see
+ * `listenerFor`).
  */
-async function relayToBroker(
+async function relayBuffered(
   options: EgressShimOptions,
   rule: ShimBrokerRule,
   host: string,
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
+  request: Request,
   body: Buffer,
-): Promise<void> {
+): Promise<Response> {
   // Forward only the request's own headers. Nothing secret is added here —
   // that is the entire point of this mode.
   const forwarded: Record<string, string> = {}
-  for (const [name, value] of Object.entries(req.headers)) {
+  for (const [name, value] of request.headers) {
     const lower = name.toLowerCase()
     if (BLOCKED_REQUEST_HEADERS.has(lower)) continue
-    if (typeof value === 'string') forwarded[lower] = value
+    forwarded[lower] = value
   }
   // Force identity, ALWAYS, overriding whatever the guest asked for.
   //
-  // This is a security control, not a compatibility tweak. The broker redacts
-  // an echoed credential by scanning the response bytes; a gzipped body does
-  // not contain those bytes, so the scan finds nothing and the credential is
+  // This is a security control, not a compatibility tweak. Kortix redacts an
+  // echoed credential by scanning the response bytes; a gzipped body does not
+  // contain those bytes, so the scan finds nothing and the credential is
   // returned to the guest intact. The broker itself now forces `identity` on
   // its upstream leg for exactly this reason (it DROPS any caller value rather
   // than 400ing it, so this line and every already-deployed daemon that sends
@@ -212,10 +198,10 @@ async function relayToBroker(
 
   // The REQUEST leg gets the same treatment, for the mirror-image reason:
   // substitution scans the outgoing bytes for the handle, and a compressed
-  // body does not contain them. Undo the encoding here so the broker sees raw
+  // body does not contain them. Undo the encoding here so Kortix sees raw
   // bytes, and drop the header so the upstream is told what it actually gets.
   let payload = body
-  const contentEncoding = req.headers['content-encoding']
+  const contentEncoding = request.headers.get('content-encoding')
   if (typeof contentEncoding === 'string' && contentEncoding.trim().length > 0) {
     delete forwarded['content-encoding']
     // An empty body carries no handle, so there is nothing to make visible and
@@ -225,21 +211,21 @@ async function relayToBroker(
     if (!decoded) {
       // Refuse rather than relay. The alternative is a request whose handle is
       // never substituted, an upstream 401, and an agent with nothing to read.
-      res.writeHead(400, { 'content-type': 'application/json' })
-      res.end(
+      return new Response(
         JSON.stringify({
           error:
             `kortix egress shim: cannot relay a request body encoded as ` +
             `'${contentEncoding}'. Send it uncompressed.`,
           code: 'unsupported_request_encoding',
         }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
       )
-      return
     }
     payload = decoded
   }
 
   const call = options.brokerFetch ?? fetch
+  const target = new URL(request.url)
   const url =
     `${options.apiUrl.replace(/\/$/, '')}/projects/${options.projectId}` +
     `/secrets/${encodeURIComponent(rule.identifier)}/broker`
@@ -247,8 +233,8 @@ async function relayToBroker(
     method: 'POST',
     headers: { authorization: `Bearer ${options.token}`, 'content-type': 'application/json' },
     body: JSON.stringify({
-      url: `https://${host}${req.url ?? '/'}`,
-      method: (req.method ?? 'GET').toUpperCase(),
+      url: `https://${host}${target.pathname}${target.search}`,
+      method: request.method.toUpperCase(),
       ...(Object.keys(forwarded).length > 0 ? { headers: forwarded } : {}),
       ...(payload.length > 0 ? { body_base64: payload.toString('base64') } : {}),
     }),
@@ -260,9 +246,10 @@ async function relayToBroker(
     // host must reach the agent as that, not as a generic proxy error it will
     // waste a turn guessing about.
     const detail = await response.text().catch(() => '')
-    res.writeHead(response.status, { 'content-type': 'application/json' })
-    res.end(detail || JSON.stringify({ error: 'broker refused the request' }))
-    return
+    return new Response(detail || JSON.stringify({ error: 'broker refused the request' }), {
+      status: response.status,
+      headers: { 'content-type': 'application/json' },
+    })
   }
 
   const result = (await response.json()) as {
@@ -278,9 +265,7 @@ async function relayToBroker(
   // which reads as a hang with no error anywhere (measured).
   delete headers['transfer-encoding']
   headers['content-length'] = String(out.length)
-  if (/close/i.test(String(req.headers.connection ?? ''))) headers.connection = 'close'
-  res.writeHead(result.status ?? 502, headers)
-  res.end(out)
+  return new Response(out, { status: result.status ?? 502, headers })
 }
 
 /**
@@ -304,29 +289,103 @@ export async function createEgressShim(options: EgressShimOptions): Promise<http
    * unique per connection and is what the inner server sees as
    * `req.socket.remotePort`.
    */
-  const bindings = new Map<number, { rule: ShimBrokerRule; host: string }>()
-  const onTerminatedRequest: http.RequestListener = (req, res) => {
-    const binding = bindings.get(req.socket.remotePort ?? -1)
-    if (!binding) {
-      res.writeHead(500).end('kortix egress shim: no rule bound to connection')
-      return
+  /**
+   * The per-connection rule, keyed by the loopback SOURCE PORT.
+   *
+   * Unique per connection, and — verified through the real CONNECT pipe — equal
+   * to what the inner listener reports as `server.requestIP(req)?.port` and what
+   * this side sees as `inner.localPort`.
+   */
+  interface Binding {
+    rule: ShimBrokerRule
+    host: string
+    /**
+     * Destroy this guest connection.
+     *
+     * The ONLY way to tell the guest "this response is incomplete". Measured on
+     * bun 1.3.14: erroring a `Response` body stream still emits a clean
+     * `0\r\n\r\n` and the client's fetch/curl succeeds, so framing carries no
+     * failure signal in either direction. Killing the TLS connection does: curl
+     * reports `transfer closed with outstanding read data remaining` and exits
+     * non-zero instead of handing the agent half a document.
+     */
+    abort(): void
+  }
+  const bindings = new Map<number, Binding>()
+
+  /**
+   * Which transport this shim uses, decided ONCE at construction.
+   *
+   * Not per request, and that is deliberate: a streamed body that has already
+   * been consumed cannot be replayed onto a fallback, so the choice has to be
+   * made before any body exists. `syncEgressShim` tears the shim down and
+   * rebuilds it on a live capability push, so a re-probe happens naturally
+   * there. See relay-client.ts.
+   */
+  let relaySupported = false
+  /**
+   * The in-flight construction-time probe, or null once its answer is in.
+   *
+   * Awaited on the FIRST relayed request instead of at construction: awaiting it
+   * in `createEgressShim` put a 5 s network round trip in front of
+   * `startProxy()`, so `/kortix/health` answered nothing for that whole window
+   * and the readiness poller saw a closed port — the exact failure the comment
+   * block in main.ts exists to prevent. Same cost is paid again on fork
+   * adoption and on every live capability push through `syncEgressShim`.
+   */
+  let relayProbe: Promise<boolean> | null = null
+
+  async function serveTerminated(request: Request, binding: Binding): Promise<Response> {
+    // `content-encoding: deflate` cannot be undone in a stream (raw vs zlib is
+    // decided by a retry), so those requests take the buffered path and keep
+    // today's 1 MiB decompression-bomb guard. Everything else streams.
+    const contentEncoding = request.headers.get('content-encoding')?.trim() ?? ''
+    const streamable =
+      contentEncoding === '' ||
+      contentEncoding.toLowerCase() === 'identity' ||
+      canStreamDecode(contentEncoding)
+
+    if (relayProbe) {
+      relaySupported = await relayProbe.catch(() => false)
+      relayProbe = null
     }
-    const chunks: Buffer[] = []
-    req.on('data', (chunk: Buffer) => chunks.push(chunk))
-    req.on('end', () => {
-      void relayToBroker(
-        options,
-        binding.rule,
-        binding.host,
-        req,
-        res,
-        Buffer.concat(chunks),
-      ).catch((err: Error) => {
-        fail('broker', err)
-        if (!res.headersSent) res.writeHead(502)
-        res.end('kortix egress shim: broker relay failed')
-      })
-    })
+
+    // A bodyless request is trivially replayable, so a transport downgrade can
+    // be recovered from IN THIS TURN rather than only on the next call.
+    const replayable =
+      request.body === null || request.method === 'GET' || request.method === 'HEAD'
+
+    if (relaySupported && streamable) {
+      try {
+        return await relayStreaming(options, binding.rule, binding.host, request, binding.abort)
+      } catch (err) {
+        if (err instanceof RelayRefusedError) {
+          if (err.downgrade) {
+            // /relay is gone — the kill switch, or an API rolled back under a
+            // live sandbox. `/broker` is permanent and still works; use it for
+            // the rest of this process's life.
+            relaySupported = false
+            if (replayable) {
+              return await relayBuffered(
+                options,
+                binding.rule,
+                binding.host,
+                request,
+                Buffer.alloc(0),
+              )
+            }
+          }
+          return new Response(err.payload, {
+            status: err.status,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        throw err
+      }
+    }
+    // Buffered: read the whole body first, exactly as before.
+    const body = request.body ? Buffer.from(await request.arrayBuffer()) : Buffer.alloc(0)
+    return await relayBuffered(options, binding.rule, binding.host, request, body)
   }
 
   /**
@@ -339,35 +398,80 @@ export async function createEgressShim(options: EgressShimOptions): Promise<http
    * while the same script works under Node — so the certificate has to be fixed
    * at listen() time. Listeners are bounded by the number of distinct hosts
    * carrying a rule, which is small, and are created once.
+   *
+   * ## Why `Bun.serve` and not `https.createServer`
+   *
+   * Two reasons, both measured, and one of them is a hard blocker:
+   *
+   *  1. **Websockets are impossible on the node path.** `inner.on('upgrade')`
+   *     under Bun hands you a socket that is an inert stub in BOTH directions —
+   *     not `instanceof net.Socket`, `_handle.fd` undefined, `write()` returns
+   *     `true` while dropping the bytes, and client bytes sent after the upgrade
+   *     never arrive. Node v22.22.0 delivers all of it. There is no workaround
+   *     at the node:http layer because there is no fd to recover. That is why
+   *     the old code simply destroyed the socket and the client hung with no log
+   *     line.
+   *  2. **Streaming needs a web `ReadableStream` body**, which is what a
+   *     `Bun.serve` `fetch` handler gets and `req.on('data')` is not.
+   *
+   * The outer CONNECT proxy STAYS on node:http — `Bun.serve` cannot handle HTTP
+   * CONNECT, and the node one works (verified: `200 Connection Established`, a
+   * byte-transparent tunnel, and a 101 through it).
+   *
+   * Accepted fidelity loss: Bun's parser lowercases header names and collapses
+   * duplicate non-known headers to the LAST value at the guest edge. No worse
+   * than before — the old code's `if (typeof value === 'string')` already
+   * dropped every multi-value header — and `x-kortix-relay-meta` stops a SECOND
+   * collapse on the shim → API hop.
    */
   const listeners = new Map<string, Promise<number>>()
-  const innerServers: https.Server[] = []
+  const innerServers: Array<{ stop(closeActiveConnections?: boolean): void }> = []
   function listenerFor(host: string): Promise<number> {
     const existing = listeners.get(host)
     if (existing) return existing
     const started = (async () => {
       const leaf = issuer.issue(host)
-      const inner = https.createServer({ cert: leaf.certPem, key: leaf.keyPem })
-      inner.on('request', onTerminatedRequest)
-      inner.on('clientError', (err) => fail('terminated-client', err))
-      // A protocol upgrade (websocket) on a terminated host fires 'upgrade',
-      // never 'request', so nothing above would run and the client would hang
-      // forever with no log line. The relay is request/response and fully
-      // buffered — it cannot carry a socket — so the connection is reset.
-      //
-      // It is RESET rather than answered 501, and that is a Bun limitation, not
-      // a preference. Measured (bun 1.3.14 vs node v22.22.0): Bun fires the
-      // event but a write from this handler never reaches the client, which
-      // then times out; Node delivers the same bytes fine. This is the THIRD
-      // divergence in this file's neighbourhood, after `emit('connection')`
-      // being a no-op and SNICallback never firing.
-      inner.on('upgrade', (_req, socket) => {
-        fail('upgrade', new Error('protocol upgrade is not supported through the egress shim'))
-        socket.destroy()
+      const inner = Bun.serve({
+        port: 0,
+        hostname: '127.0.0.1',
+        tls: { cert: leaf.certPem, key: leaf.keyPem },
+        // Bun's default is 10s and its MAX is 255s, and it is an IDLE timer that
+        // server->client writes do not reset. Any fixed ceiling kills a healthy
+        // SSE stream — the exact shape of the gateway idleTimeout incident.
+        idleTimeout: 0,
+        async fetch(request: Request, server): Promise<Response> {
+          const sourcePort = server.requestIP(request)?.port ?? -1
+          const binding = bindings.get(sourcePort)
+          if (!binding) {
+            return new Response('kortix egress shim: no rule bound to connection', { status: 500 })
+          }
+          if (request.headers.get('upgrade')?.toLowerCase() === 'websocket') {
+            // A REAL response, which the node:http upgrade handler could not
+            // write at all. Even the unsupported path now tells the agent why
+            // instead of resetting the socket and letting it time out silently.
+            fail('upgrade', new Error('websocket relay is not enabled'))
+            return new Response(
+              JSON.stringify({
+                error: 'kortix egress shim: websocket relay is not enabled',
+                code: 'websocket_relay_unavailable',
+              }),
+              { status: 501, headers: { 'content-type': 'application/json' } },
+            )
+          }
+          try {
+            return await serveTerminated(request, binding)
+          } catch (err) {
+            fail('broker', err as Error)
+            return new Response('kortix egress shim: broker relay failed', { status: 502 })
+          }
+        },
       })
-      await new Promise<void>((resolve) => inner.listen(0, '127.0.0.1', resolve))
       innerServers.push(inner)
-      return (inner.address() as net.AddressInfo).port
+      // `port` is optional in the type because a Bun server can be bound to a
+      // unix socket; ours is always TCP on 127.0.0.1.
+      const bound = inner.port
+      if (bound === undefined) throw new Error('kortix egress shim: inner listener has no port')
+      return bound
     })()
     listeners.set(host, started)
     return started
@@ -413,7 +517,17 @@ export async function createEgressShim(options: EgressShimOptions): Promise<http
         const inner = net.connect(terminatedPort, '127.0.0.1', () => {
           // Bind BEFORE any byte flows, so the request handler can never look
           // up a port that has not been registered yet.
-          bindings.set(inner.localPort ?? -1, { rule, host: target.host })
+          bindings.set(inner.localPort ?? -1, {
+            rule,
+            host: target.host,
+            abort: () => {
+              // Both ends: `inner` is the loopback leg into our TLS listener,
+              // `socket` is the guest's own CONNECT tunnel. Destroying them is
+              // what turns a truncated relay into a visible transport error.
+              inner.destroy()
+              socket.destroy()
+            },
+          })
           socket.write('HTTP/1.1 200 Connection Established\r\n\r\n')
           if (head?.length) inner.write(head)
           inner.pipe(socket)
@@ -449,10 +563,31 @@ export async function createEgressShim(options: EgressShimOptions): Promise<http
     issuer.issue(host)
   }
 
+  // Ask ONCE whether Kortix speaks the streaming relay, beside the leaf warm-up
+  // so it costs nothing on the request path. Anything but a 204 — a 404 from an
+  // older self-hosted API, a 503 from the kill switch, a timeout — leaves this
+  // shim on the permanent buffered `/broker` transport for its whole life.
+  const probeIdentifier = options.rules[0]?.identifier
+  if (probeIdentifier) {
+    // NOT awaited: `startEgressShim` is awaited before `startProxy()` binds the
+    // daemon's health port, so blocking here for up to PROBE_TIMEOUT_MS leaves
+    // every readiness poll hitting a closed port. The first relayed request
+    // awaits the answer instead.
+    relayProbe = probeRelay(options, probeIdentifier).then((ok) => {
+      relaySupported = ok
+      return ok
+    })
+    relayProbe.catch(() => undefined)
+  }
+
   // Closing the shim must also close every per-host listener, or the process
   // hangs on open handles after server.close().
   server.on('close', () => {
-    for (const inner of innerServers) inner.close()
+    // Bun.serve servers are NOT https.Server and have no `.close()`. Without
+    // `.stop(true)` the process hangs on open handles after shutdown, and
+    // `syncEgressShim`'s stop-then-start re-arm (which rebinds the same port)
+    // fails on every live capability push.
+    for (const inner of innerServers) inner.stop(true)
   })
   return server
 }

--- a/apps/kortix-sandbox-agent-server/tsconfig.json
+++ b/apps/kortix-sandbox-agent-server/tsconfig.json
@@ -15,7 +15,27 @@
     "verbatimModuleSyntax": false,
     "allowImportingTsExtensions": true,
     "noEmit": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    // The relay wire contract is SHARED with apps/api, not copied — a base64
+    // codec is far too risky to duplicate (blocked-headers.test.ts exists
+    // because a hand copy of ten strings drifted and broke every deployed
+    // daemon).
+    //
+    // It is reached through a tsconfig path and NOT through a package.json
+    // dependency, deliberately. This app is built STANDALONE: apps/sandbox/
+    // Dockerfile copies only its own package.json + bun.lock into the builder
+    // stage, and .github/workflows/ci.yml runs `bun install --frozen-lockfile`
+    // with this directory as the working directory. A `"workspace:*"` entry
+    // makes both of those fail outright — reproduced: `error: Workspace
+    // dependency "@kortix/api-contract" not found / Searched in "./*"`, exit 1,
+    // which red-lines the sandbox-agent-build job AND stops any new sandbox
+    // image from being produced. A path mapping costs no lockfile entry and is
+    // honoured by `bun run`, `bun test` and `bun build --compile` (verified).
+    // The Dockerfile places packages/api-contract at the matching relative
+    // path.
+    "paths": {
+      "@kortix/api-contract/*": ["../../packages/api-contract/src/*"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -15,7 +15,7 @@
 # Three-stage build:
 #   1. `builder`     — installs the daemon's deps and runs
 #                      `bun build --compile` for the target image architecture
-#                      to produce /agent/dist/kortix-agent.
+#                      to produce dist/kortix-agent.
 #   2. `cli-builder` — assembles a minimal workspace (apps/cli + the two
 #                      `@kortix/*` packages it imports) and compiles the
 #                      `kortix` CLI to a self-contained /cli/kortix binary.
@@ -34,9 +34,19 @@ FROM oven/bun:1.3.14-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a02
 
 ARG TARGETARCH
 
-WORKDIR /agent
+# The daemon builds STANDALONE — its own package.json + bun.lock, no workspace
+# root. It does share ONE module with apps/api: the relay wire contract
+# (packages/api-contract/src/secret-relay.ts, dependency-free by design and
+# asserted so by blocked-headers.test.ts). That is reached through a tsconfig
+# `paths` mapping rather than a `"workspace:*"` dependency, because a workspace
+# dependency makes `bun install --frozen-lockfile` in this directory fail
+# outright ("Workspace dependency ... not found / Searched in ./*") and no
+# sandbox image can be built at all. So mirror the repo layout here and copy the
+# one package the mapping points at.
+WORKDIR /repo/apps/kortix-sandbox-agent-server
 COPY apps/kortix-sandbox-agent-server/package.json apps/kortix-sandbox-agent-server/bun.lock ./
 RUN bun install --frozen-lockfile
+COPY packages/api-contract /repo/packages/api-contract
 COPY apps/kortix-sandbox-agent-server/ ./
 RUN case "${TARGETARCH:-}" in \
         amd64) export BUN_COMPILE_TARGET=bun-linux-x64 ;; \
@@ -220,7 +230,7 @@ RUN mkdir -p /opt/kortix/opencode-config-deps \
     && rm -rf /tmp/opencode-deps-bundle-check
 
 USER root
-COPY --from=builder /agent/dist/kortix-agent /usr/local/bin/kortix-agent
+COPY --from=builder /repo/apps/kortix-sandbox-agent-server/dist/kortix-agent /usr/local/bin/kortix-agent
 # The admin CLI every in-sandbox agent reaches for: `kortix cr open`,
 # `kortix secrets`, `kortix sessions`, … Pre-authenticated at runtime via the
 # project-scoped token the platform injects (KORTIX_CLI_TOKEN).

--- a/apps/web/src/components/iam/audit-http-routes.generated.ts
+++ b/apps/web/src/components/iam/audit-http-routes.generated.ts
@@ -459,6 +459,7 @@ const AUDIT_HTTP_ROUTE_KEYS = [
   "GET|v1|projects|:projectId|secrets",
   "POST|v1|projects|:projectId|secrets",
   "POST|v1|projects|:projectId|secrets|:identifier|broker",
+  "POST|v1|projects|:projectId|secrets|:identifier|relay",
   "POST|v1|projects|:projectId|secrets|:identifier|grant",
   "PUT|v1|projects|:projectId|secrets|:identifier|strategy",
   "DELETE|v1|projects|:projectId|secrets|:name",

--- a/docs/specs/2026-08-19-secrets-exposure-usage-model.md
+++ b/docs/specs/2026-08-19-secrets-exposure-usage-model.md
@@ -173,6 +173,249 @@ One visible control: **"Can your code read this value?"**
 Plus "Disabled". Connector and Git usages remain assigned by their own flows and render as
 read-only labels (the `git_proxy` treatment generalized). LLM gateway is auto-assigned.
 
+## 7.5. The streaming relay — a second transport, not a replacement
+
+§4 puts an in-guest shim in front of every egress-enforced secret and relays each
+request to Kortix, which holds the credential. The original transport buffers:
+the shim base64s the whole request into a JSON envelope, POSTs it, and buffers
+the whole response back. That is where the **1 MiB request / 5 MiB response
+caps** come from, and why SSE, chunked responses and websockets were impossible.
+
+There are now **two transports over the same policy engine**.
+
+### 7.5.1 The two routes
+
+| | Buffered (permanent) | Streaming |
+| --- | --- | --- |
+| Path | `POST …/secrets/{id}/broker` | `POST …/secrets/{id}/relay` |
+| Envelope | JSON, `body_base64` | body bytes VERBATIM, `application/octet-stream` |
+| Metadata | in the JSON body | `x-kortix-relay-meta` (base64url JSON) |
+| Caps | 1 MiB / 5 MiB | byte budgets only (default 1 GiB, `0` = unlimited) |
+| SSE / long bodies | no | yes |
+
+`/broker` is **PERMANENT, not deprecated**. The daemon ships inside the sandbox
+image and a box booted today can be resumed months from now, so its path,
+schema, status codes, error codes and audit actions are frozen. Both routes run
+the same authorization core (`apps/api/src/secrets/relay-authorize.ts`) and the
+same head-side policy gate (`prepareRelayHead`, `apps/api/src/secrets/http-broker.ts`)
+— one implementation, two callers, so the two cannot drift.
+
+### 7.5.2 The wire contract
+
+Request: `x-kortix-relay: 1`, `x-kortix-relay-meta: base64url(JSON)` (≤ 64 KiB),
+body = the guest's bytes after the shim has undone any `content-encoding`.
+
+The meta carries `{v, url, method, headers, body}` where `headers` is an
+**ordered array of `[name, value]` pairs with duplicates preserved**. It is an
+array and not an object because Bun's HTTP header parser silently collapses
+duplicate headers outside its known-header table to the LAST value (measured on
+bun 1.3.14), so the API cannot recover the guest's header list from the wire.
+
+Response, on success:
+
+```
+HTTP/1.1 200 OK
+x-kortix-relay-status: base64url({"v":1,"status":429,"headers":[["retry-after","5"]]})
+<redacted upstream body, streamed>
+```
+
+**The disambiguator, and it is the load-bearing rule:** `x-kortix-relay-status`
+PRESENT ⟺ Kortix reached the upstream and that payload's `status` is the
+upstream's. ABSENT ⟺ Kortix itself refused, and the relay's own status plus
+`x-kortix-relay-error` say why. The relay's own status is therefore **always
+200 on success**, whatever the upstream said — mirroring it would make a bare
+`403` ambiguous between "policy denied" and "Stripe said 403", a distinction the
+buffered envelope preserves and the agent acts on.
+
+A failure AFTER the 200 is committed terminates the chunked response without its
+final `0\r\n\r\n`. Chunked framing is self-terminating, so the missing
+terminator IS the error signal. No HTTP trailers are used.
+
+### 7.5.3 Framing, in decision order
+
+The guest's own `content-length` / `transfer-encoding` never travel — both are
+in `BLOCKED_REQUEST_HEADERS`.
+
+1. **No body** → no body, no length header.
+2. **Nothing substitutable here** (`isPassThrough`) **and a known length** →
+   forward that exact `content-length` and stream the bytes untouched. The
+   length is provably unchanged. `openUpstream` emits EXACTLY ONE framing
+   header: a caller-set `content-length` on a stream suppresses
+   `transfer-encoding: chunked`, and the declared count is enforced in the write
+   loop (`413 relay_request_too_large` on an overrun, `400` on a short body).
+   Setting both is a request-smuggling primitive under Node, and under bun
+   1.3.14 it silently drops the `Content-Length` — measured — which made this
+   promise inert and sent every pass-through body chunked.
+3. **Known length ≤ 64 KiB** (`RELAY_EXACT_LENGTH_MAX`) → buffer it, substitute
+   with the same whole-buffer routine `/broker` uses, and set the exact
+   post-substitution `content-length`. Byte-for-byte identical to today for the
+   ordinary small JSON POST, replayable across a redirect, and the full body is
+   available to the handle-refusal classifier.
+
+   The read is **bounded by the read itself**, not by the declaration:
+   `meta.body.length` is an assertion by the caller and is never a size
+   guarantee. Byte `declared + 1` ends the request with
+   `413 relay_request_too_large` before the upstream is opened. There is no
+   ambient ceiling to fall back on — `Bun.serve` applies no `maxRequestBodySize`
+   to a chunked body, and this route is exempt from both the 25 s request
+   deadline and Bun's per-request timeout — so an unbounded read here is a
+   one-request OOM of a shared multi-tenant pod.
+4. **Otherwise** → `transfer-encoding: chunked`, streamed through
+   `StreamSubstituter`.
+
+Case 4 is the one chunked-hostile exposure (a SigV4-style signer with a handle
+in a >64 KiB body); it surfaces as the upstream's own `411`, relayed honestly.
+Do not pre-scan to compute a length — that reintroduces the cap.
+
+### 7.5.4 Substitution and redaction stream
+
+`apps/api/src/secrets/stream-substitute.ts` is the kernel: a chunk-boundary-safe
+find/replace whose memory is bounded by `longestNeedle - 1`, not by the body.
+Its retention is **prefix-aware** — it holds back only bytes that are a proper
+prefix of some needle. A blind `longestNeedle` window is also correct but not
+PROMPT: measured on a 500 ms/event SSE stream it delayed each 29-byte event by
+1503 ms for a 53-byte API key, and withheld the final event until the connection
+closed. A relay that streams bytes but not events fails every real user.
+
+Two unsound alternatives, recorded so they are not re-invented: a **time-based
+idle flush** emits the secret's PREFIX un-redacted and the guest reassembles the
+raw value across two writes; a **`\n\n` delimiter flush** breaks on any
+multi-line secret (every PEM contains the delimiter).
+
+### 7.5.4b The end-of-stream sentinel — how truncation is signalled
+
+A relay that has already sent its headers can still fail: the upstream socket
+resets, `KORTIX_RELAY_UPSTREAM_IDLE_TIMEOUT_MS` fires, or the response byte
+budget blows. The agent MUST be able to tell that answer apart from a complete
+one.
+
+Chunked framing does **not** provide that signal. Measured on bun 1.3.14 across
+four shapes — the source `Readable` destroyed with an error, `controller.error()`,
+`pull()` throwing, and a declared `content-length` cut short — Bun always writes
+the final `0\r\n\r\n` and the client's `fetch` resolves cleanly. Raw wire bytes
+off a `net.Socket` client, with the source destroyed mid-body:
+
+```
+HTTP/1.1 200 OK … Transfer-Encoding: chunked\r\n\r\n
+12\r\nevent: a…\r\n12\r\nevent: b…\r\n0\r\n\r\n
+```
+
+So truncation is signalled **positively**:
+
+- The shim asks for it (`meta.eos: true`). A daemon baked before this existed
+  does not ask, gets no sentinel, and sees byte-for-byte the old wire — which is
+  why the protocol version stays at **1**.
+- The API mints `RELAY_EOS_BYTES` (32) random bytes per response, names them in
+  `x-kortix-relay-status` (`eos`, hex), and appends them **only** on a clean
+  flush of the response substituter. `flush()` does not run on an errored
+  source, so their presence is exactly "the body completed".
+- The shim holds back the last 32 bytes, strips them on a match, and on a
+  mismatch **destroys the guest's TLS connection**. That is the only way to
+  reach the guest: the same Bun behaviour applies on the shim → guest hop, so a
+  clean 200 carrying half a document is what an errored stream would otherwise
+  produce. `curl` reports `transfer closed with outstanding read data remaining`
+  and exits non-zero.
+
+The `secret.broker.completed` audit row is written at header time, before a
+single body byte flows, so it can never assert completion. A second row,
+`secret.broker.streamed`, is written when the body ends cleanly and carries
+`response_bytes`, `complete: true`, and the FINAL substituted set. On a streamed
+request body `completed` carries `substitution: "streamed_superset"` plus
+`substitution_candidates` rather than an empty `substituted` — an operator must
+never read "no secret was spent" for a hop that spent one.
+
+### 7.5.4c Fail-closed on a compressed response
+
+`prepareRelayHead` forces `accept-encoding: identity` upstream so the echo scan
+sees plaintext. If the upstream answers with a `content-encoding` anyway, the
+relay refuses with `502 upstream_encoding_unsupported` instead of piping bytes
+the redactor provably cannot match. Decompressing server-side is the alternative
+and is rejected: it reintroduces a decompression-bomb budget on a path whose
+whole purpose is to have no size ceiling.
+
+### 7.5.5 What did NOT change
+
+Every security invariant is shared with the buffered path, not re-implemented:
+https/443 only, no userinfo, per-hop `matchRule` re-admission, CRLF rejection,
+the unsafe-target check, the post-substitution path re-match, forced
+`accept-encoding: identity`, DNS-pinned egress IPs (which is why the upstream leg
+uses `node:https` and not `fetch` — `fetch` cannot pin the resolved address and
+would drop the DNS-rebinding guard), the `SAFE_RESPONSE_HEADERS` whitelist, and
+echo redaction on BOTH the body and the whitelisted headers.
+
+Redirect behaviour narrows in exactly one case: a `POST` with a body over
+64 KiB, no handle anywhere, and a 3xx. The request stream is already consumed
+and cannot be replayed, so it returns `502 redirect_not_replayable`. A redirect
+after any secret is on the wire stays refused unconditionally, as before.
+
+### 7.5.6 Transport selection and rollout
+
+The shim probes ONCE at construction (`POST …/relay` with
+`x-kortix-relay-probe: 1` → `204` + `x-kortix-relay: 1`). Anything else — a
+`404` from an older self-hosted API, a `503 relay_disabled`, a timeout — pins
+that shim to `/broker` for its whole process lifetime. It is a construction-time
+probe and not a per-request one because **a streamed body that has already been
+consumed cannot be replayed onto a fallback**. `syncEgressShim` rebuilds the
+shim on a live capability push, so a re-probe happens naturally there.
+
+Per-request fallbacks inside a relay-capable shim: `content-encoding: deflate`
+takes the buffered path (its raw-vs-zlib ambiguity needs a retry that cannot be
+done mid-stream) and keeps today's 1 MiB decompression-bomb guard; `gzip`,
+`x-gzip` and `br` stream-decompress.
+
+The probe is **not awaited at construction**. `startEgressShim` is awaited before
+`startProxy()` binds the daemon's health port, so blocking there for the 5 s
+probe timeout left `/kortix/health` answering nothing and every readiness poll
+hitting a closed port. The probe is kicked off unawaited and the FIRST relayed
+request awaits its result.
+
+The verdict is **revisable downward, never upward**. A refusal that means
+"/relay is not available here" — `404`, `501`, or `relay_disabled` — flips the
+shim to `/broker` permanently, and a bodyless request (every GET/HEAD) is
+replayed through `/broker` in the same turn. A `403 policy_denied` and every
+other request-level refusal never change the transport. Without this, both
+documented incident levers BROKE every running boundary-secret sandbox instead
+of healing it: proven with a shim whose probe answered 204 and whose every
+`/relay` then answered `503 relay_disabled` — two consecutive guest GETs both
+returned 503 to the guest and zero requests reached `/broker`, which was up the
+whole time.
+
+Kill switch: `KORTIX_SECRET_RELAY_STREAM_ENABLED=false` makes `/relay` answer
+`503 relay_disabled` with no image rebuild. New sessions revert to `/broker` at
+their probe; already-running relay-mode sessions downgrade on their next call.
+
+Deploy order is **API first** (both routes are additive and `/broker` is
+byte-identical), then the sandbox image. Existing running sessions keep their
+old daemon and old transport; nothing is forced to restart.
+
+### 7.5.7 Accepted limits
+
+- Header fidelity at the GUEST edge is lossy and cannot be fixed: Bun's parser
+  lowercases names and collapses duplicate non-known headers to the LAST value.
+  This is no worse than the buffered path, which dropped every multi-value
+  header outright, and `x-kortix-relay-meta` prevents a SECOND collapse on the
+  shim → API hop. The same collapse was measured on the RESPONSE leg
+  (`res.rawHeaders` under Bun keeps only the last value for a repeated custom
+  header); it costs nothing today because every name in `SAFE_RESPONSE_HEADERS`
+  is single-valued and `set-cookie` is excluded from that list.
+- Bun applies **no inbound flow control** — measured, a 200 MiB body into a
+  50 ms/chunk consumer produced 12 chunks, one of 23,003,148 bytes. The byte
+  budget in the read loop is the only guard; peak RSS is roughly 2x Bun's
+  largest coalesced chunk. Do not write code that assumes a ~64 KiB chunk.
+- A long-lived SSE relay holds decrypted values in the substituter for the life
+  of the connection rather than milliseconds. `dispose()` zero-fills them.
+  `flush()` is not enough on its own — a `TransformStream` flush runs ONLY on a
+  clean close, so disposal is also tied to the request's abort signal, to the
+  upstream body's `'error'`, and to the route's catch block. The guest still
+  never sees the value, which is the invariant that matters.
+- The handle-refusal classifier sees the URL and headers always, and the first
+  64 KiB of the request body on EVERY branch: the buffered branch classifies the
+  whole body, and both streaming branches tee a bounded prefix past the
+  substituter. Feeding it only the buffered body made it a detection control the
+  attacker could switch off at will, simply by declaring `body.length: null`.
+  Beyond 64 KiB a refused handle is still NOT substituted — fail-closed is
+  intact — but loses its forensic line.
+
 ## 8. Docs, skills, CLI — accuracy is a release gate
 
 Every surface that describes secrets MUST describe THIS model, and only this model:

--- a/packages/api-contract/package.json
+++ b/packages/api-contract/package.json
@@ -6,7 +6,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./secret-relay": "./src/secret-relay.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/api-contract/src/__tests__/secret-relay.test.ts
+++ b/packages/api-contract/src/__tests__/secret-relay.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  decodeRelayMeta,
+  decodeRelayStatus,
+  encodeRelayMeta,
+  encodeRelayStatus,
+  RELAY_EOS_BYTES,
+  RELAY_ERROR_HEADER,
+  RELAY_META_HEADER,
+  RELAY_META_MAX_BYTES,
+  RELAY_PROBE_HEADER,
+  RELAY_STATUS_HEADER,
+  RELAY_TICKET_HEADER,
+  RELAY_VERSION,
+  RELAY_VERSION_HEADER,
+  RelayCodecError,
+  type SecretRelayMeta,
+} from '../secret-relay';
+
+const META: SecretRelayMeta = {
+  v: 1,
+  url: 'https://api.stripe.com/v1/charges?expand=x',
+  method: 'POST',
+  headers: [
+    ['authorization', 'Bearer kortix_brokered__KXS1abc'],
+    ['content-type', 'application/json'],
+  ],
+  body: { present: true, length: 312 },
+};
+
+describe('the relay meta codec round-trips exactly what the wire contract says', () => {
+  test('round-trips a full meta unchanged', () => {
+    expect(decodeRelayMeta(encodeRelayMeta(META))).toEqual(META);
+  });
+
+  test('preserves DUPLICATE headers and their ORDER', () => {
+    // The whole reason headers ride in the meta instead of on the wire: Bun's
+    // HTTP header parser silently collapses duplicate headers outside its
+    // known-header table to the LAST value, so the API cannot recover the
+    // guest's list from the request itself.
+    const meta: SecretRelayMeta = {
+      ...META,
+      headers: [
+        ['x-dup', 'one'],
+        ['accept', 'text/event-stream'],
+        ['x-dup', 'two'],
+      ],
+    };
+    expect(decodeRelayMeta(encodeRelayMeta(meta)).headers).toEqual([
+      ['x-dup', 'one'],
+      ['accept', 'text/event-stream'],
+      ['x-dup', 'two'],
+    ]);
+  });
+
+  test('encodes base64url — no +, / or = that would need header quoting', () => {
+    const encoded = encodeRelayMeta({
+      ...META,
+      url: 'https://api.stripe.com/v1/a?b=%F0%9F%92%B3&c=~~~???',
+    });
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test('round-trips non-ASCII header values byte-exactly', () => {
+    const meta: SecretRelayMeta = { ...META, headers: [['x-note', 'café — naïve']] };
+    expect(decodeRelayMeta(encodeRelayMeta(meta)).headers[0]![1]).toBe('café — naïve');
+  });
+
+  test('a bodyless request encodes body.present false', () => {
+    const meta: SecretRelayMeta = { ...META, method: 'GET', body: { present: false } };
+    expect(decodeRelayMeta(encodeRelayMeta(meta)).body).toEqual({ present: false });
+  });
+
+  test('an unknown body length round-trips as null', () => {
+    const meta: SecretRelayMeta = { ...META, body: { present: true, length: null } };
+    expect(decodeRelayMeta(encodeRelayMeta(meta)).body).toEqual({ present: true, length: null });
+  });
+});
+
+describe('the decoder is a security boundary, so it validates rather than trusts', () => {
+  const decodes = (meta: unknown) =>
+    decodeRelayMeta(Buffer.from(JSON.stringify(meta), 'utf8').toString('base64url'));
+
+  test('rejects a non-https url', () => {
+    expect(() => decodes({ ...META, url: 'http://api.stripe.com/v1' })).toThrow(RelayCodecError);
+  });
+
+  test('rejects a url carrying userinfo', () => {
+    expect(() => decodes({ ...META, url: 'https://user:pw@api.stripe.com/v1' })).toThrow(
+      RelayCodecError,
+    );
+  });
+
+  test('rejects a relative url', () => {
+    expect(() => decodes({ ...META, url: '/v1/charges' })).toThrow(RelayCodecError);
+  });
+
+  test('rejects an unknown method', () => {
+    expect(() => decodes({ ...META, method: 'TRACE' })).toThrow(RelayCodecError);
+  });
+
+  test('rejects a header name with characters HTTP does not allow', () => {
+    expect(() => decodes({ ...META, headers: [['bad name', 'x']] })).toThrow(RelayCodecError);
+  });
+
+  test('rejects CR or LF in a header value — response splitting', () => {
+    expect(() => decodes({ ...META, headers: [['x-a', 'v\r\nx-injected: 1']] })).toThrow(
+      RelayCodecError,
+    );
+    expect(() => decodes({ ...META, headers: [['x-a', 'v\nx']] })).toThrow(RelayCodecError);
+  });
+
+  test('rejects more than 64 headers', () => {
+    const headers = Array.from({ length: 65 }, (_, i) => [`x-h${i}`, 'v'] as [string, string]);
+    expect(() => decodes({ ...META, headers })).toThrow(RelayCodecError);
+  });
+
+  test('accepts exactly 64 headers', () => {
+    const headers = Array.from({ length: 64 }, (_, i) => [`x-h${i}`, 'v'] as [string, string]);
+    expect(decodes({ ...META, headers }).headers).toHaveLength(64);
+  });
+
+  test('rejects a protocol version it does not implement', () => {
+    expect(() => decodes({ ...META, v: 2 })).toThrow(RelayCodecError);
+  });
+
+  test('rejects garbage that is not base64url JSON', () => {
+    expect(() => decodeRelayMeta('!!!not base64!!!')).toThrow(RelayCodecError);
+    expect(() => decodeRelayMeta(Buffer.from('{oops').toString('base64url'))).toThrow(RelayCodecError);
+  });
+
+  test('rejects an encoded meta over the header budget', () => {
+    const huge = 'x'.repeat(RELAY_META_MAX_BYTES);
+    expect(() => decodeRelayMeta(huge)).toThrow(RelayCodecError);
+  });
+
+  test('refuses to ENCODE a meta that would exceed the header budget', () => {
+    // Fail on the shim side rather than shipping a header the API must reject.
+    const headers = Array.from(
+      { length: 60 },
+      (_, i) => [`x-h${i}`, 'v'.repeat(2000)] as [string, string],
+    );
+    expect(() => encodeRelayMeta({ ...META, headers })).toThrow(RelayCodecError);
+  });
+
+  test('rejects a negative or non-integer body length', () => {
+    expect(() => decodes({ ...META, body: { present: true, length: -1 } })).toThrow(RelayCodecError);
+    expect(() => decodes({ ...META, body: { present: true, length: 1.5 } })).toThrow(RelayCodecError);
+  });
+});
+
+describe('the relay status codec carries the UPSTREAM verdict', () => {
+  test('round-trips status and ordered headers', () => {
+    const status = {
+      v: RELAY_VERSION,
+      status: 429,
+      headers: [
+        ['content-type', 'application/json'],
+        ['retry-after', '5'],
+      ] as Array<[string, string]>,
+    };
+    expect(decodeRelayStatus(encodeRelayStatus(status))).toEqual(status);
+  });
+
+  test('rejects a status code outside 100..599', () => {
+    expect(() =>
+      decodeRelayStatus(
+        Buffer.from(JSON.stringify({ v: 1, status: 99, headers: [] })).toString('base64url'),
+      ),
+    ).toThrow(RelayCodecError);
+  });
+});
+
+describe('the control header names are the contract', () => {
+  test('every header name is fixed and lowercase', () => {
+    // These strings ARE the wire contract. A daemon baked into a sandbox image
+    // months ago still sends them, so they are pinned here rather than left to
+    // whatever each side happens to type.
+    expect(RELAY_VERSION_HEADER).toBe('x-kortix-relay');
+    expect(RELAY_META_HEADER).toBe('x-kortix-relay-meta');
+    expect(RELAY_STATUS_HEADER).toBe('x-kortix-relay-status');
+    expect(RELAY_ERROR_HEADER).toBe('x-kortix-relay-error');
+    expect(RELAY_PROBE_HEADER).toBe('x-kortix-relay-probe');
+    expect(RELAY_TICKET_HEADER).toBe('x-kortix-relay-ticket');
+    expect(RELAY_META_MAX_BYTES).toBe(65536);
+    expect(RELAY_VERSION).toBe(1);
+  });
+});
+
+/**
+ * The end-of-stream sentinel fields.
+ *
+ * Both are ADDITIVE and OPTIONAL, and that is the whole compatibility story: a
+ * daemon baked before this existed sends no `meta.eos`, so the API mints no
+ * `status.eos` and the wire is byte-for-byte what it was. The protocol version
+ * therefore stays at 1 — bumping it would refuse every already-deployed daemon.
+ */
+describe('the end-of-stream sentinel is an optional, additive field', () => {
+  test('meta round-trips eos: true', () => {
+    const meta = decodeRelayMeta(
+      encodeRelayMeta({
+        v: 1,
+        url: 'https://api.example.com/v1/x',
+        method: 'POST',
+        headers: [['content-type', 'application/json']],
+        body: { present: true, length: 2 },
+        eos: true,
+      }),
+    );
+    expect(meta.eos).toBe(true);
+  });
+
+  test('a meta with NO eos decodes without one — an old daemon is unchanged', () => {
+    const meta = decodeRelayMeta(
+      encodeRelayMeta({
+        v: 1,
+        url: 'https://api.example.com/v1/x',
+        method: 'GET',
+        headers: [],
+        body: { present: false },
+      }),
+    );
+    expect(meta.eos).toBeUndefined();
+  });
+
+  test('a non-boolean eos is refused', () => {
+    const encoded = Buffer.from(
+      JSON.stringify({
+        v: 1,
+        url: 'https://api.example.com/v1/x',
+        method: 'GET',
+        headers: [],
+        body: { present: false },
+        eos: 'yes',
+      }),
+      'utf8',
+    ).toString('base64url');
+    expect(() => decodeRelayMeta(encoded)).toThrow(RelayCodecError);
+  });
+
+  test('status round-trips a hex sentinel of exactly RELAY_EOS_BYTES', () => {
+    const eos = 'ab'.repeat(RELAY_EOS_BYTES);
+    const status = decodeRelayStatus(
+      encodeRelayStatus({ v: 1, status: 200, headers: [], eos }),
+    );
+    expect(status.eos).toBe(eos);
+    expect(Buffer.from(status.eos!, 'hex').byteLength).toBe(RELAY_EOS_BYTES);
+  });
+
+  test('a sentinel of the wrong length or alphabet is refused', () => {
+    for (const bad of ['ab', 'AB'.repeat(RELAY_EOS_BYTES), 'zz'.repeat(RELAY_EOS_BYTES)]) {
+      const encoded = Buffer.from(
+        JSON.stringify({ v: 1, status: 200, headers: [], eos: bad }),
+        'utf8',
+      ).toString('base64url');
+      expect(() => decodeRelayStatus(encoded)).toThrow(RelayCodecError);
+    }
+  });
+});

--- a/packages/api-contract/src/secret-relay.ts
+++ b/packages/api-contract/src/secret-relay.ts
@@ -1,0 +1,332 @@
+/**
+ * The streaming secret-relay WIRE CONTRACT — one module, imported by BOTH the
+ * API (`apps/api/src/projects/routes/secret-relay.ts`) and the in-guest daemon
+ * (`apps/kortix-sandbox-agent-server/src/egress-shim/relay-client.ts`).
+ *
+ * ## Why the metadata is a header and not a body
+ *
+ * The relay's request body IS the guest's request body, verbatim — no base64,
+ * no JSON envelope. That is the entire point: a JSON-RPC envelope forces both
+ * ends to buffer, which is where the legacy `/broker` route's 1 MiB request and
+ * 5 MiB response caps come from. So everything that is NOT body bytes — url,
+ * method, headers — travels in `x-kortix-relay-meta`, base64url-encoded JSON.
+ *
+ * ## Why headers are an ORDERED ARRAY of pairs and not an object
+ *
+ * Measured on bun 1.3.14: Bun's HTTP header parser silently collapses duplicate
+ * headers outside its known-header table to the LAST value. `X-Dup: one` +
+ * `X-Dup: two` arrives as `two`; the same happens to `x-forwarded-for`,
+ * `forwarded`, `warning`, `x-request-id` and every custom `X-*`. Bun has no
+ * `rawHeaders`, and `Headers.getAll()` throws for anything but `set-cookie`. So
+ * the API CANNOT reconstruct the guest's header list from the wire, and the shim
+ * has to ship it as one opaque field. An object would lose duplicates all over
+ * again.
+ *
+ * ## Why this file has zero dependencies
+ *
+ * It is a subpath export (`@kortix/api-contract/secret-relay`) with no zod and
+ * no node-only API beyond `Buffer`, so `bun build --compile` pulls THIS module
+ * into the sandbox binary and not `index.ts`. The repo's previous answer to
+ * "two sides must agree" was a hand copy plus a disk-reading tripwire test
+ * (`blocked-headers.test.ts`) — that pattern exists precisely because a hand
+ * copy of ten strings drifted and broke every deployed daemon (the
+ * accept-encoding incident). A base64/JSON codec is far riskier to duplicate,
+ * so both sides get literally the same module.
+ *
+ * Validation here is hand-written rather than zod: the runtime path parses one
+ * of these per relayed request, and a zod parse on the hot path is pure
+ * overhead. `index.ts` carries zod mirrors of these shapes for the OpenAPI docs
+ * surface only.
+ */
+
+/** Protocol version. Bumped only for a change old daemons cannot parse. */
+export const RELAY_VERSION = 1 as const;
+
+/** Present on the request to declare the protocol, and on the response to confirm it. */
+export const RELAY_VERSION_HEADER = 'x-kortix-relay';
+/** base64url(JSON) request metadata — url, method, ordered headers, body shape. */
+export const RELAY_META_HEADER = 'x-kortix-relay-meta';
+/**
+ * base64url(JSON) UPSTREAM status + safe headers, on a successful relay.
+ *
+ * Its PRESENCE is the disambiguator, and that is the single most load-bearing
+ * rule in this contract: present ⟺ Kortix reached the upstream and the payload's
+ * `status` is the upstream's. Absent ⟺ Kortix itself refused or failed, and the
+ * relay's own HTTP status plus `x-kortix-relay-error` say why. The upstream
+ * status is deliberately NOT mirrored onto the relay's own status line, because
+ * a bare `403` would then be ambiguous between "Kortix policy denied" and
+ * "Stripe said 403" — a distinction the legacy JSON envelope preserves and the
+ * agent needs in order to act.
+ */
+export const RELAY_STATUS_HEADER = 'x-kortix-relay-status';
+/** The `SecretBrokerErrorCode` when Kortix refused, alongside the JSON envelope. */
+export const RELAY_ERROR_HEADER = 'x-kortix-relay-error';
+/** Capability probe marker — one bodyless POST per shim process. */
+export const RELAY_PROBE_HEADER = 'x-kortix-relay-probe';
+/** The HMAC ticket that carries the IAM verdict into the websocket upgrade. */
+export const RELAY_TICKET_HEADER = 'x-kortix-relay-ticket';
+
+/**
+ * Length, in bytes, of the END-OF-STREAM SENTINEL.
+ *
+ * ## Why a sentinel exists at all
+ *
+ * The obvious end-of-stream signal is "the chunked response ended without its
+ * final `0\r\n\r\n`". It does not work. Measured on bun 1.3.14, across four
+ * shapes (source `Readable` destroyed with an error, `controller.error()`,
+ * `pull()` throwing, and a declared `content-length` cut short): Bun ALWAYS
+ * writes `0\r\n\r\n` and the client's `fetch` resolves cleanly. Raw wire bytes
+ * from a `net.Socket` client:
+ *
+ *   HTTP/1.1 200 OK … Transfer-Encoding: chunked\r\n\r\n
+ *   12\r\nevent: a…\r\n12\r\nevent: b…\r\n0\r\n\r\n
+ *
+ * — with the source stream destroyed mid-body. So a truncated relay (upstream
+ * socket reset, idle timeout, response byte budget) was indistinguishable from
+ * a complete one, and the agent parsed half a JSON document as the whole answer.
+ *
+ * The fix is a POSITIVE signal instead of a negative one: on a clean end the
+ * API appends `eos` — 32 random bytes, unguessable, minted per response — and
+ * the shim strips it. Its ABSENCE is what says "truncated", and no truncation
+ * point can forge it.
+ *
+ * ## Why it is opt-in
+ *
+ * A daemon baked before this contract existed would hand the sentinel bytes to
+ * the guest as trailing garbage. So the client asks for it (`meta.eos: true`)
+ * and only then does the API mint one (`status.eos`). Old daemon, no request,
+ * no sentinel, byte-for-byte today's behaviour. That is why the protocol
+ * version stays at 1: both new fields are additive and optional.
+ */
+export const RELAY_EOS_BYTES = 32;
+
+/** Lowercase hex of `RELAY_EOS_BYTES` random bytes. */
+const EOS_HEX = new RegExp(`^[0-9a-f]{${RELAY_EOS_BYTES * 2}}$`);
+
+/**
+ * Encoded-byte ceiling for the meta header.
+ *
+ * 64 KiB, comfortably inside every proxy header limit in the path while leaving
+ * room for a large cookie jar. Enforced on BOTH ends: the shim refuses to build
+ * a header the API would reject, and the API refuses to decode one that arrived
+ * anyway.
+ */
+export const RELAY_META_MAX_BYTES = 65536;
+
+/** Methods the relay carries. Mirrors `SecretBrokerRequestSchema.method`. */
+export const RELAY_METHODS = [
+  'GET',
+  'POST',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'HEAD',
+  'OPTIONS',
+] as const;
+export type RelayMethod = (typeof RELAY_METHODS)[number];
+
+/** Same cap as the legacy broker's `headers` record. */
+const MAX_HEADERS = 64;
+
+/** RFC 7230 token. Header names are lowercased before this is applied. */
+const HEADER_NAME = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+
+export interface SecretRelayMeta {
+  v: typeof RELAY_VERSION;
+  /** Absolute https URL. Advisory — the API re-validates and re-matches policy. */
+  url: string;
+  method: RelayMethod;
+  /** Ordered `[name, value]` pairs, names lowercased, DUPLICATES PRESERVED. */
+  headers: Array<[string, string]>;
+  /**
+   * The body's shape, not its bytes.
+   *
+   * `length` is the guest's declared `content-length` AFTER the shim has undone
+   * any `content-encoding`, or `null` when unknown (a chunked guest request).
+   * The API uses it to choose framing: a known length under the exact-length
+   * threshold keeps today's byte-for-byte buffered behaviour, an unknown or
+   * large one streams chunked.
+   */
+  body: { present: false } | { present: true; length: number | null };
+  /**
+   * `true` ⟺ this client strips and verifies the end-of-stream sentinel.
+   *
+   * Absent or `false` means a daemon baked before the sentinel existed, and the
+   * API must not append one. See `RELAY_EOS_BYTES`.
+   */
+  eos?: boolean;
+}
+
+export interface SecretRelayStatus {
+  v: typeof RELAY_VERSION;
+  /** The UPSTREAM status, never the relay's own. */
+  status: number;
+  /** Whitelisted response headers, ordered, duplicates preserved, echo-redacted. */
+  headers: Array<[string, string]>;
+  /**
+   * Hex of the `RELAY_EOS_BYTES` sentinel this response will END with, if it
+   * completes. Present ⟺ the client asked for it in `meta.eos`.
+   */
+  eos?: string;
+}
+
+/** A malformed or out-of-contract relay header. Callers map it to a 400. */
+export class RelayCodecError extends Error {
+  constructor(
+    readonly code: 'relay_meta_invalid' | 'relay_meta_too_large',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RelayCodecError';
+  }
+}
+
+function invalid(message: string): never {
+  throw new RelayCodecError('relay_meta_invalid', message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate an ordered header list.
+ *
+ * Rejecting CR and LF here is not belt-and-braces: these values are written
+ * onto a real request line by `node:https`, so a value carrying `\r\n` is a
+ * request-splitting primitive. The API applies the same check again after
+ * substitution, because substitution can introduce bytes that were not here.
+ */
+function parseHeaders(raw: unknown, field: string): Array<[string, string]> {
+  if (!Array.isArray(raw)) invalid(`${field} must be an array of [name, value] pairs`);
+  if (raw.length > MAX_HEADERS) invalid(`${field} must contain at most ${MAX_HEADERS} entries`);
+  const headers: Array<[string, string]> = [];
+  for (const entry of raw) {
+    if (!Array.isArray(entry) || entry.length !== 2) invalid(`${field} entries must be [name, value]`);
+    const [name, value] = entry as [unknown, unknown];
+    if (typeof name !== 'string' || typeof value !== 'string') {
+      invalid(`${field} entries must be strings`);
+    }
+    const lower = name.toLowerCase();
+    if (!HEADER_NAME.test(lower)) invalid(`invalid header name: ${name}`);
+    if (value.includes('\r') || value.includes('\n')) invalid(`invalid header value: ${lower}`);
+    headers.push([lower, value]);
+  }
+  return headers;
+}
+
+/**
+ * The URL check the shim's copy is only ADVISORY about.
+ *
+ * The API re-runs the identical constraints (and the policy match, and the SSRF
+ * resolve) before anything leaves — this exists so a malformed target fails at
+ * the codec with a legible code instead of deeper in the transport.
+ */
+function parseUrl(raw: unknown): string {
+  if (typeof raw !== 'string' || raw.length === 0 || raw.length > 4096) invalid('url is invalid');
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    invalid('url must be absolute');
+  }
+  if (url.protocol !== 'https:') invalid('url must use HTTPS');
+  if (url.username || url.password) invalid('url must not contain credentials');
+  return raw;
+}
+
+function decodeJson(encoded: string, field: string): unknown {
+  if (typeof encoded !== 'string' || encoded.length === 0) invalid(`${field} is missing`);
+  if (encoded.length > RELAY_META_MAX_BYTES) {
+    throw new RelayCodecError(
+      'relay_meta_too_large',
+      `${field} exceeds ${RELAY_META_MAX_BYTES} bytes`,
+    );
+  }
+  // base64url only — the alphabet a header can carry unquoted.
+  if (!/^[A-Za-z0-9_-]*$/.test(encoded)) invalid(`${field} is not base64url`);
+  let text: string;
+  try {
+    text = Buffer.from(encoded, 'base64url').toString('utf8');
+  } catch {
+    invalid(`${field} is not base64url`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    invalid(`${field} is not valid JSON`);
+  }
+}
+
+function encodeJson(value: unknown, field: string): string {
+  const encoded = Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+  if (encoded.length > RELAY_META_MAX_BYTES) {
+    throw new RelayCodecError(
+      'relay_meta_too_large',
+      `${field} exceeds ${RELAY_META_MAX_BYTES} bytes`,
+    );
+  }
+  return encoded;
+}
+
+export function encodeRelayMeta(meta: SecretRelayMeta): string {
+  return encodeJson(meta, RELAY_META_HEADER);
+}
+
+export function decodeRelayMeta(encoded: string): SecretRelayMeta {
+  const raw = decodeJson(encoded, RELAY_META_HEADER);
+  if (!isRecord(raw)) invalid('meta must be an object');
+  if (raw.v !== RELAY_VERSION) invalid(`unsupported relay protocol version: ${String(raw.v)}`);
+  const method = raw.method;
+  if (typeof method !== 'string' || !(RELAY_METHODS as readonly string[]).includes(method)) {
+    invalid(`unsupported method: ${String(method)}`);
+  }
+  const body = raw.body;
+  if (!isRecord(body) || typeof body.present !== 'boolean') invalid('body shape is invalid');
+  let parsedBody: SecretRelayMeta['body'];
+  if (body.present === false) {
+    parsedBody = { present: false };
+  } else {
+    const length = body.length;
+    if (length === null || length === undefined) {
+      parsedBody = { present: true, length: null };
+    } else if (typeof length !== 'number' || !Number.isSafeInteger(length) || length < 0) {
+      invalid('body.length must be a non-negative integer or null');
+    } else {
+      parsedBody = { present: true, length };
+    }
+  }
+  if (raw.eos !== undefined && typeof raw.eos !== 'boolean') invalid('eos must be a boolean');
+  return {
+    v: RELAY_VERSION,
+    url: parseUrl(raw.url),
+    method: method as RelayMethod,
+    headers: parseHeaders(raw.headers, RELAY_META_HEADER),
+    body: parsedBody,
+    ...(raw.eos === true ? { eos: true } : {}),
+  };
+}
+
+export function encodeRelayStatus(status: SecretRelayStatus): string {
+  return encodeJson(status, RELAY_STATUS_HEADER);
+}
+
+export function decodeRelayStatus(encoded: string): SecretRelayStatus {
+  const raw = decodeJson(encoded, RELAY_STATUS_HEADER);
+  if (!isRecord(raw)) invalid('status must be an object');
+  if (raw.v !== RELAY_VERSION) invalid(`unsupported relay protocol version: ${String(raw.v)}`);
+  const status = raw.status;
+  if (typeof status !== 'number' || !Number.isInteger(status) || status < 100 || status > 599) {
+    invalid('status must be an integer HTTP status');
+  }
+  const eos = raw.eos;
+  if (eos !== undefined && (typeof eos !== 'string' || !EOS_HEX.test(eos))) {
+    invalid(`eos must be ${RELAY_EOS_BYTES * 2} lowercase hex characters`);
+  }
+  return {
+    v: RELAY_VERSION,
+    status,
+    headers: parseHeaders(raw.headers, RELAY_STATUS_HEADER),
+    ...(typeof eos === 'string' ? { eos } : {}),
+  };
+}

--- a/tests/spec/routes.generated.json
+++ b/tests/spec/routes.generated.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "static",
-  "count": 598,
+  "count": 599,
   "routes": [
     {
       "method": "GET",
@@ -1829,6 +1829,10 @@
     {
       "method": "POST",
       "path": "/v1/projects/:projectId/secrets/:identifier/broker"
+    },
+    {
+      "method": "POST",
+      "path": "/v1/projects/:projectId/secrets/:identifier/relay"
     },
     {
       "method": "POST",

--- a/tests/src/flows/secrets.flow.ts
+++ b/tests/src/flows/secrets.flow.ts
@@ -133,6 +133,7 @@ flow(
       "GET /v1/projects/:projectId/secrets",
       "PUT /v1/projects/:projectId/secrets/:identifier/strategy",
       "POST /v1/projects/:projectId/secrets/:identifier/broker",
+      "POST /v1/projects/:projectId/secrets/:identifier/relay",
       "POST /v1/projects/:projectId/secrets/:identifier/grant",
       "POST /v1/projects/:projectId/secrets/sync",
       "PATCH /v1/projects/:projectId/features",
@@ -389,6 +390,22 @@ flow(
           },
           { params: { projectId: p.id, identifier: "CONTROL_PLANE_KEY" } },
         );
+      r.status(403).body().has("$.code", "session_agent_token_required");
+    });
+
+    // The STREAMING sibling of the route above. It carries the same
+    // credential-spending authority, so it must refuse the same caller — an
+    // owner's user token is not a session-scoped agent token. Everything past
+    // this gate needs a real sandbox (the shim holds the CA and the session
+    // PAT), which the local profile excludes; the daemon's own shim tests and
+    // apps/api/src/__tests__/unit-project-secret-relay-route.test.ts carry the
+    // transport contract.
+    await ctx.step("streaming relay execution requires a session-scoped agent token", async () => {
+      const r = await ctx.client
+        .as(ctx.P.OWNER)
+        .post("/v1/projects/:projectId/secrets/:identifier/relay", undefined, {
+          params: { projectId: p.id, identifier: "CONTROL_PLANE_KEY" },
+        });
       r.status(403).body().has("$.code", "session_agent_token_required");
     });
 


### PR DESCRIPTION
## Why

The relay was never an egress proxy. The shim buffered the **whole** request into base64 inside a JSON body, POSTed it, and buffered the **whole** response back. That one choice produced every limit we had: the 1 MiB / 5 MiB caps, no streaming or SSE, and no websockets.

This makes it stream: guest → Kortix → upstream, with handle→value substitution applied **inline** and echo redaction inline on the way back. Memory is `O(longest needle)`, not `O(body)`. TLS still terminates in-guest and the secret still exists only server-side — **the security model is unchanged**; only the transport moved.

## Built on measurements, not docs

Four probe agents ran real scripts before anything was designed. This subsystem has paid for that rule twice (an architecture built on a Daytona field that did not exist; three silent Bun/node divergences in the shim). Two measurements changed the design:

**1. Truncation was invisible.** The design signalled mid-stream failure by omitting the chunked terminator — but bun 1.3.14 writes `0\r\n\r\n` on **every** errored response-body stream (measured at a raw socket, 4 shapes). A truncated relay reached the agent as a clean `200` with a short body. Now a positive 32-byte random sentinel, opt-in per client so baked daemons are byte-for-byte unaffected; its absence destroys the guest TLS connection.

**2. Blind retention destroyed SSE.** The kernel withheld a fixed window: every event delayed one full event period (307 ms measured), and a secret longer than one event (a 1606-byte PEM) collapsed the entire stream into one end-of-body emission. Retention is now **prefix-aware** — it withholds only a genuine partial-needle suffix, so ordinary traffic retains 0 bytes. A time-based idle flush was rejected: flushing pending bytes is a secret-**disclosure** path, not a latency fix.

## The daemon could not be built at all

It shares the wire contract with `apps/api`, and a `workspace:*` dep makes `bun install --frozen-lockfile` fail in both the CI standalone tree and the Dockerfile — so **no sandbox image could be produced**, and the API half would have shipped with the guest half unreachable. The contract is shared via a tsconfig `paths` mapping instead (no lockfile entry, honoured by `bun build --compile`), with the Dockerfile mirroring the repo layout. Copying the codec was rejected — a hand copy of ten header names already drifted once and broke every deployed daemon.

## Compatibility

`/broker` is untouched and still green. Every deployed daemon depends on it, and the shim **downgrades** to it on `404` / `501` / `relay_disabled`, so an API rollback or the kill switch *heals* running sandboxes rather than breaking them. No coordinated deploy. Gated by `secrets_egress` + a `KORTIX_SECRET_RELAY_STREAM_ENABLED` kill switch.

## Verification (run independently, not taken from a self-report)

| gate | result |
|---|---|
| api secrets | **177/0** (2956 assertions) |
| relay + broker routes | **63/0** |
| streaming kernel | **19/0** (478 assertions, incl. 300-round fuzz vs whole-buffer oracle) |
| daemon egress-shim | **74/0** |
| daemon `tsc` | clean |
| standalone daemon build (Docker shape) | exit 0; binary contains the contract |

Adversarial review ran three lenses (security / correctness / compat): **14 findings, 2 CRITICAL + 4 HIGH, zero false positives**, each fixed with a regression test proven to fail against the pre-fix code.

`src/projects/` reports 279 failures — **pre-existing**, byte-identical on a clean `origin/main` worktree. Not caused here, but worth its own fix.

## Not done (deliberately stated)

- **No live-sandbox run** against dev-api. Everything is unit/black-box against real sockets, a real CONNECT tunnel and a real loopback HTTPS upstream.
- **Websocket leg is unbuilt** (`KORTIX_RELAY_WS_ENABLED`) and carries no sentinel — if it ships in the same release it has the truncation gap this PR closes for HTTP.
- `/broker` still relays a compressed upstream body unredacted (fixed on `/relay` only, to keep the frozen route byte-identical).