### PR TITLE
perf(snapshots): materialize Platinum templates before activation

### DIFF
--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -50,19 +50,15 @@ const OVERSIZE_TEMPLATE_NAME = 'kortix-oversize-template';
 let fromBuildPayloads: FromBuildPayload[] = [];
 let registeredTemplateName = '';
 let registeredTemplateId = '';
-let materializeRequests: Array<{ path: string; init: RequestInit }> = [];
+let lifecycleEvents: string[] = [];
 /** Counts from-build POSTs the oversize stub rejected — proves a size-cap
  *  failure never burns more than one BUILD_ATTEMPTS slot. */
 let oversizeAttempts = 0;
 
 mock.module('../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
-  platinumJsonResponse: async (path: string, init: RequestInit = {}) => {
-    materializeRequests.push({ path, init });
-    return {
-      status: 200,
-      body: { status: 'ready', template_id: registeredTemplateId },
-    };
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected default Platinum materialization request');
   },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     if (path === '/v1/templates/from-build/presign') {
@@ -81,6 +77,12 @@ mock.module('../shared/platinum', () => ({
       registeredTemplateId = `tpl-${fromBuildPayloads.length}`;
       return { id: registeredTemplateId, name: payload.name, state: 'building' };
     }
+    if (path === '/v1/templates/from-patch') {
+      const payload = JSON.parse(String(init.body ?? '{}')) as { name: string };
+      registeredTemplateName = payload.name;
+      registeredTemplateId = 'tpl-patch-1';
+      return { id: registeredTemplateId, name: payload.name, state: 'building' };
+    }
     if (path === '/v1/templates') {
       return registeredTemplateName
         ? [{ id: registeredTemplateId, name: registeredTemplateName, state: 'ready' }]
@@ -90,6 +92,7 @@ mock.module('../shared/platinum', () => ({
     // its id (`GET /v1/templates/:id`), never the name list, once from-build
     // hands one back — see platinum.ts's requireExternalTemplateId/waitForActive.
     if (registeredTemplateId && path === `/v1/templates/${registeredTemplateId}`) {
+      lifecycleEvents.push(`ready:${registeredTemplateId}`);
       return { id: registeredTemplateId, name: registeredTemplateName, state: 'ready' };
     }
     throw new Error(`unexpected Platinum path: ${path}`);
@@ -106,19 +109,19 @@ const stubFetch = Object.assign(
 ) as typeof fetch;
 
 const {
+  PlatinumAdapter,
   platinumProvider,
   PLATINUM_MAX_BUILD_SIZE_MB,
   PLATINUM_MIN_BUILD_SIZE_MB,
   PLATINUM_SIZE_CAP_LOG_TOKEN,
   platinumBuildSizeMb,
 } = await import('../snapshots/providers/platinum');
-const { config } = await import('../config');
 
 beforeEach(() => {
   fromBuildPayloads = [];
   registeredTemplateName = '';
   registeredTemplateId = '';
-  materializeRequests = [];
+  lifecycleEvents = [];
   oversizeAttempts = 0;
   globalThis.fetch = stubFetch;
   // Per-test (not module load): build-context reads these lazily, so setting here
@@ -132,13 +135,11 @@ beforeEach(() => {
   // The build-size knob is read LAZILY per call (platinumBuildSizeMb) — reset
   // it before every test so no test's override leaks into the next.
   delete process.env.PLATINUM_BUILD_SIZE_MB;
-  config.KORTIX_FAST_COLD_BOOT_ENABLED = false;
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.PLATINUM_BUILD_SIZE_MB;
-  config.KORTIX_FAST_COLD_BOOT_ENABLED = false;
 });
 
 afterAll(() => {
@@ -188,10 +189,14 @@ describe('platinumBuildSizeMb (lazy PLATINUM_BUILD_SIZE_MB env knob)', () => {
 });
 
 describe('Platinum snapshot build sizing', () => {
-  test('the experimental flag materializes the exact returned template before buildSnapshot resolves', async () => {
-    config.KORTIX_FAST_COLD_BOOT_ENABLED = true;
+  test('buildSnapshot awaits exact-id materialization after readiness', async () => {
+    const adapter = new PlatinumAdapter(async (externalId) => {
+      lifecycleEvents.push(`materialize:${externalId}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      lifecycleEvents.push(`materialized:${externalId}`);
+    });
 
-    const result = await platinumProvider.buildSnapshot({
+    const result = await adapter.buildSnapshot({
       snapshotName: 'kortix-materialized-template',
       image: 'ubuntu:24.04',
       spec: { diskGb: 10 },
@@ -199,11 +204,45 @@ describe('Platinum snapshot build sizing', () => {
     });
 
     expect(result.externalTemplateId).toBe(registeredTemplateId);
-    expect(materializeRequests).toHaveLength(1);
-    expect(materializeRequests[0].path).toBe(
-      `/v1/templates/${encodeURIComponent(result.externalTemplateId!)}/materialize`,
-    );
-    expect(materializeRequests[0].init.method).toBe('POST');
+    expect(lifecycleEvents).toEqual([
+      `ready:${registeredTemplateId}`,
+      `materialize:${registeredTemplateId}`,
+      `materialized:${registeredTemplateId}`,
+    ]);
+  });
+
+  test('swapAgent awaits exact-id materialization after readiness', async () => {
+    const adapter = new PlatinumAdapter(async (externalId) => {
+      lifecycleEvents.push(`materialize:${externalId}`);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      lifecycleEvents.push(`materialized:${externalId}`);
+    });
+
+    const result = await adapter.swapAgent('kortix-patched-template', 'kortix-source-template');
+
+    expect(result.externalTemplateId).toBe('tpl-patch-1');
+    expect(lifecycleEvents).toEqual([
+      'ready:tpl-patch-1',
+      'materialize:tpl-patch-1',
+      'materialized:tpl-patch-1',
+    ]);
+  });
+
+  test.each(['build', 'agent swap'] as const)('%s remains successful when materialization rejects', async (flow) => {
+    const adapter = new PlatinumAdapter(async () => {
+      throw new Error('materialization unavailable');
+    });
+
+    const result = flow === 'build'
+      ? await adapter.buildSnapshot({
+        snapshotName: 'kortix-materialize-fail-open',
+        image: 'ubuntu:24.04',
+        spec: { diskGb: 10 },
+        slug: 'materialize-fail-open',
+      })
+      : await adapter.swapAgent('kortix-patch-fail-open', 'kortix-source-template');
+
+    expect(result.externalTemplateId).toBe(registeredTemplateId);
   });
 
   test('a disk under the cap is sent verbatim as the build ceiling', async () => {

--- a/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
+++ b/apps/api/src/__tests__/unit-platinum-snapshot-size.test.ts
@@ -50,12 +50,20 @@ const OVERSIZE_TEMPLATE_NAME = 'kortix-oversize-template';
 let fromBuildPayloads: FromBuildPayload[] = [];
 let registeredTemplateName = '';
 let registeredTemplateId = '';
+let materializeRequests: Array<{ path: string; init: RequestInit }> = [];
 /** Counts from-build POSTs the oversize stub rejected — proves a size-cap
  *  failure never burns more than one BUILD_ATTEMPTS slot. */
 let oversizeAttempts = 0;
 
 mock.module('../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async (path: string, init: RequestInit = {}) => {
+    materializeRequests.push({ path, init });
+    return {
+      status: 200,
+      body: { status: 'ready', template_id: registeredTemplateId },
+    };
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     if (path === '/v1/templates/from-build/presign') {
       return { upload_url: 'https://upload.test/context.tar.gz', context_s3_key: 'ctx-key' };
@@ -104,11 +112,13 @@ const {
   PLATINUM_SIZE_CAP_LOG_TOKEN,
   platinumBuildSizeMb,
 } = await import('../snapshots/providers/platinum');
+const { config } = await import('../config');
 
 beforeEach(() => {
   fromBuildPayloads = [];
   registeredTemplateName = '';
   registeredTemplateId = '';
+  materializeRequests = [];
   oversizeAttempts = 0;
   globalThis.fetch = stubFetch;
   // Per-test (not module load): build-context reads these lazily, so setting here
@@ -122,11 +132,13 @@ beforeEach(() => {
   // The build-size knob is read LAZILY per call (platinumBuildSizeMb) — reset
   // it before every test so no test's override leaks into the next.
   delete process.env.PLATINUM_BUILD_SIZE_MB;
+  config.KORTIX_FAST_COLD_BOOT_ENABLED = false;
 });
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.PLATINUM_BUILD_SIZE_MB;
+  config.KORTIX_FAST_COLD_BOOT_ENABLED = false;
 });
 
 afterAll(() => {
@@ -176,6 +188,24 @@ describe('platinumBuildSizeMb (lazy PLATINUM_BUILD_SIZE_MB env knob)', () => {
 });
 
 describe('Platinum snapshot build sizing', () => {
+  test('the experimental flag materializes the exact returned template before buildSnapshot resolves', async () => {
+    config.KORTIX_FAST_COLD_BOOT_ENABLED = true;
+
+    const result = await platinumProvider.buildSnapshot({
+      snapshotName: 'kortix-materialized-template',
+      image: 'ubuntu:24.04',
+      spec: { diskGb: 10 },
+      slug: 'materialized',
+    });
+
+    expect(result.externalTemplateId).toBe(registeredTemplateId);
+    expect(materializeRequests).toHaveLength(1);
+    expect(materializeRequests[0].path).toBe(
+      `/v1/templates/${encodeURIComponent(result.externalTemplateId!)}/materialize`,
+    );
+    expect(materializeRequests[0].init.method).toBe('POST');
+  });
+
   test('a disk under the cap is sent verbatim as the build ceiling', async () => {
     await platinumProvider.buildSnapshot({
       snapshotName: 'kortix-small-template',

--- a/apps/api/src/platform/providers/platinum-app-runtime.test.ts
+++ b/apps/api/src/platform/providers/platinum-app-runtime.test.ts
@@ -28,6 +28,9 @@ let lifecycleExecError: Error | null = null;
 
 mock.module("../../shared/platinum", () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error("unexpected Platinum materialization request");
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     const body = init.body
       ? (JSON.parse(String(init.body)) as Record<string, unknown>)

--- a/apps/api/src/platform/providers/platinum-create-dedup.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-dedup.test.ts
@@ -59,6 +59,9 @@ function normalizeHeaders(h: RequestInit['headers']): Record<string, string> {
 
 mock.module('../../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected Platinum materialization request');
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
     const headers = normalizeHeaders(init.headers);

--- a/apps/api/src/platform/providers/platinum-create-from-id.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-from-id.test.ts
@@ -28,6 +28,9 @@ let sandboxesError: Error | null = null;
 
 mock.module('../../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected Platinum materialization request');
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     const body = init.body ? (JSON.parse(String(init.body)) as Record<string, unknown>) : undefined;
     calls.push({ path, method: String(init.method ?? 'GET'), body });

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -20,6 +20,9 @@ const calls: { path: string; method: string }[] = [];
 
 mock.module('../../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected Platinum materialization request');
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     calls.push({ path, method: String(init.method ?? 'GET') });
     // POST /v1/sandboxes?wait_for_state=running — return a box in `createState`.

--- a/apps/api/src/platform/providers/platinum-expose-not-running.test.ts
+++ b/apps/api/src/platform/providers/platinum-expose-not-running.test.ts
@@ -30,6 +30,9 @@ class PlatinumSandboxNotRunningError extends Error {
 
 mock.module('../../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected Platinum materialization request');
+  },
   isPlatinumSandboxNotRunningError: (e: unknown) => e instanceof PlatinumSandboxNotRunningError,
   PlatinumSandboxNotRunningError,
   platinumJson: async (path: string) => {

--- a/apps/api/src/platform/providers/provider-shim-env.test.ts
+++ b/apps/api/src/platform/providers/provider-shim-env.test.ts
@@ -105,6 +105,9 @@ mock.module('../../projects/disk-quota-guard', () => ({
 
 mock.module('../../shared/platinum', () => ({
   isPlatinumConfigured: () => true,
+  platinumJsonResponse: async () => {
+    throw new Error('unexpected Platinum materialization request');
+  },
   platinumJson: async (path: string, init: RequestInit = {}) => {
     if (path.startsWith('/v1/sandboxes?')) {
       const body = JSON.parse(String(init.body)) as { envVars: Record<string, string> };

--- a/apps/api/src/shared/platinum.test.ts
+++ b/apps/api/src/shared/platinum.test.ts
@@ -76,6 +76,25 @@ test('platinumJson respects an explicit caller-provided signal instead of the de
   expect(elapsed).toBeLessThan(2_000);
 });
 
+test('platinumJsonResponse preserves successful HTTP status without changing the body', async () => {
+  fetchScenario = {
+    status: 202,
+    body: JSON.stringify({ status: 'in_progress', template_id: 'tpl_exact' }),
+  };
+  mockFetchScenario();
+
+  const { platinumJsonResponse } = await import('./platinum');
+
+  await expect(platinumJsonResponse('/v1/templates/tpl_exact/materialize', {
+    method: 'POST',
+  })).resolves.toEqual({
+    status: 202,
+    body: { status: 'in_progress', template_id: 'tpl_exact' },
+  });
+
+  globalThis.fetch = originalFetch;
+});
+
 // Platinum auto-stops idle microVMs natively; while a box is stopped, POST
 // /:id/expose answers `409 {"code":"sandbox_not_running"}`. That is an EXPECTED
 // state — the caller wakes+retries or surfaces a retryable 503 — and must NOT

--- a/apps/api/src/shared/platinum.ts
+++ b/apps/api/src/shared/platinum.ts
@@ -103,8 +103,19 @@ function isSandboxNotRunningBody(status: number, text: string): boolean {
   }
 }
 
-/** GET/POST JSON. Throws `platinum <method> <path> -> <status> <body>` on non-2xx. */
-export async function platinumJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+export type PlatinumJsonResponse<T> = {
+  status: number;
+  body: T;
+};
+
+/**
+ * GET/POST JSON while preserving the successful HTTP status. Non-2xx behavior
+ * stays identical to platinumJson(), including typed stopped-sandbox errors.
+ */
+export async function platinumJsonResponse<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<PlatinumJsonResponse<T>> {
   const res = await platinumFetch(path, init);
   const text = await res.text();
   if (!res.ok) {
@@ -123,5 +134,13 @@ export async function platinumJson<T>(path: string, init: RequestInit = {}): Pro
     }
     throw new Error(`platinum ${init.method ?? 'GET'} ${path} -> ${res.status} ${text.slice(0, 300)}${suffix}`);
   }
-  return (text ? JSON.parse(text) : {}) as T;
+  return {
+    status: res.status,
+    body: (text ? JSON.parse(text) : {}) as T,
+  };
+}
+
+/** GET/POST JSON. Throws `platinum <method> <path> -> <status> <body>` on non-2xx. */
+export async function platinumJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+  return (await platinumJsonResponse<T>(path, init)).body;
 }

--- a/apps/api/src/snapshots/providers/platinum-materialize.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.test.ts
@@ -175,7 +175,7 @@ describe('Platinum template materialization', () => {
       ['agent swap', swap, 'await waitForActive(newSnapshotName, undefined, externalId);'],
     ] as const) {
       const waitIndex = body.indexOf(waitCall);
-      const materializeIndex = body.indexOf('await materializeReadyTemplate(externalId).catch(');
+      const materializeIndex = body.indexOf('await this.materializeTemplate(externalId).catch(');
       const returnIndex = body.indexOf('return { externalTemplateId: externalId };');
 
       expect(waitIndex, `${flow} readiness call`).toBeGreaterThan(-1);

--- a/apps/api/src/snapshots/providers/platinum-materialize.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.test.ts
@@ -161,4 +161,28 @@ describe('Platinum template materialization', () => {
     expect(probe.sleeps).toEqual([100]);
     expect(result.elapsedMs).toBe(18_000);
   });
+
+  test('build and agent-swap materialize the exact id after readiness and before return', async () => {
+    const source = await Bun.file(new URL('./platinum.ts', import.meta.url)).text();
+    const buildStart = source.indexOf('private async buildOnce(');
+    const swapStart = source.indexOf('async swapAgent(', buildStart);
+    const stateStart = source.indexOf('async getSnapshotState(', swapStart);
+    const build = source.slice(buildStart, swapStart);
+    const swap = source.slice(swapStart, stateStart);
+
+    for (const [flow, body, waitCall] of [
+      ['build', build, 'await waitForActive(input.snapshotName, tap, externalId);'],
+      ['agent swap', swap, 'await waitForActive(newSnapshotName, undefined, externalId);'],
+    ] as const) {
+      const waitIndex = body.indexOf(waitCall);
+      const materializeIndex = body.indexOf('await materializeReadyTemplate(externalId).catch(');
+      const returnIndex = body.indexOf('return { externalTemplateId: externalId };');
+
+      expect(waitIndex, `${flow} readiness call`).toBeGreaterThan(-1);
+      expect(materializeIndex, `${flow} materialization call`).toBeGreaterThan(waitIndex);
+      expect(returnIndex, `${flow} exact-id return`).toBeGreaterThan(materializeIndex);
+    }
+
+    expect(source).toContain('enabled: config.KORTIX_FAST_COLD_BOOT_ENABLED');
+  });
 });

--- a/apps/api/src/snapshots/providers/platinum-materialize.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  PlatinumMaterializeRequest,
+  PlatinumMaterializeResult,
+} from './platinum-materialize';
+
+const { materializePlatinumTemplate } = await import('./platinum-materialize');
+
+type Step =
+  | { status: number; body: unknown; elapsedMs?: number }
+  | { error: Error; elapsedMs?: number };
+
+function harness(steps: Step[]) {
+  let nowMs = 1_000;
+  const paths: string[] = [];
+  const inits: RequestInit[] = [];
+  const sleeps: number[] = [];
+  let index = 0;
+  const request: PlatinumMaterializeRequest = async (path, init) => {
+    paths.push(path);
+    inits.push(init);
+    const step = steps[Math.min(index++, steps.length - 1)];
+    nowMs += step.elapsedMs ?? 0;
+    if ('error' in step) throw step.error;
+    return { status: step.status, body: step.body };
+  };
+  return {
+    paths,
+    inits,
+    sleeps,
+    request,
+    now: () => nowMs,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      nowMs += ms;
+    },
+  };
+}
+
+async function run(steps: Step[], enabled = true): Promise<{
+  result: PlatinumMaterializeResult;
+  probe: ReturnType<typeof harness>;
+}> {
+  const probe = harness(steps);
+  const result = await materializePlatinumTemplate('tpl_exact', {
+    enabled,
+    request: probe.request,
+    sleep: probe.sleep,
+    now: probe.now,
+  });
+  return { result, probe };
+}
+
+describe('Platinum template materialization', () => {
+  test('the disabled flag makes zero requests', async () => {
+    const { result, probe } = await run([{ status: 200, body: {} }], false);
+
+    expect(result).toMatchObject({ status: 'disabled', attempts: 0 });
+    expect(probe.paths).toHaveLength(0);
+  });
+
+  test('200 ready succeeds once', async () => {
+    const { result, probe } = await run([{
+      status: 200,
+      body: { status: 'ready', template_id: 'tpl_exact' },
+    }]);
+
+    expect(result).toMatchObject({ status: 'ready', attempts: 1, httpStatus: 200 });
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  test.each([
+    ['202 then ready', { status: 202, body: { status: 'in_progress' } } satisfies Step],
+    ['503 then ready', { error: new Error('platinum POST /v1/templates/tpl_exact/materialize -> 503 unavailable') } satisfies Step],
+  ])('%s retries and succeeds only on 200 ready', async (_label, first) => {
+    const { result, probe } = await run([
+      first,
+      { status: 200, body: { status: 'ready', template_id: 'tpl_exact' } },
+    ]);
+
+    expect(result).toMatchObject({ status: 'ready', attempts: 2, httpStatus: 200 });
+    expect(probe.sleeps).toEqual([250]);
+  });
+
+  test.each([
+    ['202', { status: 202, body: { status: 'in_progress' } } satisfies Step],
+    ['503', { error: new Error('platinum POST /v1/templates/tpl_exact/materialize -> 503 unavailable') } satisfies Step],
+  ])('repeated %s stops after four requests', async (_label, step) => {
+    const { result, probe } = await run([step]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 4 });
+    expect(probe.paths).toHaveLength(4);
+    expect(probe.sleeps).toEqual([250, 750, 1_500]);
+  });
+
+  test('202 never succeeds from a misleading ready body', async () => {
+    const { result } = await run([{
+      status: 202,
+      body: { status: 'ready', template_id: 'tpl_exact' },
+    }]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 4, httpStatus: 202 });
+  });
+
+  test('200 with the wrong template id fails open without retry', async () => {
+    const { result, probe } = await run([{
+      status: 200,
+      body: { status: 'ready', template_id: 'tpl_other' },
+    }]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 1, httpStatus: 200 });
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  test.each([404, 409, 502])('%s fails open without retry', async (status) => {
+    const { result, probe } = await run([{
+      error: new Error(`platinum POST /v1/templates/tpl_exact/materialize -> ${status} failed`),
+    }]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 1, httpStatus: status });
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  test.each([
+    ['timeout', { error: new DOMException('timed out', 'TimeoutError') } satisfies Step],
+    ['invalid JSON', { error: new SyntaxError('Unexpected token') } satisfies Step],
+    ['malformed response', { status: 200, body: null } satisfies Step],
+  ])('%s fails open without retry', async (_label, step) => {
+    const { result, probe } = await run([step]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 1 });
+    expect(probe.sleeps).toEqual([]);
+  });
+
+  test('the request encodes the exact external template id', async () => {
+    const probe = harness([{
+      status: 200,
+      body: { status: 'ready', template_id: 'tpl/a b?' },
+    }]);
+
+    await materializePlatinumTemplate('tpl/a b?', {
+      enabled: true,
+      request: probe.request,
+      sleep: probe.sleep,
+      now: probe.now,
+    });
+
+    expect(probe.paths).toEqual(['/v1/templates/tpl%2Fa%20b%3F/materialize']);
+    expect(probe.inits[0]?.method).toBe('POST');
+    expect(probe.inits[0]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('the total retry budget is bounded at 18 seconds', async () => {
+    const { result, probe } = await run([{
+      status: 202,
+      body: { status: 'in_progress' },
+      elapsedMs: 17_900,
+    }]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 1 });
+    expect(probe.sleeps).toEqual([100]);
+    expect(result.elapsedMs).toBe(18_000);
+  });
+});

--- a/apps/api/src/snapshots/providers/platinum-materialize.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.ts
@@ -1,0 +1,128 @@
+import type { PlatinumJsonResponse } from '../../shared/platinum';
+
+const MATERIALIZE_BUDGET_MS = 18_000;
+const MATERIALIZE_RETRY_MS = [250, 750, 1_500] as const;
+
+type MaterializeBody = {
+  status?: unknown;
+  template_id?: unknown;
+};
+
+export type PlatinumMaterializeRequest = (
+  path: string,
+  init: RequestInit,
+) => Promise<PlatinumJsonResponse<unknown>>;
+
+export type PlatinumMaterializeResult = {
+  status: 'disabled' | 'ready' | 'failed';
+  attempts: number;
+  elapsedMs: number;
+  httpStatus: number | null;
+  reason: string;
+};
+
+export type PlatinumMaterializeDependencies = {
+  enabled: boolean;
+  request: PlatinumMaterializeRequest;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+};
+
+function statusFromError(error: unknown): number | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/platinum\s+\S+\s+\S+\s+->\s+(\d{3})(?:\s|$)/i);
+  return match ? Number(match[1]) : null;
+}
+
+function logResult(externalId: string, result: PlatinumMaterializeResult): void {
+  const line =
+    `[snapshots] platinum materialize ${externalId}: ${result.status} ` +
+    `reason=${result.reason} attempts=${result.attempts} ` +
+    `elapsed_ms=${result.elapsedMs} http_status=${result.httpStatus ?? 'none'}`;
+  if (result.status === 'ready') console.info(line);
+  else console.warn(line);
+}
+
+/**
+ * Materialize one exact immutable Platinum template before it becomes active.
+ * Failure is always fail-open because this changes boot latency, not correctness.
+ */
+export async function materializePlatinumTemplate(
+  externalId: string,
+  deps: PlatinumMaterializeDependencies,
+): Promise<PlatinumMaterializeResult> {
+  const now = deps.now ?? Date.now;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const startedAt = now();
+  if (!deps.enabled) {
+    return {
+      status: 'disabled',
+      attempts: 0,
+      elapsedMs: 0,
+      httpStatus: null,
+      reason: 'feature_disabled',
+    };
+  }
+
+  const finish = (
+    status: 'ready' | 'failed',
+    attempts: number,
+    httpStatus: number | null,
+    reason: string,
+  ): PlatinumMaterializeResult => {
+    const result = {
+      status,
+      attempts,
+      elapsedMs: Math.max(0, now() - startedAt),
+      httpStatus,
+      reason,
+    };
+    logResult(externalId, result);
+    return result;
+  };
+
+  const deadline = startedAt + MATERIALIZE_BUDGET_MS;
+  let attempts = 0;
+  let lastStatus: number | null = null;
+
+  while (attempts < 4 && now() < deadline) {
+    attempts += 1;
+    const remainingMs = Math.max(1, deadline - now());
+    try {
+      const response = await deps.request(
+        `/v1/templates/${encodeURIComponent(externalId)}/materialize`,
+        {
+          method: 'POST',
+          body: JSON.stringify({}),
+          signal: AbortSignal.timeout(remainingMs),
+        },
+      );
+      lastStatus = response.status;
+      const body = response.body as MaterializeBody | null;
+      if (
+        response.status === 200 &&
+        body !== null &&
+        typeof body === 'object' &&
+        body.status === 'ready' &&
+        body.template_id === externalId
+      ) {
+        return finish('ready', attempts, response.status, 'materialized');
+      }
+      if (response.status !== 202) {
+        return finish('failed', attempts, response.status, 'unexpected_response');
+      }
+    } catch (error) {
+      lastStatus = statusFromError(error);
+      if (lastStatus !== 503) {
+        return finish('failed', attempts, lastStatus, 'request_failed');
+      }
+    }
+
+    if (attempts >= 4) break;
+    const remainingAfterRequestMs = deadline - now();
+    if (remainingAfterRequestMs <= 0) break;
+    await sleep(Math.min(MATERIALIZE_RETRY_MS[attempts - 1], remainingAfterRequestMs));
+  }
+
+  return finish('failed', attempts, lastStatus, now() >= deadline ? 'budget_exhausted' : 'attempts_exhausted');
+}

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -545,8 +545,12 @@ export class UploadUrlRejectedError extends Error {
   }
 }
 
-class PlatinumAdapter implements SandboxProviderAdapter {
+export class PlatinumAdapter implements SandboxProviderAdapter {
   readonly id = 'platinum' as const;
+
+  constructor(
+    private readonly materializeTemplate: (externalId: string) => Promise<unknown> = materializeReadyTemplate,
+  ) {}
 
   isConfigured(): boolean {
     return isPlatinumConfigured();
@@ -648,7 +652,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       // poll THAT id (never the truncated name list) — see waitForActive.
       const externalId = requireExternalTemplateId(registered?.id, `from-build for ${input.snapshotName}`);
       await waitForActive(input.snapshotName, tap, externalId);
-      await materializeReadyTemplate(externalId).catch((error) => {
+      await this.materializeTemplate(externalId).catch((error) => {
         console.warn(
           `[snapshots] platinum materialize ${externalId}: fail-open guard caught ` +
           `${error instanceof Error ? error.message : String(error)}`,
@@ -707,7 +711,7 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       // the name list.
       const externalId = requireExternalTemplateId(patched?.id, `from-patch for ${newSnapshotName}`);
       await waitForActive(newSnapshotName, undefined, externalId);
-      await materializeReadyTemplate(externalId).catch((error) => {
+      await this.materializeTemplate(externalId).catch((error) => {
         console.warn(
           `[snapshots] platinum materialize ${externalId}: fail-open guard caught ` +
           `${error instanceof Error ? error.message : String(error)}`,

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -13,7 +13,11 @@
 
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
-import { platinumJson, isPlatinumConfigured } from '../../shared/platinum';
+import {
+  platinumJson,
+  platinumJsonResponse,
+  isPlatinumConfigured,
+} from '../../shared/platinum';
 import {
   stageAgentBinaryGz,
   DEFAULT_CPU,
@@ -44,6 +48,7 @@ import {
   retryAfterMsFromError,
 } from './platinum-poll-classify';
 import { config } from '../../config';
+import { materializePlatinumTemplate } from './platinum-materialize';
 
 const ACTIVATE_DEADLINE_MS = 12 * 60 * 1000; // build + activate ceiling
 const POLL_MS = 3_000;
@@ -52,6 +57,13 @@ const BUILD_ATTEMPTS = 3;
 const UPLOAD_ATTEMPTS = 3;
 const UPLOAD_MIN_TIMEOUT_MS = 10 * 60_000;
 const UPLOAD_TIMEOUT_MS_PER_GIB = 60_000;
+
+async function materializeReadyTemplate(externalId: string) {
+  return materializePlatinumTemplate(externalId, {
+    enabled: config.KORTIX_FAST_COLD_BOOT_ENABLED,
+    request: (path, init) => platinumJsonResponse(path, init),
+  });
+}
 // Platinum's POST /v1/templates/from-build hard-caps size_mb at this value (see
 // platinum apps/api/src/api/templates.ts ORG_MAX_SIZE_MB + the from-build zod).
 // The build ext4 is a FLOOR Platinum grows-to-fit, so clamping the build ceiling
@@ -636,6 +648,12 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       // poll THAT id (never the truncated name list) — see waitForActive.
       const externalId = requireExternalTemplateId(registered?.id, `from-build for ${input.snapshotName}`);
       await waitForActive(input.snapshotName, tap, externalId);
+      await materializeReadyTemplate(externalId).catch((error) => {
+        console.warn(
+          `[snapshots] platinum materialize ${externalId}: fail-open guard caught ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
       // FIX-B: hand the EXACT proven id back to the caller (ppwarm → transition
       // runner) — no name-list re-derivation downstream.
       return { externalTemplateId: externalId };
@@ -689,6 +707,12 @@ class PlatinumAdapter implements SandboxProviderAdapter {
       // the name list.
       const externalId = requireExternalTemplateId(patched?.id, `from-patch for ${newSnapshotName}`);
       await waitForActive(newSnapshotName, undefined, externalId);
+      await materializeReadyTemplate(externalId).catch((error) => {
+        console.warn(
+          `[snapshots] platinum materialize ${externalId}: fail-open guard caught ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
       // FIX-B: return the exact patched-template id (same contract as buildSnapshot).
       return { externalTemplateId: externalId };
     } finally {


### PR DESCRIPTION
## Problem

A newly published Platinum template can enter session routing before any host has materialized its rootfs. The first session then pays the full CAS reconstruction cost.

## Changes

- Add a status-preserving Platinum JSON client.
- Request exact-template rootfs materialization after build and agent-patch readiness.
- Wait for completion within an absolute 18-second budget.
- Retry only active and temporarily unavailable responses.
- Fail open for every materialization error.
- Gate all requests behind KORTIX_FAST_COLD_BOOT_ENABLED.
- Add executable build, agent-swap, ordering, timeout, and fail-open coverage.

This starts zero sandboxes and keeps zero warm VMs.

## Verification

- bash scripts/test.sh: 8001 passed, 74 skipped, 0 failed across 689 files.
- bunx tsc --noEmit: exit 0.
- Focused materialization suite: 45 passed, 0 failed.
- ECS Development flag contract: 3 passed, 0 failed.
- Independent review: no remaining defects.

## Rollback

Set KORTIX_FAST_COLD_BOOT_ENABLED=false and redeploy the API. Disabled mode sends zero materialization requests.

## Dependency

Platinum materialization endpoint: https://github.com/kortix-ai/platinum/pull/722