### PR TITLE
perf(sandbox): reduce cold OpenCode startup latency

### DIFF
--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -186,3 +186,38 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
     }
   });
 });
+
+describe('buildSessionRuntimeEnv — OpenCode executable prefetch', () => {
+  test('enables prefetch through the single fast cold boot flag', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      fastColdBootEnabled: true,
+      freshSession: false,
+    });
+
+    expect(env.KORTIX_OPENCODE_BINARY_PREFETCH).toBe('1');
+    expect(env).not.toHaveProperty('KORTIX_SESSION_FRESH');
+  });
+
+  test('omits prefetch when the fast cold boot flag is disabled', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      fastColdBootEnabled: false,
+      freshSession: true,
+    });
+
+    expect(env).not.toHaveProperty('KORTIX_OPENCODE_BINARY_PREFETCH');
+  });
+
+  test('keeps prefetch enabled for runtime-only sessions', () => {
+    const env = buildSessionRuntimeEnv({
+      ...BASE_INPUT,
+      workspaceMode: 'runtime',
+      fastColdBootEnabled: true,
+      freshSession: true,
+    });
+
+    expect(env.KORTIX_OPENCODE_BINARY_PREFETCH).toBe('1');
+    expect(env).not.toHaveProperty('KORTIX_REPO_URL');
+  });
+});

