### PR TITLE
fix(web): restore voice input and subordinate menu styling — main was red

### DIFF
--- a/apps/web/src/features/session/composer/composer-toolbar.tsx
+++ b/apps/web/src/features/session/composer/composer-toolbar.tsx
@@ -10,6 +10,7 @@ import type { FlatModel } from '../model-flatten';
 import type { ModelDefaultControls } from '../model-selector';
 import { ModelSelector } from '../model-selector';
 import { ReasoningEffortSelector } from '../reasoning-effort-selector';
+import { VoiceRecorder } from '../voice-recorder';
 import { SendStopControl } from './send-stop-control';
 
 /**
@@ -221,6 +222,12 @@ export function ComposerToolbar({
         )}
 
         {toolbarSlot}
+
+        <VoiceRecorder
+          onTranscription={onTranscription}
+          disabled={voiceDisabled}
+          startRequestId={voiceStartRequestId}
+        />
 
         <SendStopControl
           isSending={isSending}

--- a/apps/web/src/features/session/header/session-site-header.tsx
+++ b/apps/web/src/features/session/header/session-site-header.tsx
@@ -246,12 +246,18 @@ export function SessionSiteHeader({
         </>
       )}
 
-      <DropdownMenuItem className="cursor-pointer" onClick={() => setExportOpen(true)}>
+      <DropdownMenuItem
+        className="text-muted-foreground hover:text-foreground/90 cursor-pointer [&_svg]:opacity-70"
+        onClick={() => setExportOpen(true)}
+      >
         <FileDown />
         Export conversation
       </DropdownMenuItem>
 
-      <DropdownMenuItem className="cursor-pointer" onClick={() => setCompactOpen(true)}>
+      <DropdownMenuItem
+        className="text-muted-foreground hover:text-foreground/90 cursor-pointer [&_svg]:opacity-70"
+        onClick={() => setCompactOpen(true)}
+      >
         <Layers />
         Summarize conversation
       </DropdownMenuItem>

--- a/apps/web/src/features/session/voice-recorder.tsx
+++ b/apps/web/src/features/session/voice-recorder.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import Loading from '@/components/ui/loading';
+import { errorToast } from '@/components/ui/toast';
+import { useTranscription } from '@/hooks/transcription/use-transcription';
+import { cn } from '@/lib/utils';
+import { MicrophoneIcon as Mic, SquareIcon as Square } from '@phosphor-icons/react';
+import { AnimatePresence, m } from 'motion/react';
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+
+interface VoiceRecorderProps {
+  onTranscription: (text: string) => void;
+  disabled?: boolean;
+  /**
+   * Starts a recording from OUTSIDE the button — the `/` palette's "Start voice
+   * input" row. A monotonically increasing counter, not a boolean: two
+   * consecutive requests must both fire, and a boolean that is already `true`
+   * produces no change to react to. `null`/`0` never starts anything, so a
+   * toolbar rendered without it behaves exactly as before.
+   */
+  startRequestId?: number | null;
+}
+
+const MAX_RECORDING_TIME = 15 * 60 * 1000; // 15 minutes in milliseconds
+
+/** `mm:ss`, zero-padded, so the readout never changes width mid-recording. */
+function formatElapsed(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** Icon state swaps cross-fade rather than cutting — same values everywhere. */
+const ICON_SWAP = {
+  initial: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  animate: { scale: 1, opacity: 1, filter: 'blur(0px)' },
+  exit: { scale: 0.25, opacity: 0, filter: 'blur(4px)' },
+  transition: { type: 'spring', duration: 0.3, bounce: 0 },
+} as const;
+
+export const VoiceRecorder: React.FC<VoiceRecorderProps> = memo(function VoiceRecorder({
+  onTranscription,
+  disabled = false,
+  startRequestId = null,
+}) {
+  const [state, setState] = useState<'idle' | 'recording' | 'processing'>('idle');
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const recordingStartTimeRef = useRef<number | null>(null);
+  const maxTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const transcriptionMutation = useTranscription();
+
+  const cleanupStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+  }, []);
+
+  // The 15-minute cap, plus the elapsed readout that makes it legible. Without
+  // the readout the cap is invisible: a recording just ends.
+  useEffect(() => {
+    if (state !== 'recording') {
+      recordingStartTimeRef.current = null;
+      setElapsedMs(0);
+      if (maxTimeoutRef.current) {
+        clearTimeout(maxTimeoutRef.current);
+        maxTimeoutRef.current = null;
+      }
+      return;
+    }
+
+    const startedAt = Date.now();
+    recordingStartTimeRef.current = startedAt;
+    setElapsedMs(0);
+    maxTimeoutRef.current = setTimeout(() => stopRecording(), MAX_RECORDING_TIME);
+    const tick = setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+
+    return () => {
+      clearInterval(tick);
+      if (maxTimeoutRef.current) {
+        clearTimeout(maxTimeoutRef.current);
+        maxTimeoutRef.current = null;
+      }
+    };
+  }, [state, stopRecording]);
+
+  // The microphone must not outlive this component. Without this the stream
+  // stays open after the composer unmounts — the OS recording indicator keeps
+  // burning and the tab holds the mic until it is closed.
+  useEffect(() => {
+    return () => {
+      if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+        mediaRecorderRef.current.stop();
+      }
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+    };
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const options = { mimeType: 'audio/webm' };
+      const mediaRecorder = new MediaRecorder(stream, options);
+      mediaRecorderRef.current = mediaRecorder;
+      chunksRef.current = [];
+
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          chunksRef.current.push(event.data);
+        }
+      };
+
+      mediaRecorder.onstop = async () => {
+        if (chunksRef.current.length === 0) {
+          // Recording was cancelled
+          cleanupStream();
+          setState('idle');
+          return;
+        }
+
+        setState('processing');
+        const audioBlob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        const audioFile = new File([audioBlob], 'recording.webm', { type: 'audio/webm' });
+
+        transcriptionMutation.mutate(audioFile, {
+          onSuccess: (data) => {
+            onTranscription(data.text);
+            setState('idle');
+          },
+          // No toast here: `useTranscription`'s own `onError` already routes
+          // the failure through `handleApiError`, which toasts it. A second
+          // one would stack two cards for one failure.
+          onError: () => setState('idle'),
+        });
+
+        cleanupStream();
+      };
+
+      mediaRecorder.start();
+      setState('recording');
+    } catch (error) {
+      // The common case here is a denied or missing microphone. It used to be
+      // `console.error` only, so the button lit up, went dark, and never said
+      // why.
+      cleanupStream();
+      setState('idle');
+      const name = error instanceof Error ? error.name : '';
+      errorToast(
+        name === 'NotAllowedError' || name === 'SecurityError'
+          ? 'Microphone access denied'
+          : 'Could not start recording',
+        {
+          description:
+            name === 'NotAllowedError' || name === 'SecurityError'
+              ? 'Allow microphone access for this site, then try again.'
+              : 'No microphone was available. Check your input device and try again.',
+        },
+      );
+    }
+  }, [cleanupStream, onTranscription, transcriptionMutation]);
+
+  const cancelRecording = () => {
+    if (mediaRecorderRef.current && state === 'recording') {
+      chunksRef.current = []; // Clear chunks to signal cancellation
+      mediaRecorderRef.current.stop();
+      cleanupStream();
+      setState('idle');
+    }
+  };
+
+  const handleClick = () => {
+    if (state === 'idle') {
+      startRecording();
+    } else if (state === 'recording') {
+      stopRecording();
+    }
+  };
+
+  const handleRightClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (state === 'recording') {
+      cancelRecording();
+    }
+  };
+
+  // An external start request (the `/` palette). Guarded on `idle` so a request
+  // that lands mid-recording is ignored rather than restarting the take.
+  const lastStartRequestRef = useRef<number | null>(startRequestId ?? null);
+  useEffect(() => {
+    if (startRequestId == null) return;
+    if (lastStartRequestRef.current === startRequestId) return;
+    lastStartRequestRef.current = startRequestId;
+    if (disabled || state !== 'idle') return;
+    startRecording();
+  }, [startRequestId, disabled, state, startRecording]);
+
+  const label =
+    state === 'recording'
+      ? 'Stop recording — right-click to discard'
+      : state === 'processing'
+        ? 'Transcribing…'
+        : 'Start voice input';
+
+  return (
+    <Hint side="top" label={label}>
+      <Button
+        type="button"
+        variant="ghost"
+        size={state === 'recording' ? 'sm' : 'icon-base'}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+        disabled={disabled || state === 'processing'}
+        aria-label={label}
+        className={cn(
+          'hit-area-1 shrink-0 duration-300 ease-out active:scale-[0.96] active:duration-150',
+          state === 'recording' ? 'gap-1.5 px-2' : 'p-0',
+        )}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          <m.span key={state} className="flex items-center gap-1.5" {...ICON_SWAP}>
+            {state === 'recording' ? (
+              <Square weight="fill" className="size-4 shrink-0 rounded-sm" />
+            ) : state === 'processing' ? (
+              <Loading className="size-4 shrink-0" />
+            ) : (
+              <Mic className="size-4 shrink-0" />
+            )}
+            {state === 'recording' && (
+              <span className="text-xs tabular-nums">{formatElapsed(elapsedMs)}</span>
+            )}
+          </m.span>
+        </AnimatePresence>
+      </Button>
+    </Hint>
+  );
+});


### PR DESCRIPTION
Two `apps/web` tests have been failing **on main**, which fails the `packages` CI lane and blocks every unrelated PR that runs it (hit on #6705 and #6710).

## 1. `voice-recorder.tsx` was missing entirely

`0f8d7e0f7f` ("fix(web): restore composer voice input") added the 254-line `VoiceRecorder` component **and** its wiring in `composer-toolbar.tsx`. Neither is on main — a merge dropped the commit's content while keeping the commit in history.

The damage wasn't just a red test. `composer-toolbar.tsx` still declares, threads and destructures `onTranscription`, `voiceDisabled` and `voiceStartRequestId` — so **dictation type-checked perfectly while being unreachable from every composer in the app**. That is precisely the failure mode the test's own comment describes, recurring:

> "`onTranscription` and `voiceDisabled` were declared, threaded from `composer.tsx`, and destructured here — and `VoiceRecorder` was never placed in the JSX. The whole dictation feature was unreachable from every composer in the app, with nothing type-checking wrong."

## 2. Export/Summarize lost their subordinate styling

`session-site-header.tsx` had them as bare `className="cursor-pointer"`, rendering at full emphasis beside Rename and Delete. The test pins them as visually subordinate.

## Verification

- `apps/web` — **8090 pass / 0 fail** across 627 files (was 8088/2)
- `eslint` clean on all three touched files
- `tsc` shows only the pre-existing `@types/bun` `test.each` noise and the generated `@/.source` module, neither related to these files

No new behaviour — this returns main to what its own tests already say it should be.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW