### PR TITLE
fix(web): restore the voice control and subordinate menu items reverted by #6701

### DIFF
--- a/apps/web/src/features/session/composer/composer-toolbar.tsx
+++ b/apps/web/src/features/session/composer/composer-toolbar.tsx
@@ -10,6 +10,7 @@ import type { FlatModel } from '../model-flatten';
 import type { ModelDefaultControls } from '../model-selector';
 import { ModelSelector } from '../model-selector';
 import { ReasoningEffortSelector } from '../reasoning-effort-selector';
+import { VoiceRecorder } from '../voice-recorder';
 import { SendStopControl } from './send-stop-control';
 
 /**
@@ -221,6 +222,12 @@ export function ComposerToolbar({
         )}
 
         {toolbarSlot}
+
+        <VoiceRecorder
+          onTranscription={onTranscription}
+          disabled={voiceDisabled}
+          startRequestId={voiceStartRequestId}
+        />
 
         <SendStopControl
           isSending={isSending}

--- a/apps/web/src/features/session/header/session-site-header.tsx
+++ b/apps/web/src/features/session/header/session-site-header.tsx
@@ -246,12 +246,18 @@ export function SessionSiteHeader({
         </>
       )}
 
-      <DropdownMenuItem className="cursor-pointer" onClick={() => setExportOpen(true)}>
+      <DropdownMenuItem
+        className="text-muted-foreground hover:text-foreground/90 cursor-pointer [&_svg]:opacity-70"
+        onClick={() => setExportOpen(true)}
+      >
         <FileDown />
         Export conversation
       </DropdownMenuItem>
 
-      <DropdownMenuItem className="cursor-pointer" onClick={() => setCompactOpen(true)}>
+      <DropdownMenuItem
+        className="text-muted-foreground hover:text-foreground/90 cursor-pointer [&_svg]:opacity-70"
+        onClick={() => setCompactOpen(true)}
+      >
         <Layers />
         Summarize conversation
       </DropdownMenuItem>

--- a/apps/web/src/features/session/voice-recorder.tsx
+++ b/apps/web/src/features/session/voice-recorder.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import Loading from '@/components/ui/loading';
+import { errorToast } from '@/components/ui/toast';
+import { useTranscription } from '@/hooks/transcription/use-transcription';
+import { cn } from '@/lib/utils';
+import { MicrophoneIcon as Mic, SquareIcon as Square } from '@phosphor-icons/react';
+import { AnimatePresence, m } from 'motion/react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+
+interface VoiceRecorderProps {
+  onTranscription: (text: string) => void;
+  disabled?: boolean;
+  /**
+   * Starts a recording from OUTSIDE the button — the `/` palette's "Start voice
+   * input" row. A monotonically increasing counter, not a boolean: two
+   * consecutive requests must both fire, and a boolean that is already `true`
+   * produces no change to react to. `null`/`0` never starts anything, so a
+   * toolbar rendered without it behaves exactly as before.
+   */
+  startRequestId?: number | null;
+}
+
+const MAX_RECORDING_TIME = 15 * 60 * 1000; // 15 minutes in milliseconds
+
+/** `mm:ss`, zero-padded, so the readout never changes width mid-recording. */
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** Icon state swaps cross-fade rather than cutting — same values everywhere. */
+const ICON_SWAP = {
+  initial: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  animate: { scale: 1, opacity: 1, filter: 'blur(0px)' },
+  exit: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  transition: { type: 'spring', duration: 0.3, bounce: 0 },
+} as const;
+
+export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRecorder({
+  onTranscription,
+  disabled = false,
+  startRequestId = null,
+}) {
+  const [state, setState] = useState<'idle' | 'recording' | 'processing'>('idle');
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recordingStartTimeRef = useRef<number | null>(null);
+  const maxTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const transcriptionMutation = useTranscription();
+
+  const cleanupStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  // The 15-minute cap, plus the elapsed readout that makes it legible. Without
+  // the readout the cap is invisible: a recording just ends.
+  useEffect(() => {
+    if (state !== 'recording') {
+      recordingStartTimeRef.current = null;
+      setElapsedMs(0);
+      if (maxTimeoutRef.current) {
+        clearTimeout(maxTimeoutRef.current);
+        maxTimeoutRef.current = null;
+      }
+      return;
+    }
+
+    const startedAt = Date.now();
+    recordingStartTimeRef.current = startedAt;
+    setElapsedMs(0);
+    maxTimeoutRef.current = setTimeout(() => stopRecording(), MAX_RECORDING_TIME);
+    const tick = setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+
+    return () => {
+      clearInterval(tick);
+      if (maxTimeoutRef.current) {
+        clearTimeout(maxTimeoutRef.current);
+        maxTimeoutRef.current = null;
+      }
+    };
+  }, [state, stopRecording]);
+
+  // The microphone must not outlive this component. Without this the stream
+  // stays open after the composer unmounts — the OS recording indicator keeps
+  // burning and the tab holds the mic until it is closed.
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop();
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const options = { mimeType: 'audio/webm' };
+      const mediaRecorder = new MediaRecorder(stream, options);
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        if (chunksRef.current.length === 0) {
+          // Recording was cancelled
+          cleanupStream();
+          setState('idle');
+          return;
+        }
+
+        setState('processing');
+        const audioBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const audioFile = new File([audioBlob], 'recording.webm', { type: 'audio/webm' });
+
+        transcriptionMutation.mutate(audioFile, {
+          onSuccess: (data) => {
+            onTranscription(data.text);
+            setState('idle');
+          },
+          // No toast here: `useTranscription`'s own `onError` already routes
+          // the failure through `handleApiError`, which toasts it. A second
+          // one would stack two cards for one failure.
+          onError: () => setState('idle'),
+        });
+
+        cleanupStream();
+      };
+
+      mediaRecorder.start();
+      setState('recording');
+    } catch (error) {
+      // The common case here is a denied or missing microphone. It used to be
+      // `console.error` only, so the button lit up, went dark, and never said
+      // why.
+      cleanupStream();
+      setState('idle');
+      const name = error instanceof Error ? error.name : '';
+      errorToast(
+        name === 'NotAllowedError' || name === 'SecurityError'
+          ? 'Microphone access denied'
+          : 'Could not start recording',
+        {
+          description:
+            name === 'NotAllowedError' || name === 'SecurityError'
+              ? 'Allow microphone access for this site, then try again.'
+              : 'No microphone was available. Check your input device and try again.',
+        },
+      );
+    }
+  }, [cleanupStream, onTranscription, transcriptionMutation]);
+
+  const cancelRecording = () => {
+    if (mediaRecorderRef.current && state === 'recording') {
+      chunksRef.current = []; // Clear chunks to signal cancellation
+      mediaRecorderRef.current.stop();
+      cleanupStream();
+      setState('idle');
+    }
+  };
+
+  const handleClick = () => {
+    if (state === 'idle') {
+      startRecording();
+    } else if (state === 'recording') {
+      stopRecording();
+    }
+  };
+
+  const handleRightClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (state === 'recording') {
+      cancelRecording();
+    }
+  };
+
+  // An external start request (the `/` palette). Guarded on `idle` so a request
+  // that lands mid-recording is ignored rather than restarting the take.
+  const lastStartRequestRef = useRef<number | null>(startRequestId ?? null);
+  useEffect(() => {
+    if (startRequestId == null) return;
+    if (lastStartRequestRef.current === startRequestId) return;
+    lastStartRequestRef.current = startRequestId;
+    if (disabled || state !== 'idle') return;
+    startRecording();
+  }, [startRequestId, disabled, state, startRecording]);
+
+  const label =
+    state === 'recording'
+      ? 'Stop recording — right-click to discard'
+      : state === 'processing'
+        ? 'Transcribing…'
+        : 'Start voice input';
+
+  return (
+    <Hint side="top" label={label}>
+      <Button
+        type="button"
+        variant="ghost"
+        size={state === 'recording' ? 'sm' : 'icon-base'}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+        disabled={disabled || state === 'processing'}
+        aria-label={label}
+        className={cn(
+          'hit-area-1 shrink-0 duration-300 ease-out active:scale-[0.96] active:duration-150',
+          state === 'recording' ? 'gap-1.5 px-2' : 'p-0',
+        )}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          <m.span key={state} className="flex items-center gap-1.5" {...ICON_SWAP}>
+            {state === 'recording' ? (
+              <Square weight="fill" className="size-4 shrink-0 rounded-sm" />
+            ) : state === 'processing' ? (
+              <Loading className="size-4 shrink-0" />
+            ) : (
+              <Mic className="size-4 shrink-0" />
+            )}
+            {state === 'recording' && (
+              <span className="text-xs tabular-nums">{formatElapsed(elapsedMs)}</span>
+            )}
+          </m.span>
+        </AnimatePresence>
+      </Button>
+    </Hint>
+  );
+});


### PR DESCRIPTION
## Summary

Two tests are failing on `main` right now:

```
(fail) ComposerToolbar voice input > renders the microphone control
(fail) SessionSiteHeader "more actions" menu … > Export and Summarize items are
       renamed to plain language and styled as visually subordinate
```

Both come from one cause. #6701 was branched before `7248cd3c1` (`fix(web): preserve subordinate session actions`) and `0f8d7e0f7` (`fix(web): restore composer voice input`) landed, and carried a stale snapshot of those two files back onto `main`, undoing both.

This is an accident rather than a reversal, and #6701's own commit message is the evidence — it asserts the opposite of what it did:

> `session-site-header.tsx` is byte-identical to origin/main again, and the `fix(web): preserve subordinate session actions` change that landed there meanwhile is **untouched**.

It was not untouched. The file was reverted to a blob from before that change existed.

### 1. Voice input is gone from the composer, but nothing upstream was unwired

`VoiceRecorder` was deleted and its usage dropped from `ComposerToolbar` — yet every wire that feeds it is still live on `main`:

- `composer.tsx` still holds `const [voiceStartRequestId, setVoiceStartRequestId] = useState(0)`
- it still bumps that counter from the `/` palette: `case 'start-voice': setVoiceStartRequestId((n) => n + 1)`
- it still passes `onTranscription={handleTranscription}`, `voiceDisabled={submitDisabled || isBusy}`, `voiceStartRequestId={voiceStartRequestId}` into the toolbar
- `ComposerToolbar` still declares and destructures all three props

