### PR TITLE
docs(gateway): state the in-flight budget's unit, and pin it with a test

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -197,14 +197,20 @@ const envSchema = z.object({
   // 0 = unlimited, for self-host operators who want no ceiling at all.
   KORTIX_RELAY_MAX_REQUEST_BYTES: optInt(1_073_741_824),
   /**
-   * Total request bytes (BEFORE amplification) the in-process LLM gateway will
-   * hold at once. Beyond this it answers 503 + Retry-After instead of accepting
-   * work it cannot hold — see InflightBudget. 0 disables admission control.
+   * Estimated process memory, in AMPLIFIED bytes, that the in-process LLM
+   * gateway will hold for request bodies at once. Beyond this it answers 503 +
+   * Retry-After instead of accepting work it cannot hold — see InflightBudget.
+   * 0 disables admission control.
    *
-   * 512 MiB is sized for the smallest container that runs this code (self-host
-   * kortix-api at 2048m); a host with more memory can raise it. Bounding ONE
-   * request is not enough on its own: unbounded concurrency multiplies a
-   * bounded per-request cost straight back into an OOM.
+   * AMPLIFIED, not wire bytes: a body costs a UTF-16 string plus a JSON.parse
+   * graph, which InflightBudget charges at 3x by default. So this 512 MiB
+   * admits roughly 170 MiB of concurrent request bodies. Reading it as raw
+   * request bytes over-provisions the host by 3x.
+   *
+   * Sized for the smallest container that runs this code (self-host kortix-api
+   * at 2048m); a host with more memory can raise it. Bounding ONE request is
+   * not enough on its own: unbounded concurrency multiplies a bounded
+   * per-request cost straight back into an OOM.
    */
   GATEWAY_INFLIGHT_BUDGET_BYTES: optInt(536_870_912),
   KORTIX_RELAY_MAX_RESPONSE_BYTES: optInt(1_073_741_824),

--- a/packages/llm-gateway/src/pipeline/inflight-budget.test.ts
+++ b/packages/llm-gateway/src/pipeline/inflight-budget.test.ts
@@ -106,4 +106,18 @@ describe('InflightBudget', () => {
     b.admit(250);
     expect(b.utilisation).toBeCloseTo(0.25, 5);
   });
+
+  // The unit of `maxBytes` is AMPLIFIED bytes, not wire bytes. Pinning it here
+  // because the two differ by 3x by default and the difference is invisible at
+  // a call site -- a host sized on the wrong reading takes 3x the traffic it
+  // can actually hold.
+  test('maxBytes is denominated in AMPLIFIED bytes, not wire bytes', () => {
+    const b = new InflightBudget({ maxBytes: 300, perRequestMaxBytes: 1_000, amplification: 3 });
+    // 100 wire bytes costs 300 amplified -> exactly fills a 300 budget.
+    expect(b.admit(100).ok).toBe(true);
+    expect(b.inflightBytes).toBe(300);
+    expect(b.utilisation).toBe(1);
+    // If maxBytes were wire-denominated, another 100 would still fit.
+    expect(b.admit(100).ok).toBe(false);
+  });
 });

--- a/packages/llm-gateway/src/pipeline/inflight-budget.ts
+++ b/packages/llm-gateway/src/pipeline/inflight-budget.ts
@@ -116,11 +116,17 @@ export class InflightBudget {
 }
 
 /**
- * Default in-flight budget, in WIRE bytes before amplification.
+ * Default in-flight budget, in AMPLIFIED bytes — the same unit `maxBytes` is
+ * compared against, i.e. an estimate of real process memory, NOT wire bytes.
+ *
+ * Stated explicitly because getting it wrong is a silent 3x error in either
+ * direction: at the default amplification this 512 MiB admits roughly 170 MiB
+ * of concurrent WIRE bytes, and an operator who reads it as "512 MiB of request
+ * body" will size a host for three times the traffic it can really take.
  *
  * Sized for the smallest container that runs this code (self-host kortix-api at
  * 2048m). A host with more memory should raise it; a host with less must lower
- * it. The relationship to enforce is the point: this is a fraction of process
- * memory, never a number picked in isolation.
+ * it. The relationship is the point: this is a fraction of process memory,
+ * never a number picked in isolation.
  */
 export const DEFAULT_INFLIGHT_BUDGET_BYTES = 512 * 1024 * 1024;


### PR DESCRIPTION
Follow-up to #6708, found while sizing the self-host container.

`InflightBudget.maxBytes` is compared against the **amplified** cost, but two comments described it as wire bytes:

- `DEFAULT_INFLIGHT_BUDGET_BYTES` — *"in WIRE bytes before amplification"*
- `config.GATEWAY_INFLIGHT_BUDGET_BYTES` — *"Total request bytes (BEFORE amplification)"*

Both are wrong by the amplification factor, and the error is silent and 3x. An operator reading 512 MiB as "request bytes in flight" sizes a host for three times the traffic it can actually take — the real figure at the default amplification is ~170 MiB of concurrent wire bytes.

**No behaviour change** — the code was already correct. The added test asserts the denomination directly (100 wire bytes fills a 300 amplified budget), so a later edit cannot quietly redefine the unit.

Verified: `packages/llm-gateway` 477 pass / 0 fail; `apps/api` tsc clean.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW