### PR TITLE
fix(reaper): stop killing live turns on a box that is merely transitioning

### DIFF
--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -2746,8 +2746,11 @@ describe('project session API contract', () => {
             },
           },
           // An earlier poll recorded the first observation, longer ago than
-          // MIDTURN_STOP_CONFIRMATION_MS.
-          pendingStopObservedAtMs: Date.now() - 20_000,
+          // MIDTURN_STOP_CONFIRMATION_MS. That window is 60s (raised from 15s
+          // after a Platinum transition outlasted it and parked a healthy box
+          // mid-turn on 2026-08-21), so the marker has to be older than that —
+          // 20s no longer confirms anything.
+          pendingStopObservedAtMs: Date.now() - 90_000,
         },
         lastUsedAt: null,
         createdAt: new Date('2026-01-02T00:00:00Z'),

--- a/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.test.ts
@@ -488,6 +488,49 @@ describe('decideStoppedObservation — one stopped read is not proof mid-turn', 
     },
   };
 
+  // Incident 2026-08-21T23:58Z, Platinum sbx_01M0JE5DDBE9JCZ, session 541ea985:
+  // parked mid-turn with `provider_reconcile`, and the SAME box reported running
+  // ten seconds later. The guest never rebooted and OpenCode never restarted —
+  // nothing had gone away. Five turns died this way in one day.
+  describe('REGRESSION: a box that proved it was running is never parked', () => {
+    const observedAt = Date.parse('2026-08-21T23:58:22.000Z');
+    const withStop = (extraMeta: Record<string, unknown> = {}) => ({
+      ...turn,
+      pendingStopObservedAtMs: observedAt,
+      ...extraMeta,
+    });
+
+    test('a running confirmation AFTER the stop observation defeats the park', () => {
+      const meta = withStop({ providerRunningConfirmedAt: '2026-08-21T23:58:47.693Z' });
+      // Even well past the confirmation window: the box was WATCHED running
+      // after the reading that suspected it, so the suspicion is stale.
+      const wayLater = new Date(observedAt + 10 * 60_000);
+      expect(decideStoppedObservation(meta, wayLater)).toBe('await_confirmation');
+    });
+
+    test('a running confirmation from BEFORE the observation does not defeat it', () => {
+      // Otherwise any box that ever ran could never be parked.
+      const meta = withStop({ providerRunningConfirmedAt: '2026-08-21T23:00:00.000Z' });
+      const past = new Date(observedAt + MIDTURN_STOP_CONFIRMATION_MS);
+      expect(decideStoppedObservation(meta, past)).toBe('park');
+    });
+
+    test('an unparseable confirmation is ignored rather than trusted', () => {
+      const meta = withStop({ providerRunningConfirmedAt: 'not-a-date' });
+      const past = new Date(observedAt + MIDTURN_STOP_CONFIRMATION_MS);
+      expect(decideStoppedObservation(meta, past)).toBe('park');
+    });
+
+    test('the window outlasts the measured Platinum transition', () => {
+      // The incident resumed 10s after the park. 15s could not cover it; the
+      // window must exceed a real provider transition by a clear margin.
+      expect(MIDTURN_STOP_CONFIRMATION_MS).toBeGreaterThanOrEqual(60_000);
+      const meta = withStop();
+      const during = new Date(observedAt + 30_000);
+      expect(decideStoppedObservation(meta, during)).toBe('await_confirmation');
+    });
+  });
+
   test('REGRESSION: a box with NO turn authority parks on the first read', () => {
     // An idle box must not gain a pass of latency, or every ordinary park is
     // one reaper cadence later and its meter runs that much longer.
@@ -534,10 +577,20 @@ describe('decideStoppedObservation — one stopped read is not proof mid-turn', 
     ).toBe('await_confirmation');
   });
 
-  test('the confirmation window is shorter than one active-turn renewal pass', () => {
-    // The lane runs every 20s (projects/active-turn-renewal.ts). A window at or
-    // above that cadence costs a second pass for every genuine park.
-    expect(MIDTURN_STOP_CONFIRMATION_MS).toBeLessThan(20_000);
+  test('the confirmation window outlasts a real provider transition', () => {
+    // This DELIBERATELY replaces "shorter than one active-turn renewal pass
+    // (20s), so a genuine park costs one extra pass". That was a COST argument,
+    // never a correctness one, and it was the wrong trade: on 2026-08-21 a
+    // Platinum transition outlasted the 15s window, so both reads landed inside
+    // one transition and the guard parked a box that reported running ten
+    // seconds later — destroying a live turn. Five turns died that way in a day.
+    //
+    // The cost of the longer window is one-sided and bounded: a GENUINELY
+    // stopped box mid-turn parks up to a minute later, and its meter runs that
+    // much longer. The cost of the shorter one was the user's work.
+    expect(MIDTURN_STOP_CONFIRMATION_MS).toBeGreaterThanOrEqual(60_000);
+    // Still bounded — this must not become "never park".
+    expect(MIDTURN_STOP_CONFIRMATION_MS).toBeLessThanOrEqual(120_000);
   });
 });
 

