### PR TITLE
fix(edge): accept webhooks without User-Agent

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,17 @@ linked, not inlined.
 
 ## Register
 
+### Normalize missing User-Agent at webhook ingress before AWS WAF (2026-08-21)
+
+**When:** proxying public provider webhooks through the API router to an AWS
+WAF-protected origin. Providers may omit `User-Agent`; signatures, not that
+informational header, authenticate these requests. AWS Managed Rules reject the
+request before the API can verify its signature. Add a relay `User-Agent` only
+for POST webhook routes and only when absent. Preserve sender headers elsewhere.
+*Incident:* Agency webhooks returned origin `403`; the same body with any
+`User-Agent` reached Suna. *Enforcer:* `api-router/worker.test.mjs` covers every
+webhook path family, sender-header preservation, and non-webhook exclusion.
+
 ### A JWKS is not evidence of how tokens are signed, and publishing a key changes behavior before you promote it (2026-08-21)
 
 **When:** migrating a Supabase project to asymmetric JWT signing keys, or

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -42,6 +42,7 @@ const AUTOMATIC_MAINTENANCE = {
 // the real origin response instead. Compared against the CI_PASSTHROUGH_SECRET
 // binding; absent or wrong, the request is treated as ordinary public traffic.
 const CI_PASSTHROUGH_HEADER = 'X-Kortix-CI-Passthrough';
+const WEBHOOK_RELAY_USER_AGENT = 'Kortix-Webhook-Relay/1.0';
 
 // Constant-time over the compared bytes. The length is not secret (a mismatched
 // length returns false immediately), the contents are.
@@ -77,6 +78,16 @@ function isReadOnlyRequest(request) {
     request.method === 'GET' ||
     request.method === 'HEAD' ||
     request.method === 'OPTIONS'
+  );
+}
+
+function isWebhookIngressRequest(request, url) {
+  if (request.method !== 'POST') return false;
+  return (
+    url.pathname.startsWith('/v1/webhooks/') ||
+    url.pathname.startsWith('/v1/billing/webhook/') ||
+    url.pathname.startsWith('/v1/billing/webhooks/') ||
+    url.pathname === '/v1/connectors/webhook/pipedream'
   );
 }
 
@@ -300,9 +311,21 @@ export default {
     // `302 → kortix.com/projects/...` got followed here, kortix.com bounced to
     // /auth, and the worker returned that /auth HTML as a 200, so the browser
     // never saw the redirect (blank page, URL stuck on the callback).
+    const originHeaders = new Headers(request.headers);
+    // AWSManagedRulesCommonRuleSet rejects a missing User-Agent before the API
+    // can verify the webhook signature. External webhook providers are not
+    // required to send this informational header. Supply a relay identity only
+    // on public POST webhook routes and only when the sender omitted the header.
+    if (
+      !isGateway &&
+      isWebhookIngressRequest(request, url) &&
+      !originHeaders.has('User-Agent')
+    ) {
+      originHeaders.set('User-Agent', WEBHOOK_RELAY_USER_AGENT);
+    }
     const modifiedRequest = new Request(targetUrl, {
       method: request.method,
-      headers: request.headers,
+      headers: originHeaders,
       body: request.body,
       redirect: 'manual',
     });

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -288,6 +288,71 @@ describe('api-router worker', () => {
     expect(response.headers.get('X-Backend-Service')).toBe('api');
   });
 
+  test.each([
+    '/v1/webhooks/projects/00000000-0000-4000-a000-000000000000/hook',
+    '/v1/webhooks/slack',
+    '/v1/billing/webhook/stripe',
+    '/v1/billing/webhooks/stripe',
+    '/v1/connectors/webhook/pipedream',
+  ])('adds a relay User-Agent only when webhook ingress omits it: %s', async (path) => {
+    let proxiedRequest;
+    globalThis.fetch = async (request) => {
+      proxiedRequest = request;
+      return Response.json({ accepted: true });
+    };
+
+    const response = await worker.fetch(
+      new Request(`https://api.kortix.com${path}`, {
+        method: 'POST',
+        body: '{"event":"test"}',
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(proxiedRequest.headers.get('User-Agent')).toBe(
+      'Kortix-Webhook-Relay/1.0',
+    );
+    expect(await proxiedRequest.text()).toBe('{"event":"test"}');
+  });
+
+  test('preserves a webhook sender User-Agent', async () => {
+    let proxiedUserAgent = '';
+    globalThis.fetch = async (request) => {
+      proxiedUserAgent = request.headers.get('User-Agent');
+      return Response.json({ accepted: true });
+    };
+
+    await worker.fetch(
+      new Request('https://api.kortix.com/v1/webhooks/slack', {
+        method: 'POST',
+        headers: { 'User-Agent': 'Slackbot 1.0' },
+        body: '{}',
+      }),
+      env,
+    );
+
+    expect(proxiedUserAgent).toBe('Slackbot 1.0');
+  });
+
+  test('does not add User-Agent to non-webhook requests', async () => {
+    let proxiedUserAgent;
+    globalThis.fetch = async (request) => {
+      proxiedUserAgent = request.headers.get('User-Agent');
+      return Response.json({ accepted: true });
+    };
+
+    await worker.fetch(
+      new Request('https://api.kortix.com/v1/projects', {
+        method: 'POST',
+        body: '{}',
+      }),
+      env,
+    );
+
+    expect(proxiedUserAgent).toBeNull();
+  });
+
   test('routes gateway hostnames to the gateway backend, independent of the API toggle', async () => {
     let proxiedUrl = '';
     globalThis.fetch = async (request) => {


### PR DESCRIPTION
## Problem

AWS WAF rejects provider webhook requests that omit `User-Agent` before Suna can verify their signatures. The public API returned an origin `403`. The same body reached Suna when any `User-Agent` was present.

## Fix

- Add `Kortix-Webhook-Relay/1.0` at the API router only when a POST webhook request omits `User-Agent`.
- Cover project, channel, billing, sandbox/auth/email, and Pipedream webhook route families.
- Preserve provider-supplied headers.
- Leave non-webhook traffic unchanged.
- Record the incident rule and regression enforcer.

## Verification

- `$HOME/.bun/bin/bun test infra/cloudflare/workers/api-router/worker.test.mjs` — 39 pass, 0 fail.
- `PATH="$HOME/.bun/bin:$PATH" pnpm test` — all five core lanes passed; SDK 2,424 pass, 2 skip, 0 fail.
- Dev Worker version `dfaf81dc-ad08-4ba5-a027-74795cd7c558` deployed directly.
- `POST https://dev-api.kortix.com/v1/webhooks/projects/not-a-uuid/probe` with an empty `User-Agent` returns `400 {"error":"Invalid project id"}` from Suna. Before the fix it returned origin `403` HTML.