### PR TITLE
Prepare active Platinum images before cold boots

### DIFF
--- a/apps/api/src/snapshots/builder-prepare-snapshot.test.ts
+++ b/apps/api/src/snapshots/builder-prepare-snapshot.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import type { SandboxProviderAdapter } from './providers';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'platinum');
+setTestEnv('KORTIX_URL', 'https://api.example.test');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('PLATINUM_API_URL', 'https://platinum.test');
+setTestEnv('PLATINUM_API_KEY', 'pt_live_testkey');
+
+const { ensureFastSandboxImage, ensureMetaSandboxImage, prepareSnapshotForReuse } = await import(
+  './builder'
+);
+const { platinumProvider } = await import('./providers/platinum');
+
+const originalWarn = console.warn;
+const originalIsConfigured = platinumProvider.isConfigured;
+const originalGetSnapshotState = platinumProvider.getSnapshotState;
+const originalPrepareSnapshot = platinumProvider.prepareSnapshot;
+const originalBuildSnapshot = platinumProvider.buildSnapshot;
+const originalListSnapshots = platinumProvider.listSnapshots;
+
+afterEach(() => {
+  console.warn = originalWarn;
+  platinumProvider.isConfigured = originalIsConfigured;
+  platinumProvider.getSnapshotState = originalGetSnapshotState;
+  platinumProvider.prepareSnapshot = originalPrepareSnapshot;
+  platinumProvider.buildSnapshot = originalBuildSnapshot;
+  platinumProvider.listSnapshots = originalListSnapshots;
+});
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function provider(prepareSnapshot?: (snapshotName: string) => Promise<void>) {
+  return {
+    id: 'platinum',
+    prepareSnapshot,
+  } as Pick<SandboxProviderAdapter, 'id' | 'prepareSnapshot'>;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) await Promise.resolve();
+}
+
+async function expectSessionReuseDoesNotJoinBlockingPreparation(
+  ensureImage: (opts: {
+    source?: 'session-start' | 'startup';
+    provider: string;
+  }) => Promise<unknown>,
+): Promise<void> {
+  const firstGate = deferred();
+  const firstStarted = deferred();
+  let preparationCalls = 0;
+  let stateCalls = 0;
+  platinumProvider.isConfigured = () => true;
+  platinumProvider.getSnapshotState = async () => {
+    stateCalls += 1;
+    return 'active';
+  };
+  platinumProvider.prepareSnapshot = async () => {
+    preparationCalls += 1;
+    if (preparationCalls === 1) {
+      firstStarted.resolve();
+      await firstGate.promise;
+    }
+  };
+
+  const startup = ensureImage({ source: 'startup', provider: 'platinum' });
+  await firstStarted.promise;
+  let sessionSettled = false;
+  const session = ensureImage({ source: 'session-start', provider: 'platinum' }).then(() => {
+    sessionSettled = true;
+  });
+
+  try {
+    await flushMicrotasks();
+    expect(stateCalls).toBe(1);
+    expect(preparationCalls).toBe(1);
+    expect(sessionSettled).toBe(true);
+  } finally {
+    firstGate.resolve();
+    await Promise.all([startup, session]);
+  }
+}
+
+async function expectConcurrentColdBuildIsDeduplicated(
+  ensureImage: (opts: { source?: 'session-start'; provider: string }) => Promise<unknown>,
+): Promise<void> {
+  const buildGate = deferred();
+  const buildStarted = deferred();
+  let stateCalls = 0;
+  let buildCalls = 0;
+  platinumProvider.isConfigured = () => true;
+  platinumProvider.getSnapshotState = async () => {
+    stateCalls += 1;
+    return 'missing';
+  };
+  platinumProvider.buildSnapshot = async () => {
+    buildCalls += 1;
+    buildStarted.resolve();
+    await buildGate.promise;
+    return { externalTemplateId: 'tpl_test' };
+  };
+  platinumProvider.listSnapshots = async () => [];
+
+  const first = ensureImage({ source: 'session-start', provider: 'platinum' });
+  const second = ensureImage({ source: 'session-start', provider: 'platinum' });
+  await buildStarted.promise;
+
+  expect(stateCalls).toBe(1);
+  expect(buildCalls).toBe(1);
+  buildGate.resolve();
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+  expect(firstResult).toBe(secondResult);
+}
+
+describe('prepareSnapshotForReuse', () => {
+  test('returns the same value when the provider has no preparation capability', async () => {
+    const result = { snapshotName: 'kortix-default-current' };
+
+    expect(
+      await prepareSnapshotForReuse(provider(), result.snapshotName, result, { blocking: true }),
+    ).toBe(result);
+  });
+
+  test('waits for preparation in blocking mode', async () => {
+    const gate = deferred();
+    let settled = false;
+    const result = { snapshotName: 'kortix-default-current' };
+    const operation = prepareSnapshotForReuse(
+      provider(async () => gate.promise),
+      result.snapshotName,
+      result,
+      { blocking: true },
+    ).then((value) => {
+      settled = true;
+      return value;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    gate.resolve();
+
+    expect(await operation).toBe(result);
+  });
+
+  test('starts preparation without waiting in non-blocking mode', async () => {
+    const gate = deferred();
+    let calls = 0;
+    const result = { snapshotName: 'kortix-default-current' };
+
+    const value = await prepareSnapshotForReuse(
+      provider(async () => {
+        calls += 1;
+        await gate.promise;
+      }),
+      result.snapshotName,
+      result,
+      { blocking: false },
+    );
+
+    expect(value).toBe(result);
+    expect(calls).toBe(1);
+    gate.resolve();
+  });
+
+  test('shares one in-flight preparation across concurrent callers', async () => {
+    const gate = deferred();
+    let calls = 0;
+    const adapter = provider(async () => {
+      calls += 1;
+      await gate.promise;
+    });
+
+    await prepareSnapshotForReuse(adapter, 'kortix-default-current', undefined, {
+      blocking: false,
+    });
+    let blockingSettled = false;
+    const blocking = prepareSnapshotForReuse(
+      adapter,
+      'kortix-default-current',
+      undefined,
+      { blocking: true },
+    ).then(() => {
+      blockingSettled = true;
+    });
+    await flushMicrotasks();
+
+    expect(calls).toBe(1);
+    expect(blockingSettled).toBe(false);
+    gate.resolve();
+    await blocking;
+  });
+
+  test.each([true, false])(
+    'preserves the return value after a rejection when blocking=%s',
+    async (blocking) => {
+      const warnings: unknown[][] = [];
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args);
+      };
+      const result = { snapshotName: 'kortix-default-current' };
+
+      const value = await prepareSnapshotForReuse(
+        provider(async () => {
+          throw new Error('materializer unavailable');
+        }),
+        result.snapshotName,
+        result,
+        { blocking },
+      );
+      await Promise.resolve();
+
+      expect(value).toBe(result);
+      expect(warnings).toHaveLength(1);
+      expect(String(warnings[0]?.[0])).toContain('kortix-default-current');
+      expect(String(warnings[0]?.[1])).toContain('materializer unavailable');
+    },
+  );
+});
+
+test('wires every active-reuse path through source-aware preparation', async () => {
+  const source = await Bun.file(new URL('./builder.ts', import.meta.url)).text();
+
+  expect(source.match(/prepareSnapshotForReuse\(/g)).toHaveLength(11);
+  expect(source.match(/blocking: blockingPreparation/g)).toHaveLength(6);
+  expect(
+    source.match(/blocking: \(opts\.source \?\? 'session-start'\) !== 'session-start'/g),
+  ).toHaveLength(2);
+  expect(source.match(/blocking: true/g)).toHaveLength(2);
+  expect(source.match(/warmName, undefined, \{ blocking: false \}/g)).toHaveLength(1);
+});
+
+test('a fast session reuse never joins startup preparation', async () => {
+  await expectSessionReuseDoesNotJoinBlockingPreparation(ensureFastSandboxImage);
+});
+
+test('a meta session reuse never joins startup preparation', async () => {
+  await expectSessionReuseDoesNotJoinBlockingPreparation(ensureMetaSandboxImage);
+});
+
+test('concurrent fast cold builds share one provider build', async () => {
+  await expectConcurrentColdBuildIsDeduplicated(ensureFastSandboxImage);
+});
+
+test('concurrent meta cold builds share one provider build', async () => {
+  await expectConcurrentColdBuildIsDeduplicated(ensureMetaSandboxImage);
+});

--- a/apps/api/src/snapshots/builder.ts
+++ b/apps/api/src/snapshots/builder.ts
@@ -92,6 +92,43 @@ export async function waitForProviderBuild(
   } while (true);
 }
 
+const snapshotReusePreparations = new WeakMap<object, Map<string, Promise<void>>>();
+
+export async function prepareSnapshotForReuse<T>(
+  provider: Pick<SandboxProviderAdapter, 'id' | 'prepareSnapshot'>,
+  snapshotName: string,
+  result: T,
+  opts: { blocking: boolean },
+): Promise<T> {
+  if (!provider.prepareSnapshot) return result;
+  let bySnapshot = snapshotReusePreparations.get(provider);
+  if (!bySnapshot) {
+    bySnapshot = new Map();
+    snapshotReusePreparations.set(provider, bySnapshot);
+  }
+  let preparation = bySnapshot.get(snapshotName);
+  if (!preparation) {
+    const preparations = bySnapshot;
+    preparation = (async () => {
+      try {
+        await provider.prepareSnapshot?.(snapshotName);
+      } catch (err) {
+        console.warn(
+          `[snapshots] ${provider.id} preparation failed for ${snapshotName}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    })().finally(() => {
+      preparations.delete(snapshotName);
+      if (preparations.size === 0) snapshotReusePreparations.delete(provider);
+    });
+    bySnapshot.set(snapshotName, preparation);
+  }
+  if (opts.blocking) await preparation;
+  else void preparation;
+  return result;
+}
+
 export interface EnsureSandboxImageResult {
   snapshotName: string;
   slug: string;
@@ -171,6 +208,7 @@ export async function ensureSandboxImage(
   }
 
   const identity = await computeTemplateIdentity(project, template);
+  const blockingPreparation = (opts.source ?? 'session-start') !== 'session-start';
 
   // Per-project warm preference. On a session boot, if a per-project warm image
   // — same runtime identity, current default-branch tip, repo baked into
@@ -192,13 +230,18 @@ export async function ensureSandboxImage(
             `[snapshots] per-project warm HIT: booting ${template.slug} from ${warmName} ` +
             `(project ${project.projectId.slice(0, 8)}, tip ${warmTip.slice(0, 8)}, provider ${buildProvider})`,
           );
-          return {
-            snapshotName: warmName,
-            slug: template.slug,
-            contentHash: identity.contentHash,
-            built: false,
-            isDefault: !!template.isShared,
-          };
+          return prepareSnapshotForReuse(
+            provider,
+            warmName,
+            {
+              snapshotName: warmName,
+              slug: template.slug,
+              contentHash: identity.contentHash,
+              built: false,
+              isDefault: !!template.isShared,
+            },
+            { blocking: blockingPreparation },
+          );
         }
         // LEGACY-FORMAT FALLBACK. The ppwarm name gained a `<tpl8>` segment when
         // warm images became (project, template)-scoped, so no image baked before
@@ -233,13 +276,18 @@ export async function ensureSandboxImage(
               `provider ${buildProvider}) — pre-dates template scoping; will re-bake under the ` +
               `new name when this branch next moves`,
             );
-            return {
-              snapshotName: legacyName,
-              slug: template.slug,
-              contentHash: identity.contentHash,
-              built: false,
-              isDefault: true,
-            };
+            return prepareSnapshotForReuse(
+              provider,
+              legacyName,
+              {
+                snapshotName: legacyName,
+                slug: template.slug,
+                contentHash: identity.contentHash,
+                built: false,
+                isDefault: true,
+              },
+              { blocking: blockingPreparation },
+            );
           }
         }
         // MISS — no warm image for this (project, tip) yet. Kick a fire-and-forget
@@ -270,13 +318,18 @@ export async function ensureSandboxImage(
     template.contentHash === identity.contentHash &&
     template.providerSnapshotName === identity.snapshotName
   ) {
-    return {
-      snapshotName: identity.snapshotName,
-      slug: template.slug,
-      contentHash: identity.contentHash,
-      built: false,
-      isDefault: !!template.isShared,
-    };
+    return prepareSnapshotForReuse(
+      provider,
+      identity.snapshotName,
+      {
+        snapshotName: identity.snapshotName,
+        slug: template.slug,
+        contentHash: identity.contentHash,
+        built: false,
+        isDefault: !!template.isShared,
+      },
+      { blocking: blockingPreparation },
+    );
   }
 
   // Cache hit? (checks the ACTIVE provider — so a row built elsewhere doesn't
@@ -290,13 +343,18 @@ export async function ensureSandboxImage(
       provider: buildProvider,
       swapKey: identity.swapKey,
     });
-    return {
-      snapshotName: identity.snapshotName,
-      slug: template.slug,
-      contentHash: identity.contentHash,
-      built: false,
-      isDefault: !!template.isShared,
-    };
+    return prepareSnapshotForReuse(
+      provider,
+      identity.snapshotName,
+      {
+        snapshotName: identity.snapshotName,
+        slug: template.slug,
+        contentHash: identity.contentHash,
+        built: false,
+        isDefault: !!template.isShared,
+      },
+      { blocking: blockingPreparation },
+    );
   }
 
   // ─── Graceful background rebuild (hot path only) ──────────────────────────
@@ -327,13 +385,18 @@ export async function ensureSandboxImage(
         `[snapshots] ${template.slug}: identity drifted to ${identity.snapshotName}; ` +
         `booting last-known-good ${template.providerSnapshotName} and rebuilding in background`,
       );
-      return {
-        snapshotName: template.providerSnapshotName,
-        slug: template.slug,
-        contentHash: template.contentHash ?? identity.contentHash,
-        built: false,
-        isDefault: !!template.isShared,
-      };
+      return prepareSnapshotForReuse(
+        provider,
+        template.providerSnapshotName,
+        {
+          snapshotName: template.providerSnapshotName,
+          slug: template.slug,
+          contentHash: template.contentHash ?? identity.contentHash,
+          built: false,
+          isDefault: !!template.isShared,
+        },
+        { blocking: blockingPreparation },
+      );
     }
   }
 
@@ -347,13 +410,18 @@ export async function ensureSandboxImage(
         provider: buildProvider,
         swapKey: identity.swapKey,
       });
-      return {
-        snapshotName: identity.snapshotName,
-        slug: template.slug,
-        contentHash: identity.contentHash,
-        built: false,
-        isDefault: !!template.isShared,
-      };
+      return prepareSnapshotForReuse(
+        provider,
+        identity.snapshotName,
+        {
+          snapshotName: identity.snapshotName,
+          slug: template.slug,
+          contentHash: identity.contentHash,
+          built: false,
+          isDefault: !!template.isShared,
+        },
+        { blocking: blockingPreparation },
+      );
     }
     if (state === 'building') {
       throw new SnapshotBuildError(
@@ -1205,7 +1273,10 @@ async function prebakeForProvider(
     if (!tip) return;
     const warmName = perProjectWarmImageName(project.projectId, tip, identity.snapshotName, template.slug);
     // Tip unchanged (or already warm for this commit) → nothing to do.
-    if ((await provider.getSnapshotState(warmName)) === 'active') return;
+    if ((await provider.getSnapshotState(warmName)) === 'active') {
+      await prepareSnapshotForReuse(provider, warmName, undefined, { blocking: false });
+      return;
+    }
     kickBackgroundWarmBuild(project, { accountId, provider: buildProvider, snapshotName: warmName });
     console.log(
       `[snapshots] warm prebake-on-push kicked: project ${project.projectId.slice(0, 8)} ` +
@@ -1510,43 +1581,53 @@ export async function ensureFastSandboxImage(opts: {
   const contentHash = createHash('sha256').update(`fast-runtime-v1\0${fingerprint}`).digest('hex');
   const snapshotName = fastSnapshotName(contentHash);
   const buildKey = `${opts.provider}:${snapshotName}`;
-  const existing = fastImageBuilds.get(buildKey);
-  if (existing) return existing;
-
-  const build = (async () => {
-    let state = await provider.getSnapshotState(snapshotName);
-    if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
-    if (state === 'active') {
+  let image = fastImageBuilds.get(buildKey);
+  let ownsImage = false;
+  if (!image) {
+    ownsImage = true;
+    image = (async () => {
+      let state = await provider.getSnapshotState(snapshotName);
+      if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
+      if (state === 'active') {
+        return {
+          snapshotName,
+          slug: DEFAULT_SANDBOX_SLUG,
+          contentHash,
+          built: false,
+          isDefault: true,
+          runtimeProfile: 'fast' as const,
+        };
+      }
+      if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
+      await provider.buildSnapshot({
+        snapshotName,
+        userDockerfile: '# platform fast cold-boot runtime',
+        spec: {},
+        slug: DEFAULT_SANDBOX_SLUG,
+        isShared: true,
+        runtimeProfile: 'fast',
+      });
+      await reapSupersededFastSnapshots(provider, snapshotName);
       return {
         snapshotName,
         slug: DEFAULT_SANDBOX_SLUG,
         contentHash,
-        built: false,
+        built: true,
         isDefault: true,
         runtimeProfile: 'fast' as const,
       };
-    }
-    if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
-    await provider.buildSnapshot({
-      snapshotName,
-      userDockerfile: '# platform fast cold-boot runtime',
-      spec: {},
-      slug: DEFAULT_SANDBOX_SLUG,
-      isShared: true,
-      runtimeProfile: 'fast',
+    })();
+    fastImageBuilds.set(buildKey, image);
+  }
+  try {
+    const result = await image;
+    if (result.built) return result;
+    return await prepareSnapshotForReuse(provider, snapshotName, result, {
+      blocking: (opts.source ?? 'session-start') !== 'session-start',
     });
-    await reapSupersededFastSnapshots(provider, snapshotName);
-    return {
-      snapshotName,
-      slug: DEFAULT_SANDBOX_SLUG,
-      contentHash,
-      built: true,
-      isDefault: true,
-      runtimeProfile: 'fast' as const,
-    };
-  })().finally(() => fastImageBuilds.delete(buildKey));
-  fastImageBuilds.set(buildKey, build);
-  return build;
+  } finally {
+    if (ownsImage) fastImageBuilds.delete(buildKey);
+  }
 }
 
 export async function ensureMetaSandboxImage(opts: {
@@ -1561,45 +1642,55 @@ export async function ensureMetaSandboxImage(opts: {
   const contentHash = createHash('sha256').update(`meta-runtime-v1\0${fingerprint}`).digest('hex');
   const snapshotName = metaSnapshotName(contentHash);
   const buildKey = `${opts.provider}:${snapshotName}`;
-  const existing = metaImageBuilds.get(buildKey);
-  if (existing) return existing;
-
-  const build = (async () => {
-    let state = await provider.getSnapshotState(snapshotName);
-    if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
-    if (state === 'active') {
+  let image = metaImageBuilds.get(buildKey);
+  let ownsImage = false;
+  if (!image) {
+    ownsImage = true;
+    image = (async () => {
+      let state = await provider.getSnapshotState(snapshotName);
+      if (state === 'building') state = await waitForProviderBuild(provider, snapshotName);
+      if (state === 'active') {
+        return {
+          snapshotName,
+          slug: 'meta',
+          contentHash,
+          built: false,
+          isDefault: false,
+          runtimeProfile: 'meta' as const,
+        };
+      }
+      if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
+      await provider.buildSnapshot({
+        snapshotName,
+        userDockerfile: '# platform meta runtime',
+        spec: { cpu: 1, memoryGb: 2, diskGb: 8 },
+        slug: 'meta',
+        isShared: true,
+        runtimeProfile: 'meta' as const,
+      });
+      // Tidy only after the replacement is actually active, so a failed build
+      // can never leave the environment with nothing to boot.
+      await reapSupersededMetaSnapshots(provider, snapshotName);
       return {
         snapshotName,
         slug: 'meta',
         contentHash,
-        built: false,
+        built: true,
         isDefault: false,
         runtimeProfile: 'meta' as const,
       };
-    }
-    if (state === 'build_failed') await provider.deleteSnapshot(snapshotName);
-    await provider.buildSnapshot({
-      snapshotName,
-      userDockerfile: '# platform meta runtime',
-      spec: { cpu: 1, memoryGb: 2, diskGb: 8 },
-      slug: 'meta',
-      isShared: true,
-      runtimeProfile: 'meta' as const,
+    })();
+    metaImageBuilds.set(buildKey, image);
+  }
+  try {
+    const result = await image;
+    if (result.built) return result;
+    return await prepareSnapshotForReuse(provider, snapshotName, result, {
+      blocking: (opts.source ?? 'session-start') !== 'session-start',
     });
-    // Tidy only after the replacement is actually active, so a failed build
-    // can never leave the environment with nothing to boot.
-    await reapSupersededMetaSnapshots(provider, snapshotName);
-    return {
-      snapshotName,
-      slug: 'meta',
-      contentHash,
-      built: true,
-      isDefault: false,
-      runtimeProfile: 'meta' as const,
-    };
-  })().finally(() => metaImageBuilds.delete(buildKey));
-  metaImageBuilds.set(buildKey, build);
-  return build;
+  } finally {
+    if (ownsImage) metaImageBuilds.delete(buildKey);
+  }
 }
 
 let startupPreBuildKicked = false;
@@ -1675,6 +1766,10 @@ async function reconcileProjectTemplates(
     for (const providerId of providers) {
       const provider = getSandboxProvider(providerId);
       const state = await provider.getSnapshotState(identity.snapshotName);
+      if (state === 'active') {
+        await prepareSnapshotForReuse(provider, identity.snapshotName, undefined, { blocking: true });
+        continue;
+      }
       if (!shouldReconcileProviderState(state)) continue;
       kickPreBuild(project, {
         slug: t.slug,
@@ -1783,7 +1878,12 @@ export async function ensurePerProjectWarmImage(
   const existingState = await provider.getSnapshotState(snapshotName);
   if (existingState === 'active') {
     await reapOldPerProjectWarm(project.projectId, snapshotName, buildProvider);
-    return { snapshotName, tip, built: false, provider: buildProvider };
+    return prepareSnapshotForReuse(
+      provider,
+      snapshotName,
+      { snapshotName, tip, built: false, provider: buildProvider },
+      { blocking: true },
+    );
   }
   if (existingState === 'building') {
     // Another API replica already owns this provider build. Do not issue a

--- a/apps/api/src/snapshots/providers/index.ts
+++ b/apps/api/src/snapshots/providers/index.ts
@@ -121,6 +121,13 @@ export interface SandboxProviderAdapter {
   /** Query the live provider state. Returns 'missing' if not found. */
   getSnapshotState(snapshotName: string): Promise<ProviderState>;
 
+  /**
+   * Optional: prepare an already-active snapshot for the provider's fastest
+   * launch path. Providers without a separate preparation phase omit it.
+   * Implementations may throw; reuse callers must preserve the usable snapshot.
+   */
+  prepareSnapshot?(snapshotName: string): Promise<void>;
+
   /** Delete the snapshot (no-op if missing). */
   deleteSnapshot(snapshotName: string): Promise<void>;
   /** List provider snapshots/templates owned by the current account. */

--- a/apps/api/src/snapshots/providers/platinum-materialize.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.test.ts
@@ -79,16 +79,56 @@ describe('Platinum template materialization', () => {
     ]);
 
     expect(result).toMatchObject({ status: 'ready', attempts: 2, httpStatus: 200 });
-    expect(probe.sleeps).toEqual([250]);
+    expect(probe.sleeps).toEqual([_label === '202 then ready' ? 5_666 : 250]);
   });
 
-  test.each([
-    ['202', { status: 202, body: { status: 'in_progress' } } satisfies Step],
-    ['503', { error: new Error('platinum POST /v1/templates/tpl_exact/materialize -> 503 unavailable') } satisfies Step],
-  ])('repeated %s stops after four requests', async (_label, step) => {
-    const { result, probe } = await run([step]);
+  test('pre-existing work gets the full budget and can become ready after 10 seconds', async () => {
+    const { result, probe } = await run([
+      { status: 202, body: { status: 'in_progress' } },
+      { status: 202, body: { status: 'in_progress' } },
+      { status: 200, body: { status: 'ready', template_id: 'tpl_exact' } },
+    ]);
 
-    expect(result).toMatchObject({ status: 'failed', attempts: 4 });
+    expect(result).toMatchObject({ status: 'ready', attempts: 3, httpStatus: 200 });
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(10_000);
+    expect(result.elapsedMs).toBeLessThan(18_000);
+    expect(probe.sleeps).toEqual([5_666, 5_667]);
+  });
+
+  test('a request that consumes 15 seconds still gets a final readiness probe', async () => {
+    const { result, probe } = await run([
+      { status: 202, body: { status: 'in_progress' }, elapsedMs: 15_000 },
+      { status: 200, body: { status: 'ready', template_id: 'tpl_exact' } },
+    ]);
+
+    expect(result).toMatchObject({ status: 'ready', attempts: 2, httpStatus: 200 });
+    expect(result.elapsedMs).toBe(15_666);
+    expect(probe.sleeps).toEqual([666]);
+  });
+
+  test('four immediate 202 responses spread four probes across the 18 second budget', async () => {
+    const { result, probe } = await run([{
+      status: 202,
+      body: { status: 'in_progress' },
+    }]);
+
+    expect(result).toMatchObject({
+      status: 'failed',
+      attempts: 4,
+      reason: 'attempts_exhausted',
+    });
+    expect(result.elapsedMs).toBe(17_000);
+    expect(probe.paths).toHaveLength(4);
+    expect(probe.sleeps).toEqual([5_666, 5_667, 5_667]);
+  });
+
+  test('503 keeps the short fail-open backoff instead of delaying session boot', async () => {
+    const { result, probe } = await run([{
+      error: new Error('platinum POST /v1/templates/tpl_exact/materialize -> 503 unavailable'),
+    }]);
+
+    expect(result).toMatchObject({ status: 'failed', attempts: 4, httpStatus: 503 });
+    expect(result.elapsedMs).toBe(2_500);
     expect(probe.paths).toHaveLength(4);
     expect(probe.sleeps).toEqual([250, 750, 1_500]);
   });

--- a/apps/api/src/snapshots/providers/platinum-materialize.ts
+++ b/apps/api/src/snapshots/providers/platinum-materialize.ts
@@ -1,7 +1,9 @@
 import type { PlatinumJsonResponse } from '../../shared/platinum';
 
 const MATERIALIZE_BUDGET_MS = 18_000;
-const MATERIALIZE_RETRY_MS = [250, 750, 1_500] as const;
+const MATERIALIZE_MAX_ATTEMPTS = 4;
+const MATERIALIZE_UNAVAILABLE_RETRY_MS = [250, 750, 1_500] as const;
+const MATERIALIZE_FINAL_REQUEST_RESERVE_MS = 1_000;
 
 type MaterializeBody = {
   status?: unknown;
@@ -85,7 +87,7 @@ export async function materializePlatinumTemplate(
   let attempts = 0;
   let lastStatus: number | null = null;
 
-  while (attempts < 4 && now() < deadline) {
+  while (attempts < MATERIALIZE_MAX_ATTEMPTS && now() < deadline) {
     attempts += 1;
     const remainingMs = Math.max(1, deadline - now());
     try {
@@ -118,10 +120,36 @@ export async function materializePlatinumTemplate(
       }
     }
 
-    if (attempts >= 4) break;
+    if (attempts >= MATERIALIZE_MAX_ATTEMPTS) break;
     const remainingAfterRequestMs = deadline - now();
     if (remainingAfterRequestMs <= 0) break;
-    await sleep(Math.min(MATERIALIZE_RETRY_MS[attempts - 1], remainingAfterRequestMs));
+
+    if (lastStatus === 202) {
+      // A reused command returns 202 immediately. Spread the remaining probes
+      // across the absolute budget instead of spending all four in 2.5 seconds.
+      // Keep one second for the final HTTP request and its response parsing.
+      if (remainingAfterRequestMs <= MATERIALIZE_FINAL_REQUEST_RESERVE_MS) {
+        await sleep(remainingAfterRequestMs);
+        break;
+      }
+      const remainingRequestSlots = MATERIALIZE_MAX_ATTEMPTS - attempts;
+      const delayMs = Math.max(
+        1,
+        Math.floor(
+          (remainingAfterRequestMs - MATERIALIZE_FINAL_REQUEST_RESERVE_MS)
+          / remainingRequestSlots,
+        ),
+      );
+      await sleep(delayMs);
+      continue;
+    }
+
+    // 503 means no eligible host accepted work. Keep this path short so an
+    // unavailable optimization cannot add the whole budget to session boot.
+    await sleep(Math.min(
+      MATERIALIZE_UNAVAILABLE_RETRY_MS[attempts - 1],
+      remainingAfterRequestMs,
+    ));
   }
 
   return finish('failed', attempts, lastStatus, now() >= deadline ? 'budget_exhausted' : 'attempts_exhausted');

--- a/apps/api/src/snapshots/providers/platinum-prepare-snapshot.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-prepare-snapshot.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+function setTestEnv(name: string, value: string): void {
+  if (!process.env[name] || process.env[name]?.startsWith('encrypted:')) {
+    process.env[name] = value;
+  }
+}
+
+setTestEnv('DATABASE_URL', 'postgres://postgres:postgres@127.0.0.1:54322/postgres');
+setTestEnv('SUPABASE_URL', 'http://127.0.0.1:54321');
+setTestEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-service-role');
+setTestEnv('API_KEY_SECRET', 'test-api-key-secret');
+setTestEnv('TUNNEL_SIGNING_SECRET', 'test-tunnel-signing-secret');
+setTestEnv('ALLOWED_SANDBOX_PROVIDERS', 'platinum');
+setTestEnv('KORTIX_URL', 'https://api.example.test');
+setTestEnv('FRONTEND_URL', 'http://localhost:3000');
+setTestEnv('INTERNAL_KORTIX_ENV', 'dev');
+setTestEnv('PLATINUM_API_URL', 'https://platinum.test');
+setTestEnv('PLATINUM_API_KEY', 'pt_live_testkey');
+
+const { PlatinumAdapter } = await import('./platinum');
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('PlatinumAdapter.prepareSnapshot', () => {
+  test('materializes the exact id resolved for the active snapshot name', async () => {
+    const ids: string[] = [];
+    const adapter = new PlatinumAdapter(
+      async (id) => {
+        ids.push(id);
+      },
+      () => true,
+    );
+    globalThis.fetch = (async () =>
+      jsonResponse([
+        { id: 'tpl_other', name: 'kortix-default-other', state: 'ready' },
+        { id: 'tpl_exact', name: 'kortix-default-current', state: 'ready' },
+      ])) as unknown as typeof fetch;
+
+    await adapter.prepareSnapshot('kortix-default-current');
+
+    expect(ids).toEqual(['tpl_exact']);
+  });
+
+  test('does not materialize a missing snapshot', async () => {
+    let calls = 0;
+    const adapter = new PlatinumAdapter(
+      async () => {
+        calls += 1;
+      },
+      () => true,
+    );
+    globalThis.fetch = (async () => jsonResponse([])) as unknown as typeof fetch;
+
+    await adapter.prepareSnapshot('kortix-default-missing');
+
+    expect(calls).toBe(0);
+  });
+
+  test.each(['building', 'failed', 'pending'])(
+    'does not materialize a %s snapshot',
+    async (state) => {
+      let calls = 0;
+      const adapter = new PlatinumAdapter(
+        async () => {
+          calls += 1;
+        },
+        () => true,
+      );
+      globalThis.fetch = (async () =>
+        jsonResponse([
+          { id: `tpl_${state}`, name: 'kortix-default-current', state },
+        ])) as unknown as typeof fetch;
+
+      await adapter.prepareSnapshot('kortix-default-current');
+
+      expect(calls).toBe(0);
+    },
+  );
+
+  test('propagates materialization failures to the fail-open builder boundary', async () => {
+    const adapter = new PlatinumAdapter(
+      async () => {
+        throw new Error('materializer unavailable');
+      },
+      () => true,
+    );
+    globalThis.fetch = (async () =>
+      jsonResponse([
+        { id: 'tpl_exact', name: 'kortix-default-current', state: 'ready' },
+      ])) as unknown as typeof fetch;
+
+    await expect(adapter.prepareSnapshot('kortix-default-current')).rejects.toThrow(
+      'materializer unavailable',
+    );
+  });
+
+  test('does not resolve or materialize when fast cold boot is disabled', async () => {
+    let fetchCalls = 0;
+    let materializeCalls = 0;
+    const adapter = new PlatinumAdapter(
+      async () => {
+        materializeCalls += 1;
+      },
+      () => false,
+    );
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return jsonResponse([{ id: 'tpl_exact', name: 'kortix-default-current', state: 'ready' }]);
+    }) as unknown as typeof fetch;
+
+    await adapter.prepareSnapshot('kortix-default-current');
+
+    expect(fetchCalls).toBe(0);
+    expect(materializeCalls).toBe(0);
+  });
+});

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -549,7 +549,11 @@ export class PlatinumAdapter implements SandboxProviderAdapter {
   readonly id = 'platinum' as const;
 
   constructor(
-    private readonly materializeTemplate: (externalId: string) => Promise<unknown> = materializeReadyTemplate,
+    private readonly materializeTemplate: (
+      externalId: string,
+    ) => Promise<unknown> = materializeReadyTemplate,
+    private readonly isPreparationEnabled: () => boolean = () =>
+      config.KORTIX_FAST_COLD_BOOT_ENABLED,
   ) {}
 
   isConfigured(): boolean {
@@ -737,6 +741,14 @@ export class PlatinumAdapter implements SandboxProviderAdapter {
       if (isPlatinumAuthFailure(err)) throw err;
       return 'unknown';
     }
+  }
+
+  async prepareSnapshot(snapshotName: string): Promise<void> {
+    if (!this.isPreparationEnabled() || !isPlatinumConfigured()) return;
+    const template = await findTemplateByName(snapshotName);
+    if (!template || normalizeExistingProviderState(template.state) !== 'active') return;
+    const externalId = requireExternalTemplateId(template.id, `template lookup for ${snapshotName}`);
+    await this.materializeTemplate(externalId);
   }
 
   /**


### PR DESCRIPTION
## What changed

- Use the full 18-second retry budget when Platinum reports materialization in progress.
- Prepare every active Platinum snapshot reuse path before future session boots.
- Keep session-start preparation non-blocking.
- Share concurrent preparation requests and preserve fast/meta build deduplication.
- Keep Daytona and E2B behavior unchanged.
- Gate all Platinum preparation behind `KORTIX_FAST_COLD_BOOT_ENABLED`.

## Verification

- API suite: 8,021 passed, 74 skipped, 0 failed.
- Boot and snapshot tests: 91 passed, 0 failed.
- Sandbox-agent runtime tests: 49 passed, 0 failed.
- Dockerfile and OpenCode warm-up tests: 48 passed, 0 failed.
- Focused materialization tests: 37 passed, 0 failed.
- API TypeScript: zero diagnostics.
- `git diff --check`: clean.

## Rollback

Set `KORTIX_FAST_COLD_BOOT_ENABLED=false`. The disabled-path test confirms zero Platinum lookup or materialization requests.