### PR TITLE
perf(web): verify the session JWT in-process instead of calling GoTrue on every navigation

### DIFF
--- a/apps/web/src/lib/supabase/middleware-identity.test.ts
+++ b/apps/web/src/lib/supabase/middleware-identity.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+
+import { resolveMiddlewareIdentity, type MiddlewareAuth } from './middleware-identity';
+
+/** Build a fake auth surface and record which calls the resolver actually made. */
+function fakeAuth(overrides: Partial<MiddlewareAuth>) {
+  const calls: string[] = [];
+  const auth: MiddlewareAuth = {
+    getClaims: async () => {
+      calls.push('getClaims');
+      return { data: null, error: null };
+    },
+    getUser: async () => {
+      calls.push('getUser');
+      return { data: { user: null }, error: null };
+    },
+    ...overrides,
+  };
+  // Re-wrap the overrides so they are recorded too.
+  const recorded: MiddlewareAuth = {
+    getClaims: async () => {
+      calls.push('getClaims');
+      return auth.getClaims();
+    },
+    getUser: async () => {
+      calls.push('getUser');
+      return auth.getUser();
+    },
+  };
+  return { auth: recorded, calls };
+}
+
+describe('resolveMiddlewareIdentity', () => {
+  test('a locally verified JWT settles the identity without calling getUser', async () => {
+    const { auth, calls } = fakeAuth({
+      getClaims: async () => ({
+        data: { claims: { sub: 'user-123', user_metadata: { locale: 'de' } } },
+        error: null,
+      }),
+      getUser: async () => {
+        throw new Error('getUser must not be called on the verified fast path');
+      },
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toEqual({ id: 'user-123', user_metadata: { locale: 'de' } });
+    expect(identity.authError).toBeNull();
+    expect(identity.source).toBe('claims');
+    expect(calls.filter((c) => c === 'getUser')).toHaveLength(0);
+  });
+
+  test('an anonymous request costs no network call at all', async () => {
+    // getSession() found nothing: no claims, and no error either.
+    const { auth, calls } = fakeAuth({
+      getClaims: async () => ({ data: null, error: null }),
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toBeNull();
+    expect(identity.authError).toBeNull();
+    expect(identity.source).toBe('no-session');
+    expect(calls.filter((c) => c === 'getUser')).toHaveLength(0);
+  });
+
+  test('claims without a subject are not an identity — it falls back to getUser', async () => {
+    const { auth, calls } = fakeAuth({
+      getClaims: async () => ({ data: { claims: { email: 'a@b.c' } }, error: null }),
+      getUser: async () => ({ data: { user: { id: 'user-9' } }, error: null }),
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toEqual({ id: 'user-9' });
+    expect(identity.source).toBe('get-user');
+    expect(calls.filter((c) => c === 'getUser')).toHaveLength(1);
+  });
+
+  test('an expired token falls back to getUser so the session can still refresh', async () => {
+    const expired = Object.assign(new Error('JWT has expired'), { code: 'jwt_expired' });
+    const { auth, calls } = fakeAuth({
+      getClaims: async () => ({ data: null, error: expired }),
+      getUser: async () => ({ data: { user: { id: 'user-refreshed' } }, error: null }),
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toEqual({ id: 'user-refreshed' });
+    expect(identity.authError).toBeNull();
+    expect(identity.source).toBe('get-user');
+    expect(calls.filter((c) => c === 'getUser')).toHaveLength(1);
+  });
+
+  test('a rotated refresh token keeps its error code so the caller can self-heal', async () => {
+    const rotated = Object.assign(new Error('Already Used'), {
+      code: 'refresh_token_already_used',
+    });
+    const { auth } = fakeAuth({
+      getClaims: async () => ({ data: null, error: rotated }),
+      getUser: async () => ({ data: { user: null }, error: rotated }),
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toBeNull();
+    expect((identity.authError as { code?: string } | null)?.code).toBe(
+      'refresh_token_already_used',
+    );
+  });
+
+  test('getClaims rethrowing a non-auth error never escapes the resolver', async () => {
+    // WebCrypto importKey throws a DOMException, which getClaims rethrows.
+    const { auth, calls } = fakeAuth({
+      getClaims: async () => {
+        throw new TypeError('Unsupported key algorithm');
+      },
+      getUser: async () => ({ data: { user: { id: 'user-fallback' } }, error: null }),
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toEqual({ id: 'user-fallback' });
+    expect(identity.source).toBe('get-user');
+    expect(calls.filter((c) => c === 'getUser')).toHaveLength(1);
+  });
+
+  test('getUser throwing is captured as an auth error, not propagated', async () => {
+    const { auth } = fakeAuth({
+      getClaims: async () => ({ data: null, error: new Error('boom') }),
+      getUser: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    const identity = await resolveMiddlewareIdentity(auth);
+
+    expect(identity.user).toBeNull();
+    expect(identity.authError?.message).toBe('network down');
+    expect(identity.source).toBe('get-user');
+  });
+});

--- a/apps/web/src/lib/supabase/middleware-identity.ts
+++ b/apps/web/src/lib/supabase/middleware-identity.ts
@@ -1,0 +1,89 @@
+/**
+ * Identity resolution for the middleware auth gate.
+ *
+ * The gate used to call `getUser()` on every non-auth route. `getUser()`
+ * validates the access token by round-tripping GoTrue, so every client-side
+ * navigation paid one edge → Supabase hop before its RSC payload could even
+ * start. That cost is invisible in a page-load benchmark and very visible when
+ * clicking between sessions.
+ *
+ * Our projects sign with ES256, so `getClaims()` verifies the signature
+ * in-process against a JWKS that auth-js caches globally — no network on the
+ * common path. This is not a weaker check than `getUser()`: the cookie is
+ * still never trusted unverified, the signature is checked with WebCrypto.
+ *
+ * `getUser()` remains the fallback for everything `getClaims()` cannot settle
+ * locally — an expired token that needs a refresh, symmetric (HS*) signing
+ * keys, WebCrypto unavailable — because it is also what produces the precise
+ * error codes the caller's stale-session self-heal matches on.
+ */
+
+export interface MiddlewareUser {
+  id: string;
+  user_metadata?: { locale?: string };
+}
+
+export interface MiddlewareIdentity {
+  user: MiddlewareUser | null;
+  authError: Error | null;
+  /** Which path settled the identity. Kept for tests and tracing. */
+  source: 'claims' | 'no-session' | 'get-user';
+}
+
+/**
+ * The slice of `supabase.auth` this resolver needs. Declared structurally so
+ * the tests can drive it without standing up a Supabase client.
+ */
+export interface MiddlewareAuth {
+  getClaims: () => Promise<{
+    data: { claims?: Record<string, unknown> | null } | null;
+    error: unknown;
+  }>;
+  getUser: () => Promise<{
+    data: { user: MiddlewareUser | null };
+    error: unknown;
+  }>;
+}
+
+function asError(value: unknown): Error | null {
+  if (value === null || value === undefined) return null;
+  return value instanceof Error ? value : (value as Error);
+}
+
+export async function resolveMiddlewareIdentity(
+  auth: MiddlewareAuth,
+): Promise<MiddlewareIdentity> {
+  try {
+    const { data, error } = await auth.getClaims();
+
+    if (!error) {
+      const sub = data?.claims?.sub;
+      if (typeof sub === 'string' && sub.length > 0) {
+        // Signature verified locally. No network was involved.
+        const metadata = data?.claims?.user_metadata as MiddlewareUser['user_metadata'];
+        return {
+          user: metadata ? { id: sub, user_metadata: metadata } : { id: sub },
+          authError: null,
+          source: 'claims',
+        };
+      }
+
+      // No claims and no error means there is simply no session on this
+      // request. An anonymous visitor needs no round trip to learn that.
+      if (!data?.claims) {
+        return { user: null, authError: null, source: 'no-session' };
+      }
+    }
+    // Anything else (expired, symmetric keys, unverifiable) falls through.
+  } catch {
+    // getClaims rethrows errors that are not AuthErrors — a WebCrypto
+    // DOMException, a malformed JWKS. Those must never 500 the middleware.
+  }
+
+  try {
+    const { data, error } = await auth.getUser();
+    return { user: data.user ?? null, authError: asError(error), source: 'get-user' };
+  } catch (error) {
+    return { user: null, authError: asError(error), source: 'get-user' };
+  }
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -13,6 +13,10 @@ import {
   resolveDefaultLandingPath,
 } from '@/lib/onboarding/landing-destination';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
+import {
+  resolveMiddlewareIdentity,
+  type MiddlewareUser,
+} from '@/lib/supabase/middleware-identity';
 import { redirectPreservingCookies } from '@/lib/supabase/redirect-preserving-session';
 import { createServerClient } from '@supabase/ssr';
 import type { NextRequest } from 'next/server';
@@ -453,31 +457,32 @@ export async function middleware(request: NextRequest) {
     },
   });
 
-  // Fetch user ONCE and reuse for auth checks.
-  // IMPORTANT: Skip getUser() for auth routes — the auth page handles its
-  // own session client-side. Calling getUser() here can trigger a server-side
-  // token refresh that consumes the refresh token (GoTrue refresh tokens are
-  // single-use). The updated cookie is set on the response, but if the browser
-  // does a client-side navigation (router.push) instead of a full page load,
-  // the Set-Cookie header may not be processed, leaving the browser with a
-  // stale (revoked) refresh token → "Refresh Token Not Found" on the next request.
-  let user: { id: string; user_metadata?: { locale?: string } } | null = null;
+  // Resolve the identity ONCE and reuse it for every auth check below.
+  //
+  // The common path verifies the access token's ES256 signature in-process
+  // (see lib/supabase/middleware-identity.ts) instead of round-tripping
+  // GoTrue, so a client-side navigation no longer pays an edge -> Supabase hop
+  // before its RSC payload can start. getUser() still runs for what cannot be
+  // settled locally.
+  //
+  // IMPORTANT: Skip the lookup entirely for auth routes — the auth page
+  // handles its own session client-side. Resolving here can trigger a
+  // server-side token refresh that consumes the refresh token (GoTrue refresh
+  // tokens are single-use). The updated cookie is set on the response, but if
+  // the browser does a client-side navigation (router.push) instead of a full
+  // page load, the Set-Cookie header may not be processed, leaving the browser
+  // with a stale (revoked) refresh token → "Refresh Token Not Found" on the
+  // next request. Local verification also shrinks that window: the fast path
+  // never refreshes.
+  let user: MiddlewareUser | null = null;
   let authError: Error | null = null;
 
   const isAuthRoute = pathname === '/auth' || pathname.startsWith('/auth/');
 
   if (!isAuthRoute) {
-    try {
-      const {
-        data: { user: fetchedUser },
-        error: fetchedError,
-      } = await supabase.auth.getUser();
-      user = fetchedUser;
-      authError = fetchedError as Error | null;
-    } catch (error) {
-      // User might not be authenticated, continue
-      authError = error as Error;
-    }
+    const identity = await resolveMiddlewareIdentity(supabase.auth);
+    user = identity.user;
+    authError = identity.authError;
   }
 
   // Self-heal a stale/rotated session. A refresh token that's invalid or


### PR DESCRIPTION
## The problem

Every client-side navigation in the web app paid a network round trip before its
RSC payload could start.

`src/middleware.ts` matched every app route, and on every non-auth route it ran
`await supabase.auth.getUser()`. `getUser()` validates the access token by
round-tripping GoTrue. RSC navigation requests hit the route path itself, so they
match the matcher too — meaning every project/session switch went
browser -> Vercel edge -> Supabase -> back before any data loading even began.

This is invisible in a page-load benchmark and very visible when clicking around.

## The fix

Our Supabase projects sign user tokens with **ES256**, verified on both local and
dev:

```
$ curl https://<dev-project>.supabase.co/auth/v1/.well-known/jwks.json
{"keys":[{"alg":"ES256","crv":"P-256","kid":"3558308f-...","kty":"EC",...}]}

$ # header of a real user access token
{"alg":"ES256","kid":"b81269f1-21d8-4f2e-b719-c2240a840d90","typ":"JWT"}
```

So `getClaims()` verifies the signature **in-process** against a JWKS that
auth-js caches globally. No network on the common path.

`getUser()` remains the fallback for everything that cannot be settled locally —
an expired token that needs a refresh, symmetric (HS\*) signing keys, WebCrypto
unavailable — because it is also what produces the precise error codes the
existing stale-session self-heal matches on. That self-heal is unchanged.

The logic lives in `src/lib/supabase/middleware-identity.ts` so it is testable
without standing up a Supabase client; `middleware.ts` just calls it.

### This is not a weaker check

The cookie is still never trusted unverified — the signature is checked with
WebCrypto, which is exactly what Supabase documents `getClaims()` for. Proven
below with a forged token.

## Verification

All against a real local Supabase, with a logging reverse proxy in front of it so
every outbound auth call is counted and attributed by user-agent.

**Middleware-only route** (`/projects` redirects in middleware, never renders):

| | baseline | this PR |
|---|---|---|
| GoTrue calls / 10 authed navigations | **10** (`GET /auth/v1/user`) | **0** |
| latency / navigation (loopback) | 39.0ms avg | 8.9ms avg |

**Rendering route** (`/settings`): 3 requests -> **6** server `getUser` calls on
baseline, **3** on this PR. The middleware's call is gone; the remaining one per
request is that page's own server-side check, untouched here. (Worth a follow-up.)

**Cold instance**: exactly one `GET /auth/v1/.well-known/jwks.json` on the first
authenticated request, then 0 for every navigation after.

**Security — forged token rejected.** Took a genuine session cookie, swapped the
`sub` claim, left the now-invalid signature, re-encoded it the way
`@supabase/ssr` does:

```
FORGED  (sub swapped, signature stale) -> 307 location: /auth?redirect=%2Fprojects
GENUINE                                -> 307 location: /projects/start
NO COOKIE                              -> 307 location: /auth?redirect=%2Fprojects
```

**Real browser**: signed in through the actual `/auth` page against the running
app, landed on `/projects/start`, session cookie accepted by the new resolver.

**Suites**: `bun test src` in `apps/web` -> **7963 pass / 0 fail** across 621
files. `tsc --noEmit` clean apart from the two pre-existing `@/.source` fumadocs
codegen errors. `eslint` clean on all three touched files.

## Where the win actually lands — measured per environment

`getClaims()` only verifies locally when the project publishes asymmetric keys.
I pulled every environment's JWKS:

| env | Supabase | JWKS | effect of this PR |
|---|---|---|---|
| local | `127.0.0.1:54321` | `ES256` | round trip eliminated |
| dev | `heprlhlltebrxydgtsjs.supabase.co` | `ES256` | round trip eliminated |
| staging | `ujzsbwvurfyeuerxxeaz.supabase.co` | `{"keys":[]}` | no change |
| prod | `supa.kortix.com` (self-hosted) | `{"keys":[]}` | no change |

An empty `keys` array means the project still signs with the legacy HS256 shared
secret. On those, `getClaims()` sees `alg: HS*`, skips local verification, and
internally calls `getUser()` — so staging and prod get **exactly the same number
of network calls as today**. Correct, just not faster.

So: the win lands on dev now. **Users on prod get nothing until prod's Supabase
migrates to asymmetric JWT signing keys.** That migration is the follow-up that
actually delivers this to customers; this PR is the prerequisite that makes it pay
off the moment it happens.

## Risk

None identified. On ES256 projects the check is strictly stronger than trusting a
cookie and strictly cheaper than a round trip. On HS256 projects the code path is
equivalent to today's. Behavior is identical in every case — only the number of
network calls changes, and only downward.