So the props are dead ends, the mic control is absent from the toolbar, and **"Start voice input" is still offered in the `/` menu and does nothing when chosen.**

That last part is the standard the palette is explicitly held to. From `slash-items.test.ts`:

> It queried `'scope'` while `set-scope` existed; that row **was removed because it opened nothing**, and `start-voice` came back with **a real control behind it (`VoiceRecorder` in the composer toolbar)**.

`main` currently violates that rule: `start-voice` is a row with nothing behind it.

Worth noting for anyone reading the history — the earlier removal `641c343506` justified itself with *"The VoiceRecorder component has been removed from the project, as it was not utilized in the ComposerToolbar."* That premise was wrong; the same commit deleted 11 lines of its usage **from** `ComposerToolbar`. `0f8d7e0f7` then restored it. #6701 removed it a second time. The test asserting the mic renders has never been touched by any of these — it has outlived every removal, which is the clearest statement available of what the intended behaviour is.

### 2. Export / Summarize lost their subordinate styling

`Export conversation` and `Summarize conversation` sit below a separator as secondary actions next to `Delete`. `7248cd3c1` gave them `text-muted-foreground hover:text-foreground/90 … [&_svg]:opacity-70` so they read as subordinate rather than as peers of the destructive action. That reverted to a bare `cursor-pointer`, so they now render at full emphasis.

### What changed

Both files are restored to their **pre-#6701 blobs verbatim** — this adds no new code and makes no new decisions.

| File | Change |
|---|---|
| `apps/web/src/features/session/voice-recorder.tsx` | restored (254 lines, unmodified from `0f8d7e0f7`) |
| `apps/web/src/features/session/composer/composer-toolbar.tsx` | restored the `VoiceRecorder` import and its render site |
| `apps/web/src/features/session/header/session-site-header.tsx` | restored the two `DropdownMenuItem` class lists |

Verified byte-exactness rather than eyeballing it — the restored header blob hashes to `54a6b6da30fe3ea69b7cee09850d1459dbdf85ca`, which is precisely the pre-image recorded in #6701's own diff header (`index 54a6b6da30..f9f8dee9a4`). `git diff 7248cd3c18` and `git diff 0f8d7e0f7f` against these paths are both empty.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

**Full `apps/web` suite, before and after** (`bun test src`):

| | pass | fail | ran |
|---|---|---|---|
| `main` | 8088 | **2** | 8090 |
| this branch | **8090** | **0** | 8090 |

Same 8090 tests collected in both runs — exactly the two failures turn green and nothing else moves. Both confirmed individually by name:

```
bun test … -t "renders the microphone control"   → 1 pass, 0 fail
bun test … -t "visually subordinate"             → 1 pass, 0 fail
```

**Lint** — the gate CI actually runs (`pnpm --dir apps/web exec eslint src --quiet`) exits `0` on all three files.

**Typecheck** — `tsc --noEmit` over `apps/web` reports **19 errors on `main` and 19 on this branch**, all pre-existing and none in these files. The restored component's imports all resolve.

**Biome** — the two pre-existing files report the same 15 findings before and after; nothing new introduced.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control) — n/a, no endpoints touched
- [x] User input is validated (e.g. Zod) and output is safe — restored code only; no new input path
- [x] No sensitive data (tokens, PII, secrets) is written to logs — nothing added
- [x] DB schema / migration changes are reviewed and reversible — n/a, no schema change
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner — n/a

Note for review: `VoiceRecorder` captures microphone audio for transcription. It is not new code and not new behaviour — it is the component that was live on `main` until #6701, restored unmodified. If its removal was in fact intentional, the correct change is the opposite of this PR (delete the failing test, the three dead props in `ComposerToolbar`, the `start-voice` palette row and its counter in `composer.tsx`) — happy to switch to that instead. I've assumed accidental because the surrounding wiring was all left in place and #6701 stated it was not touching these files.

## Why this reached `main` undetected

Worth flagging separately, because the same gap will let the next one through.

The only `apps/web` test any workflow runs is a single file — `ci.yml`'s "Enforce frontend SDK boundary" step:

```yaml
pnpm --dir apps/web exec bun test src/sdk-boundary.test.ts
pnpm --dir apps/web exec eslint src --quiet
```

The remaining ~8,090 web unit tests are in no CI lane at all. `tests.yml`'s full matrix covers `sdk`, `flow-runner-unit`, `worktree-unit`, `route-coverage`, `package-quality`, and the api/browser targets — but not `apps/web`. So the two tests that have been red since #6701 merged were never going to block anything, and `eslint`/`next build` both pass on the broken state.

I have not touched CI in this PR — that is a maintainer call on runtime cost. But a lane running `bun test src` in `apps/web` would have caught this at the source PR. Happy to open that separately if it is wanted.

## Rollout / rollback

No migrations, feature flags, or env vars. Pure UI restore; reverting this commit returns to today's `main`.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied

