### PR TITLE
fix(triggers): stop initial prompt replay loops

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Mint every OpenCode message id with the native sortable codec (2026-08-22)
+
+**When:** delivering an initial, queued, retried, or imported OpenCode prompt.
+Never compose `msg_` ids from base36 timestamps or UUIDs. OpenCode 1.17.11
+uses id order to detect an answered prompt; an id that sorts after native
+assistant ids repeats a completed initial prompt indefinitely.
+*Incident:* Agency production webhooks created 40+ duplicate assistant answers
+per session across DeepSeek and GLM. *Enforcer:* `sandbox-turn-lifecycle.test.ts`
+requires `prepareInitialSandboxTurn()` to match `WIRE_MESSAGE_ID`.
+
 ### Normalize missing User-Agent at webhook ingress before AWS WAF (2026-08-21)
 
 **When:** proxying public provider webhooks through the API router to an AWS

--- a/apps/api/src/projects/sandbox-turn-lifecycle.test.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { mockConfigModule } from './reaping/test-support/mock-config';
+import { WIRE_MESSAGE_ID } from './wire-message-id';
 
 let executed: string[] = [];
 let executeResults: unknown[] = [];
@@ -87,7 +88,7 @@ describe('daemon-delivered initial turn authority', () => {
   test('mints one token-bound delivering record and OpenCode message identity', () => {
     const turn = prepareInitialSandboxTurn(1234);
     expect(turn.token).toBeString();
-    expect(turn.messageId).toStartWith('msg_');
+    expect(turn.messageId).toMatch(WIRE_MESSAGE_ID);
     expect(turn.startedAtMs).toBe(1234);
     expect(initialSandboxTurnMetadata(turn)).toEqual({
       token: turn.token,

--- a/apps/api/src/projects/sandbox-turn-lifecycle.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.ts
@@ -24,6 +24,7 @@ import {
   turnGrantMs,
 } from './sandbox-deadline-policy';
 import { confirmInboxPromptConsumed } from './session-lifecycle/consumption';
+import { mintWireMessageId } from './wire-message-id';
 
 export interface SandboxTurnIdentity {
   opencodeSessionId: string;
@@ -390,7 +391,10 @@ export async function settleOrphanedSandboxTurns(): Promise<number> {
 export function prepareInitialSandboxTurn(nowMs = Date.now()): PreparedInitialSandboxTurn {
   return {
     token: randomUUID(),
-    messageId: `msg_${nowMs.toString(36)}${randomUUID().replaceAll('-', '')}`,
+    // OpenCode <= 1.18.14 compares message ids to decide whether the initial
+    // user message already has an answer. A UUID-like id sorts after every
+    // native assistant id and makes the runtime answer the same prompt forever.
+    messageId: mintWireMessageId({ nowMs }).id,
     startedAtMs: nowMs,
   };
 }


### PR DESCRIPTION
## Problem

Production webhook sessions used a base36-plus-UUID initial `messageID`. OpenCode 1.17.11 orders messages by id when it decides whether a prompt already has an answer. The custom id sorted after native assistant ids, so one accepted webhook repeated its completed answer indefinitely. The defect reproduced with both `deepseek-v4-flash` and `glm-5.2`.

## Fix

- Mint the boot-delivered initial prompt with the existing OpenCode-compatible `mintWireMessageId()` codec.
- Require the initial id to match `WIRE_MESSAGE_ID`.
- Record the incident rule in the append-only learnings register.

## Verification

- Red test before implementation: `prepareInitialSandboxTurn(1234)` produced `msg_ya...`, which failed `WIRE_MESSAGE_ID`.
- `/Users/markokraemer/.bun/bin/bun test apps/api/src/projects/sandbox-turn-lifecycle.test.ts apps/api/src/projects/wire-message-id.test.ts` — 53 pass, 0 fail.
- `pnpm --filter kortix-api typecheck` — exit 0.
- `pnpm exec biome check apps/api/src/projects/sandbox-turn-lifecycle.ts apps/api/src/projects/sandbox-turn-lifecycle.test.ts` — 2 files clean.
- `git diff --check` — exit 0.