### PR TITLE
fix(web): hash the whole snippet into the Shiki cache key

### DIFF
--- a/apps/web/src/components/markdown/code/shiki-highlighter.test.ts
+++ b/apps/web/src/components/markdown/code/shiki-highlighter.test.ts
@@ -90,10 +90,10 @@ describe('shikiKey', () => {
     );
   });
 
-  test('BUG: two different long strings of the same length collide on one key', () => {
-    // Past 200 characters the signature is head(100) + tail(100) + length, so
-    // any edit that stays inside the middle and keeps the length produces the
-    // same key as the text it replaced. Documented, not asserted away.
+  test('two different long strings of the same length get different keys', () => {
+    // The signature used to be head(100) + tail(100) + length, so any edit that
+    // stayed inside the middle and kept the length produced a byte-identical
+    // key. The key now hashes the whole snippet, so the middle counts.
     const head = 'a'.repeat(100);
     const tail = 'b'.repeat(100);
     const plus = `${head}const total = subtotal + tax;${tail}`;
@@ -101,14 +101,32 @@ describe('shikiKey', () => {
 
     expect(plus).not.toBe(minus);
     expect(plus.length).toBe(minus.length);
-    expect(shikiKey(plus, 'typescript', SHIKI_THEME_DARK)).toBe(
+    expect(shikiKey(plus, 'typescript', SHIKI_THEME_DARK)).not.toBe(
       shikiKey(minus, 'typescript', SHIKI_THEME_DARK),
     );
   });
 
-  test('BUG: the collision serves one snippet the other snippet’s highlighted HTML', () => {
-    // What the key collision costs a reader: highlightSync answers from the
-    // cache before it looks at the code it was handed.
+  test('a one-character edit in the middle of a long snippet changes the key', () => {
+    const head = 'a'.repeat(100);
+    const tail = 'b'.repeat(100);
+
+    expect(shikiKey(`${head}xMIDDLEx${tail}`, 'typescript', SHIKI_THEME_DARK)).not.toBe(
+      shikiKey(`${head}xMIDDLEy${tail}`, 'typescript', SHIKI_THEME_DARK),
+    );
+  });
+
+  test('the same long snippet always hashes to the same key', () => {
+    const code = `${'a'.repeat(100)}const total = subtotal + tax;${'b'.repeat(100)}`;
+
+    expect(shikiKey(code, 'typescript', SHIKI_THEME_DARK)).toBe(
+      shikiKey(code, 'typescript', SHIKI_THEME_DARK),
+    );
+  });
+
+  test('a cached snippet is never served for a different snippet', () => {
+    // What the old key collision cost a reader: highlightSync answers from the
+    // cache before it looks at the code it was handed, so the wrong snippet's
+    // highlighted HTML was rendered verbatim.
     const head = 'a'.repeat(100);
     const tail = 'b'.repeat(100);
     const plus = `${head}const total = subtotal + tax;${tail}`;
@@ -116,7 +134,8 @@ describe('shikiKey', () => {
 
     cacheHtml(shikiKey(plus, 'typescript', SHIKI_THEME_DARK), '<pre>PLUS</pre>');
 
-    expect(highlightSync(minus, 'typescript', SHIKI_THEME_DARK)).toBe('<pre>PLUS</pre>');
+    expect(highlightSync(minus, 'typescript', SHIKI_THEME_DARK)).not.toBe('<pre>PLUS</pre>');
+    expect(highlightSync(plus, 'typescript', SHIKI_THEME_DARK)).toBe('<pre>PLUS</pre>');
   });
 });
 

--- a/apps/web/src/components/markdown/code/shiki-highlighter.ts
+++ b/apps/web/src/components/markdown/code/shiki-highlighter.ts
@@ -173,8 +173,31 @@ const shikiCache = new Map<string, string>();
 const shikiPending = new Map<string, Promise<string | null>>();
 const SHIKI_CACHE_MAX = 64;
 
+// A 53-bit content hash (two interleaved FNV-1a-style lanes, mixed at the end).
+// Every character is read, so an edit anywhere in the code changes the digest --
+// which is the whole point: the signature this replaced sampled head(100) +
+// tail(100) + length, and any same-length edit between those windows produced a
+// byte-identical key. Short of a real cryptographic digest there is no such
+// thing as collision-free, but a full-content hash makes a collision an
+// astronomical accident rather than the routine outcome of editing the middle
+// of a snippet.
+function hashCode(code: string): string {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < code.length; i++) {
+    const ch = code.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+}
+
 function shikiKey(code: string, lang: string, theme: string): string {
-  const sig = code.length <= 200 ? code : code.slice(0, 100) + code.slice(-100) + code.length;
+  // Short snippets keep their literal text: it is already cheaper to compare
+  // than to hash, and it keeps keys readable when debugging the cache.
+  const sig = code.length <= 200 ? code : `${code.length}:${hashCode(code)}`;
   return `${lang}:${theme}:${sig}`;
 }
 


### PR DESCRIPTION
## Summary

`shikiKey` — the key for the module-level Shiki highlight cache — did not read the whole snippet it was keying. Past 200 characters it built the signature from `head(100) + tail(100) + code.length`:

```ts
const sig = code.length <= 200 ? code : code.slice(0, 100) + code.slice(-100) + code.length;
```

Any edit that stays between those two windows and keeps the length produces a **byte-identical key** for different code. `highlightSync` answers from the cache before it looks at the code it was handed:

```ts
const key = shikiKey(code, lang, theme);
const cached = shikiCache.get(key);
if (cached) return cached;   // ← never compares `code` against what was cached
```

So the second snippet renders the **first snippet's highlighted HTML** — the reader sees a code block containing code that is not the code they asked for. Concretely, these two collide today:

```
…100 chars… const total = subtotal + tax; …100 chars…
…100 chars… const total = subtotal - tax; …100 chars…
```

This is not a hypothetical. Agent output is exactly where it bites: the same file re-emitted with a small in-place edit, a diff shown before and after, or a snippet re-streamed by Streamdown across the remount cycle this cache exists to absorb. All of those are same-length middle edits on blocks well over 200 characters.

The bug was already known and pinned by two tests named `BUG: …`, which asserted the collision rather than its absence — documented, not fixed. This closes it.

**Why the signature was truncated in the first place:** to keep key construction cheap for large blocks. That intent is preserved — the fix hashes rather than concatenates, so the key stays short and bounded; it just reads every character on the way there.

### What changed

**`apps/web/src/components/markdown/code/shiki-highlighter.ts`**

- Added `hashCode()` — a 53-bit content hash (two interleaved FNV-1a-style lanes, `Math.imul` mixing, base-36 output). Every character is read, so an edit anywhere in the snippet changes the digest.
- `shikiKey()` now signs long snippets as `` `${code.length}:${hashCode(code)}` ``. Length stays in the key as a free discriminator on top of the hash.
- Snippets of **200 characters or less are unchanged** — they keep their literal text as the signature. Comparing a short string is cheaper than hashing it, and it keeps keys readable when inspecting the cache.

**`apps/web/src/components/markdown/code/shiki-highlighter.test.ts`**

- The two `BUG: …` tests now assert the **absence** of a collision instead of documenting its presence, and are renamed accordingly.
- Added: a one-character edit in the middle of a long snippet changes the key.
- Added: the same long snippet hashes to the same key across calls (guards the hash against being non-deterministic, which would silently disable the cache).

### Notes on scope

- No public API change. `shikiKey` keeps its signature; the cache, its ceiling, and the LRU eviction path are untouched.
- Keys are not persisted anywhere, so the changed key format needs no migration — the worst case at deploy is one cold in-memory cache.
- No cryptographic claim is intended. A 53-bit digest is not collision-free; it makes a collision an astronomical accident rather than the routine outcome of editing the middle of a snippet, which is the current behaviour.
- Cost is O(n) over a block already capped at 50,000 characters by `clampCode`, and only on a cache miss — the path that was about to call Shiki's full tokenizer anyway.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

`bun test src/components/markdown/code/shiki-highlighter.test.ts` from `apps/web`:

```
 20 pass
 0 fail
 41 expect() calls
```

I checked the new tests are not vacuous by reverting **only** the source change and re-running against the updated tests — 3 fail, including the one that matters:

```
(fail) shikiKey > a cached snippet is never served for a different snippet
(fail) shikiKey > two different long strings of the same length get different keys
(fail) shikiKey > a one-character edit in the middle of a long snippet changes the key
```

Also verified:

- `biome check` on both files reports the **same 7 findings before and after** this change (all pre-existing on `main`) — nothing new introduced.
- `tsc --noEmit` over `apps/web` reports no errors in either file.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control) — n/a, no endpoints touched
- [x] User input is validated (e.g. Zod) and output is safe — the hash is over content already rendered by Shiki; no new sink
- [x] No sensitive data (tokens, PII, secrets) is written to logs — nothing is logged
- [x] DB schema / migration changes are reviewed and reversible — n/a, no schema change
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner — n/a; `hashCode` is a cache discriminator, not a security primitive, and is not used for authentication, integrity, or storage

## Rollout / rollback

No migrations, feature flags, or env vars. The cache is in-memory and per-session, so deploying this simply starts producing keys in the new format; old keys are never read back from anywhere. Reverting the commit restores the previous behaviour with no cleanup.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied
