### PR TITLE
hotfix(webhooks): accept unsigned-agent requests and stop prompt replay

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Normalize missing User-Agent at webhook ingress before AWS WAF (2026-08-21)
+
+**When:** proxying public provider webhooks through the API router to an AWS
+WAF-protected origin. Providers may omit `User-Agent`; signatures, not that
+informational header, authenticate these requests. Add a relay `User-Agent` only
+for POST webhook routes and only when absent. Preserve sender headers elsewhere.
+*Incident:* Agency webhooks returned origin `403`; the same body with any
+`User-Agent` reached Suna. *Enforcer:* `api-router/worker.test.mjs` covers every
+webhook path family, sender-header preservation, and non-webhook exclusion.
+
 ### A per-host credential never goes in a client-wide header bag (2026-08-20)
 
 **When:** giving any browser/HTTP client a token that authorises ONE origin —

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Mint every OpenCode message id with the native sortable codec (2026-08-22)
+
+**When:** delivering an initial, queued, retried, or imported OpenCode prompt.
+Never compose `msg_` ids from base36 timestamps or UUIDs. OpenCode 1.17.11
+uses id order to detect an answered prompt; an id that sorts after native
+assistant ids repeats a completed initial prompt indefinitely.
+*Incident:* Agency production webhooks created 40+ duplicate assistant answers
+per session across DeepSeek and GLM. *Enforcer:* `sandbox-turn-lifecycle.test.ts`
+requires `prepareInitialSandboxTurn()` to match `WIRE_MESSAGE_ID`.
+
 ### Normalize missing User-Agent at webhook ingress before AWS WAF (2026-08-21)
 
 **When:** proxying public provider webhooks through the API router to an AWS

--- a/apps/api/src/projects/sandbox-turn-lifecycle.test.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { mockConfigModule } from './reaping/test-support/mock-config';
+import { WIRE_MESSAGE_ID } from './wire-message-id';
 
 let executed: string[] = [];
 let executeResults: unknown[] = [];
@@ -87,7 +88,7 @@ describe('daemon-delivered initial turn authority', () => {
   test('mints one token-bound delivering record and OpenCode message identity', () => {
     const turn = prepareInitialSandboxTurn(1234);
     expect(turn.token).toBeString();
-    expect(turn.messageId).toStartWith('msg_');
+    expect(turn.messageId).toMatch(WIRE_MESSAGE_ID);
     expect(turn.startedAtMs).toBe(1234);
     expect(initialSandboxTurnMetadata(turn)).toEqual({
       token: turn.token,

--- a/apps/api/src/projects/sandbox-turn-lifecycle.ts
+++ b/apps/api/src/projects/sandbox-turn-lifecycle.ts
@@ -24,6 +24,7 @@ import {
   turnGrantMs,
 } from './sandbox-deadline-policy';
 import { confirmInboxPromptConsumed } from './session-lifecycle/consumption';
+import { mintWireMessageId } from './wire-message-id';
 
 export interface SandboxTurnIdentity {
   opencodeSessionId: string;
@@ -390,7 +391,10 @@ export async function settleOrphanedSandboxTurns(): Promise<number> {
 export function prepareInitialSandboxTurn(nowMs = Date.now()): PreparedInitialSandboxTurn {
   return {
     token: randomUUID(),
-    messageId: `msg_${nowMs.toString(36)}${randomUUID().replaceAll('-', '')}`,
+    // OpenCode <= 1.18.14 compares message ids to decide whether the initial
+    // user message already has an answer. A UUID-like id sorts after every
+    // native assistant id and makes the runtime answer the same prompt forever.
+    messageId: mintWireMessageId({ nowMs }).id,
     startedAtMs: nowMs,
   };
 }

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -42,6 +42,7 @@ const AUTOMATIC_MAINTENANCE = {
 // the real origin response instead. Compared against the CI_PASSTHROUGH_SECRET
 // binding; absent or wrong, the request is treated as ordinary public traffic.
 const CI_PASSTHROUGH_HEADER = 'X-Kortix-CI-Passthrough';
+const WEBHOOK_RELAY_USER_AGENT = 'Kortix-Webhook-Relay/1.0';
 
 // Constant-time over the compared bytes. The length is not secret (a mismatched
 // length returns false immediately), the contents are.
@@ -77,6 +78,16 @@ function isReadOnlyRequest(request) {
     request.method === 'GET' ||
     request.method === 'HEAD' ||
     request.method === 'OPTIONS'
+  );
+}
+
+function isWebhookIngressRequest(request, url) {
+  if (request.method !== 'POST') return false;
+  return (
+    url.pathname.startsWith('/v1/webhooks/') ||
+    url.pathname.startsWith('/v1/billing/webhook/') ||
+    url.pathname.startsWith('/v1/billing/webhooks/') ||
+    url.pathname === '/v1/connectors/webhook/pipedream'
   );
 }
 
@@ -300,9 +311,21 @@ export default {
     // `302 → kortix.com/projects/...` got followed here, kortix.com bounced to
     // /auth, and the worker returned that /auth HTML as a 200, so the browser
     // never saw the redirect (blank page, URL stuck on the callback).
+    const originHeaders = new Headers(request.headers);
+    // AWSManagedRulesCommonRuleSet rejects a missing User-Agent before the API
+    // can verify the webhook signature. External webhook providers are not
+    // required to send this informational header. Supply a relay identity only
+    // on public POST webhook routes and only when the sender omitted the header.
+    if (
+      !isGateway &&
+      isWebhookIngressRequest(request, url) &&
+      !originHeaders.has('User-Agent')
+    ) {
+      originHeaders.set('User-Agent', WEBHOOK_RELAY_USER_AGENT);
+    }
     const modifiedRequest = new Request(targetUrl, {
       method: request.method,
-      headers: request.headers,
+      headers: originHeaders,
       body: request.body,
       redirect: 'manual',
     });

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -288,6 +288,71 @@ describe('api-router worker', () => {
     expect(response.headers.get('X-Backend-Service')).toBe('api');
   });
 
+  test.each([
+    '/v1/webhooks/projects/00000000-0000-4000-a000-000000000000/hook',
+    '/v1/webhooks/slack',
+    '/v1/billing/webhook/stripe',
+    '/v1/billing/webhooks/stripe',
+    '/v1/connectors/webhook/pipedream',
+  ])('adds a relay User-Agent only when webhook ingress omits it: %s', async (path) => {
+    let proxiedRequest;
+    globalThis.fetch = async (request) => {
+      proxiedRequest = request;
+      return Response.json({ accepted: true });
+    };
+
+    const response = await worker.fetch(
+      new Request(`https://api.kortix.com${path}`, {
+        method: 'POST',
+        body: '{"event":"test"}',
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(proxiedRequest.headers.get('User-Agent')).toBe(
+      'Kortix-Webhook-Relay/1.0',
+    );
+    expect(await proxiedRequest.text()).toBe('{"event":"test"}');
+  });
+
+  test('preserves a webhook sender User-Agent', async () => {
+    let proxiedUserAgent = '';
+    globalThis.fetch = async (request) => {
+      proxiedUserAgent = request.headers.get('User-Agent');
+      return Response.json({ accepted: true });
+    };
+
+    await worker.fetch(
+      new Request('https://api.kortix.com/v1/webhooks/slack', {
+        method: 'POST',
+        headers: { 'User-Agent': 'Slackbot 1.0' },
+        body: '{}',
+      }),
+      env,
+    );
+
+    expect(proxiedUserAgent).toBe('Slackbot 1.0');
+  });
+
+  test('does not add User-Agent to non-webhook requests', async () => {
+    let proxiedUserAgent;
+    globalThis.fetch = async (request) => {
+      proxiedUserAgent = request.headers.get('User-Agent');
+      return Response.json({ accepted: true });
+    };
+
+    await worker.fetch(
+      new Request('https://api.kortix.com/v1/projects', {
+        method: 'POST',
+        body: '{}',
+      }),
+      env,
+    );
+
+    expect(proxiedUserAgent).toBeNull();
+  });
+
   test('routes gateway hostnames to the gateway backend, independent of the API toggle', async () => {
     let proxiedUrl = '';
     globalThis.fetch = async (request) => {


### PR DESCRIPTION
## Release scope

Selective production hotfix. This PR carries exactly two changes already merged to `main`:

1. PR #6709: add a relay `User-Agent` only when a public webhook POST omits it. This lets AWS WAF pass the request to HMAC verification.
2. PR #6716: mint daemon-delivered initial prompts with the native OpenCode wire-id codec. This stops OpenCode 1.17.11 from replaying one completed webhook prompt indefinitely.

## Production evidence before fix

- Signed request without `User-Agent`: `202 fired`.
- Identical delivery: `202 deduped` with the same command and session.
- Session metadata: `source=trigger:webhook`; the edge supplied `Kortix-Webhook-Relay/1.0`.
- Both `deepseek-v4-flash` and `glm-5.2` returned `finish=stop`, but the initial `msg_ya...` id sorted after native assistant ids and repeated 40+ answers.

## Verification

- `bun test` for the worker, initial-turn lifecycle, and wire-id codec: 92 pass, 0 fail.
- `pnpm --filter kortix-api typecheck`: exit 0.
- `git diff --check origin/staging...HEAD`: exit 0.

No schema or migration changes.