--- a/apps/api/src/projects/reaping/sandbox-state-sync.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.ts
@@ -29,12 +29,23 @@ export function mergeMetadata(patch: Record<string, unknown>) {
  * How long a first provider-`stopped` observation must age before a second one
  * may park a box that still holds turn authority.
  *
- * Shorter than the 20-second active-turn renewal pass
- * (projects/active-turn-renewal.ts), so a genuine park costs exactly one extra
- * pass, and long enough that two reads inside one provider transition can never
- * both count.
+ * SIZED FROM A MEASURED TRANSITION, not from the renewal cadence. It was
+ * 15_000, chosen so two reads could not fall inside one provider transition —
+ * but a Platinum lifecycle transition outlasts that, so both reads landed
+ * inside it and the guard expired mid-transition instead of covering it.
+ *
+ * Incident 2026-08-21T23:58Z (session 541ea985, Platinum sbx_01M0JE5DDBE9JCZ):
+ * parked at 23:58:37 with `provider_reconcile`, and the SAME box reported
+ * running again at 23:58:47 — ten seconds later. The guest never rebooted
+ * (uptime spanned the whole window) and OpenCode never restarted, so nothing
+ * had actually gone away; a live turn was destroyed by a state field read
+ * during a transition. That session lost five turns to this in one day.
+ *
+ * 60s covers the observed transition with margin. The cost is bounded and
+ * one-sided: a GENUINELY stopped box mid-turn waits up to a minute longer to
+ * park, while a box that is merely transitioning keeps the user's work.
  */
-export const MIDTURN_STOP_CONFIRMATION_MS = 15_000;
+export const MIDTURN_STOP_CONFIRMATION_MS = 60_000;
 
 export type StoppedObservationDecision = 'park' | 'await_confirmation';
 
@@ -64,6 +75,21 @@ export function decideStoppedObservation(
   if (storedSandboxTurns(metadata).length === 0) return 'park';
   const observedAtMs = Number(metadata?.pendingStopObservedAtMs);
   if (!Number.isFinite(observedAtMs) || observedAtMs <= 0) return 'await_confirmation';
+
+  // POSITIVE LIVENESS OUTRANKS A STATE FIELD. `providerRunningConfirmedAt` is
+  // written when the provider confirms the box RUNNING (routes/shared.ts). A
+  // confirmation stamped at or after the pending-stop observation is direct
+  // evidence the box outlived the reading that suspected it, so the suspicion
+  // is stale no matter how long ago it was recorded — waiting out a clock would
+  // park a box we have since watched run.
+  //
+  // This is the same asymmetry the window encodes, made explicit: uncertainty
+  // fails toward the LIVE box. In the 2026-08-21 incident the running
+  // confirmation landed ten seconds after the park, and consulting it would
+  // have saved the turn on its own.
+  const confirmedAtMs = Date.parse(String(metadata?.providerRunningConfirmedAt ?? ''));
+  if (Number.isFinite(confirmedAtMs) && confirmedAtMs >= observedAtMs) return 'await_confirmation';
+
   return now.getTime() - observedAtMs >= MIDTURN_STOP_CONFIRMATION_MS
     ? 'park'
     : 'await_confirmation';

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -2391,9 +2391,14 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     ).toBe(true);
   });
 
-  test('a second stopped read one pass later parks the box exactly as before', async () => {
+  test('a stopped read after the confirmation window parks the box', async () => {
+    // Was "one pass later" (20s), which parked under the old 15s window. The
+    // window is now 60s — sized to outlast a real provider transition after one
+    // parked a healthy box mid-turn on 2026-08-21 — so a genuine park takes a
+    // few passes instead of one. Same behaviour, later: the marker must be
+    // older than MIDTURN_STOP_CONFIRMATION_MS, not merely older than a pass.
     candidates = [
-      midTurnCandidate({}, { pendingStopObservedAtMs: NOW.getTime() - 20_000 }),
+      midTurnCandidate({}, { pendingStopObservedAtMs: NOW.getTime() - 90_000 }),
     ];
     statusByExternal['ext-1'] = 'stopped';
 
@@ -2404,6 +2409,38 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     expect(pausedCompute).toEqual(['sb-1']);
     // The park still settles the turns it erases authority for.
     expect(ledgerSettleStatements.some((s) => s.includes('runtime_gone'))).toBe(true);
+  });
+
+  test('a stopped read INSIDE the window does not park — the turn survives', async () => {
+    // The 2026-08-21 shape exactly: a second stopped read 20s after the first,
+    // while the provider was still transitioning. Under the old window this
+    // parked the box and settled a live turn `runtime_gone`; the box reported
+    // running ten seconds later.
+    // Future deadline on purpose: with an expired one the box parks under the
+    // deadline rule and this would assert nothing about the stop guard.
+    candidates = [
+      midTurnCandidate(
+        { deadlineAt: new Date(NOW.getTime() + HOUR) },
+        { pendingStopObservedAtMs: NOW.getTime() - 20_000 },
+      ),
+    ];
+    statusByExternal['ext-1'] = 'stopped';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    // Not reconciled and not paused IS "the turn survives": the park is the only
+    // thing in this path that erases turn authority and settles `runtime_gone`.
+    // Asserting on the ledger statements directly would be wrong here — other
+    // lanes in the same pass settle unrelated boxes, so that log says nothing
+    // about THIS candidate.
+    expect(r.reconciled).toBe(0);
+    expect(pausedCompute).toEqual([]);
+    // The suspicion is kept, not discarded: a genuine stop still parks later.
+    expect(
+      rowUpdates().some((c) =>
+        describeSql(c.updates.metadata).includes('pendingStopObservedAtMs'),
+      ),
+    ).toBe(true);
   });
 
   test('a running read between the two clears the pending marker', async () => {


### PR DESCRIPTION
Investigated from a session reported as **"clogged"**: every prompt delivered, a turn opened, and no answer ever came back. **Five turns died there in one day.**

## What it was not

I was wrong twice before I was right, and both wrong answers looked convincing:

- **Not the queue.** Every inbox row on that session reads `succeeded`/`delivered` — one at 23:55:08, delivered in 6s.
- **Not the API OOM** fixed earlier tonight.
- **Not a sandbox OOM**, which is where I went first. Platinum reported `mem_used_mb: 7665 / 8448` and I watched it drop to 4125 — which looked exactly like an OOM restart. It wasn't. Inside the guest:

```
uptime 3:54            ← the VM never rebooted
opencode 03:54:51 elapsed, ~1 GB   ← same age as the guest; never restarted
free -m: 1668 used / 2246 available
dmesg:   "invm-agent (123): drop_caches: 3"   ← no OOM kill anywhere
```

Platinum's `mem_used_mb` counts page cache; the drop was its agent running `drop_caches`.

## What it actually was

We parked a **healthy, running** box and settled its live turn `runtime_gone`:

```
stopped_at        23:58:37   stop_reason = provider_reconcile
running_confirmed 23:58:47   ← the same box, ten seconds later
guest uptime spans both      ← it never stopped
```

`getStatus` maps `stopping` → `stopped` (both providers do), so a box mid-transition reads as terminal. `decideStoppedObservation` exists precisely to absorb that, and **it was applied here** — but its window was 15s, chosen to sit under the 20s active-turn renewal pass *"so a genuine park costs exactly one extra pass."*

That's a **cost** argument, not a correctness one, and it was the wrong trade. A real Platinum transition outlasts 15s, so both reads landed *inside* one transition and the guard expired mid-transition instead of covering it.

## The fix

**1. `MIDTURN_STOP_CONFIRMATION_MS` 15s → 60s**, sized from the measured transition rather than the renewal cadence. A `running` read clears the marker (`box-reaper.ts:247`), so the incident now resolves on its own:

```
23:58:22  stopped observed → marker set
23:58:47  running confirmed → marker CLEARED
23:59:22  park would have been due → never reached
```

**2. `providerRunningConfirmedAt` at or after the observation defeats the park outright.** We already record that the provider confirmed the box RUNNING and never consulted it. Positive liveness must outrank a state field, at any age.

The cost is one-sided and bounded: a genuinely stopped box mid-turn parks up to a minute later and its meter runs that much longer. The cost of the short window was the user's work.

## On overturning a pinned decision

The test asserting *"shorter than one active-turn renewal pass"* is **rewritten, not deleted** — it carries why it was overturned, and an upper bound (`≤ 120s`) so this can't drift into "never park". Same for the reaper test that assumed a park happens one pass later; it now also has a companion asserting the 2026-08-21 shape (a second stopped read 20s in) leaves the turn alive.

## Verification

- `apps/api/src/projects` — **1657 pass / 0 fail**
- `tsc --noEmit` clean

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW
