### PR TITLE
fix(dev): stop OOM-killing the dev API — 1024 MiB was a quarter of every other environment

### DIFF
--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -535,7 +535,9 @@ describe('full self-host Docker distribution', () => {
     }
     const db = document.services['supabase-db'];
     expect(db?.oom_score_adj).toBeLessThan(0);
-    expect(document.services['kortix-api']?.mem_limit).toBe('${KORTIX_API_MEMORY_LIMIT:-640m}');
+    // Matched to the gateway's ceiling on purpose: the API mounts the gateway
+    // in-process, so image-heavy request bodies transit BOTH containers.
+    expect(document.services['kortix-api']?.mem_limit).toBe('${KORTIX_API_MEMORY_LIMIT:-2048m}');
     const analytics = document.services['supabase-analytics'];
     const vector = document.services['supabase-vector'];
     expect(analytics?.oom_score_adj).toBeGreaterThan(0);

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -641,7 +641,14 @@ interface MemSpec {
 
 const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
   'supabase-db': { limit: '1280m', reservation: '512m', oomScoreAdj: -900 },
-  'kortix-api': { limit: '${KORTIX_API_MEMORY_LIMIT:-640m}', reservation: '256m' },
+  // The API HOSTS THE GATEWAY IN-PROCESS (apps/api/src/index.ts mounts
+  // `/v1/llm` via mountLlmGateway), so every byte the note below describes for
+  // the standalone gateway also transits this container. 640m was the same
+  // mistake one service down: on 2026-08-21 the dev API — capped at 1024 MiB,
+  // still under the 2 GiB proven necessary here — was OOM-killed three times
+  // in eleven minutes during an image-heavy session, and the browser was shown
+  // Cloudflare's "Bad Gateway" page. Matched to the gateway's ceiling.
+  'kortix-api': { limit: '${KORTIX_API_MEMORY_LIMIT:-2048m}', reservation: '256m' },
   // Headroom for large multimodal requests: the gateway buffers the raw request
   // body (image-heavy agent turns run tens of MiB — see DEFAULT_MAX_REQUEST_BYTES),
   // so 512m was far too tight once the body ceiling was raised. Give it a generous

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -121,9 +121,19 @@ module "api" {
   # Only Cloudflare's edge may reach the ALB (no direct-to-origin WAF bypass).
   alb_ingress_cidrs = local.cloudflare_ip_ranges
 
-  # dev sizing: small + spot, floor of 1
-  task_cpu         = 512
-  task_memory      = 1024
+  # dev sizing: spot, floor of 1 — but NOT a quarter of every other environment.
+  # 2026-08-21: the API was OOM-killed (exit 137, "OutOfMemoryError: container
+  # killed due to memory usage") three times in eleven minutes while a founder
+  # ran an image-heavy session (Image Search, 5 queries, 40 images). Cloudflare
+  # answered the dead origin with its own 502 page, which the session surfaced
+  # as "Bad Gateway" + "Retrying in 53s". Nothing had regressed: MemoryUtilization
+  # sat under a 65-70% ceiling for ten straight days and broke it only that day
+  # (85.5% max), with the AVERAGE unchanged at ~37% — peak, not drift, which is
+  # what a few large payloads through the in-process LLM gateway look like.
+  # 1024 MiB was simply too small a ceiling to have. prod and staging both run
+  # task_memory 4096; dev now has the same headroom at half their CPU.
+  task_cpu         = 1024
+  task_memory      = 4096
   desired_count    = 2
   min_capacity     = 2
   max_capacity     = 6


### PR DESCRIPTION
## The symptom

Sessions on dev.kortix.com rendered **"Bad Gateway"** with "Retrying in 53s". The same string appeared on a self-hosted box earlier today, which sent us looking for a code regression.

## The cause

The dev API container is being **OOM-killed**:

```
exit 137  OutOfMemoryError: container killed due to memory usage  19:51:01
exit 137  OutOfMemoryError: container killed due to memory usage  19:51:31
exit 137  OutOfMemoryError: container killed due to memory usage  20:02:19
```

A dead origin is a dead origin, so Cloudflare returns its own 502/504 page. Measured 10-40% of requests to `/v1/health` failing that way (`server: cloudflare`, a `cf-ray`, and **no** `x-kortix-*` or `x-amzn-*` header), with ECS replacing tasks every 2-4 minutes and **no** "unhealthy in target-group" events at all.

`/v1/health` runs no database query and no gateway work. That is what ruled out every application-level suspect.

## Nothing regressed

```
Aug 11  57.9    Aug 16  66.8
Aug 12  67.2    Aug 17  65.3
Aug 13  69.6    Aug 18  64.7
Aug 14  60.6    Aug 19  65.1
Aug 15  66.6    Aug 20  65.5
                Aug 21  85.5   <- first break of a 10-day ceiling
```

Daily max MemoryUtilization sat under 65-70% for ten consecutive days and broke it only today — while the **average was unchanged at ~37%**, exactly where it has been all month. Peak without drift is a handful of large payloads, not a leak. The LLM gateway is mounted **in-process** (`apps/api/src/index.ts:88`, `app.route('/v1/llm', llm)`), so whole image-heavy request bodies transit this container; the session that triggered it was running `Image Search, 5 queries, 40 images`.

## The fix

`task_memory` has been **1024 since at least Aug 15** (revision 500) while prod (`prod/main.tf:118`) and staging (`staging/main.tf:121`) both run **4096**. Dev was provisioned at a quarter of every other environment. It gets the same headroom now, at half their CPU, still on Fargate spot.

It has to live in Terraform: a manual `ecs-scale` here is silently reverted by the next deploy's TF apply — the note on staging's own sizing block records that exact lesson. I applied revision 619 (1024/4096) by hand for immediate relief; this PR is what makes it survive.

## Not the cause (checked and cleared)

- **The API's crash guards** (`index.ts:169-207`) log and keep serving, explicitly overriding crash-on-unhandled-rejection — a thrown error cannot kill this process.
- **The gateway refactor #6679** was the leading suspect and does not fit the timing: it merged Aug 20 21:38 and memory was flat all of Aug 20 (65.5%) and Aug 21 morning (47-52%).
- **#6702 / #6699** (today's merges) landed at 16:57 and 17:32 UTC; the memory climb started ~15:30.
- **The self-hosted box** is currently healthy — zero 502/503/504 through Caddy in 2h, 10.6 GB of 15.7 GB free. Its gateway restarts (32/37) all predate 14:09 and stabilised there, hours before either of today's PRs reached it.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW