### PR TITLE
fix(api): fail closed on unsafe FAST activation

### DIFF
--- a/apps/api/src/snapshots/providers/platinum-build-capacity.test.ts
+++ b/apps/api/src/snapshots/providers/platinum-build-capacity.test.ts
@@ -50,7 +50,7 @@ describe('PlatinumAdapter.getSnapshotBuildCapacity', () => {
         method: init?.method ?? (input instanceof Request ? input.method : 'GET'),
       });
       return jsonResponse({
-        templates: { used: 4, cap: 12, ignored: 99 },
+        templates: { used: 4, cap: 12, atomicAdmission: true, ignored: 99 },
         sandboxes: { used: 80, cap: 100 },
       });
     }) as unknown as typeof fetch;
@@ -70,8 +70,18 @@ describe('PlatinumAdapter.getSnapshotBuildCapacity', () => {
       { used: 9, cap: 9 },
     ]) {
       globalThis.fetch = (async () =>
-        jsonResponse({ templates: capacity })) as unknown as typeof fetch;
+        jsonResponse({ templates: { ...capacity, atomicAdmission: true } })) as unknown as typeof fetch;
       await expect(new PlatinumAdapter().getSnapshotBuildCapacity()).resolves.toEqual(capacity);
+    }
+  });
+
+  test('fails closed when the provider does not advertise atomic admission', async () => {
+    for (const atomicAdmission of [undefined, false, 'true', 1]) {
+      globalThis.fetch = (async () =>
+        jsonResponse({ templates: { used: 4, cap: 12, atomicAdmission } })) as unknown as typeof fetch;
+      await expect(new PlatinumAdapter().getSnapshotBuildCapacity()).rejects.toThrow(
+        /atomic template admission capability/,
+      );
     }
   });
 

--- a/apps/api/src/snapshots/providers/platinum.ts
+++ b/apps/api/src/snapshots/providers/platinum.ts
@@ -582,6 +582,8 @@ export class UploadUrlRejectedError extends Error {
 
 const MALFORMED_BUILD_CAPACITY =
   'Malformed Platinum template build capacity: expected integer values with 0 <= templates.used <= templates.cap and templates.cap >= 1';
+const MISSING_ATOMIC_ADMISSION =
+  'Platinum template builds require the atomic template admission capability';
 
 function parseSnapshotBuildCapacity(body: unknown): { used: number; cap: number } {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -591,7 +593,7 @@ function parseSnapshotBuildCapacity(body: unknown): { used: number; cap: number 
   if (!templates || typeof templates !== 'object' || Array.isArray(templates)) {
     throw new Error(MALFORMED_BUILD_CAPACITY);
   }
-  const { used, cap } = templates as Record<string, unknown>;
+  const { used, cap, atomicAdmission } = templates as Record<string, unknown>;
   if (
     typeof used !== 'number' ||
     typeof cap !== 'number' ||
@@ -602,6 +604,9 @@ function parseSnapshotBuildCapacity(body: unknown): { used: number; cap: number 
     used > cap
   ) {
     throw new Error(MALFORMED_BUILD_CAPACITY);
+  }
+  if (atomicAdmission !== true) {
+    throw new Error(MISSING_ATOMIC_ADMISSION);
   }
   return { used, cap };
 }

--- a/docs/specs/2026-08-19-fast-cold-boot.md
+++ b/docs/specs/2026-08-19-fast-cold-boot.md
@@ -118,7 +118,16 @@ Platinum now admits a template build through one control-plane transaction.
 The transaction evaluates the current count and quota before it creates the
 template. Concurrent API replicas cannot oversubscribe the reserved capacity
 through separate list and create calls. The dev control plane serves this
-contract from commit `d3741b01995e1b8b670d7047e2cb46d2ef0a01b6`.
+contract from commit `d3741b01995e1b8b670d7047e2cb46d2ef0a01b6` and advertises
+it as `templates.atomicAdmission=true` in `GET /v1/auth/orgs/quota`. Kortix
+rejects FAST image builds when the configured Platinum endpoint omits this
+exact boolean. The ECS deploy script also rejects a flag-on rollout before it
+registers a task definition. Flag-off deployments and non-Platinum providers
+do not require this capability.
+
+On 2026-08-21, Kortix dev pointed at `https://api.platinum.dev`. That production
+endpoint did not contain commit `d3741b01995e1b8b670d7047e2cb46d2ef0a01b6`.
+Keep FAST disabled until the configured endpoint advertises the capability.
 
 Activation re-reads the project before it publishes an image pin. An archived
 project cannot acquire a new pin after an in-flight build completes. Archived
@@ -315,8 +324,11 @@ The first deployment uses the automatic `main` push. This path always injects
 5. Read `/v1/runtime-assets/manifest` with dev authentication. Record the
    immutable agent `version` and `sha256`. The manifest does not guarantee a
    daemon source SHA, so it is not merge-SHA evidence.
+6. Require the configured Platinum quota response to contain the exact boolean
+   `templates.atomicAdmission=true`. The deploy script performs this check again
+   before it registers a flag-on task definition.
 
-Activate the second rollout only after all five checks pass:
+Activate the second rollout only after all six checks pass:
 
 ```sh
 gh workflow run deploy-dev.yml --ref main \

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -94,6 +94,33 @@ merge_environment_overrides() {
   '
 }
 
+fast_cold_boot_requires_atomic_admission() {
+  local overrides_json="${1:-}" secret_json="${2:-}"
+  local enabled providers
+  [ -n "$overrides_json" ] || overrides_json='{}'
+  [ -n "$secret_json" ] || secret_json='{}'
+  if ! enabled="$(printf '%s' "$overrides_json" | jq -er '.KORTIX_FAST_COLD_BOOT_ENABLED // "false"')"; then
+    echo 'refusing deployment: malformed KORTIX_ECS_ENV_OVERRIDES JSON' >&2
+    return 2
+  fi
+  [ "$enabled" = "true" ] || return 1
+  if ! providers="$(printf '%s' "$secret_json" | jq -er '.ALLOWED_SANDBOX_PROVIDERS // "" | ascii_downcase')"; then
+    echo 'refusing FAST cold boot activation: malformed environment secret JSON' >&2
+    return 2
+  fi
+  printf '%s' "$providers" | grep -Eq '(^|[[:space:],])platinum([[:space:],]|$)'
+}
+
+validate_platinum_atomic_admission() {
+  local quota_json="${1:-}"
+  [ -n "$quota_json" ] || quota_json='{}'
+  if printf '%s' "$quota_json" | jq -e '.templates.atomicAdmission == true' >/dev/null 2>&1; then
+    return 0
+  fi
+  echo 'refusing FAST cold boot activation: Platinum does not advertise atomic template admission' >&2
+  return 1
+}
+
 # Allow sourcing for tests: `KORTIX_ECS_DEPLOY_LIB=1 source ecs-deploy.sh`.
 if [ "${KORTIX_ECS_DEPLOY_LIB:-}" = "1" ]; then
   # shellcheck disable=SC2317 # `exit` is the non-sourced fallback for `return`
@@ -186,6 +213,36 @@ SECRET_VALUE="$(aws secretsmanager get-secret-value --region "$REGION" \
   --secret-id "$SECRET_ARN" --query 'SecretString' --output text)"
 KEYCOUNT="$(printf '%s' "$SECRET_VALUE" | jq 'if type == "object" and all(.[]; type == "string") then length else error("secret must be a JSON object of strings") end')"
 [ "$KEYCOUNT" -gt 0 ] || { echo "blob $SECRET_NAME has 0 keys — refusing to deploy" >&2; exit 1; }
+
+FAST_OVERRIDES_JSON="${KORTIX_ECS_ENV_OVERRIDES:-}"
+[ -n "$FAST_OVERRIDES_JSON" ] || FAST_OVERRIDES_JSON='{}'
+FAST_CAPABILITY_REQUIRED=0
+fast_cold_boot_requires_atomic_admission "$FAST_OVERRIDES_JSON" "$SECRET_VALUE" || FAST_CAPABILITY_REQUIRED=$?
+if [ "$FAST_CAPABILITY_REQUIRED" -eq 2 ]; then
+  exit 1
+elif [ "$FAST_CAPABILITY_REQUIRED" -eq 0 ]; then
+  PLATINUM_URL="$(printf '%s' "$SECRET_VALUE" | jq -r '.PLATINUM_API_URL // empty')"
+  PLATINUM_KEY="$(printf '%s' "$SECRET_VALUE" | jq -r '.PLATINUM_API_KEY // empty')"
+  case "$PLATINUM_URL" in
+    https://*) ;;
+    *) echo 'refusing FAST cold boot activation: PLATINUM_API_URL must use https' >&2; exit 1 ;;
+  esac
+  [ -n "$PLATINUM_KEY" ] || { echo 'refusing FAST cold boot activation: PLATINUM_API_KEY is missing' >&2; exit 1; }
+
+  FAST_HEADER_FILE="$(mktemp)"
+  cleanup_fast_header() { rm -f -- "$FAST_HEADER_FILE"; }
+  trap cleanup_fast_header EXIT
+  chmod 600 "$FAST_HEADER_FILE"
+  printf 'Authorization: Bearer %s\n' "$PLATINUM_KEY" > "$FAST_HEADER_FILE"
+  PLATINUM_QUOTA="$(curl --silent --show-error --fail --connect-timeout 10 --max-time 30 \
+    --header "@$FAST_HEADER_FILE" "$PLATINUM_URL/v1/auth/orgs/quota")"
+  cleanup_fast_header
+  trap - EXIT
+  unset PLATINUM_KEY
+  validate_platinum_atomic_admission "$PLATINUM_QUOTA"
+  unset PLATINUM_QUOTA
+  echo '▶ verified Platinum atomic template admission for FAST cold boot'
+fi
 unset SECRET_VALUE
 SECRETS_JSON="$(jq -cn --arg arn "$SECRET_ARN" '[{name: "KORTIX_ENV_JSON", valueFrom: $arn}]')"
 echo "▶ wired $KEYCOUNT environment values through KORTIX_ENV_JSON from $SECRET_NAME"

--- a/infra/scripts/ecs-fast-cold-boot-gate.test.mjs
+++ b/infra/scripts/ecs-fast-cold-boot-gate.test.mjs
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const deployScript = fileURLToPath(new URL('./ecs-deploy.sh', import.meta.url));
+
+function runFunction(name, ...args) {
+  const result = spawnSync(
+    'bash',
+    [
+      '-c',
+      'set -uo pipefail; export KORTIX_ECS_DEPLOY_LIB=1; source "$1"; shift; "$@"',
+      'bash',
+      deployScript,
+      name,
+      ...args,
+    ],
+    { encoding: 'utf8' },
+  );
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe('fast cold boot deployment gate', () => {
+  test('requires the capability only for a flag-on deployment that can use Platinum', () => {
+    expect(runFunction(
+      'fast_cold_boot_requires_atomic_admission',
+      '{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}',
+      '{"ALLOWED_SANDBOX_PROVIDERS":"platinum,daytona"}',
+    ).status).toBe(0);
+
+    for (const [overrides, secret] of [
+      ['{"KORTIX_FAST_COLD_BOOT_ENABLED":"false"}', '{"ALLOWED_SANDBOX_PROVIDERS":"platinum"}'],
+      ['{}', '{"ALLOWED_SANDBOX_PROVIDERS":"platinum"}'],
+      ['{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}', '{"ALLOWED_SANDBOX_PROVIDERS":"daytona,e2b"}'],
+    ]) {
+      expect(runFunction('fast_cold_boot_requires_atomic_admission', overrides, secret).status).toBe(1);
+    }
+
+    for (const [overrides, secret] of [
+      ['{', '{"ALLOWED_SANDBOX_PROVIDERS":"platinum"}'],
+      ['{"KORTIX_FAST_COLD_BOOT_ENABLED":"true"}', '{'],
+    ]) {
+      const result = runFunction('fast_cold_boot_requires_atomic_admission', overrides, secret);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('refusing');
+    }
+  });
+
+  test('accepts only an explicit atomic admission capability', () => {
+    expect(runFunction(
+      'validate_platinum_atomic_admission',
+      '{"templates":{"used":4,"cap":500,"atomicAdmission":true}}',
+    ).status).toBe(0);
+
+    for (const quota of [
+      '{"templates":{"used":4,"cap":500}}',
+      '{"templates":{"used":4,"cap":500,"atomicAdmission":false}}',
+      '{"templates":{"used":4,"cap":500,"atomicAdmission":"true"}}',
+      '{}',
+    ]) {
+      const result = runFunction('validate_platinum_atomic_admission', quota);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('atomic template admission');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- require Platinum to advertise `templates.atomicAdmission=true` before optional FAST image admission
- reject flag-on ECS deployments before task-definition registration when the configured Platinum endpoint lacks the capability
- pass flag-off deployments and non-Platinum provider configurations unchanged
- document the provider dependency and six-step rollout gate

## Verification
- `pnpm --filter kortix-api test` — 8,211 pass, 78 skip, 0 fail
- `pnpm --filter kortix-api typecheck` — pass
- `bun test infra/scripts/ecs-fast-cold-boot-gate.test.mjs apps/api/src/snapshots/providers/platinum-build-capacity.test.ts apps/api/src/snapshots/project-image-admission.test.ts` — 15 pass, 0 fail
- `bash -n infra/scripts/ecs-deploy.sh` — pass
- real dev endpoint, flag-on dry-run — exit 1 before registration: Platinum does not advertise atomic template admission
- real dev endpoint, flag-off dry-run — exit 0 and renders `KORTIX_FAST_COLD_BOOT_ENABLED=false`

## Dependency
Platinum PR #727 adds the advertised capability. FAST remains disabled. Do not activate it until the configured Platinum endpoint serves that capability.