### PR TITLE
fix(slack): an app_mention was answered by whichever project got the callback, not the bot that was mentioned

### DIFF
--- a/apps/api/src/__tests__/unit-slack-classify-event.test.ts
+++ b/apps/api/src/__tests__/unit-slack-classify-event.test.ts
@@ -192,3 +192,57 @@ describe('classifyEvent — non-mention routing is unchanged', () => {
     expect(cls).toBe('ignore');
   });
 });
+
+// ─── THE 2026-08-20 WRONG-BOT REPLY ──────────────────────────────────────────
+//
+// A user typed `@Kortix hey man` in a channel that also contains the "Incident
+// reporter" bot, and Incident reporter answered:
+//
+//   mentioned bot    U0B7QL26690  (Kortix)
+//   bot that replied U0B5W5XN49Y  (Incident reporter)
+//   session created  inside kortix-incident-reporter
+//
+// Two Kortix-platform apps in one workspace, each with its own BYO webhook at
+// /slack/events/{projectId}. classifyEvent accepted EVERY app_mention on the
+// strength of its type alone, so whichever project the callback landed on
+// answered — while the plain-`message` branch had checked botUserId all along.
+// The same event, arriving as the other Slack event type, routed correctly.
+describe('classifyEvent — an app_mention addressed to a DIFFERENT bot', () => {
+  const mention = (text: string) => ({ type: 'app_mention', text }) as any;
+
+  test('THE FIX: app_mention naming another workspace bot → ignore', async () => {
+    const cls = await classifyEvent('T1', mention('<@U0B7QL26690> hey man'), 'U0B5W5XN49Y');
+    expect(cls).toBe('ignore');
+  });
+
+  test('the bot that WAS mentioned still answers', async () => {
+    const cls = await classifyEvent('T1', mention('<@U0B7QL26690> hey man'), 'U0B7QL26690');
+    expect(cls).toBe('mention');
+  });
+
+  test('mentioned alongside another bot → still ours to answer', async () => {
+    const cls = await classifyEvent('T1', mention('<@U0B7QL26690> <@B1> both of you'), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  // Slack also renders mentions as <@U123|display-name>. A gate that only knows
+  // the bare form fails CLOSED on this one — the bot goes silent on a real
+  // mention, which is #6590's failure wearing a different hat.
+  test('the <@ID|label> render is still a mention, not silence', async () => {
+    const cls = await classifyEvent('T1', mention('<@B1|kortix> hey'), BOT);
+    expect(cls).toBe('mention');
+  });
+
+  // A BYO app that has never run link-bot has no recorded bot id. Refusing those
+  // would take every such workspace offline to fix a two-bot workspace's
+  // routing, so the gate fails open and says so in the log.
+  test('unknown bot id → still a mention (fail open, not a silent workspace)', async () => {
+    const cls = await classifyEvent('T1', mention('<@U0B7QL26690> hey man'), null);
+    expect(cls).toBe('mention');
+  });
+
+  test('an empty mention of OUR bot is still ours (the help-text path)', async () => {
+    const cls = await classifyEvent('T1', mention('<@B1>'), BOT);
+    expect(cls).toBe('mention');
+  });
+});

--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -553,3 +553,44 @@ describe('dispatchSlackEvent — exactly-once per inbound user message', () => {
     expect(createSessionCalls).toBe(0);
   });
 });
+
+// ─── THE 2026-08-20 WRONG-BOT REPLY, at the level the damage happened ─────────
+//
+// `@Kortix hey man` in a channel that also has the "Incident reporter" bot, and
+// Incident reporter answered — a session was created inside the wrong project
+// and a message was posted as the wrong bot. classifyEvent's unit test pins the
+// routing decision; this pins the consequence, which is what the user saw:
+// nothing is created and nothing is said by the project that was not addressed.
+describe('dispatchSlackEvent — a mention addressed to another workspace bot', () => {
+  const forBot = (botId: string, ts: string) =>
+    ({
+      team_id: 'T1',
+      event: { type: 'app_mention', channel: 'C1', ts, user: 'U1', text: `<@${botId}> hey man` },
+    }) as any;
+
+  test('THE FIX: no session, no reply, nothing bound to this project', async () => {
+    // Only the channel-binding query is reached; the claim is never attempted,
+    // because the event is declined before it can be claimed.
+    dbResults = [[]];
+    await dispatchSlackEvent('proj-1', forBot('U0B7QL26690', '300.1'));
+
+    expect(createSessionCalls, 'a session was created inside the project that was NOT mentioned').toBe(0);
+    expect(deliverCalls, 'the turn was routed into a session of the wrong project').toBe(0);
+    expect(messages, 'the wrong bot answered in the channel').toHaveLength(0);
+    expect(ephemerals, 'the wrong bot posted an ephemeral').toHaveLength(0);
+  });
+
+  test('the project that WAS mentioned still answers', async () => {
+    deliverOutcome = 'delivered';
+    dbResults = [
+      [], // ensureProjectChannelBinding
+      [{ eventId: 'slack:msg:T1:C1:301.1' }], // claimInboundMessage → WON
+      [project],
+      [{ sessionId: 'sess-1', createdBy: 'user-1', metadata: {} }], // known thread
+      [], // update lastMessageAt
+    ];
+    await dispatchSlackEvent('proj-1', forBot('B1', '301.1'));
+
+    expect(deliverCalls, 'the correctly-addressed bot went silent — this fix must not cost that').toBe(1);
+  });
+});

--- a/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
+++ b/apps/api/src/__tests__/unit-slack-dispatch-session.test.ts
@@ -487,7 +487,7 @@ describe('inboundMessageKey — one message ⇒ one identity', () => {
 
 describe('dispatchSlackEvent — exactly-once per inbound user message', () => {
   const mention = (ts: string) =>
-    ({ team_id: 'T1', event: { type: 'app_mention', channel: 'C1', ts, user: 'U1', thread_ts: '90.0', text: 'hi' } }) as any;
+    ({ team_id: 'T1', event: { type: 'app_mention', channel: 'C1', ts, user: 'U1', thread_ts: '90.0', text: '<@B1> hi' } }) as any;
 
   test('a LOST message claim → the agent does NOT run (duplicate suppressed)', async () => {
     deliverOutcome = 'delivered';

--- a/apps/api/src/__tests__/unit-slack-mentions-user.test.ts
+++ b/apps/api/src/__tests__/unit-slack-mentions-user.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { mentionsUser } from '../channels/slack/util';
+
+// The predicate both mention gates route on. It decides "was I the one
+// addressed", so it has two ways to be wrong and they cost opposite things:
+// a false NO makes the bot ignore a real mention (silence, #6590's shape), and
+// a false YES lets one project answer for another (the 2026-08-20 wrong-bot
+// reply this predicate was extracted for).
+describe('mentionsUser', () => {
+  test('the plain render', () => {
+    expect(mentionsUser('<@U0B7QL26690> hey man', 'U0B7QL26690')).toBe(true);
+  });
+
+  test('the <@ID|label> render Slack still emits', () => {
+    expect(mentionsUser('<@U0B7QL26690|kortix> hey', 'U0B7QL26690')).toBe(true);
+  });
+
+  test('a different bot in the same message is not us', () => {
+    expect(mentionsUser('<@U0B7QL26690> hey man', 'U0B5W5XN49Y')).toBe(false);
+  });
+
+  test('mentioned among others', () => {
+    expect(mentionsUser('cc <@UAAA> and <@UBBB>', 'UBBB')).toBe(true);
+  });
+
+  // A prefix must not match a longer id, or every project whose bot id starts
+  // with another's would answer for it.
+  test('a prefix of a longer id is not a match', () => {
+    expect(mentionsUser('<@U0B7QL26690> hi', 'U0B7QL2669')).toBe(false);
+  });
+
+  test('the bare id without Slack’s wrapper is not a mention', () => {
+    expect(mentionsUser('talk to U0B7QL26690 about it', 'U0B7QL26690')).toBe(false);
+  });
+
+  test('an empty or malformed id never matches', () => {
+    expect(mentionsUser('<@U0B7QL26690> hi', '')).toBe(false);
+    // Regex metacharacters must not be able to widen the pattern into a wildcard.
+    expect(mentionsUser('<@U0B7QL26690> hi', '.*')).toBe(false);
+    expect(mentionsUser('<@U0B7QL26690> hi', 'U0B7QL26690|X')).toBe(false);
+  });
+});

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -42,7 +42,7 @@ import {
   clearThreadErrorNotice,
   inboundMessageKey,
 } from './dedup';
-import { escapeMrkdwn, sessionWebUrl, stripMentions } from './util';
+import { escapeMrkdwn, mentionsUser, sessionWebUrl, stripMentions } from './util';
 import { config } from '../../config';
 import type {
   EventClass,
@@ -428,7 +428,48 @@ export async function classifyEvent(
   event: SlackEvent,
   botUserId: string | null,
 ): Promise<EventClass> {
-  if (event.type === 'app_mention') return 'mention';
+  // AN app_mention MUST ACTUALLY MENTION THIS PROJECT'S BOT.
+  //
+  // PROD 2026-08-20. A user typed `@Kortix hey man` in a channel that also has
+  // the "Incident reporter" bot in it, and Incident reporter answered:
+  //
+  //   mentioned bot   U0B7QL26690  (Kortix)
+  //   bot that replied U0B5W5XN49Y  (Incident reporter)
+  //   session created inside kortix-incident-reporter
+  //
+  // Two Kortix-platform apps in one workspace, each with its own BYO webhook at
+  // /slack/events/{projectId}. Whichever project the callback lands on answers,
+  // because this line accepted EVERY app_mention on the strength of its type
+  // alone. `botUserId` was already loaded and already passed in — it was simply
+  // never consulted, while the plain-`message` branch below has checked it all
+  // along. The asymmetry is the whole bug: the same event, arriving as the other
+  // Slack event type, was routed correctly.
+  //
+  // A cross-wired Events Request URL or a swapped signing-secret/token pair can
+  // deliver the event here, and that may well also be true. It does not matter:
+  // a project that is not the one addressed must decline, so a misconfiguration
+  // is a bot that stays quiet rather than a bot that impersonates another.
+  //
+  // Fails OPEN when we do not know our own bot id, which is a real state for a
+  // BYO app that has never run `link-bot`. Refusing those would take every such
+  // workspace's mentions offline to fix a two-bot workspace's routing, so it is
+  // logged instead — the degradation is visible, and link-bot closes it.
+  if (event.type === 'app_mention') {
+    if (!botUserId) {
+      console.warn(
+        '[slack] app_mention accepted without verifying the mentioned bot: this project has no ' +
+          'recorded bot user id (run `link-bot`). In a workspace with more than one Kortix app ' +
+          'installed, this is how the wrong bot answers.',
+      );
+      return 'mention';
+    }
+    if (mentionsUser(event.text ?? '', botUserId)) return 'mention';
+    console.warn(
+      `[slack] ignoring an app_mention that does not mention this project's bot (${botUserId}) — ` +
+        'it is addressed to another app in this workspace',
+    );
+    return 'ignore';
+  }
   if (event.type !== 'message') return 'ignore';
   if (event.subtype) {
     // Allow these user-generated subtypes through:
@@ -458,7 +499,7 @@ export async function classifyEvent(
   // case), the exactly-once `inboundMessageKey` gate — keyed on the shared
   // (team, channel, ts) — collapses them into a single run, so this never
   // double-answers.
-  if (botUserId && (event.text ?? '').includes(`<@${botUserId}>`)) return 'mention';
+  if (botUserId && mentionsUser(event.text ?? '', botUserId)) return 'mention';
   if (event.channel_type === 'im') return 'dm';
   if (event.thread_ts && (await threadIsOwned(teamId, event.thread_ts))) return 'follow_up';
   return 'ignore';

--- a/apps/api/src/channels/slack/util.ts
+++ b/apps/api/src/channels/slack/util.ts
@@ -32,6 +32,25 @@ export function stripMentions(text: string): string {
   return text.replace(/<@[A-Z0-9]+>/g, '').trim();
 }
 
+/**
+ * Does `text` @-mention this exact Slack user?
+ *
+ * Slack renders a mention as `<@U123>` and, on older and enterprise-grid paths,
+ * as `<@U123|display-name>`. A check that only knows the first form fails CLOSED
+ * on the second: a real mention is dropped and the bot silently says nothing,
+ * which is the same shape of failure as #6590.
+ *
+ * One predicate, used by every caller that has to decide "was I the one
+ * addressed" — the app_mention gate and the plain-message gate both route on
+ * this, and two hand-rolled versions of it are how they drift apart.
+ */
+export function mentionsUser(text: string, userId: string): boolean {
+  // Slack user ids are [A-Z0-9]. Anything else is not an id we can build a
+  // pattern from, and answering "yes" to a malformed one would defeat the gate.
+  if (!/^[A-Z0-9]+$/.test(userId)) return false;
+  return new RegExp(`<@${userId}(\\|[^>]*)?>`).test(text);
+}
+
 export function repoOgImage(repoUrl: string): string | null {
   const m = repoUrl.match(/github\.com[\/:]([\w.-]+)\/([\w.-]+?)(\.git)?$/i);
   if (!m) return null;


### PR DESCRIPTION
A user typed `@Kortix hey man` in a channel that also contains the **Incident reporter** bot, and Incident reporter answered:

| | |
|---|---|
| mentioned bot | `U0B7QL26690` (Kortix) |
| bot that replied | `U0B5W5XN49Y` (Incident reporter) |
| session created | inside `kortix-incident-reporter` |

Two Kortix-platform apps in one workspace, each with its own BYO webhook at `/slack/events/{projectId}`. `classifyEvent` accepted every `app_mention` on the strength of its type alone:

```ts
if (event.type === 'app_mention') return 'mention';
```

`botUserId` was already loaded by `dispatchSlackEvent` and already passed into this function — it was simply never consulted. The plain-`message` branch twenty lines below has checked it all along, so the **same mention, arriving as the other Slack event type, routed correctly**. That asymmetry is the whole bug.

A cross-wired Events Request URL or a swapped signing-secret/token pair can be what delivers the callback to the wrong project, and may well also be true here. It does not change the fix: a project that is not the one addressed must decline, so a misconfiguration produces a bot that stays quiet rather than a bot that answers as somebody else.

### What changed

- The `app_mention` branch now requires the text to mention **this project's** bot.
- The check goes through a shared `mentionsUser()` rather than a second hand-rolled `includes('<@' + id + '>')`, and the message branch routes on it too — two copies of "was I the one addressed" are how the branches drifted apart in the first place.
- `mentionsUser()` also matches Slack's `<@U123|display-name>` render, which the old `includes` did not. A gate that misses that form fails **closed** and the bot silently ignores a real mention — #6590's failure in a new place.
- **Fails open** when the project has no recorded bot id, a real state for a BYO app that has never run `link-bot`. Refusing those would take every such workspace's mentions offline to fix a two-bot workspace's routing, so it is logged instead.

### Not the cause of this: the recent Slack work

`git blame` puts the offending line at `7510e3fb99d` (**2026-06-04**), about ten weeks before #6577 / #6590 / #6606 / #6612 / #6616, none of which touch it. What those PRs did change is that a second bot in one workspace is now a configuration people reach — the defect was latent until someone stood one up. All five are already in prod (v0.13.1), and prod carries this same unfixed line.

### Still owed, deliberately not in here

`SlackEnvelope` drops Slack's `api_app_id`, so the handler cannot independently verify the callback belongs to the installed app. That is a second, weaker layer; this one is sufficient to stop the misrouting and needs no schema change.

### Tests

- `unit-slack-mentions-user` — the predicate, both renders, prefix/malformed-id cases (a regex metacharacter must not widen the pattern into a wildcard).
- `unit-slack-classify-event` — the routing decision, including the fail-open and `<@ID|label>` cases.
- `unit-slack-dispatch-session` — the **consequence**: no session created, no message, no ephemeral from the project that was not addressed; and the addressed project still answers.

Negative control: reverting the gate reds the wrong-bot test. Pre-existing failures in the `src/__tests__/*slack*` group are identical on clean `origin/main` (49 fail / 9 errors either way; the `dispatch-session` file baselines at 17 pass / 1 fail, 19 / 1 with these).