--- a/apps/api/src/projects/lib/session-runtime-env.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.ts
@@ -63,6 +63,7 @@ export function buildSessionRuntimeEnv(input: SessionRuntimeEnvInput): Record<st
   return {
     ...projectGitEnv,
     ...fastGitBootEnv,
+    ...(input.fastColdBootEnabled ? { KORTIX_OPENCODE_BINARY_PREFETCH: '1' } : {}),
     KORTIX_PROJECT_ID: input.projectId,
     KORTIX_SESSION_ID: input.sessionId,
     KORTIX_SERVICE_PORT: '8000',

--- a/apps/api/src/snapshots/templates.ts
+++ b/apps/api/src/snapshots/templates.ts
@@ -221,7 +221,7 @@ const FINGERPRINT_EXCLUDES = ['node_modules', '.bin', 'dist', '.turbo', '.cache'
 // does not survive provider startup.
 // v41: store durable daemon state under /home/kortix/.local/state/kortix. This
 // path remains writable when a provider replaces /run or discards image USER.
-const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v41';
+const RUNTIME_LAYER_VERSION = 'verified-runtime-artifacts-v42';
 const DEFAULT_CPU = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_CPU', 2);
 const DEFAULT_MEMORY_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_MEMORY_GB', 4);
 const DEFAULT_DISK_GB = readPositiveIntEnv('KORTIX_DEFAULT_SANDBOX_DISK_GB', 20);

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-replay-prevention.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-replay-prevention.test.ts
@@ -153,6 +153,23 @@ describe('finalizeOrphanedTurn — the abort gate fed by known (hole 1, orphan h
 })
 
 describe('resolveExistingRoot — waitForRootList timeout (hole 2)', () => {
+  test('reports the first HTTP response once while OpenCode is still not ready', async () => {
+    const { port } = rootServer({ hangRootList: true })
+    const baseUrl = `http://127.0.0.1:${port}`
+    const listeningMarks: string[] = []
+
+    const result = await resolveExistingRoot(
+      baseUrl,
+      '/workspace',
+      null,
+      300,
+      () => listeningMarks.push('listening'),
+    )
+
+    expect(result.status).toBe('create')
+    expect(listeningMarks).toEqual(['listening'])
+  })
+
   test('timeout WITH a prior pin: defers, creates nothing', async () => {
     // `/session` never answers 200, so `waitForRootList` never gets a
     // definitive list and hits its deadline. A short deadline keeps this test
@@ -182,6 +199,19 @@ describe('resolveExistingRoot — waitForRootList timeout (hole 2)', () => {
 })
 
 describe('the boot path is wired to the defer outcome, not just resolveExistingRoot', () => {
+  test('the initial-session path records listening before answering', () => {
+    const start = SRC.indexOf('async function maybeCreateInitialOpencodeSession(')
+    const end = SRC.indexOf('\nasync function resolveExistingRoot', start)
+    const body = SRC.slice(start, end)
+    const resolveAt = body.indexOf('await resolveExistingRoot(')
+    const listeningAt = body.indexOf('onListening)', resolveAt)
+    const answeringAt = body.indexOf("bootMark('opencode-answering')")
+
+    expect(resolveAt).toBeGreaterThan(-1)
+    expect(listeningAt).toBeGreaterThan(resolveAt)
+    expect(answeringAt).toBeGreaterThan(listeningAt)
+  })
+
   test('maybeCreateInitialOpencodeSession returns before creating or pinning a session on defer', () => {
     const start = SRC.indexOf('async function maybeCreateInitialOpencodeSession(')
     expect(start).toBeGreaterThan(-1)

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary-prefetch.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary-prefetch.test.ts
@@ -38,6 +38,16 @@ describe('OpenCode executable prefetch', () => {
     })
   })
 
+  test('does not open the executable when buffer allocation fails', async () => {
+    const missing = join(tmpdir(), 'kortix-opencode-prefetch-missing-buffer-target')
+
+    await expect(
+      prefetchExecutablePages(missing, undefined, () => {
+        throw new Error('synthetic allocation failure')
+      }),
+    ).rejects.toThrow('synthetic allocation failure')
+  })
+
   test('resolves and prefetches the binary once per supervisor', async () => {
     const fixture = await fixtureFile(1024)
     const marks: string[] = []
@@ -215,12 +225,14 @@ describe('OpenCode executable prefetch', () => {
     const main = await readFile(resolve(import.meta.dir, '..', 'main.ts'), 'utf8')
     const begin = main.indexOf('const opencodeBinaryPrefetchPromise')
     const repo = main.indexOf('const repoMaterializePromise')
+    const repoErrorBranch = main.indexOf('if (bootState.repoMaterializationError)')
     const cancelPrefetch = main.indexOf('opencode.cancelBinaryPrefetch()')
     const spawn = main.indexOf('await opencode.start()')
 
     expect(begin).toBeGreaterThan(-1)
     expect(begin).toBeLessThan(repo)
     expect(cancelPrefetch).toBeGreaterThan(repo)
+    expect(cancelPrefetch).toBeLessThan(repoErrorBranch)
     expect(cancelPrefetch).toBeLessThan(spawn)
     expect(main).not.toContain('await opencodeBinaryPrefetchPromise')
   })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary-prefetch.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary-prefetch.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import type { Config } from '../config'
+import { createOpencodeSupervisor, prefetchExecutablePages } from '../opencode'
+
+const tempDirs: string[] = []
+
+async function fixtureFile(size: number): Promise<{ dir: string; path: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'kortix-opencode-prefetch-'))
+  const path = join(dir, 'opencode')
+  tempDirs.push(dir)
+  await writeFile(path, Buffer.alloc(size, 0x5a))
+  return { dir, path }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('OpenCode executable prefetch', () => {
+  test('reads the complete executable with bounded buffers', async () => {
+    const size = 4 * 1024 * 1024 + 17
+    const fixture = await fixtureFile(size)
+
+    expect(await prefetchExecutablePages(fixture.path)).toBe(size)
+  })
+
+  test('rejects before opening when the caller already stopped', async () => {
+    const fixture = await fixtureFile(1024)
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(prefetchExecutablePages(fixture.path, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError',
+    })
+  })
+
+  test('resolves and prefetches the binary once per supervisor', async () => {
+    const fixture = await fixtureFile(1024)
+    const marks: string[] = []
+    const cfg = {
+      workspace: fixture.dir,
+      projectTarget: fixture.dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const opencode = createOpencodeSupervisor(cfg, fixture.dir, undefined, {
+      binaryPathOverride: fixture.path,
+      onStartupMark: (mark) => marks.push(mark),
+    })
+
+    expect(await opencode.prefetchBinary()).toBe(true)
+    expect(await opencode.prefetchBinary()).toBe(true)
+    expect(opencode.getBinaryPath()).toBe(fixture.path)
+    expect(marks.filter((mark) => mark === 'runtime-binary-resolved')).toHaveLength(1)
+    expect(marks.filter((mark) => mark === 'runtime-binary-prefetch-started')).toHaveLength(1)
+    expect(marks.filter((mark) => mark === 'runtime-binary-prefetched')).toHaveLength(1)
+  })
+
+  test('keeps a read failure on the fallback path', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'kortix-opencode-prefetch-missing-'))
+    tempDirs.push(dir)
+    const missing = join(dir, 'missing-opencode')
+    const cfg = {
+      workspace: dir,
+      projectTarget: dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const marks: string[] = []
+    const opencode = createOpencodeSupervisor(cfg, dir, undefined, {
+      binaryPathOverride: missing,
+      onStartupMark: (mark) => marks.push(mark),
+    })
+
+    expect(await opencode.prefetchBinary()).toBe(false)
+    expect(marks).toContain('runtime-binary-prefetch-failed')
+  })
+
+  test('a failed prefetch does not prevent the resolved executable from starting', async () => {
+    const fixture = await fixtureFile(1024)
+    await writeFile(
+      fixture.path,
+      '#!/usr/bin/env bash\ntrap \'exit 0\' TERM INT\nwhile :; do /bin/sleep 0.05; done\n',
+    )
+    await chmod(fixture.path, 0o755)
+    const cfg = {
+      workspace: fixture.dir,
+      projectTarget: fixture.dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const opencode = createOpencodeSupervisor(cfg, fixture.dir, undefined, {
+      binaryPathOverride: fixture.path,
+      configPathOverride: join(fixture.dir, 'opencode-config.json'),
+      prefetchExecutableOverride: async () => {
+        throw new Error('synthetic read failure')
+      },
+    })
+
+    expect(await opencode.prefetchBinary()).toBe(false)
+    await opencode.start()
+    expect(opencode.getPid()).not.toBeNull()
+    await opencode.stop()
+  })
+
+  test('stop aborts and joins an active prefetch', async () => {
+    const fixture = await fixtureFile(1024)
+    let observedSignal: AbortSignal | undefined
+    let announceStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      announceStarted = resolve
+    })
+    const cfg = {
+      workspace: fixture.dir,
+      projectTarget: fixture.dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const opencode = createOpencodeSupervisor(cfg, fixture.dir, undefined, {
+      binaryPathOverride: fixture.path,
+      prefetchExecutableOverride: (_path, signal) =>
+        new Promise<number>((_resolve, reject) => {
+          observedSignal = signal
+          announceStarted?.()
+          signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('prefetch stopped', 'AbortError')),
+            { once: true },
+          )
+        }),
+    })
+
+    const prefetch = opencode.prefetchBinary()
+    await started
+    await opencode.stop()
+
+    expect(observedSignal?.aborted).toBe(true)
+    expect(await prefetch).toBe(false)
+  })
+
+  test('cancel stops prefetch without delaying spawn', async () => {
+    const fixture = await fixtureFile(1024)
+    await writeFile(
+      fixture.path,
+      '#!/usr/bin/env bash\ntrap \'exit 0\' TERM INT\nwhile :; do /bin/sleep 0.05; done\n',
+    )
+    await chmod(fixture.path, 0o755)
+    let releasePrefetch: (() => void) | undefined
+    let announceStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      announceStarted = resolve
+    })
+    const marks: string[] = []
+    const cfg = {
+      workspace: fixture.dir,
+      projectTarget: fixture.dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const opencode = createOpencodeSupervisor(cfg, fixture.dir, undefined, {
+      binaryPathOverride: fixture.path,
+      configPathOverride: join(fixture.dir, 'opencode-config.json'),
+      onStartupMark: (mark) => marks.push(mark),
+      prefetchExecutableOverride: (_path, _signal) =>
+        new Promise<number>((resolve) => {
+          releasePrefetch = () => resolve(1024)
+          announceStarted?.()
+        }),
+    })
+
+    const prefetch = opencode.prefetchBinary()
+    await started
+    opencode.cancelBinaryPrefetch()
+    await opencode.start()
+
+    expect(opencode.getPid()).not.toBeNull()
+    releasePrefetch?.()
+    expect(await prefetch).toBe(false)
+    expect(marks).toContain('runtime-binary-prefetch-cancelled')
+    await opencode.stop()
+  })
+
+  test('retries a transient binary lookup miss on the next start', async () => {
+    const fixture = await fixtureFile(1024)
+    await writeFile(
+      fixture.path,
+      '#!/usr/bin/env bash\ntrap \'exit 0\' TERM INT\nwhile :; do /bin/sleep 0.05; done\n',
+    )
+    await chmod(fixture.path, 0o755)
+    let attempts = 0
+    const cfg = {
+      workspace: fixture.dir,
+      projectTarget: fixture.dir,
+      opencodeInternalPort: 4096,
+      opencodeStandbyPort: 4097,
+    } as Config
+    const opencode = createOpencodeSupervisor(cfg, fixture.dir, undefined, {
+      configPathOverride: join(fixture.dir, 'opencode-config.json'),
+      binaryPathResolverOverride: async () => (++attempts === 1 ? null : fixture.path),
+    })
+
+    await opencode.start()
+    expect(opencode.getPid()).toBeNull()
+    await opencode.start()
+    expect(opencode.getPid()).not.toBeNull()
+    expect(attempts).toBe(2)
+    await opencode.stop()
+  })
+
+  test('overlaps prefetch with repository work and cancels it before spawn', async () => {
+    const main = await readFile(resolve(import.meta.dir, '..', 'main.ts'), 'utf8')
+    const begin = main.indexOf('const opencodeBinaryPrefetchPromise')
+    const repo = main.indexOf('const repoMaterializePromise')
+    const cancelPrefetch = main.indexOf('opencode.cancelBinaryPrefetch()')
+    const spawn = main.indexOf('await opencode.start()')
+
+    expect(begin).toBeGreaterThan(-1)
+    expect(begin).toBeLessThan(repo)
+    expect(cancelPrefetch).toBeGreaterThan(repo)
+    expect(cancelPrefetch).toBeLessThan(spawn)
+    expect(main).not.toContain('await opencodeBinaryPrefetchPromise')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { chmod, mkdir, mkdtemp, readdir, readlink, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  parsePnpmGlobalPackagePath,
+  publishOpencodeNativeLink,
+  resolveInstalledOpencodeNative,
+} from '../opencode-binary'
+import { installOpencodeVersion } from '../runtime-assets'
+
+const tempDirs: string[] = []
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'kortix-opencode-binary-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function executable(path: string): Promise<void> {
+  await writeFile(path, '#!/bin/sh\nexit 0\n')
+  await chmod(path, 0o755)
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe('pnpm OpenCode native binary resolution', () => {
+  test('selects the pnpm v11 package directory instead of the global root', () => {
+    const root = '/home/kortix/.local/share/pnpm/global/v11'
+    const packagePath = `${root}/1423c-1a022964b2a-a2220588c319339d/node_modules/opencode-ai`
+
+    expect(parsePnpmGlobalPackagePath(`${root}\n${packagePath}\n`)).toBe(packagePath)
+  })
+
+  test('rejects root-only, relative, and lookalike output', () => {
+    expect(parsePnpmGlobalPackagePath('/home/kortix/.local/share/pnpm/global/v11\n')).toBeNull()
+    expect(parsePnpmGlobalPackagePath('node_modules/opencode-ai\n')).toBeNull()
+    expect(
+      parsePnpmGlobalPackagePath('/tmp/node_modules/opencode-ai-malicious\n'),
+    ).toBeNull()
+  })
+
+  test('resolves bin/opencode.exe and verifies it is executable', async () => {
+    const dir = await tempDir()
+    const packagePath = join(dir, 'global', 'v11', 'hash', 'node_modules', 'opencode-ai')
+    const nativePath = join(packagePath, 'bin', 'opencode.exe')
+    await mkdir(join(packagePath, 'bin'), { recursive: true })
+    await Bun.write(join(packagePath, 'package.json'), '{}')
+    await executable(nativePath)
+    const calls: Array<{ file: string; args: string[] }> = []
+
+    const resolved = await resolveInstalledOpencodeNative(async (file, args) => {
+      calls.push({ file, args })
+      return `${join(dir, 'global', 'v11')}\n${packagePath}\n`
+    })
+
+    expect(resolved).toBe(nativePath)
+    expect(calls).toEqual([
+      {
+        file: 'pnpm',
+        args: ['list', '-g', '--parseable', '--depth', '0', 'opencode-ai'],
+      },
+    ])
+  })
+})
+
+describe('OpenCode native stable link', () => {
+  test('atomically replaces an existing link and removes the temporary link', async () => {
+    const dir = await tempDir()
+    const oldNative = join(dir, 'old-opencode')
+    const newNative = join(dir, 'new-opencode')
+    const current = join(dir, 'opencode.current')
+    await executable(oldNative)
+    await executable(newNative)
+    await symlink(oldNative, current)
+
+    await publishOpencodeNativeLink(newNative, current)
+
+    expect(await readlink(current)).toBe(newNative)
+    expect((await readdir(dir)).filter((name) => name.startsWith('opencode.current.next-'))).toEqual(
+      [],
+    )
+  })
+
+  test('keeps the previous link when the new target is missing', async () => {
+    const dir = await tempDir()
+    const oldNative = join(dir, 'old-opencode')
+    const missing = join(dir, 'missing-opencode')
+    const current = join(dir, 'opencode.current')
+    await executable(oldNative)
+    await symlink(oldNative, current)
+
+    await expect(publishOpencodeNativeLink(missing, current)).rejects.toBeTruthy()
+
+    expect(await readlink(current)).toBe(oldNative)
+    expect((await readdir(dir)).filter((name) => name.startsWith('opencode.current.next-'))).toEqual(
+      [],
+    )
+  })
+
+  test('keeps the previous link when the new target is not executable', async () => {
+    const dir = await tempDir()
+    const oldNative = join(dir, 'old-opencode')
+    const newNative = join(dir, 'new-opencode')
+    const current = join(dir, 'opencode.current')
+    await executable(oldNative)
+    await writeFile(newNative, 'not executable')
+    await symlink(oldNative, current)
+
+    await expect(publishOpencodeNativeLink(newNative, current)).rejects.toBeTruthy()
+
+    expect(await readlink(current)).toBe(oldNative)
+  })
+})
+
+describe('OpenCode runtime installation', () => {
+  test('publishes the validated native target after pnpm install', async () => {
+    const dir = await tempDir()
+    const packagePath = join(dir, 'global', 'v11', 'hash', 'node_modules', 'opencode-ai')
+    const nativePath = join(packagePath, 'bin', 'opencode.exe')
+    const oldNative = join(dir, 'old-opencode')
+    const current = join(dir, 'opencode.current')
+    await mkdir(join(packagePath, 'bin'), { recursive: true })
+    await executable(nativePath)
+    await executable(oldNative)
+    await symlink(oldNative, current)
+    const events: string[] = []
+
+    await installOpencodeVersion('1.18.19', {
+      currentLinkPath: current,
+      installPackage: async (version) => {
+        events.push(`install:${version}`)
+      },
+      capture: async (file, args) => {
+        if (file === 'pnpm') {
+          events.push(`resolve:${args.join(' ')}`)
+          return `${join(dir, 'global', 'v11')}\n${packagePath}\n`
+        }
+        events.push(`version:${file}`)
+        return '1.18.19\n'
+      },
+    })
+
+    expect(events).toEqual([
+      'install:1.18.19',
+      'resolve:list -g --parseable --depth 0 opencode-ai',
+      `version:${nativePath}`,
+    ])
+    expect(await readlink(current)).toBe(nativePath)
+  })
+
+  test('keeps the previous target when the native version is wrong', async () => {
+    const dir = await tempDir()
+    const packagePath = join(dir, 'global', 'v11', 'hash', 'node_modules', 'opencode-ai')
+    const nativePath = join(packagePath, 'bin', 'opencode.exe')
+    const oldNative = join(dir, 'old-opencode')
+    const current = join(dir, 'opencode.current')
+    await mkdir(join(packagePath, 'bin'), { recursive: true })
+    await executable(nativePath)
+    await executable(oldNative)
+    await symlink(oldNative, current)
+
+    await expect(
+      installOpencodeVersion('1.18.19', {
+        currentLinkPath: current,
+        installPackage: async () => {},
+        capture: async (file) =>
+          file === 'pnpm' ? `${packagePath}\n` : '1.18.18\n',
+      }),
+    ).rejects.toThrow('expected 1.18.19, got 1.18.18')
+
+    expect(await readlink(current)).toBe(oldNative)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
@@ -8,6 +8,7 @@ import {
   publishOpencodeNativeLink,
   resolveInstalledOpencodeNative,
 } from '../opencode-binary'
+import { detectOpencodeBinary } from '../opencode'
 import { installOpencodeVersion } from '../runtime-assets'
 
 const tempDirs: string[] = []
@@ -63,6 +64,125 @@ describe('pnpm OpenCode native binary resolution', () => {
         file: 'pnpm',
         args: ['list', '-g', '--parseable', '--depth', '0', 'opencode-ai'],
       },
+    ])
+  })
+})
+
+describe('OpenCode launch binary detection', () => {
+  test('uses the PATH launcher without pnpm discovery when the experiment is disabled', async () => {
+    const events: string[] = []
+
+    const resolved = await detectOpencodeBinary({
+      nativeBinaryFastPathEnabled: false,
+      currentLink: '/test/opencode.current',
+      systemLink: '/test/opencode-kortix',
+      isExecutable: async (path) => {
+        events.push(`executable:${path}`)
+        return false
+      },
+      resolveInstalledNative: async () => {
+        events.push('resolve-native')
+        return '/test/opencode.exe'
+      },
+      publishNativeLink: async () => {
+        events.push('publish-native')
+      },
+      findOnPath: async (name) => {
+        events.push(`path:${name}`)
+        return '/test/opencode'
+      },
+    })
+
+    expect(resolved).toBe('/test/opencode')
+    expect(events).toEqual(['path:opencode'])
+  })
+
+  test('uses an existing stable link when the experiment is enabled', async () => {
+    const events: string[] = []
+
+    const resolved = await detectOpencodeBinary({
+      nativeBinaryFastPathEnabled: true,
+      currentLink: '/test/opencode.current',
+      systemLink: '/test/opencode-kortix',
+      isExecutable: async (path) => {
+        events.push(`executable:${path}`)
+        return path === '/test/opencode.current'
+      },
+      resolveInstalledNative: async () => {
+        events.push('resolve-native')
+        return '/test/opencode.exe'
+      },
+      publishNativeLink: async () => {
+        events.push('publish-native')
+      },
+      findOnPath: async (name) => {
+        events.push(`path:${name}`)
+        return '/test/opencode'
+      },
+    })
+
+    expect(resolved).toBe('/test/opencode.current')
+    expect(events).toEqual(['executable:/test/opencode.current'])
+  })
+
+  test('falls back to an existing stable link when the disabled PATH launcher is missing', async () => {
+    const events: string[] = []
+
+    const resolved = await detectOpencodeBinary({
+      nativeBinaryFastPathEnabled: false,
+      currentLink: '/test/opencode.current',
+      systemLink: '/test/opencode-kortix',
+      isExecutable: async (path) => {
+        events.push(`executable:${path}`)
+        return path === '/test/opencode.current'
+      },
+      resolveInstalledNative: async () => {
+        events.push('resolve-native')
+        return '/test/opencode.exe'
+      },
+      publishNativeLink: async () => {
+        events.push('publish-native')
+      },
+      findOnPath: async (name) => {
+        events.push(`path:${name}`)
+        return null
+      },
+    })
+
+    expect(resolved).toBe('/test/opencode.current')
+    expect(events).toEqual(['path:opencode', 'executable:/test/opencode.current'])
+  })
+
+  test('repairs a legacy image through pnpm only when the experiment is enabled', async () => {
+    const events: string[] = []
+
+    const resolved = await detectOpencodeBinary({
+      nativeBinaryFastPathEnabled: true,
+      currentLink: '/test/opencode.current',
+      systemLink: '/test/opencode-kortix',
+      isExecutable: async (path) => {
+        events.push(`executable:${path}`)
+        return false
+      },
+      resolveInstalledNative: async () => {
+        events.push('resolve-native')
+        return '/test/opencode.exe'
+      },
+      publishNativeLink: async (nativePath, linkPath) => {
+        events.push(`publish-native:${nativePath}:${linkPath}`)
+      },
+      findOnPath: async (name) => {
+        events.push(`path:${name}`)
+        return '/test/opencode'
+      },
+    })
+
+    expect(resolved).toBe('/test/opencode.current')
+    expect(events).toEqual([
+      'executable:/test/opencode.current',
+      'executable:/test/opencode-kortix',
+      'resolve-native',
+      'publish-native:/test/opencode.exe:/test/opencode.current',
     ])
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-first-ready-response.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-first-ready-response.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Config } from '../config'
+import { createOpencodeSupervisor } from '../opencode'
+
+const MAIN = await Bun.file(new URL('../main.ts', import.meta.url).pathname).text()
+
+let root: string
+let supervisor: ReturnType<typeof createOpencodeSupervisor> | null
+
+function reservePort(): number {
+  const server = Bun.serve({ port: 0, fetch: () => new Response('reserved') })
+  const port = server.port
+  server.stop(true)
+  if (typeof port !== 'number') throw new Error('Bun did not assign a port')
+  return port
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (check()) return
+    await Bun.sleep(20)
+  }
+  throw new Error('condition did not become true')
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-first-ready-response-'))
+  supervisor = null
+})
+
+afterEach(async () => {
+  await supervisor?.stop()
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('OpenCode supervisor first ready response', () => {
+  test('reports the first successful readiness response once', async () => {
+    const workspace = join(root, 'workspace')
+    const configDir = join(root, 'config')
+    const binary = join(root, 'opencode')
+    const readyFile = join(root, 'ready')
+    const probedFile = join(root, 'probed')
+    mkdirSync(workspace)
+    mkdirSync(configDir)
+    writeFileSync(
+      binary,
+      `#!/usr/bin/env bun
+import { existsSync, writeFileSync } from 'node:fs'
+const port = Number(Bun.argv[Bun.argv.indexOf('--port') + 1])
+Bun.serve({
+  port,
+  hostname: '127.0.0.1',
+  fetch: () => {
+    writeFileSync(${JSON.stringify(probedFile)}, 'probed')
+    return existsSync(${JSON.stringify(readyFile)})
+      ? Response.json([])
+      : new Response('starting', { status: 503 })
+  },
+})
+`,
+    )
+    chmodSync(binary, 0o755)
+
+    const cfg = {
+      workspace,
+      projectTarget: workspace,
+      opencodeInternalPort: reservePort(),
+      opencodeStandbyPort: reservePort(),
+      gitUserName: 'Kortix Agent',
+      gitUserEmail: 'agent@kortix.ai',
+    } as Config
+    let reports = 0
+    supervisor = createOpencodeSupervisor(cfg, configDir, undefined, {
+      binaryPathOverride: binary,
+      configPathOverride: join(root, 'runtime-config.json'),
+      onFirstReadyResponse: () => {
+        reports += 1
+      },
+    })
+
+    await supervisor.start()
+    await waitFor(() => existsSync(probedFile))
+    expect(reports).toBe(0)
+
+    writeFileSync(readyFile, 'ready')
+    await waitFor(() => reports === 1)
+    expect(supervisor.getState()).toBe('ok')
+
+    await supervisor.restart()
+    await waitFor(() => supervisor?.getState() === 'ok')
+    expect(reports).toBe(1)
+  }, 15_000)
+
+  test('wires the first ready response to the de-duplicated listening mark', () => {
+    const supervisorAt = MAIN.indexOf('const opencode = createOpencodeSupervisor(')
+    const sessionRuntimeAt = MAIN.indexOf('void startSessionRuntime(', supervisorAt)
+    const bootPath = MAIN.slice(supervisorAt, sessionRuntimeAt)
+
+    expect(supervisorAt).toBeGreaterThan(-1)
+    expect(sessionRuntimeAt).toBeGreaterThan(supervisorAt)
+    expect(bootPath).toContain('onFirstReadyResponse: () => {')
+    expect(bootPath).toContain("mark.label === 'opencode-listening'")
+    expect(bootPath).toContain("bootMark('opencode-listening')")
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-first-ready-response.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-first-ready-response.test.ts
@@ -96,15 +96,20 @@ Bun.serve({
     expect(reports).toBe(1)
   }, 15_000)
 
-  test('wires the first ready response to the de-duplicated listening mark', () => {
+  test('wires the first ready response to its own de-duplicated boot mark', () => {
     const supervisorAt = MAIN.indexOf('const opencode = createOpencodeSupervisor(')
     const sessionRuntimeAt = MAIN.indexOf('void startSessionRuntime(', supervisorAt)
     const bootPath = MAIN.slice(supervisorAt, sessionRuntimeAt)
+    const callbackAt = bootPath.indexOf('onFirstReadyResponse: () => {')
+    const fastPathAt = bootPath.indexOf('nativeBinaryFastPathEnabled:', callbackAt)
+    const callback = bootPath.slice(callbackAt, fastPathAt)
 
     expect(supervisorAt).toBeGreaterThan(-1)
     expect(sessionRuntimeAt).toBeGreaterThan(supervisorAt)
-    expect(bootPath).toContain('onFirstReadyResponse: () => {')
-    expect(bootPath).toContain("mark.label === 'opencode-listening'")
-    expect(bootPath).toContain("bootMark('opencode-listening')")
+    expect(callbackAt).toBeGreaterThan(-1)
+    expect(fastPathAt).toBeGreaterThan(callbackAt)
+    expect(callback).toContain("mark.label === 'opencode-session-api-ready'")
+    expect(callback).toContain("bootMark('opencode-session-api-ready')")
+    expect(callback).not.toContain('opencode-listening')
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -237,6 +237,14 @@ async function main() {
   // long-pole, so the fetch costs no critical-path time.
   startManagedModelsPrefetch(process.env.KORTIX_LLM_BASE_URL, process.env.KORTIX_LLM_API_KEY)
 
+  // Platinum lazily faults image pages into a fresh VM. Read the OpenCode
+  // executable sequentially while repository and config work run. Stop at the
+  // spawn boundary, so a slow page fault cannot extend the critical path.
+  const opencodeBinaryPrefetchPromise =
+    process.env.KORTIX_OPENCODE_BINARY_PREFETCH === '1'
+      ? opencode.prefetchBinary()
+      : Promise.resolve(false)
+
   const repoMaterializePromise: Promise<void> = cfg.autoClone
     ? materializeRepo(cfg).catch((err) => {
         bootState.repoMaterializationError = err instanceof Error ? err.message : String(err)
@@ -277,6 +285,10 @@ async function main() {
         err: err instanceof Error ? err.message : String(err),
       })
     })
+    // Repository/config work defines the free overlap window. Stop any
+    // remaining sequential read here so prefetch can never extend boot.
+    opencode.cancelBinaryPrefetch()
+    void opencodeBinaryPrefetchPromise
     opencode.reconfigure(cfg, opencodeConfigDir, projectEnv)
     await opencode.start().catch((err) => {
       logger.warn('[boot] opencode.start() rejected', {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -565,6 +565,10 @@ async function startSessionRuntime(
   bootState: SandboxBootState,
   bootMark: (label: string) => void,
 ): Promise<void> {
+  const markOpencodeListening = () => {
+    if (bootState.timeline.some((mark) => mark.label === 'opencode-listening')) return
+    bootMark('opencode-listening')
+  }
   // BEFORE the event loop, the root resolution and any prompt delivery: a
   // restart here strands nothing, and the first turn must run on a provider map
   // that has every managed model the picker offers.
@@ -691,7 +695,13 @@ async function startSessionRuntime(
     // backstop for any residual gap.
     const loop = startOpencodeEventLoop(opencode, cfg, eventHandlers)
     loopStarted = true
-    await maybeCreateInitialOpencodeSession(opencode, bootState, bootMark, loop.connected).catch(
+    await maybeCreateInitialOpencodeSession(
+      opencode,
+      bootState,
+      bootMark,
+      loop.connected,
+      markOpencodeListening,
+    ).catch(
       (err) => {
         bootState.initialOpenCodeSessionError = err instanceof Error ? err.message : String(err)
         logger.warn('[boot] initial opencode session setup failed', err)
@@ -712,7 +722,7 @@ async function startSessionRuntime(
       return
     }
   }
-  const ready = await waitForOpencodeReady(opencode, cfg.projectTarget, () => bootMark('opencode-listening'))
+  const ready = await waitForOpencodeReady(opencode, cfg.projectTarget, markOpencodeListening)
   if (ready) {
     bootMark('opencode-ready')
     logger.info('[boot] opencode ready', { opencodePid: opencode.getPid(), timeline: bootState.timeline })
@@ -1200,6 +1210,7 @@ async function maybeCreateInitialOpencodeSession(
   // the reused-root / no-prompt paths (which never fire a new turn) don't depend
   // on it; a missing promise just skips the wait.
   eventLoopConnected?: Promise<void>,
+  onListening?: () => void,
 ): Promise<void> {
   const prompt = (process.env.KORTIX_INITIAL_PROMPT ?? '').trim()
   const bootstrapSession = (process.env.KORTIX_BOOTSTRAP_OPENCODE_SESSION ?? '').trim() === '1'
@@ -1225,7 +1236,7 @@ async function maybeCreateInitialOpencodeSession(
   // marker (delivery, below, hasn't happened yet) — reflects only a PRIOR
   // boot's successful delivery, never this one's own pending write.
   const priorDeliveredMarker = readInitialPromptDeliveredMarker()
-  const resolved = await resolveExistingRoot(baseUrl, workspace, priorPin)
+  const resolved = await resolveExistingRoot(baseUrl, workspace, priorPin, 20_000, onListening)
   bootMark('opencode-answering')
   if (resolved.status === 'defer') {
     // opencode never answered the root list within the deadline, and a prior
@@ -1550,13 +1561,14 @@ async function resolveExistingRoot(
   workspace: string,
   priorPin: string | null = readPinnedOpencodeSessionId(),
   rootListDeadlineMs = 20_000,
+  onListening?: () => void,
 ): Promise<ExistingRootResult> {
   // Wait for a DEFINITIVE answer from opencode before deciding. Treating a slow
   // boot as "no roots" would create a duplicate on restart — the exact bug we're
   // killing — so only conclude "create a fresh root" once opencode has actually
   // answered with an empty list (or never answers within the deadline, and
   // there is no prior pin to protect — see `defer` above).
-  const roots = await waitForRootList(baseUrl, workspace, rootListDeadlineMs)
+  const roots = await waitForRootList(baseUrl, workspace, rootListDeadlineMs, onListening)
   if (!roots) {
     if (priorPin) {
       logger.warn(
@@ -1601,10 +1613,17 @@ async function waitForRootList(
   baseUrl: string,
   workspace: string,
   deadlineMs = 20_000,
+  onListening?: () => void,
 ): Promise<RootLite[] | null> {
   const deadline = Date.now() + deadlineMs
+  let listeningSeen = false
+  const markListening = () => {
+    if (listeningSeen) return
+    listeningSeen = true
+    onListening?.()
+  }
   while (Date.now() < deadline) {
-    const roots = await listOpencodeRoots(baseUrl, workspace)
+    const roots = await listOpencodeRoots(baseUrl, workspace, markListening)
     if (roots !== null) return roots
     await new Promise((r) => setTimeout(r, 100))
   }
@@ -1631,7 +1650,11 @@ async function waitForRootList(
  *   - An OpenCode that does not know a query parameter ignores it silently. If
  *     `roots` were ever dropped, the filter is what still stops a Task-tool
  *     CHILD from being adopted as the canonical root. One line, absolute. */
-async function listOpencodeRoots(baseUrl: string, workspace: string): Promise<RootLite[] | null> {
+async function listOpencodeRoots(
+  baseUrl: string,
+  workspace: string,
+  onHttpResponse?: () => void,
+): Promise<RootLite[] | null> {
   try {
     const res = await fetch(
       `${baseUrl}/session?directory=${encodeURIComponent(workspace)}&roots=true`,
@@ -1641,6 +1664,7 @@ async function listOpencodeRoots(baseUrl: string, workspace: string): Promise<Ro
         signal: AbortSignal.timeout(5_000),
       },
     )
+    onHttpResponse?.()
     if (!res.ok) return null
     const data = (await res.json()) as Array<{ id?: string; parentID?: string | null; time?: { created?: number; updated?: number } }>
     if (!Array.isArray(data)) return []

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -180,8 +180,14 @@ async function main() {
   // reconfigured with the resolved dir below, before the process is ever
   // spawned. `reconfigure` only rewrites state read at spawn time, so this is
   // exactly equivalent to constructing it late.
+  const opencodeBinaryPrefetchEnabled = process.env.KORTIX_OPENCODE_BINARY_PREFETCH === '1'
   const opencode = createOpencodeSupervisor(cfg, cfg.defaultOpencodeConfigDir, projectEnv, {
     onStartupMark: bootMark,
+    onFirstReadyResponse: () => {
+      if (bootState.timeline.some((mark) => mark.label === 'opencode-listening')) return
+      bootMark('opencode-listening')
+    },
+    nativeBinaryFastPathEnabled: opencodeBinaryPrefetchEnabled,
   onUnplannedRespawn: () => {
       // opencode died on its own and is back. Close whatever turn it was
       // writing, or the client streams a part that will never complete.
@@ -241,7 +247,7 @@ async function main() {
   // executable sequentially while repository and config work run. Stop at the
   // spawn boundary, so a slow page fault cannot extend the critical path.
   const opencodeBinaryPrefetchPromise =
-    process.env.KORTIX_OPENCODE_BINARY_PREFETCH === '1'
+    opencodeBinaryPrefetchEnabled
       ? opencode.prefetchBinary()
       : Promise.resolve(false)
 
@@ -274,6 +280,11 @@ async function main() {
   await ensureInjectedManagedSkills(opencodeConfigDir)
   bootMark('config-deps')
 
+  // Repository/config work defines the free overlap window. Stop any
+  // remaining sequential read here so prefetch cannot outlive either outcome.
+  opencode.cancelBinaryPrefetch()
+  void opencodeBinaryPrefetchPromise
+
   if (bootState.repoMaterializationError) {
     logger.warn('[boot] skipping runtime readiness because repo materialization failed')
   } else {
@@ -285,10 +296,6 @@ async function main() {
         err: err instanceof Error ? err.message : String(err),
       })
     })
-    // Repository/config work defines the free overlap window. Stop any
-    // remaining sequential read here so prefetch can never extend boot.
-    opencode.cancelBinaryPrefetch()
-    void opencodeBinaryPrefetchPromise
     opencode.reconfigure(cfg, opencodeConfigDir, projectEnv)
     await opencode.start().catch((err) => {
       logger.warn('[boot] opencode.start() rejected', {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -184,8 +184,8 @@ async function main() {
   const opencode = createOpencodeSupervisor(cfg, cfg.defaultOpencodeConfigDir, projectEnv, {
     onStartupMark: bootMark,
     onFirstReadyResponse: () => {
-      if (bootState.timeline.some((mark) => mark.label === 'opencode-listening')) return
-      bootMark('opencode-listening')
+      if (bootState.timeline.some((mark) => mark.label === 'opencode-session-api-ready')) return
+      bootMark('opencode-session-api-ready')
     },
     nativeBinaryFastPathEnabled: opencodeBinaryPrefetchEnabled,
   onUnplannedRespawn: () => {

--- a/apps/kortix-sandbox-agent-server/src/opencode-binary.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-binary.ts
@@ -1,0 +1,81 @@
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { access, constants, rename, rm, stat, symlink } from 'node:fs/promises'
+import { isAbsolute, join, normalize } from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export const OPENCODE_SYSTEM_LINK = '/usr/local/bin/opencode-kortix'
+export const OPENCODE_CURRENT_LINK = '/opt/kortix/opencode.current'
+
+const OPENCODE_PACKAGE = 'opencode-ai'
+const OPENCODE_NATIVE_RELATIVE_PATH = 'bin/opencode.exe'
+
+export type CaptureCommand = (file: string, args: string[]) => Promise<string>
+
+export async function captureProcessOutput(file: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(file, args, {
+    timeout: 30_000,
+    maxBuffer: 4 * 1024 * 1024,
+  })
+  return String(stdout)
+}
+
+export function parsePnpmGlobalPackagePath(
+  output: string,
+  packageName = OPENCODE_PACKAGE,
+): string | null {
+  const suffix = normalize(`/node_modules/${packageName}`)
+  const paths = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => isAbsolute(line))
+
+  for (let index = paths.length - 1; index >= 0; index -= 1) {
+    const path = paths[index]
+    if (path && normalize(path).endsWith(suffix)) return path
+  }
+  return null
+}
+
+export async function requireExecutableFile(path: string): Promise<void> {
+  const info = await stat(path)
+  if (!info.isFile()) throw new Error(`OpenCode native target is not a file: ${path}`)
+  await access(path, constants.X_OK)
+}
+
+export async function resolveInstalledOpencodeNative(
+  capture: CaptureCommand = captureProcessOutput,
+): Promise<string> {
+  const output = await capture('pnpm', [
+    'list',
+    '-g',
+    '--parseable',
+    '--depth',
+    '0',
+    OPENCODE_PACKAGE,
+  ])
+  const packagePath = parsePnpmGlobalPackagePath(output)
+  if (!packagePath) {
+    throw new Error('pnpm did not report the global opencode-ai package path')
+  }
+
+  const nativePath = join(packagePath, OPENCODE_NATIVE_RELATIVE_PATH)
+  await requireExecutableFile(nativePath)
+  return nativePath
+}
+
+export async function publishOpencodeNativeLink(
+  nativePath: string,
+  linkPath = OPENCODE_CURRENT_LINK,
+): Promise<void> {
+  await requireExecutableFile(nativePath)
+  const temporaryLink = `${linkPath}.next-${process.pid}-${randomUUID()}`
+  try {
+    await symlink(nativePath, temporaryLink)
+    await rename(temporaryLink, linkPath)
+  } finally {
+    await rm(temporaryLink, { force: true })
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1473,7 +1473,7 @@ export async function prefetchExecutablePages(
 ): Promise<number> {
   if (signal?.aborted) throw signal.reason
   const buffer = allocateBuffer(EXECUTABLE_PREFETCH_BUFFER_BYTES)
-  const handle = await open(path, 'r')
+  const handle = await open(path, 'r', 0o600)
   let bytes = 0
   try {
     while (true) {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1414,23 +1414,54 @@ async function which(bin: string): Promise<string | null> {
   })
 }
 
-async function detectOpencodeBinary(): Promise<string | null> {
-  if (await isExecutable(OPENCODE_CURRENT_LINK)) return OPENCODE_CURRENT_LINK
-  if (await isExecutable(OPENCODE_SYSTEM_LINK)) return OPENCODE_SYSTEM_LINK
+export interface OpencodeBinaryDetectionOptions {
+  nativeBinaryFastPathEnabled?: boolean
+  currentLink?: string
+  systemLink?: string
+  isExecutable?: (path: string) => Promise<boolean>
+  resolveInstalledNative?: () => Promise<string>
+  publishNativeLink?: (nativePath: string, linkPath: string) => Promise<void>
+  findOnPath?: (bin: string) => Promise<string | null>
+}
 
-  // Older images only have pnpm's small shell launcher. Discover the native
-  // executable once, then repair the user-owned stable link for this and every
-  // later daemon start. A discovery failure keeps the functional launcher.
+export async function detectOpencodeBinary(
+  options: OpencodeBinaryDetectionOptions = {},
+): Promise<string | null> {
+  const currentLink = options.currentLink ?? OPENCODE_CURRENT_LINK
+  const systemLink = options.systemLink ?? OPENCODE_SYSTEM_LINK
+  const checkExecutable = options.isExecutable ?? isExecutable
+  const findOnPath = options.findOnPath ?? which
+
+  // The one cold-boot experiment switch must restore the pre-optimization
+  // launch path completely. Disabled sessions use pnpm's PATH launcher and do
+  // not discover or publish native-binary links. Existing stable links remain
+  // an availability fallback only when that verified launcher disappeared.
+  if (!options.nativeBinaryFastPathEnabled) {
+    const pathLauncher = await findOnPath('opencode')
+    if (pathLauncher) return pathLauncher
+    if (await checkExecutable(currentLink)) return currentLink
+    if (await checkExecutable(systemLink)) return systemLink
+    return null
+  }
+
+  if (await checkExecutable(currentLink)) return currentLink
+  if (await checkExecutable(systemLink)) return systemLink
+
+  const resolveInstalledNative = options.resolveInstalledNative ?? resolveInstalledOpencodeNative
+  const publishNativeLink =
+    options.publishNativeLink ??
+    ((nativePath: string, linkPath: string) => publishOpencodeNativeLink(nativePath, linkPath))
   try {
-    const nativePath = await resolveInstalledOpencodeNative()
-    await publishOpencodeNativeLink(nativePath)
-    return OPENCODE_CURRENT_LINK
+    const nativePath = await resolveInstalledNative()
+    await publishNativeLink(nativePath, currentLink)
+    return currentLink
   } catch (err) {
     logger.warn('[opencode] native binary discovery failed; using PATH launcher', {
       err: err instanceof Error ? err.message : String(err),
     })
   }
-  return await which('opencode')
+
+  return await findOnPath('opencode')
 }
 
 const EXECUTABLE_PREFETCH_BUFFER_BYTES = 4 * 1024 * 1024
@@ -1438,10 +1469,11 @@ const EXECUTABLE_PREFETCH_BUFFER_BYTES = 4 * 1024 * 1024
 export async function prefetchExecutablePages(
   path: string,
   signal?: AbortSignal,
+  allocateBuffer: (size: number) => Buffer = (size) => Buffer.allocUnsafe(size),
 ): Promise<number> {
   if (signal?.aborted) throw signal.reason
+  const buffer = allocateBuffer(EXECUTABLE_PREFETCH_BUFFER_BYTES)
   const handle = await open(path, 'r')
-  const buffer = Buffer.allocUnsafe(EXECUTABLE_PREFETCH_BUFFER_BYTES)
   let bytes = 0
   try {
     while (true) {
@@ -1505,8 +1537,10 @@ export type Opencode = {
 
 export interface OpencodeSupervisorOptions {
   onStartupMark?: (label: string) => void
+  onFirstReadyResponse?: () => void
   binaryPathOverride?: string
   binaryPathResolverOverride?: () => Promise<string | null>
+  nativeBinaryFastPathEnabled?: boolean
   prefetchExecutableOverride?: (path: string, signal: AbortSignal) => Promise<number>
   configPathOverride?: string
   /**
@@ -1550,6 +1584,7 @@ export function createOpencodeSupervisor(
   let restartDelayMs = 500
   let state: OpencodeState = 'starting'
   let readinessTimer: ReturnType<typeof setTimeout> | null = null
+  let firstReadyResponseReported = false
   let opencodeCwd = cfg.workspace
   const startupMark = options.onStartupMark ?? (() => {})
   let binaryResolutionPromise: Promise<string | null> | null = null
@@ -1560,7 +1595,10 @@ export function createOpencodeSupervisor(
     if (!binaryResolutionPromise) {
       binaryResolutionPromise = options.binaryPathOverride
         ? Promise.resolve(options.binaryPathOverride)
-        : (options.binaryPathResolverOverride?.() ?? detectOpencodeBinary())
+        : (options.binaryPathResolverOverride?.() ??
+          detectOpencodeBinary({
+            nativeBinaryFastPathEnabled: options.nativeBinaryFastPathEnabled === true,
+          }))
     }
     let resolved: string | null
     try {
@@ -1801,6 +1839,12 @@ export function createOpencodeSupervisor(
     if (state !== 'ok') logger.info('[opencode] ready')
     state = 'ok'
     restartDelayMs = 500
+  }
+
+  function reportFirstReadyResponse() {
+    if (firstReadyResponseReported) return
+    firstReadyResponseReported = true
+    options.onFirstReadyResponse?.()
   }
 
   /**
@@ -2070,6 +2114,7 @@ export function createOpencodeSupervisor(
         return
       }
       if (ready) {
+        reportFirstReadyResponse()
         markReady()
       } else if (state !== 'starting') {
         state = 'starting'

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -38,7 +38,7 @@ export type VerifiedReloadResult =
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
-import { access, constants, stat } from 'node:fs/promises'
+import { access, constants, open, stat } from 'node:fs/promises'
 import { isDeepStrictEqual } from 'node:util'
 
 import { AGENT_ENV_SH } from './agent-env-file'
@@ -49,6 +49,12 @@ import { egressShimEnv } from './egress-shim'
 import { logger } from './logger'
 import { applyManagedOpencodeEnv } from './managed-opencode-env'
 import { mergeProjectEnv, type ProjectEnvStore } from './project-env'
+import {
+  OPENCODE_CURRENT_LINK,
+  OPENCODE_SYSTEM_LINK,
+  publishOpencodeNativeLink,
+  resolveInstalledOpencodeNative,
+} from './opencode-binary'
 import {
   SECRET_CAPABILITIES_ENV_NAME,
   writeSecretCapabilitiesInstruction,
@@ -1409,10 +1415,45 @@ async function which(bin: string): Promise<string | null> {
 }
 
 async function detectOpencodeBinary(): Promise<string | null> {
-  if (await isExecutable('/usr/local/bin/opencode-kortix')) {
-    return '/usr/local/bin/opencode-kortix'
+  if (await isExecutable(OPENCODE_CURRENT_LINK)) return OPENCODE_CURRENT_LINK
+  if (await isExecutable(OPENCODE_SYSTEM_LINK)) return OPENCODE_SYSTEM_LINK
+
+  // Older images only have pnpm's small shell launcher. Discover the native
+  // executable once, then repair the user-owned stable link for this and every
+  // later daemon start. A discovery failure keeps the functional launcher.
+  try {
+    const nativePath = await resolveInstalledOpencodeNative()
+    await publishOpencodeNativeLink(nativePath)
+    return OPENCODE_CURRENT_LINK
+  } catch (err) {
+    logger.warn('[opencode] native binary discovery failed; using PATH launcher', {
+      err: err instanceof Error ? err.message : String(err),
+    })
   }
   return await which('opencode')
+}
+
+const EXECUTABLE_PREFETCH_BUFFER_BYTES = 4 * 1024 * 1024
+
+export async function prefetchExecutablePages(
+  path: string,
+  signal?: AbortSignal,
+): Promise<number> {
+  if (signal?.aborted) throw signal.reason
+  const handle = await open(path, 'r')
+  const buffer = Buffer.allocUnsafe(EXECUTABLE_PREFETCH_BUFFER_BYTES)
+  let bytes = 0
+  try {
+    while (true) {
+      if (signal?.aborted) throw signal.reason
+      const result = await handle.read(buffer, 0, buffer.byteLength, null)
+      if (result.bytesRead === 0) break
+      bytes += result.bytesRead
+    }
+  } finally {
+    await handle.close()
+  }
+  return bytes
 }
 
 async function resolveOpencodeCwd(cfg: Config): Promise<string> {
@@ -1426,6 +1467,8 @@ async function resolveOpencodeCwd(cfg: Config): Promise<string> {
 type OpencodeState = 'starting' | 'ok' | 'down'
 
 export type Opencode = {
+  prefetchBinary(): Promise<boolean>
+  cancelBinaryPrefetch(): void
   start(): Promise<void>
   stop(signal?: NodeJS.Signals): Promise<void>
   restart(): Promise<void>
@@ -1463,6 +1506,8 @@ export type Opencode = {
 export interface OpencodeSupervisorOptions {
   onStartupMark?: (label: string) => void
   binaryPathOverride?: string
+  binaryPathResolverOverride?: () => Promise<string | null>
+  prefetchExecutableOverride?: (path: string, signal: AbortSignal) => Promise<number>
   configPathOverride?: string
   /**
    * opencode died without anyone asking it to, and has just been respawned.
@@ -1507,6 +1552,66 @@ export function createOpencodeSupervisor(
   let readinessTimer: ReturnType<typeof setTimeout> | null = null
   let opencodeCwd = cfg.workspace
   const startupMark = options.onStartupMark ?? (() => {})
+  let binaryResolutionPromise: Promise<string | null> | null = null
+  let binaryPrefetchPromise: Promise<boolean> | null = null
+  let binaryPrefetchController: AbortController | null = null
+
+  async function resolveBinaryPath(): Promise<string | null> {
+    if (!binaryResolutionPromise) {
+      binaryResolutionPromise = options.binaryPathOverride
+        ? Promise.resolve(options.binaryPathOverride)
+        : (options.binaryPathResolverOverride?.() ?? detectOpencodeBinary())
+    }
+    let resolved: string | null
+    try {
+      resolved = await binaryResolutionPromise
+    } catch (err) {
+      binaryResolutionPromise = null
+      throw err
+    }
+    if (!resolved) binaryResolutionPromise = null
+    if (resolved && binaryPath !== resolved) {
+      binaryPath = resolved
+      startupMark('runtime-binary-resolved')
+    }
+    return resolved
+  }
+
+  async function prefetchBinaryOnce(signal: AbortSignal): Promise<boolean> {
+    const startedAt = Date.now()
+    let bin: string | null = null
+    try {
+      bin = await resolveBinaryPath()
+      if (!bin) throw new Error('OpenCode binary not found')
+      startupMark('runtime-binary-prefetch-started')
+      const prefetch = options.prefetchExecutableOverride ?? prefetchExecutablePages
+      const bytes = await prefetch(bin, signal)
+      if (signal.aborted) throw signal.reason
+      startupMark('runtime-binary-prefetched')
+      logger.info('[opencode] executable pages prefetched', {
+        binaryPath: bin,
+        bytes,
+        durationMs: Date.now() - startedAt,
+      })
+      return true
+    } catch (err) {
+      if (signal.aborted) {
+        startupMark('runtime-binary-prefetch-cancelled')
+        logger.info('[opencode] executable prefetch stopped before spawn', {
+          binaryPath: bin,
+          durationMs: Date.now() - startedAt,
+        })
+      } else {
+        startupMark('runtime-binary-prefetch-failed')
+        logger.warn('[opencode] executable prefetch failed; using normal demand paging', {
+          binaryPath: bin,
+          err: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - startedAt,
+        })
+      }
+      return false
+    }
+  }
 
   function ensureCwdExists(): string {
     try {
@@ -1974,18 +2079,31 @@ export function createOpencodeSupervisor(
   }
 
   return {
+    prefetchBinary() {
+      if (!binaryPrefetchPromise) {
+        const controller = new AbortController()
+        binaryPrefetchController = controller
+        binaryPrefetchPromise = prefetchBinaryOnce(controller.signal).finally(() => {
+          if (binaryPrefetchController === controller) binaryPrefetchController = null
+        })
+      }
+      return binaryPrefetchPromise
+    },
+
+    cancelBinaryPrefetch() {
+      binaryPrefetchController?.abort()
+    },
+
     async start() {
       stopping = false
       state = 'starting'
-      const bin = options.binaryPathOverride ?? await detectOpencodeBinary()
+      const bin = await resolveBinaryPath()
       if (!bin) {
-        logger.warn('[opencode] binary not found on PATH (and /usr/local/bin/opencode-kortix missing); daemon will continue, opencode reports as starting')
+        logger.warn('[opencode] binary not found; daemon will continue, opencode reports as starting')
         state = 'starting'
         scheduleReadinessProbe()
         return
       }
-      binaryPath = bin
-      startupMark('runtime-binary-resolved')
       opencodeCwd = await resolveOpencodeCwd(currentCfg)
       startupMark('runtime-cwd-resolved')
       try {
@@ -2017,6 +2135,8 @@ export function createOpencodeSupervisor(
         clearTimeout(readinessTimer)
         readinessTimer = null
       }
+      binaryPrefetchController?.abort()
+      if (binaryPrefetchPromise) await binaryPrefetchPromise
       if (!child) return
       const c = child
       // Spawned with detached: true, so c.pid also identifies the process

--- a/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
@@ -15,6 +15,13 @@ import { promisify } from 'node:util'
 import { resolveOpencodeConfigDir, type Config } from './config'
 import { ensureInjectedManagedSkills } from './injected-skills'
 import { logger } from './logger'
+import {
+  captureProcessOutput,
+  OPENCODE_CURRENT_LINK,
+  publishOpencodeNativeLink,
+  resolveInstalledOpencodeNative,
+  type CaptureCommand,
+} from './opencode-binary'
 import { OPENCODE_CONFIG_DEPS_DIR } from './opencode-config-deps'
 import { opencodeTurnInFlight } from './opencode-turn-state'
 
@@ -158,7 +165,7 @@ export interface RuntimeAssetsOptions {
   runningAgentPath?: string
   /** Present only when the daemon has a live runtime to converge. */
   seam?: RuntimeConvergenceSeam
-  /** Test seams. Production uses the real npm install / health read / turn probe. */
+  /** Test seams. The production installer also publishes the stable native link. */
   installOpencode?: (version: string) => Promise<void>
   readOpencodeVersion?: (baseUrl: string) => Promise<string | null>
   turnProbe?: (baseUrl: string, workspace: string) => Promise<boolean | null>
@@ -611,11 +618,36 @@ async function readOpencodeVersion(baseUrl: string): Promise<string | null> {
  * installer here would produce a second, subtly different runtime that only
  * ever exists on updated boxes, which is the hardest kind of drift to debug.
  */
-async function installOpencodeVersion(version: string): Promise<void> {
-  await execFileAsync(
-    'pnpm',
-    ['add', '-g', '--allow-build=opencode-ai', `opencode-ai@${version}`],
-    { timeout: OPENCODE_INSTALL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 },
+export interface InstallOpencodeVersionOptions {
+  installPackage?: (version: string) => Promise<void>
+  capture?: CaptureCommand
+  currentLinkPath?: string
+}
+
+export async function installOpencodeVersion(
+  version: string,
+  options: InstallOpencodeVersionOptions = {},
+): Promise<void> {
+  const installPackage = options.installPackage ?? (async (targetVersion: string) => {
+    await execFileAsync(
+      'pnpm',
+      ['add', '-g', '--allow-build=opencode-ai', `opencode-ai@${targetVersion}`],
+      { timeout: OPENCODE_INSTALL_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 },
+    )
+  })
+  const capture = options.capture ?? captureProcessOutput
+
+  await installPackage(version)
+  const nativePath = await resolveInstalledOpencodeNative(capture)
+  const reportedVersion = (await capture(nativePath, ['--version'])).trim()
+  if (reportedVersion !== version) {
+    throw new Error(
+      `installed OpenCode native version mismatch: expected ${version}, got ${reportedVersion || '<empty>'}`,
+    )
+  }
+  await publishOpencodeNativeLink(
+    nativePath,
+    options.currentLinkPath ?? OPENCODE_CURRENT_LINK,
   )
 }
 

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -94,7 +94,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping \
+        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping util-linux \
         build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \
         latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \
         texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \

--- a/apps/sandbox/Dockerfile
+++ b/apps/sandbox/Dockerfile
@@ -195,7 +195,15 @@ RUN AGENT_BROWSER_VERSION="$(node -e "console.log(require('/tmp/kortix-runtime-v
 RUN OPENCODE_VERSION="$(node -e "console.log(require('/tmp/kortix-runtime-versions.json').opencode)")" \
     && pnpm add -g --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \
     && command -v opencode \
-    && opencode --version
+    && opencode --version \
+    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\#/node_modules/opencode-ai$#p' | tail -n 1)" \
+    && opencode_native="$opencode_package/bin/opencode.exe" \
+    && test -x "$opencode_native" \
+    && test "$(wc -c < "$opencode_native")" -gt 50000000 \
+    && test "$("$opencode_native" --version)" = "$OPENCODE_VERSION" \
+    && ln -sfn "$opencode_native" /opt/kortix/opencode.current \
+    && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "$OPENCODE_VERSION"
 
 RUN BUN_VERSION="$(node -e "console.log(require('/tmp/kortix-runtime-versions.json').bun)")" \
     && BUN_SHA256_AMD64="$(node -e "console.log(require('/tmp/kortix-runtime-versions.json').bunSha256Amd64)")" \

--- a/apps/sandbox/opencode-warmup.sh
+++ b/apps/sandbox/opencode-warmup.sh
@@ -1,57 +1,118 @@
 #!/usr/bin/env bash
 
-# Build-time cache warming only. A failure here must not prevent the sandbox
-# image from building; the same initialization will happen on first boot.
-set +e
+# Build-time cache warming only. A successful image must contain an OpenCode
+# runtime that completed both database migration and project initialization.
+set -u
 
 mode="${1:-}"
 cleanup="${2:-targeted}"
+migration_attempts="${OPENCODE_WARMUP_MIGRATION_ATTEMPTS:-180}"
+instance_attempts="${OPENCODE_WARMUP_INSTANCE_ATTEMPTS:-300}"
+poll_seconds="${OPENCODE_WARMUP_POLL_SECONDS:-1}"
+settle_seconds="${OPENCODE_WARMUP_SETTLE_SECONDS:-3}"
+oc_pid=""
 
 stop_opencode() {
-  if [ -n "${oc_pid:-}" ]; then
+  if [ -n "$oc_pid" ]; then
     kill "$oc_pid" 2>/dev/null
     wait "$oc_pid" 2>/dev/null
+    oc_pid=""
   fi
+}
+
+print_log_tail() {
+  local label="$1"
+  local log_path="$2"
+  echo "=== ${label}: opencode log tail ==="
+  tail -25 "$log_path" 2>/dev/null
+}
+
+wait_for_opencode() {
+  local url="$1"
+  local attempts="$2"
+  local code
+  local attempt
+
+  for attempt in $(seq 1 "$attempts"); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "$url" 2>/dev/null || true)
+    case "$code" in
+      200|204|301|302) return 0 ;;
+    esac
+    kill -0 "$oc_pid" 2>/dev/null || return 1
+    sleep "$poll_seconds"
+  done
+
+  return 1
 }
 
 warm_migration() {
-  mkdir -p "$HOME/.local/share" "$HOME/.config" "$HOME/.cache"
-  opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-bake.log 2>&1 &
+  local log_path=/tmp/oc-bake.log
+  local migration_dir=/tmp/kortix-opencode-migration
+
+  mkdir -p "$HOME/.local/share" "$HOME/.config" "$HOME/.cache" "$migration_dir" || return 1
+  rm -f "$log_path"
+  opencode serve --port 4096 --hostname 127.0.0.1 >"$log_path" 2>&1 &
   oc_pid=$!
-  for _ in $(seq 1 180); do
-    curl -s -o /dev/null -m 2 http://127.0.0.1:4096/ && break
-    kill -0 "$oc_pid" 2>/dev/null || break
-    sleep 1
-  done
-  sleep 3
+  if ! wait_for_opencode \
+    "http://127.0.0.1:4096/session?directory=$migration_dir" \
+    "$migration_attempts"; then
+    echo "opencode migration warm-up did not become ready after ${migration_attempts} attempts" >&2
+    stop_opencode
+    print_log_tail migration-bake "$log_path"
+    rm -rf "$migration_dir"
+    rm -f "$log_path"
+    return 1
+  fi
+  sleep "$settle_seconds"
+  if ! kill -0 "$oc_pid" 2>/dev/null; then
+    echo "opencode migration warm-up exited after its readiness response" >&2
+    print_log_tail migration-bake "$log_path"
+    rm -rf "$migration_dir"
+    rm -f "$log_path"
+    return 1
+  fi
   stop_opencode
   echo "=== migration-bake: opencode data dir ==="
   ls -laR "$HOME/.local/share/opencode" 2>/dev/null | head -40
-  echo "=== migration-bake: opencode log tail ==="
-  tail -25 /tmp/oc-bake.log
-  rm -f /tmp/oc-bake.log
+  print_log_tail migration-bake "$log_path"
+  rm -rf "$migration_dir"
+  rm -f "$log_path"
 }
 
 warm_instance() {
-  mkdir -p /workspace/.kortix
-  staged_starter_config=0
+  local log_path=/tmp/oc-warm.log
+  local ready=0
+  local staged_starter_config=0
+
+  case "$cleanup" in
+    keep|wipe|targeted) ;;
+    *)
+      echo "unknown instance cleanup mode: $cleanup" >&2
+      return 2
+      ;;
+  esac
+
+  mkdir -p /workspace/.kortix || return 1
   if [ ! -d /workspace/.kortix/opencode ]; then
-    cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode
+    if [ ! -d /opt/kortix/warm-config/.kortix/opencode ]; then
+      echo "missing staged OpenCode warm-up config" >&2
+      return 1
+    fi
+    cp -a /opt/kortix/warm-config/.kortix/opencode /workspace/.kortix/opencode || return 1
     staged_starter_config=1
   fi
-  rm -rf /workspace/.kortix/opencode/node_modules
-  ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules
+  rm -rf /workspace/.kortix/opencode/node_modules || return 1
+  ln -s /opt/kortix/opencode-config-deps/node_modules /workspace/.kortix/opencode/node_modules || return 1
   export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode
-  cd /workspace || return 0
-  opencode serve --port 4096 --hostname 127.0.0.1 >/tmp/oc-warm.log 2>&1 &
+  cd /workspace || return 1
+  rm -f "$log_path"
+  opencode serve --port 4096 --hostname 127.0.0.1 >"$log_path" 2>&1 &
   oc_pid=$!
-  ready=0
-  for _ in $(seq 1 300); do
-    code=$(curl -s -o /dev/null -w '%{http_code}' -m 3 "http://127.0.0.1:4096/session?directory=/workspace" 2>/dev/null)
-    case "$code" in 200|204|301|302) ready=1; break ;; esac
-    kill -0 "$oc_pid" 2>/dev/null || break
-    sleep 1
-  done
+  if wait_for_opencode \
+    'http://127.0.0.1:4096/session?directory=/workspace' \
+    "$instance_attempts"; then
+    ready=1
+  fi
   echo "=== instance-warm: ready=$ready ==="
   stop_opencode
 
@@ -62,20 +123,27 @@ warm_instance() {
       [ "$staged_starter_config" = 1 ] && rm -rf /workspace/.kortix/opencode
       rmdir /workspace/.kortix 2>/dev/null
       ;;
-    *) echo "unknown instance cleanup mode: $cleanup" >&2 ;;
   esac
 
   rm -rf /opt/kortix/warm-config
-  echo "=== instance-warm: opencode log tail ==="
-  tail -20 /tmp/oc-warm.log
-  rm -f /tmp/oc-warm.log
+  print_log_tail instance-warm "$log_path"
+  rm -f "$log_path"
+
+  if [ "$ready" != 1 ]; then
+    echo "opencode instance warm-up did not become ready after ${instance_attempts} attempts" >&2
+    return 1
+  fi
 }
 
 trap stop_opencode EXIT
+status=0
 case "$mode" in
-  migration) warm_migration ;;
-  instance) warm_instance ;;
-  *) echo "usage: $0 {migration|instance [keep|wipe|targeted]}" >&2 ;;
+  migration) warm_migration || status=$? ;;
+  instance) warm_instance || status=$? ;;
+  *)
+    echo "usage: $0 {migration|instance [keep|wipe|targeted]}" >&2
+    status=2
+    ;;
 esac
 
-exit 0
+exit "$status"

--- a/apps/sandbox/opencode-warmup.sh
+++ b/apps/sandbox/opencode-warmup.sh
@@ -10,13 +10,51 @@ migration_attempts="${OPENCODE_WARMUP_MIGRATION_ATTEMPTS:-180}"
 instance_attempts="${OPENCODE_WARMUP_INSTANCE_ATTEMPTS:-300}"
 poll_seconds="${OPENCODE_WARMUP_POLL_SECONDS:-1}"
 settle_seconds="${OPENCODE_WARMUP_SETTLE_SECONDS:-3}"
+stop_attempts="${OPENCODE_WARMUP_STOP_ATTEMPTS:-50}"
+stop_poll_seconds="${OPENCODE_WARMUP_STOP_POLL_SECONDS:-0.1}"
 oc_pid=""
+oc_process_group=0
+
+start_opencode() {
+  local log_path="$1"
+  shift
+
+  # OpenCode can launch helpers while it initializes. Give the complete tree a
+  # private process group when setsid is available, so image builds never leave
+  # a helper behind after the warm-up finishes.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid opencode "$@" >"$log_path" 2>&1 &
+    oc_process_group=1
+  else
+    opencode "$@" >"$log_path" 2>&1 &
+    oc_process_group=0
+  fi
+  oc_pid=$!
+}
 
 stop_opencode() {
   if [ -n "$oc_pid" ]; then
-    kill "$oc_pid" 2>/dev/null
+    local target="$oc_pid"
+    local attempt=0
+    if [ "$oc_process_group" = 1 ]; then
+      target="-$oc_pid"
+    fi
+
+    kill -TERM -- "$target" 2>/dev/null || true
+    while kill -0 -- "$target" 2>/dev/null && [ "$attempt" -lt "$stop_attempts" ]; do
+      sleep "$stop_poll_seconds"
+      attempt=$((attempt + 1))
+    done
+    if kill -0 -- "$target" 2>/dev/null; then
+      echo "opencode warm-up did not stop after ${stop_attempts} attempts; forcing process group shutdown" >&2
+      kill -KILL -- "$target" 2>/dev/null || true
+      # Keep wait bounded even if a non-util-linux setsid implementation did
+      # not make the background PID the process-group leader.
+      kill -KILL -- "$oc_pid" 2>/dev/null || true
+    fi
     wait "$oc_pid" 2>/dev/null
     oc_pid=""
+    oc_process_group=0
   fi
 }
 
@@ -51,8 +89,7 @@ warm_migration() {
 
   mkdir -p "$HOME/.local/share" "$HOME/.config" "$HOME/.cache" "$migration_dir" || return 1
   rm -f "$log_path"
-  opencode serve --port 4096 --hostname 127.0.0.1 >"$log_path" 2>&1 &
-  oc_pid=$!
+  start_opencode "$log_path" serve --port 4096 --hostname 127.0.0.1
   if ! wait_for_opencode \
     "http://127.0.0.1:4096/session?directory=$migration_dir" \
     "$migration_attempts"; then
@@ -106,8 +143,7 @@ warm_instance() {
   export OPENCODE_CONFIG_DIR=/workspace/.kortix/opencode
   cd /workspace || return 1
   rm -f "$log_path"
-  opencode serve --port 4096 --hostname 127.0.0.1 >"$log_path" 2>&1 &
-  oc_pid=$!
+  start_opencode "$log_path" serve --port 4096 --hostname 127.0.0.1
   if wait_for_opencode \
     'http://127.0.0.1:4096/session?directory=/workspace' \
     "$instance_attempts"; then

--- a/apps/sandbox/opencode-warmup.test.ts
+++ b/apps/sandbox/opencode-warmup.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const SCRIPT = resolve(import.meta.dir, 'opencode-warmup.sh');
+
+let fixtureRoot: string;
+let fixtureBin: string;
+
+function writeExecutable(name: string, source: string): void {
+  const path = join(fixtureBin, name);
+  writeFileSync(path, source, 'utf8');
+  chmodSync(path, 0o755);
+}
+
+async function runWarmup(mode: string, env: Record<string, string> = {}) {
+  const proc = Bun.spawn({
+    cmd: ['bash', SCRIPT, mode],
+    env: {
+      ...process.env,
+      HOME: join(fixtureRoot, 'home'),
+      PATH: `${fixtureBin}:${process.env.PATH ?? ''}`,
+      ...env,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [code, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { code, stdout, stderr };
+}
+
+describe('opencode image warm-up', () => {
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-opencode-warmup-'));
+    fixtureBin = join(fixtureRoot, 'bin');
+    mkdirSync(fixtureBin, { recursive: true });
+    writeExecutable(
+      'opencode',
+      `#!/usr/bin/env bash
+if [ "\${FAKE_OPENCODE_CRASH:-0}" = "1" ]; then
+  exit 7
+fi
+trap 'exit 0' TERM INT
+while :; do /bin/sleep 0.05; done
+`,
+    );
+    writeExecutable(
+      'curl',
+      `#!/usr/bin/env bash
+if [ "\${FAKE_CURL_READY:-0}" = "1" ]; then
+  printf '%s' "\${FAKE_CURL_CODE:-200}"
+  exit 0
+fi
+printf '000'
+exit 1
+`,
+    );
+    writeExecutable('sleep', '#!/usr/bin/env bash\nexit 0\n');
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  test('returns success only after OpenCode responds', async () => {
+    const result = await runWarmup('migration', { FAKE_CURL_READY: '1' });
+    expect(result.code).toBe(0);
+  });
+
+  test('fails when OpenCode exits before readiness', async () => {
+    const result = await runWarmup('migration', { FAKE_OPENCODE_CRASH: '1' });
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('did not become ready');
+  });
+
+  test('rejects an unknown warm-up mode', async () => {
+    const result = await runWarmup('invalid');
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain('usage:');
+  });
+});

--- a/apps/sandbox/opencode-warmup.test.ts
+++ b/apps/sandbox/opencode-warmup.test.ts
@@ -34,6 +34,17 @@ async function runWarmup(mode: string, env: Record<string, string> = {}) {
   return { code, stdout, stderr };
 }
 
+function processIsExecuting(pid: number): boolean {
+  const result = Bun.spawnSync({
+    cmd: ['ps', '-o', 'stat=', '-p', String(pid)],
+    stdout: 'pipe',
+    stderr: 'ignore',
+  });
+  if (result.exitCode !== 0) return false;
+  const state = result.stdout.toString().trim();
+  return state.length > 0 && !state.startsWith('Z');
+}
+
 describe('opencode image warm-up', () => {
   beforeEach(() => {
     fixtureRoot = mkdtempSync(join(tmpdir(), 'kortix-opencode-warmup-'));
@@ -45,14 +56,44 @@ describe('opencode image warm-up', () => {
 if [ "\${FAKE_OPENCODE_CRASH:-0}" = "1" ]; then
   exit 7
 fi
-trap 'exit 0' TERM INT
+if [ "\${FAKE_OPENCODE_IGNORE_TERM:-0}" = "1" ]; then
+  trap '' TERM INT
+else
+  trap 'exit 0' TERM INT
+fi
+if [ -n "\${FAKE_OPENCODE_PID_FILE:-}" ]; then
+  printf '%s' "$$" >"$FAKE_OPENCODE_PID_FILE"
+fi
+if [ -n "\${FAKE_OPENCODE_HELPER_PID_FILE:-}" ]; then
+  (
+    trap '' TERM INT
+    printf '%s' "$BASHPID" >"$FAKE_OPENCODE_HELPER_PID_FILE"
+    while :; do /bin/sleep 0.05; done
+  ) &
+fi
+if [ -n "\${FAKE_OPENCODE_READY_FILE:-}" ]; then
+  : >"$FAKE_OPENCODE_READY_FILE"
+fi
 while :; do /bin/sleep 0.05; done
+`,
+    );
+    writeExecutable(
+      'setsid',
+      `#!/usr/bin/env python3
+import os
+import sys
+os.setsid()
+os.execvp(sys.argv[1], sys.argv[1:])
 `,
     );
     writeExecutable(
       'curl',
       `#!/usr/bin/env bash
 if [ "\${FAKE_CURL_READY:-0}" = "1" ]; then
+  if [ -n "\${FAKE_OPENCODE_READY_FILE:-}" ] && [ ! -f "$FAKE_OPENCODE_READY_FILE" ]; then
+    printf '000'
+    exit 1
+  fi
   printf '%s' "\${FAKE_CURL_CODE:-200}"
   exit 0
 fi
@@ -78,6 +119,28 @@ exit 1
     expect(result.stderr).toContain('did not become ready');
   });
 
+  test('force-kills the warm-up process group after the shutdown deadline', async () => {
+    const pidFile = join(fixtureRoot, 'opencode.pid');
+    const helperPidFile = join(fixtureRoot, 'opencode-helper.pid');
+    const readyFile = join(fixtureRoot, 'opencode.ready');
+    const result = await runWarmup('migration', {
+      FAKE_CURL_READY: '1',
+      FAKE_OPENCODE_IGNORE_TERM: '1',
+      FAKE_OPENCODE_PID_FILE: pidFile,
+      FAKE_OPENCODE_HELPER_PID_FILE: helperPidFile,
+      FAKE_OPENCODE_READY_FILE: readyFile,
+      OPENCODE_WARMUP_STOP_ATTEMPTS: '2',
+      OPENCODE_WARMUP_STOP_POLL_SECONDS: '0.01',
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toContain('forcing process group shutdown');
+    const pid = Number(readFileSync(pidFile, 'utf8'));
+    const helperPid = Number(readFileSync(helperPidFile, 'utf8'));
+    expect(() => process.kill(pid, 0)).toThrow();
+    expect(processIsExecuting(helperPid)).toBe(false);
+  });
+
   test('rejects an unknown warm-up mode', async () => {
     const result = await runWarmup('invalid');
     expect(result.code).toBe(2);
@@ -87,6 +150,7 @@ exit 1
   test('the standalone image links the native executable for the supervisor', () => {
     const dockerfile = readFileSync(resolve(import.meta.dir, 'Dockerfile'), 'utf8');
 
+    expect(dockerfile).toContain('iputils-arping util-linux');
     expect(dockerfile).toContain(
       "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
     );

--- a/apps/sandbox/opencode-warmup.test.ts
+++ b/apps/sandbox/opencode-warmup.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
@@ -82,5 +82,19 @@ exit 1
     const result = await runWarmup('invalid');
     expect(result.code).toBe(2);
     expect(result.stderr).toContain('usage:');
+  });
+
+  test('the standalone image links the native executable for the supervisor', () => {
+    const dockerfile = readFileSync(resolve(import.meta.dir, 'Dockerfile'), 'utf8');
+
+    expect(dockerfile).toContain(
+      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+    );
+    expect(dockerfile).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
+    expect(dockerfile).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
+    expect(dockerfile).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');
+    expect(dockerfile).toContain(
+      'sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix',
+    );
   });
 });

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -107,7 +107,15 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
-    && opencode --version
+    && opencode --version \\
+    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_native="$opencode_package/bin/opencode.exe" \\
+    && test -x "$opencode_native" \\
+    && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
+    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
+    && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
@@ -284,7 +292,15 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
-    && opencode --version
+    && opencode --version \\
+    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_native="$opencode_package/bin/opencode.exe" \\
+    && test -x "$opencode_native" \\
+    && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
+    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
+    && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
@@ -462,7 +478,15 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
-    && opencode --version
+    && opencode --version \\
+    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_native="$opencode_package/bin/opencode.exe" \\
+    && test -x "$opencode_native" \\
+    && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
+    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
+    && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -110,7 +110,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && opencode --version
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup migration; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
 
 RUN case "$(uname -m)" in \\
       x86_64) bun_arch=x64; bun_sha=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f ;; \\
@@ -150,7 +150,7 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && echo "opencode-config-deps: starter tool files bundle cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup instance wipe; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup instance wipe && rm -f /tmp/kortix-opencode-warmup
 
 USER root
 COPY kortix-agent.gz /tmp/kortix-agent.gz
@@ -287,7 +287,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && opencode --version
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup migration; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
 
 RUN case "$(uname -m)" in \\
       x86_64) bun_arch=x64; bun_sha=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f ;; \\
@@ -327,7 +327,7 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && echo "opencode-config-deps: starter tool files bundle cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup instance targeted; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup instance targeted && rm -f /tmp/kortix-opencode-warmup
 
 USER root
 COPY kortix-agent.gz /tmp/kortix-agent.gz
@@ -465,7 +465,7 @@ RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && opencode --version
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup migration; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
 
 RUN case "$(uname -m)" in \\
       x86_64) bun_arch=x64; bun_sha=951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f ;; \\
@@ -518,7 +518,7 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && echo "opencode-config-deps: starter tool files bundle cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup instance keep; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup instance keep && rm -f /tmp/kortix-opencode-warmup
 
 USER root
 COPY kortix-agent.gz /tmp/kortix-agent.gz
@@ -581,7 +581,7 @@ RUN cd /opt/kortix/warm-config/.kortix/opencode \\
     && echo "opencode-config-deps: starter tool files bundle cleanly"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
-RUN bash /tmp/kortix-opencode-warmup instance keep; rm -f /tmp/kortix-opencode-warmup
+RUN bash /tmp/kortix-opencode-warmup instance keep && rm -f /tmp/kortix-opencode-warmup
 
 "
 `;

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -17,7 +17,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \\
     && apt-get install -y --no-install-recommends \\
-        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping \\
+        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping util-linux \\
         build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
         latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
         texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\
@@ -202,7 +202,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \\
     && apt-get install -y --no-install-recommends \\
-        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping \\
+        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping util-linux \\
         build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
         latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
         texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\
@@ -388,7 +388,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \\
     && apt-get install -y --no-install-recommends \\
-        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping \\
+        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping util-linux \\
         build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\
         latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\
         texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -24,6 +24,15 @@ describe('buildFastSandboxDockerfile', () => {
 
 expect(dockerfile).toContain('FROM ubuntu:24.04');
     expect(dockerfile).toContain('opencode-ai@1.18.19');
+    expect(dockerfile).toContain(
+      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+    );
+    expect(dockerfile).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
+    expect(dockerfile).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
+    expect(dockerfile).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');
+    expect(dockerfile).toContain(
+      'ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix',
+    );
     expect(dockerfile).toContain('pnpm-linux-${pnpm_arch}.tar.gz');
     expect(dockerfile).toContain('bun-v1.3.14');
     expect(dockerfile).toContain('aarch64|arm64) bun_arch=aarch64');

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -139,6 +139,22 @@ describe('runtime artifact integrity', () => {
     }
   });
 
+  test('exposes the native OpenCode executable at the supervisor path', () => {
+    expect(rendered).toContain(
+      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+    );
+    expect(rendered).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
+    expect(rendered).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
+    expect(rendered).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');
+    expect(rendered).toContain(
+      'sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix',
+    );
+    expect(rendered).not.toContain(
+      'ln -sfn "$opencode_native" /usr/local/bin/opencode-kortix',
+    );
+    expect(rendered).toContain('/usr/local/bin/opencode-kortix --version');
+  });
+
 });
 
 describe('the Python runtime is managed by uv', () => {

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -124,6 +124,21 @@ describe('runtime artifact integrity', () => {
     expect(rendered).not.toMatch(/curl[^|\n]*\|\s*(?:sh|bash)/);
   });
 
+  test('fails the image build when OpenCode warm-up fails', () => {
+    expect(rendered).toContain(
+      'RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup',
+    );
+    expect(rendered).not.toContain('kortix-opencode-warmup migration; rm -f');
+
+    for (const { opts } of CASES) {
+      const image = buildLayeredDockerfile(opts);
+      expect(image).toMatch(
+        /RUN bash \/tmp\/kortix-opencode-warmup instance (?:keep|wipe|targeted) && rm -f \/tmp\/kortix-opencode-warmup/,
+      );
+      expect(image).not.toMatch(/kortix-opencode-warmup instance \w+; rm -f/);
+    }
+  });
+
 });
 
 describe('the Python runtime is managed by uv', () => {
@@ -422,7 +437,7 @@ describe('buildPerProjectWarmFromBaseDockerfile (FROM-base fast path)', () => {
     // … and MAIN's opencode instance re-warm via the cache-only warm-up script,
     // which for a per-project warm keeps the baked /workspace checkout.
     expect(rendered).toContain(
-      'RUN bash /tmp/kortix-opencode-warmup instance keep; rm -f /tmp/kortix-opencode-warmup',
+      'RUN bash /tmp/kortix-opencode-warmup instance keep && rm -f /tmp/kortix-opencode-warmup',
     );
   });
 

--- a/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
@@ -17,6 +17,15 @@ describe('buildMetaSandboxDockerfile', () => {
     expect(dockerfile).toContain('PNPM_VERSION=11.15.1');
     expect(dockerfile).toContain('pnpm runtime set node 22.23.1 --global');
     expect(dockerfile).toContain('opencode-ai@1.18.19');
+    expect(dockerfile).toContain(
+      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+    );
+    expect(dockerfile).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
+    expect(dockerfile).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
+    expect(dockerfile).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');
+    expect(dockerfile).toContain(
+      'ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix',
+    );
     expect(dockerfile).toContain('PNPM_HOME=/home/kortix/.local/share/pnpm');
     expect(dockerfile).toContain('PATH="/home/kortix/.local/share/pnpm/bin:${PATH}"');
     expect(dockerfile).toContain('/usr/local/bin/kortix-agent');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -593,7 +593,15 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     '',
     `RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@${opencodeVersion}" \\`,
     '    && command -v opencode \\',
-    '    && opencode --version',
+    '    && opencode --version \\',
+    "    && opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\" \\",
+    '    && opencode_native="$opencode_package/bin/opencode.exe" \\',
+    '    && test -x "$opencode_native" \\',
+    '    && test "$(wc -c < "$opencode_native")" -gt 50000000 \\',
+    `    && test "$("$opencode_native" --version)" = "${opencodeVersion}" \\`,
+    '    && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\',
+    '    && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\',
+    `    && test "$(/usr/local/bin/opencode-kortix --version)" = "${opencodeVersion}"`,
     '',
     // Bake OpenCode's "one time database migration" at BUILD time. The first time
     // opencode serves, it migrates its sqlite schema — logged as "Performing one

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -425,7 +425,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     'ENV DEBIAN_FRONTEND=noninteractive',
     'RUN apt-get update \\',
     '    && apt-get install -y --no-install-recommends \\',
-    '        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping \\',
+    '        ca-certificates curl git gzip libatomic1 sudo unzip tmux iproute2 iputils-arping util-linux \\',
     '        build-essential ffmpeg fonts-dejavu fonts-liberation fonts-noto fonts-noto-cjk \\',
     '        latexmk libreoffice pandoc pkg-config poppler-utils qpdf tesseract-ocr \\',
     '        texlive-bibtex-extra texlive-fonts-recommended texlive-latex-base \\',

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -324,8 +324,8 @@ function buildWarmRepoCopyLines(warmRepo: WarmRepoConfig | undefined): string[] 
  * 6–60s → ~2–4s after this bake. Requires opencode + bun + the baked config
  * deps to already be present in the image (either from the toolchain layer
  * above, or inherited via FROM on the fast path), so it must come after them.
- * Best effort: a build without network (or a warm-up failure) just falls back
- * to the runtime cost — set +e + trailing `true` keep the image build green.
+ * Required: a warm-up failure stops the image build. Shipping an unwarmed image
+ * moves the same initialization onto every session's startup path.
  *
  * Shared between `kortixToolchainLayer` and `buildPerProjectWarmFromBaseDockerfile`
  * so both render byte-identical warm-up text. Returns `[]` when there's no
@@ -348,11 +348,9 @@ function buildOpencodeInstanceWarmupLines(opts: {
     // instead of just their axios/form-data override targets — this is
     // what actually walks the full transitive dependency tree
     // (firecrawl-js, tavily-core, replicate) that ToolRegistry resolves
-    // on a session's first prompt. Deliberately its own RUN step (not
-    // folded into the `set +e` warm-up below): a tool that can't bundle
-    // breaks every session's first prompt, not just startup latency, so
-    // it must fail the build — the warm-up readiness probe below stays
-    // best-effort as before.
+    // on a session's first prompt. Deliberately its own RUN step: a tool that
+    // cannot bundle breaks every session's first prompt, so the image build
+    // must fail before it reaches the warm-up readiness probe below.
     // E2B's Dockerfile parser does not preserve COPY --chown. Correct the
     // ownership explicitly before the standard kortix user changes this tree.
     'RUN sudo chown -R kortix:kortix /opt/kortix/warm-config',
@@ -382,7 +380,7 @@ function buildOpencodeInstanceWarmupLines(opts: {
     //    the starter config we staged (and the .kortix dir if that leaves it
     //    empty) — never their bytes. `rmdir` is the no-op-unless-empty form on
     //    purpose; a user's own /workspace/.kortix survives untouched.
-    `RUN bash /tmp/kortix-opencode-warmup instance ${cleanup}; rm -f /tmp/kortix-opencode-warmup`,
+    `RUN bash /tmp/kortix-opencode-warmup instance ${cleanup} && rm -f /tmp/kortix-opencode-warmup`,
     '',
   ];
 }
@@ -608,12 +606,12 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // run opencode here once to complete the migration and bake the migrated db
     // into the image layer. Every boot afterwards — cold or warm-snapshot restore —
     // then finds an already-migrated db and answers in ~2-3s. Env MUST match the
-    // daemon's spawn (apps/kortix-sandbox-agent-server/src/opencode.ts). Best
-    // effort: if opencode can't serve at build time it just falls back to the
-    // old boot-time migration — never fail the whole image build over a warm-up.
+    // daemon's spawn (apps/kortix-sandbox-agent-server/src/opencode.ts). The
+    // build fails if OpenCode cannot serve. A platform image without this state
+    // moves the database migration onto every session's startup path.
     ...(opencodeWarmupScriptPath ? [
       `COPY --chown=kortix:kortix ${opencodeWarmupScriptPath} /tmp/kortix-opencode-warmup`,
-      'RUN bash /tmp/kortix-opencode-warmup migration; rm -f /tmp/kortix-opencode-warmup',
+      'RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup',
     ] : []),
     '',
     // Bun runtime for the agent CLIs (slack, …) + `kortix connectors mcp`.
@@ -685,8 +683,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     // silently baked into every sandbox cloned from this image until a user
     // hit it on their very first prompt. Bundling the override targets here,
     // at build time, turns that failure mode into a build failure instead —
-    // intentionally NOT `set +e`: an unbundlable dependency tree must fail
-    // the image build, unlike the best-effort warm-up steps below.
+    // An unbundlable dependency tree must fail the image build before warm-up.
     'RUN cd /opt/kortix/opencode-config-deps \\',
     '    && bun build node_modules/axios/lib/utils.js node_modules/form-data/lib/form_data.js --target=bun --outdir=/tmp/opencode-deps-bundle-check \\',
     '    && rm -rf /tmp/opencode-deps-bundle-check \\',

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -74,6 +74,14 @@ RUN case "$(uname -m)" in \
  && test "$(npm --version)" = "${NPM_VERSION}" \
  && HOME=/home/kortix pnpm add --global --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \
  && test "$(opencode --version)" = "${OPENCODE_VERSION}" \
+ && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \
+ && opencode_native="$opencode_package/bin/opencode.exe" \
+ && test -x "$opencode_native" \
+ && test "$(wc -c < "$opencode_native")" -gt 50000000 \
+ && test "$("$opencode_native" --version)" = "${OPENCODE_VERSION}" \
+ && ln -sfn "$opencode_native" /opt/kortix/opencode.current \
+ && ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \
+ && test "$(/usr/local/bin/opencode-kortix --version)" = "${OPENCODE_VERSION}" \
  && ln -sf "$(command -v node)" /usr/local/bin/node \
  && chown -R kortix:kortix /home/kortix
 

--- a/packages/shared/src/sandbox/meta-dockerfile.ts
+++ b/packages/shared/src/sandbox/meta-dockerfile.ts
@@ -77,6 +77,14 @@ RUN curl -fsSL https://get.pnpm.io/install.sh \\
       | env HOME=/home/kortix SHELL=/bin/bash PNPM_VERSION=${PNPM_VERSION} sh - \\
  && HOME=/home/kortix pnpm runtime set node ${NODE_VERSION} --global \\
  && HOME=/home/kortix pnpm add --global --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \\
+ && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+ && opencode_native="$opencode_package/bin/opencode.exe" \\
+ && test -x "$opencode_native" \\
+ && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
+ && test "$("$opencode_native" --version)" = "${OPENCODE_VERSION}" \\
+ && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
+ && ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
+ && test "$(/usr/local/bin/opencode-kortix --version)" = "${OPENCODE_VERSION}" \\
  && ln -sf "\$(command -v node)" /usr/local/bin/node \\
  && chown -R kortix:kortix /home/kortix
 


### PR DESCRIPTION
## Problem

Fresh Platinum sessions spend about 7.5 seconds between OpenCode spawn and its first response. The image also allowed a failed build-time OpenCode warm-up to pass silently.

## Changes

- Fail image builds when the OpenCode migration or instance warm-up fails.
- Resolve pnpm v11 native OpenCode executables instead of their shell shims.
- Publish the native executable through `/opt/kortix/opencode.current`.
- Refresh the stable link atomically after runtime upgrades.
- Prefetch native executable pages only while repository and config work runs.
- Cancel unfinished prefetch before spawn and on repository materialization failure.
- Record port listening and successful session-API readiness as separate boot marks.
- Bound warm-up shutdown with process-group TERM, a five-second grace period, and KILL.
- Gate the complete native fast path with `KORTIX_FAST_COLD_BOOT_ENABLED`.
- Restore PATH launcher behavior when the flag is disabled, with stable-link fallback only if PATH is unavailable.

No running sandbox pool is added.

## Verification

- Full sandbox-agent suite: 822 passed, 0 failed, 2,450 assertions.
- Focused binary and prefetch suite: 22 passed, 0 failed, 52 assertions.
- Image renderer and warm-up suite: 48 passed, 0 failed, 253 assertions, 4 snapshots.
- API runtime environment suite: 16 passed, 0 failed, 58 assertions.
- Forced warm-up shutdown test: passed 10 consecutive runs.
- Sandbox-agent typecheck and Linux x64 build: passed; output is 95,668,352 bytes.
- API typecheck: passed.
- `bash -n apps/sandbox/opencode-warmup.sh`: passed.
- `git diff --check`: passed.

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false`. New sandboxes use the verified PATH launcher and skip native executable prefetch.