### PR TITLE
fix(gateway): tell the app its real task memory instead of letting it guess

### DIFF
--- a/apps/api/src/llm-gateway/container-memory.test.ts
+++ b/apps/api/src/llm-gateway/container-memory.test.ts
@@ -124,3 +124,45 @@ describe('deriveInflightBudgetBytes', () => {
     expect(deriveInflightBudgetBytes(64 * MiB)).toBeGreaterThan(0);
   });
 });
+
+// The Fargate case, which is why this precedence exists at all: the cgroup and
+// host both report the microVM, and only the scheduler knows the task limit.
+describe('declared task memory wins over any probe', () => {
+  test('uses KORTIX_CONTAINER_MEMORY_MIB when the scheduler declares it', () => {
+    const limit = detectContainerMemoryLimitBytes({
+      read: () => 'max',
+      totalMemory: () => 7806 * MiB,
+      declaredMiB: () => '4096',
+    });
+    expect(limit).toBe(4096 * MiB);
+  });
+
+  test('a declared limit beats even a readable cgroup value', () => {
+    const limit = detectContainerMemoryLimitBytes({
+      read: (p) => (p === '/sys/fs/cgroup/memory.max' ? String(7806 * MiB) : null),
+      totalMemory: () => 7806 * MiB,
+      declaredMiB: () => '4096',
+    });
+    expect(limit).toBe(4096 * MiB);
+  });
+
+  test('garbage or empty declarations fall through to the probes', () => {
+    for (const bad of ['', 'not-a-number', '0', '-5', undefined]) {
+      const limit = detectContainerMemoryLimitBytes({
+        read: () => null,
+        totalMemory: () => 2 * GiB,
+        declaredMiB: () => bad,
+      });
+      expect(limit).toBe(2 * GiB);
+    }
+  });
+
+  test('the real dev numbers now derive 25% of 4096, not of 7806', () => {
+    const limit = detectContainerMemoryLimitBytes({
+      read: () => 'max',
+      totalMemory: () => 7806 * MiB,
+      declaredMiB: () => '4096',
+    });
+    expect(deriveInflightBudgetBytes(limit)).toBe(1024 * MiB);
+  });
+});

--- a/apps/api/src/llm-gateway/container-memory.ts
+++ b/apps/api/src/llm-gateway/container-memory.ts
@@ -54,6 +54,11 @@ export interface MemoryProbe {
   /** Returns file contents, or null when the path does not exist. */
   read: (path: string) => string | null;
   totalMemory: () => number;
+  /**
+   * The scheduler's declared task memory in MiB, when it declares one.
+   * `KORTIX_CONTAINER_MEMORY_MIB`, stamped by infra/scripts/ecs-deploy.sh.
+   */
+  declaredMiB?: () => string | undefined;
 }
 
 const defaultProbe: MemoryProbe = {
@@ -65,6 +70,7 @@ const defaultProbe: MemoryProbe = {
     }
   },
   totalMemory: () => totalmem(),
