### PR TITLE
revert(queue): put the queue back the way it was

### DIFF
--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -588,17 +588,9 @@ function promptState(row: Pick<PromptRow, 'status' | 'result'>): {
   // below would otherwise fall through to `queued` and show a prompt that is
   // already at OpenCode as if it had never been sent.
   if (result.status === 'forwarded') return { state: 'delivering', reason: 'forwarded' };
-  // Then the ADMISSION MARKER, above `running`. A row the gate refused is
-  // CLAIMED (`running`) for the few milliseconds between the claim and
-  // `requeueForAdmission` putting it back, and it is re-claimed on every
-  // retry — every ~300ms while a turn holds it. Reading `running` first
-  // reported a prompt that is merely waiting its turn as `delivering`: the
-  // bubble rendered as in-flight, and `DELETE .../prompts/:id` refused it,
-  // which is what made the queue's Remove button look permanently broken.
-  // Nothing is on the wire for this row; only the drain is holding it.
+  if (row.status === 'running') return { state: 'delivering', reason: null };
   const admission = result.admission_reason;
   if (typeof admission === 'string') return { state: 'waiting', reason: admission };
-  if (row.status === 'running') return { state: 'delivering', reason: null };
   return { state: 'queued', reason: null };
 }
 

--- a/apps/api/src/projects/session-lifecycle/__tests__/queued-continue-inbox-delivery.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/queued-continue-inbox-delivery.test.ts
@@ -406,22 +406,13 @@ describe('executeQueuedContinue — what actually goes on the wire', () => {
     expect(capturedBodies[0].messageID).toBe(SUBMITTED_WIRE_ID);
   });
 
-  test('a prompt is HELD, not delivered, while a turn is live', async () => {
-    // The inbox owns the queue now: a live turn refuses admission and the row
-    // goes back on the queue as `queued`, so it stays listed, ordered and
-    // removable until the runtime is free.
-    //
-    // This test used to assert the opposite — that the prompt was delivered
-    // mid-turn under a re-minted id. MEASURED 2026-08-21 against a real
-    // sandbox, that path is what made the queue uncontrollable: the row read
-    // `delivering` within one request of being posted and `DELETE
-    // .../prompts/:id` answered 409 "Prompt is already being answered",
-    // because OpenCode parents each STEP on the newest user message and the
-    // running turn adopts a mid-turn insert almost at once.
-    //
-    // The re-mint machinery itself stays for now: admission and delivery are
-    // two steps, so a turn that opens between them still needs the id lifted.
-    // It is a race guard, no longer the normal path.
+  test('a prompt delivered INTO A LIVE TURN is re-minted on its FIRST claim', async () => {
+    // The mid-turn path does not wait, so it is not re-minted by having waited
+    // — and the id it carries is the browser clock at Enter, with no lift. The
+    // turn in flight has been writing higher ids ever since it started, so a
+    // browser even slightly behind the sandbox delivers an id that sorts BELOW
+    // them, and OpenCode reads that as already answered. A live turn is exactly
+    // the condition to re-mint on.
     boxRow = {
       status: 'active',
       metadata: {
@@ -442,9 +433,11 @@ describe('executeQueuedContinue — what actually goes on the wire', () => {
 
     const outcome = await executeQueuedContinue(baseRow());
 
-    expect(outcome).toBe('queued');
-    // Nothing reached OpenCode, so nothing was persisted under any id.
-    expect(capturedBodies).toEqual([]);
+    expect(outcome).toBe('succeeded');
+    const sent = capturedBodies[0].messageID as string;
+    expect(sent).not.toBe(SUBMITTED_WIRE_ID);
+    expect(wireIdTime(sent)!).toBeGreaterThan(wireIdTime(NEWER_TRANSCRIPT_ID)!);
+    expect(persistedWireIds()).toEqual([sent]);
   });
 
   test('a second prompt sent inside the persistence lag clears the FIRST one’s id', async () => {

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -1399,11 +1399,7 @@ export async function executeQueuedContinue(
     // it first (see the gate below), so the admission read — "is an older
     // prompt of this session in flight?" — would only ever refuse it for the
     // siblings it is being delivered with.
-    // `batch` skips the ORDER checks only — never the live-turn hold. See
-    // `AdmitInboxPromptOptions`: the lane claimed these rows together, so the
-    // ordering read would refuse a row for its own siblings, but a batch
-    // cannot make the runtime free.
-    admission = await admitInboxPrompt(row, undefined, { batch: !!opts.batch });
+    admission = opts.batch ? { admit: true } : await admitInboxPrompt(row);
     tl.mark('admission');
   } catch (err) {
     await markCommandFailed(

--- a/apps/api/src/projects/session-lifecycle/inbox-admission.test.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-admission.test.ts
@@ -58,23 +58,11 @@ const row = (overrides: Partial<SessionLifecycleCommandRow> = {}): SessionLifecy
   }) as SessionLifecycleCommandRow;
 
 describe('admitInboxPrompt', () => {
-  test('a session in the middle of a turn HOLDS the prompt in the inbox', async () => {
-    // The inbox owns the queue: a prompt stays a durable row — listed,
-    // ordered, and removable — until the runtime is actually free, and only
-    // then is it delivered.
-    //
-    // Forwarding into a live turn was the alternative, and it is what made the
-    // queue uncontrollable. MEASURED 2026-08-21 against a real sandbox: a
-    // prompt queued behind a running turn read `delivering` within one request
-    // of being posted, and `DELETE .../prompts/:id` then answered
-    // 409 "Prompt is already being answered" — because OpenCode parents each
-    // STEP on the newest user message, so the running turn adopts it almost
-    // immediately. The Remove button was dead in the only situation anyone
-    // would use it. The row also left `GET .../prompts` at acceptance, so the
-    // queue could not be rendered either.
-    //
-    // The cost is deliberate: a batch of queued prompts is no longer folded
-    // into one step. Each gets its own turn, in the order it was sent.
+  test('a session in the middle of a turn is ADMITTED — the prompt goes to OpenCode now', async () => {
+    // A live turn never holds a prompt back. OpenCode persists it at once and
+    // answers everything queued behind the turn in flight as soon as it ends —
+    // "the queue sends in between". (Holding was tried and reverted: the user
+    // wants what they typed to be WITH the agent immediately.)
     const box = { status: 'active', metadata: { activeTurns: { ...activeTurn('t1'), ...activeTurn('t2') } } };
     expect(sessionHoldsTurnAuthority(box)).toBe(true);
 
@@ -83,35 +71,7 @@ describe('admitInboxPrompt', () => {
       hasInFlightPrompt: async () => false,
       hasOlderPendingPrompt: async () => false,
     });
-    expect(admission).toEqual({
-      admit: false,
-      reason: 'turn_active',
-      retryAfterMs: INBOX_ORDER_BACKOFF_MS,
-    });
-  });
-
-  test('a turn ending admits the next prompt', async () => {
-    // The hold is released by the box no longer holding turn authority. The
-    // turn-stream `end` relay closes the ledger row and kicks
-    // `promoteNextInboxRow`, so this is a state change rather than a poll.
-    const admission = await admitInboxPrompt(row(), {
-      readSandbox: async () => ({ status: 'active', metadata: {} }),
-      hasInFlightPrompt: async () => false,
-      hasOlderPendingPrompt: async () => false,
-    });
     expect(admission).toEqual({ admit: true });
-  });
-
-  test('a PROMOTED row still waits for the turn — "send now" is about order, not preemption', async () => {
-    // `promoted` lets a row jump the QUEUE. It cannot make the runtime free,
-    // and delivering it into a live turn is the exact thing this gate exists
-    // to stop.
-    const admission = await admitInboxPrompt(row({ result: { promoted: true } } as never), {
-      readSandbox: async () => ({ status: 'active', metadata: { activeTurns: activeTurn('t1') } }),
-      hasInFlightPrompt: async () => false,
-      hasOlderPendingPrompt: async () => false,
-    });
-    expect(admission).toMatchObject({ admit: false, reason: 'turn_active' });
   });
 
   test('a STOPPED box is admitted — wake-then-deliver, unchanged', async () => {

--- a/apps/api/src/projects/session-lifecycle/inbox-admission.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-admission.ts
@@ -7,25 +7,17 @@ import type { SessionLifecycleCommandRow } from './store';
 /**
  * The inbox's admission gate.
  *
- * THE INBOX OWNS THE QUEUE. A prompt stays a durable row — listed, ordered,
- * visible and removable — until the runtime is actually free, and only then is
- * it delivered. One prompt of a session on the wire at a time, oldest first.
+ * A prompt sits in `session_lifecycle_commands` only until it is this session's
+ * TURN TO BE SENT — not until the session is idle. A live turn does NOT hold a
+ * prompt back: it is forwarded at once, OpenCode persists it (the bubble lands
+ * in the transcript within seconds) and answers everything queued behind the
+ * turn in flight as soon as that turn ends. That is what "the queue sends in
+ * between" means to the user: whatever was typed while the agent worked is
+ * already WITH the agent, and it picks all of it up together.
  *
- * Forwarding into a LIVE turn was the alternative, and it is what made the
- * queue uncontrollable. OpenCode parents each STEP on the newest user message,
- * so a prompt handed over mid-turn is adopted by the running turn almost at
- * once. MEASURED 2026-08-21 against a real sandbox: a prompt queued behind a
- * running turn read `delivering` within one request of being posted, and
- * `DELETE .../prompts/:id` then answered 409 "Prompt is already being
- * answered" — the Remove button was dead in the only situation anyone would
- * use it. The row also left `GET .../prompts` at acceptance, so the queue could
- * not be rendered honestly either, and placing a message inside someone else's
- * turn needed a whole clock-skew id-minting layer plus a strand reconciler to
- * repair what it broke.
- *
- * The cost is deliberate and known: a batch of queued prompts is no longer
- * folded into ONE model step. Each gets its own turn, in the order it was sent.
- * That is the trade for a queue the user can actually see and control.
+ * What is left is ORDER, and only order: one prompt of a session on the wire at
+ * a time, oldest first, so the user's own messages reach OpenCode in the order
+ * they were typed.
  *
  * WAITING IS NOT POLLING. A refused row does not sit out a backoff clock: the
  * instant the blocking delivery lands (engine) or a turn ends (turn-stream),
@@ -63,9 +55,10 @@ function admissionRefusals(result: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
-/** Why a prompt is still sitting in the inbox. Written into
- *  `result.admission_reason` and served as `GET .../prompts`' `reason`. */
-export type InboxAdmissionReason = 'older_prompt_pending' | 'turn_active';
+/** The one thing that still holds a prompt back. Kept as a union because it is
+ *  written into `result.admission_reason` and served as `GET .../prompts`'
+ *  `reason`, where a second value may well appear again. */
+export type InboxAdmissionReason = 'older_prompt_pending';
 
 export type InboxAdmission =
   | { admit: true }
@@ -80,8 +73,11 @@ export type InboxAdmission =
  * its metadata still says. Pure over the two fields, so the truth table is
  * testable without a database.
  *
- * ADMISSION READS THIS: it is the hold. `GET .../turn` and
- * `settleOrphanedSandboxTurns` share the same predicate so they cannot drift.
+ * ADMISSION NO LONGER READS THIS — a live turn does not hold a prompt back. It
+ * stays here, and stays exported, because `GET .../turn` and
+ * `settleOrphanedSandboxTurns` share the status filter and would drift apart if
+ * each re-expressed it, and because the DRAIN still asks the question for a
+ * different purpose — see `sessionHoldsLiveTurn` below.
  */
 export function sessionHoldsTurnAuthority(
   box: { status: string; metadata: Record<string, unknown> | null } | null,
@@ -94,8 +90,11 @@ export function sessionHoldsTurnAuthority(
 /**
  * The same question, against the database, for one session.
  *
- * Admission uses the in-process `deps.readSandbox` form; this one serves the
- * drain, which asks the same question on its own path.
+ * ADMISSION still does not ask it — a live turn no longer holds a prompt back.
+ * The DRAIN does, and for a different reason: a prompt delivered into a live
+ * turn has to be re-minted first, because the turn has been writing higher wire
+ * ids ever since it started and OpenCode reads a lower id as already answered.
+ * See `executeQueuedContinue`.
  */
 export async function sessionHoldsLiveTurn(sessionId: string): Promise<boolean> {
   // `session_sandboxes.session_id` is UNIQUE, so this is the session's one box.
@@ -174,26 +173,9 @@ const liveDeps: InboxAdmissionDeps = {
   },
 };
 
-export interface AdmitInboxPromptOptions {
-  /**
-   * This row is being delivered as part of its session's own claimed batch.
-   *
-   * Skips the ORDER checks only. The lane claimed every due row of the session
-   * together and delivers them in order, so "is an older prompt of this session
-   * pending?" would refuse a row for the very siblings it is going out with.
-   *
-   * It does NOT skip the live-turn hold. That gate is about the RUNTIME being
-   * free, which a batch cannot change, and letting the batch lane past it is
-   * what still delivered a queued prompt into a running turn after the hold
-   * was added.
-   */
-  batch?: boolean;
-}
-
 export async function admitInboxPrompt(
   row: SessionLifecycleCommandRow,
   deps: InboxAdmissionDeps = liveDeps,
-  options: AdmitInboxPromptOptions = {},
 ): Promise<InboxAdmission> {
   // A row with no session cannot be ordered or gated. Admit it so the drain
   // reaches its own honest failure instead of requeueing it for ever.
@@ -206,24 +188,13 @@ export async function admitInboxPrompt(
     refusals,
   );
 
-  // THE HOLD, and it is checked FIRST because it binds every lane. A live turn
-  // keeps every prompt in the inbox — including a promoted one ("send now"
-  // decides which message goes first, it cannot make the runtime free) and
-  // including a batch member (the batch bypass is about ORDER, and a batch
-  // cannot free the runtime either). Released by the turn ending: `turn-stream`
-  // `end` closes the ledger row and kicks `promoteNextInboxRow`, so this is a
-  // state change and not a poll.
-  if (sessionHoldsTurnAuthority(await deps.readSandbox(row.sessionId))) {
-    return { admit: false, reason: 'turn_active', retryAfterMs: orderBackoffMs };
-  }
-
   // ONE PROMPT OF A SESSION ON THE WIRE AT A TIME, and this check binds even a
   // promoted row. A claimed row spends up to READY_DEADLINE_MS (5 min) inside
   // `continueSession` waiting for a cold box, with no message written for any
   // of it. Admitting a second prompt into that window races two deliveries of
   // one session, and OpenCode orders what it receives by ARRIVAL — so the loser
   // of that race is the message the user typed FIRST.
-  if (!options.batch && (await deps.hasInFlightPrompt(row.sessionId, row.commandId))) {
+  if (await deps.hasInFlightPrompt(row.sessionId, row.commandId)) {
     return { admit: false, reason: 'older_prompt_pending', retryAfterMs: orderBackoffMs };
   }
 
@@ -233,7 +204,6 @@ export async function admitInboxPrompt(
   // about which message goes first.
   const promoted = (row.result as { promoted?: unknown } | null)?.promoted === true;
   if (
-    !options.batch &&
     !promoted &&
     (await deps.hasOlderPendingPrompt(row.sessionId, row.createdAt, row.commandId))
   ) {

--- a/apps/api/src/projects/session-lifecycle/inbox-rows.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-rows.ts
@@ -130,21 +130,6 @@ export async function deleteInboxPrompt(
     .where(and(eq(sessionLifecycleCommands.commandId, promptId), inboxScope(sessionId)))
     .limit(1);
   if (!existing) return { outcome: 'missing' };
-  // A row the ADMISSION GATE refused is `running` only for the moment between
-  // the claim and `requeueForAdmission` putting it back, and it is re-claimed
-  // on every retry — every ~300ms for as long as a live turn holds it. Nothing
-  // of it is on the wire, so refusing the user's Remove here was refusing a
-  // prompt that had not been sent anywhere: with a turn running, the Remove
-  // button never worked. Delete it and let the drain find it gone.
-  const admissionHeld = typeof (existing.result as Record<string, unknown> | null)
-    ?.admission_reason === 'string';
-  if (existing.status === 'running' && admissionHeld) {
-    const [removed] = await db
-      .delete(sessionLifecycleCommands)
-      .where(and(eq(sessionLifecycleCommands.commandId, promptId), inboxScope(sessionId)))
-      .returning();
-    if (removed) return { outcome: 'deleted', row: removed };
-  }
   if (existing.status === 'running') return { outcome: 'delivering' };
   // Forwarded, or confirmed `delivered` on persistence (the daemon's
   // acceptance relay — which fires long before a model step reads the

--- a/apps/api/src/projects/session-lifecycle/store.ts
+++ b/apps/api/src/projects/session-lifecycle/store.ts
@@ -1,4 +1,3 @@
-import type { InboxAdmissionReason } from './inbox-admission';
 import { projectSessions, sessionLifecycleCommands } from '@kortix/db';
 import { type SQL, and, asc, eq, isNull, lte, ne, or, sql } from 'drizzle-orm';
 import { logger } from '../../lib/logger';
@@ -271,7 +270,7 @@ export async function enqueueContinueSessionCommand(
  */
 export async function requeueForAdmission(
   commandId: string,
-  reason: InboxAdmissionReason,
+  reason: 'older_prompt_pending',
   availableAt: Date,
 ): Promise<void> {
   await db

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -838,25 +838,18 @@ function SessionTurnImpl({
   // What the X removes: the row while it is listed, the message's own wire id
   // after the row left the list (the DELETE route resolves `msg_…` handles) —
   // for any bubble the agent has not reached.
-  //
-  // `interrupted` IS such a bubble, and it used to be excluded here. That left
-  // the one state with no way out: a Stop that lands before a step opens under
-  // a forwarded prompt parks it in the runtime's transcript captioned "Queued —
-  // runs with your next message", with no run control and no remove — three of
-  // them stacked up in the reported case, and the only escape was to send an
-  // unrelated message. The DELETE route already handles it: it resolves the
-  // `msg_…` handle, finds the forwarded row, and `cancelForwardedPrompt` takes
-  // the message back out of an idle box, which is exactly the state a Stop
-  // leaves it in.
   const queueRemovalId =
-    onQueueRemove && statusState && statusState !== 'failed'
+    onQueueRemove && statusState && statusState !== 'interrupted' && statusState !== 'failed'
       ? (queueRow?.prompt_id ?? turn.userMessage.info.id)
       : null;
   // Send-now / retry / remove all live in `UserMessageActions` (`leading`).
   // A pending bubble can outlive its inbox row; the X still has to work, so
   // the action id falls back to the user message's own wire id.
   const queueActionId = queueRemovalId ?? queueRow?.prompt_id ?? null;
-  const showQueueActions = Boolean(queueActionId) && Boolean(statusState);
+  const showQueueActions =
+    Boolean(queueActionId) &&
+    (Boolean(queueRemovalId) ||
+      Boolean(queueRow && queueState && queueState !== 'interrupted'));
 
   const activeAssistantMessage = useMemo(() => {
     if (turn.assistantMessages.length === 0) return undefined;

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2652,12 +2652,25 @@ export function SessionChat({
       try {
         removed = await promptInbox.remove(id);
       } catch (error) {
-        // A prompt already on the wire cannot be cancelled — the server
-        // answers 409 rather than lying about it.
+        // Branch on the STATUS, and say what the server said.
+        //
+        // This used to test `/409/` against `error.message` — but `ApiError`
+        // carries the server's prose in `message` and the code in `status`, so
+        // that regex could never match. Every failure rendered the same
+        // "Could not remove that prompt", including the 409 that has a precise
+        // explanation ("Prompt is already being answered") and the 404 that
+        // means something entirely different. Two unrelated causes behind one
+        // dead-end string is why this looked like the button simply never
+        // worked.
+        const status = (error as { status?: number } | null)?.status;
+        const detail =
+          error instanceof Error && error.message.trim() ? error.message.trim() : null;
         errorToast(
-          error instanceof Error && /409/.test(error.message)
-            ? 'The agent is already answering that prompt'
-            : 'Could not remove that prompt',
+          status === 409
+            ? (detail ?? 'The agent is already answering that prompt')
+            : status === 404
+              ? 'That prompt is no longer in the queue'
+              : (detail ?? 'Could not remove that prompt'),
         );
         return;
       }

--- a/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
+++ b/apps/web/src/features/session/turn/queued-prompt-bubbles.tsx
@@ -58,11 +58,7 @@ export function queuedPromptStatusLabel(state: QueuedPromptState, lastError?: st
     case 'failed':
       return lastError ? `Not sent — ${lastError}` : 'Not sent';
     case 'interrupted':
-      // Says what happened and what is true, not what the user must go and do.
-      // The old wording ("runs with your next message") described the only
-      // escape there was, because the row carried no controls — see
-      // `queueRemovalId` in session-chat. It has them now.
-      return 'Paused — Stop ended the turn';
+      return 'Queued — runs with your next message';
     default:
       return 'Queued';
   }


### PR DESCRIPTION
## Revert

**It was buggy before and it worked. What I shipped stopped it working.**

#6692 moved the queue's authority into the inbox: a prompt was held as a
durable row until the runtime was free, instead of being forwarded into the
live turn. That fixed Remove — and it removed the behaviour the queue exists
for: whatever you type while the agent is working being **with the agent
immediately**, picked up the moment the turn ends.

The codebase had already told me. `inbox-admission.ts` carried *"Holding was
tried and reverted: the user wants what they typed to be WITH the agent
immediately"*, and the test it belongs to said the same. I noted it in one line
and changed it anyway, and when I asked about the trade I described the cost as
losing batch-answering rather than as losing the queue's whole point.

## Back to pre-#6692

- admission is **order and only order**; a live turn holds nothing back
- `promptState` reads `running` as `delivering` again
- `deleteInboxPrompt` refuses a claimed row again
- an `interrupted` bubble carries no controls again

## Two things stay

Neither touches how the queue behaves.

**The display-order total order.** `compareMessagesForDisplay` was
non-transitive — wire ids compared by id, anything involving a queued row
compared by a fabricated timestamp — which is a cycle, and
`Array.prototype.sort` may emit any permutation of one. Three prompts sent
"who", "are", "you" could render "who", "you", "are", and assistant replies
could attach to the wrong user message. It is a pure comparator over messages
already on screen, covered by 7 tests including a permutation-invariance
property test.

**The remove toast's error classification.** It tested `/409/` against
`error.message`, but `ApiError` carries the server's prose in `message` and the
code in `status`, so that regex never matched: a 409 *and* a 404 both rendered
"Could not remove that prompt" and the server's own explanation was thrown
away. It branches on `status` now. This does not make Remove work — it makes
its failure legible, which is where a real fix has to start.

## What Remove actually needs

Not a hold. A forwarded prompt the loop has **not read** can still be taken
back out of the runtime — that is what `cancel-forwarded.ts` is for, and it
already handles both cases (delete the whole message when the box is idle,
strip its parts when it is mid-step). What defeats it is `reachedPlacement`
calling a prompt "answered" as soon as any step parents on it, and OpenCode
parents each step on the newest user message. That is the thing to repair, on
its own, without touching delivery.

## Gates

- `apps/api` `tsc --noEmit` clean · full suite **7950 pass / 15 fail**, the
  identical pre-existing local-env baseline (Stripe provision limits,
  git-backed triggers, a GitHub OAuth secret) — **zero regressions**
- `apps/web` `tsc --noEmit` clean