+  declaredMiB: () => process.env.KORTIX_CONTAINER_MEMORY_MIB,
 };
 
 /**
@@ -72,6 +78,20 @@ const defaultProbe: MemoryProbe = {
  * is unconstrained. Never throws: a probe failure degrades to host memory.
  */
 export function detectContainerMemoryLimitBytes(probe: MemoryProbe = defaultProbe): number | null {
+  // The scheduler's own number wins, because on Fargate the process CANNOT
+  // derive this correctly: the task runs in a microVM sized above its
+  // allocation and `memory.max` reads "max", so a cgroup probe falls through to
+  // host memory and sees the microVM. Measured on dev 2026-08-21 — a 4096 MiB
+  // task probed 7806 MiB, and the budget came out at 48% of the real ceiling
+  // rather than 25%. ecs-deploy.sh stamps KORTIX_CONTAINER_MEMORY_MIB from the
+  // same value it sets the task size to.
+  try {
+    const declared = Number(probe.declaredMiB?.() ?? '');
+    if (Number.isFinite(declared) && declared > 0) return declared * MiB;
+  } catch {
+    // fall through to the probes below
+  }
+
   let host: number | null = null;
   try {
     const total = probe.totalMemory();

--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -310,6 +310,19 @@ else
   echo "▶ task size ${DESIRED_CPU} cpu / ${DESIRED_MEMORY} MiB (unchanged)"
 fi
 
+# ── tell the app its REAL task memory ────────────────────────────────────────
+# Stamped as KORTIX_CONTAINER_MEMORY_MIB below, from the same $DESIRED_MEMORY the
+# task size uses, because the app CANNOT read this correctly on its own.
+#
+# On Fargate the task runs in a microVM sized ABOVE the task allocation, and
+# `/sys/fs/cgroup/memory.max` reads "max" — so a process probing its own cgroup
+# falls through to host memory and sees the microVM, not its limit. Measured on
+# dev 2026-08-21: a 4096 MiB task reported a 7806 MiB "container limit", and the
+# gateway sized its in-flight budget against that — 48% of the real ceiling
+# instead of the intended 25%.
+#
+# The scheduler knows the number; the process does not. So the scheduler tells
+# it, and container-memory.ts prefers this over any probe.
 NEW_TD_JSON="$(printf '%s' "$CURRENT_TD_JSON" \
   | jq --arg img "$IMAGE" --arg c "$CONTAINER" --arg ver "$VERSION_OVERRIDE" \
        --arg version_env "$VERSION_ENV_NAME" \
@@ -341,10 +354,12 @@ NEW_TD_JSON="$(printf '%s' "$CURRENT_TD_JSON" \
                     .name != "KORTIX_VERSION" and
                     .name != "KORTIX_PUBLIC_VERSION" and
                     .name != "NEXT_PUBLIC_KORTIX_VERSION" and
-                    .name != "KORTIX_COMMIT"
+                    .name != "KORTIX_COMMIT" and
+                    .name != "KORTIX_CONTAINER_MEMORY_MIB"
                   )
                 ))
-                + (if $ver == "" then [] else [{name: $version_env, value: $ver}] end))
+                + (if $ver == "" then [] else [{name: $version_env, value: $ver}] end)
+                + (if $memory == "" then [] else [{name: "KORTIX_CONTAINER_MEMORY_MIB", value: $memory}] end))
           else . end)')"
 
 if [ "$DRY_RUN" = "1" ]; then


### PR DESCRIPTION
Found by **verifying #6712 on deployed dev** rather than assuming it worked. The boot line read:

```
[gateway] in-flight budget 1952 MiB (container limit 7806 MiB, derived)
```

The ECS task is **4096 MiB**. 7806 is the Fargate microVM.

## Why the probe can't work on Fargate

The task runs in a microVM sized *above* its allocation, and `/sys/fs/cgroup/memory.max` reads `"max"` — so a process probing its own cgroup falls through to host memory and sees the microVM, not its limit. The budget came out at **48% of the real ceiling instead of the intended 25%**: safe enough by luck, wrong by design, and silently wrong.

## The fix

The scheduler knows the number and the process does not, so the scheduler says it. `ecs-deploy.sh` stamps `KORTIX_CONTAINER_MEMORY_MIB` from the same `$DESIRED_MEMORY` it uses for the task size — the same mechanism, and the same stale-value scrub, already used for `KORTIX_VERSION`.

`container-memory.ts` prefers that declaration over any probe, and falls through to cgroup v2 → cgroup v1 → host memory exactly as before when it's absent (self-host, where Docker sets the container cgroup correctly, and local dev).

With dev's real numbers:

| | before | after |
|---|---|---|
| detected limit | 7806 MiB (microVM) | **4096 MiB** (task) |
| derived budget | 1952 MiB (48%) | **1024 MiB** (25%) |

Malformed declarations — empty, non-numeric, `0`, negative — fall through to the probes rather than being trusted, so a bad stamp can't make this worse than it was.

## Verification

- `apps/api` llm-gateway — **297 pass / 0 fail** (4 new, including the exact 4096-vs-7806 case)
- ecs-deploy environment contract — **3 pass / 0 fail**
- `bash -n` clean, `tsc --noEmit` clean

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW