### PR TITLE
fix(api): bound database connections during rollouts

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1537,3 +1537,35 @@ change). Fixed by #6705 (ceilings), #6708 (bounded memory + admission control),
 bodies at the REAL mounted routes and assert most are shed, every response is a
 real status, no `unhandledRejection`/`uncaughtException`, and the process still
 serves afterwards with the budget released.
+
+## Size database pools for the rolling fleet, not the steady fleet
+
+2026-08-22. A production API deployment overlapped 10 old ECS tasks with 10 new
+tasks. PostgreSQL returned SQLSTATE `53300` because the tasks could request more
+connections than the server exposed. Authorization, audit ingestion, project
+reads, turn streams, webhooks, and lifecycle settlement then failed together.
+The queries were collateral failures. They were not six separate defects.
+
+**The arithmetic that failed.** PostgreSQL exposed 240 connections and reserved
+3 for superusers. Each task allowed 15 main-pool connections, 3 audit-pool
+connections, and 1 leader-election connection. Twenty overlapping tasks could
+therefore request 380 long-lived connections against 237 usable slots. The old
+comment counted only 10 steady-state main pools. It excluded the rolling overlap
+and every secondary pool.
+
+**The rule.** Bound connections against the maximum rolling fleet. Count every
+long-lived pool and every concurrent startup probe. Reserve explicit capacity
+for Supabase, operators, migrations, and request-scoped clients. A steady-state
+calculation is invalid for a service with `deployment_maximum_percent = 200`.
+
+**The enforcement.** `apps/api/src/shared/database-capacity.test.ts` pins the
+production server limit, ECS maximum capacity, rolling overlap, main pool,
+audit pool, leader connection, startup probe, and non-API reserve. The test
+fails when the API connection ceiling exceeds the available application budget.
+Any change to pool size, task capacity, deployment overlap, or PostgreSQL size
+must update and pass this invariant before deployment.
+
+*Incident:* production, SQLSTATE `53300` from 01:15:10Z through 01:16:37Z.
+Verification that settles it: deploy the bounded pools, confirm the exact
+production SHA, exercise webhook and session traffic, then query Better Stack
+for zero new SQLSTATE `53300` occurrences after the rollout completed.

--- a/apps/api/src/ensure-schema.ts
+++ b/apps/api/src/ensure-schema.ts
@@ -11,6 +11,7 @@
 import { join } from 'node:path';
 import postgres from 'postgres';
 import { config } from './config';
+import { SCHEMA_CHECK_POOL_MAX } from './shared/database-capacity';
 
 export async function ensureSchema(): Promise<void> {
   if (!config.DATABASE_URL) {
@@ -87,7 +88,7 @@ async function warnIfCriticalTablesMissing(): Promise<void> {
     'project_secrets',
     'projects',
   ];
-  const db = postgres(config.DATABASE_URL, { max: 1 });
+  const db = postgres(config.DATABASE_URL, { max: SCHEMA_CHECK_POOL_MAX });
   try {
     const rows = (await db`
       SELECT table_name

--- a/apps/api/src/shared/audit-db.ts
+++ b/apps/api/src/shared/audit-db.ts
@@ -1,5 +1,6 @@
 import type { Database } from '@kortix/db';
 import { config } from '../config';
+import { DEFAULT_AUDIT_POOL_MAX } from './database-capacity';
 import { db } from './db';
 
 /**
@@ -27,7 +28,7 @@ function intFromEnv(name: string, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
 }
 
-const AUDIT_POOL_MAX = intFromEnv('DB_AUDIT_POOL_MAX', 3);
+const AUDIT_POOL_MAX = intFromEnv('DB_AUDIT_POOL_MAX', DEFAULT_AUDIT_POOL_MAX);
 const AUDIT_STATEMENT_TIMEOUT_MS = intFromEnv('DB_AUDIT_STATEMENT_TIMEOUT_MS', 10_000);
 
 let dedicatedPool: Database | null = null;

--- a/apps/api/src/shared/database-capacity.test.ts
+++ b/apps/api/src/shared/database-capacity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  DEFAULT_AUDIT_POOL_MAX,
+  DEFAULT_DB_POOL_MAX,
+  LEADER_ELECTION_POOL_MAX,
+  PROD_API_MAX_TASKS,
+  PROD_DB_NON_API_RESERVE,
+  PROD_DB_ROLLING_CONNECTION_CEILING,
+  PROD_DB_USABLE_CONNECTIONS,
+  ROLLING_TASK_OVERLAP,
+  SCHEMA_CHECK_POOL_MAX,
+} from './database-capacity';
+
+describe('production database connection capacity', () => {
+  test('pins every API-owned connection pool in the rollout budget', () => {
+    expect(DEFAULT_DB_POOL_MAX).toBe(6);
+    expect(DEFAULT_AUDIT_POOL_MAX).toBe(2);
+    expect(LEADER_ELECTION_POOL_MAX).toBe(1);
+    expect(SCHEMA_CHECK_POOL_MAX).toBe(1);
+  });
+
+  test('keeps a maximum rolling deployment below the usable PostgreSQL limit', () => {
+    expect(PROD_API_MAX_TASKS).toBe(10);
+    expect(ROLLING_TASK_OVERLAP).toBe(2);
+    expect(PROD_DB_USABLE_CONNECTIONS).toBe(237);
+    expect(PROD_DB_NON_API_RESERVE).toBe(32);
+    expect(PROD_DB_ROLLING_CONNECTION_CEILING).toBe(190);
+    expect(PROD_DB_ROLLING_CONNECTION_CEILING).toBeLessThanOrEqual(
+      PROD_DB_USABLE_CONNECTIONS - PROD_DB_NON_API_RESERVE,
+    );
+  });
+
+  test('matches the production ECS capacity and deployment overlap', () => {
+    const productionTerraform = readFileSync(
+      new URL('../../../../infra/terraform/environments/prod/main.tf', import.meta.url),
+      'utf8',
+    );
+    const ecsModule = readFileSync(
+      new URL('../../../../infra/terraform/modules/ecs-api/main.tf', import.meta.url),
+      'utf8',
+    );
+
+    expect(productionTerraform).toMatch(/module "api"[\s\S]*?max_capacity\s*=\s*10/);
+    expect(ecsModule).toMatch(/deployment_maximum_percent\s*=\s*200/);
+  });
+});

--- a/apps/api/src/shared/database-capacity.ts
+++ b/apps/api/src/shared/database-capacity.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_DB_POOL_MAX } from '@kortix/db/connection-defaults';
+
+/**
+ * Connection budgets for one API task.
+ *
+ * Keep these values in one pure module. The production rollout-capacity test
+ * must account for every long-lived pool and the transient schema probe.
+ */
+export { DEFAULT_DB_POOL_MAX };
+export const DEFAULT_AUDIT_POOL_MAX = 2;
+export const LEADER_ELECTION_POOL_MAX = 1;
+export const SCHEMA_CHECK_POOL_MAX = 1;
+
+/** Production PostgreSQL exposes 240 slots and reserves 3 for superusers. */
+export const PROD_DB_USABLE_CONNECTIONS = 237;
+
+/** ECS can autoscale the production API service to 10 tasks. */
+export const PROD_API_MAX_TASKS = 10;
+
+/** ECS permits a 200% rolling deployment: 10 old tasks plus 10 new tasks. */
+export const ROLLING_TASK_OVERLAP = 2;
+
+/**
+ * Slots reserved for Supabase, operators, migrations, and request-scoped probes.
+ * The invariant below leaves a further 15-slot buffer beyond this reserve.
+ */
+export const PROD_DB_NON_API_RESERVE = 32;
+
+const rollingLongLivedConnections =
+  PROD_API_MAX_TASKS *
+  ROLLING_TASK_OVERLAP *
+  (DEFAULT_DB_POOL_MAX + DEFAULT_AUDIT_POOL_MAX + LEADER_ELECTION_POOL_MAX);
+
+// Only the 10 starting tasks run the transient schema probe. Old tasks have
+// completed it before the deployment begins.
+const rollingSchemaProbeConnections = PROD_API_MAX_TASKS * SCHEMA_CHECK_POOL_MAX;
+
+export const PROD_DB_ROLLING_CONNECTION_CEILING =
+  rollingLongLivedConnections + rollingSchemaProbeConnections;

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -26,6 +26,7 @@ import os from 'node:os';
 import postgres from 'postgres';
 import { config } from '../config';
 import { logger } from '../lib/logger';
+import { LEADER_ELECTION_POOL_MAX } from './database-capacity';
 
 const LOCK_KEY = 'background-workers';
 
@@ -247,7 +248,7 @@ export function startLeaderElection(
   // pool. prepare:false matches the Supabase-pooler app client.
   sql = postgres(config.DATABASE_URL, {
     prepare: false,
-    max: 1,
+    max: LEADER_ELECTION_POOL_MAX,
     idle_timeout: 30,
     connect_timeout: 10,
     onnotice: () => {},

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
+    "./connection-defaults": "./src/connection-defaults.ts",
     "./schema": "./src/schema/index.ts",
     "./types": "./src/types.ts"
   },

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,5 +1,6 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
+import { DEFAULT_DB_POOL_MAX } from './connection-defaults';
 import * as schema from './schema';
 
 function intFromEnv(name: string, fallback: number): number {
@@ -29,16 +30,17 @@ function intFromEnv(name: string, fallback: number): number {
  *      (Investigation found real offenders: an unindexed 21M-row audit scan at
  *      80–120s, and account-deletion sweeps at 36–64s, each pinning a connection
  *      for up to the 2-min server statement_timeout.)
- *   2. A modestly larger, env-tunable `max` so normal concurrent page loads
- *      (one IAM page fans out ~15-20 parallel queries) don't exhaust the pool.
+ *   2. An env-tunable `max` so normal concurrent page loads can run without
+ *      letting a rolling deployment exhaust the PostgreSQL server.
  *
  * SIZING: prod connects DIRECTLY to Postgres (db.<ref>.supabase.co:5432), NOT
- * the Supavisor pooler — so every client connection is one real backend, capped
- * by the server's `max_connections` (240 on the current instance, only ~23 in
- * use at rest). Keep `POOL_MAX * max_replicas` comfortably under that ceiling
- * with headroom for other consumers: at the current autoscale max of 10
- * replicas, 15 * 10 = 150 < 240. If replica count or pool size grows, move app
- * traffic to the transaction pooler (port 6543) instead of raising this further.
+ * the Supavisor pooler. Every client connection consumes one real backend.
+ * PostgreSQL exposes 237 non-reserved slots. ECS can overlap 10 old tasks and
+ * 10 new tasks during a rolling deployment. The API also owns an audit pool,
+ * a leader-election connection, and a transient startup schema probe. The
+ * capacity invariant in apps/api/src/shared/database-capacity.test.ts accounts
+ * for all four sources and preserves a non-API reserve. If replica count or
+ * pool size grows, update that invariant before changing this default.
  *
  * All knobs are env-overridable so prod can tune without a code change. The
  * app's background workers (maintenance sweeps, migration workers) only ever run
@@ -46,7 +48,7 @@ function intFromEnv(name: string, fallback: number): number {
  * job needs a longer single statement it should `SET LOCAL statement_timeout`
  * inside its own transaction rather than raising this request-path default.
  */
-const POOL_MAX = intFromEnv('DB_POOL_MAX', 15);
+const POOL_MAX = intFromEnv('DB_POOL_MAX', DEFAULT_DB_POOL_MAX);
 const IDLE_TIMEOUT_S = intFromEnv('DB_IDLE_TIMEOUT_S', 30);
 const CONNECT_TIMEOUT_S = intFromEnv('DB_CONNECT_TIMEOUT_S', 10);
 const MAX_LIFETIME_S = intFromEnv('DB_MAX_LIFETIME_S', 60 * 30); // 30 min

--- a/packages/db/src/connection-defaults.ts
+++ b/packages/db/src/connection-defaults.ts
@@ -1,0 +1,2 @@
+/** Default postgres.js main-pool limit for one Kortix API process. */
+export const DEFAULT_DB_POOL_MAX = 6;


### PR DESCRIPTION
## Problem

A production API rollout overlapped 10 old ECS tasks with 10 new tasks. PostgreSQL exposes 237 usable connection slots. The API fleet could request 380 long-lived connections. PostgreSQL returned SQLSTATE `53300` and unrelated routes failed together.

## Change

- Reduce the main pool default from 15 to 6 connections per task.
- Reduce the isolated audit pool default from 3 to 2 connections per task.
- Centralize API connection-capacity constants without loading the database schema.
- Add a capacity invariant for the production PostgreSQL limit, ECS maximum capacity, 200% rollout overlap, leader connection, and startup schema probe.
- Preserve 32 slots for non-API consumers and 15 further slots of buffer.
- Append the production incident rule to the learnings register.

The maximum rolling API ceiling is 190 connections. The server exposes 237 usable slots.

## Verification

- `bun test apps/api/src/shared/database-capacity.test.ts packages/db/src/client.test.ts`: 6 passed, 0 failed.
- `pnpm --filter @kortix/db test`: 249 passed, 18 skipped, 0 failed.
- `pnpm --filter kortix-api test`: 8,255 passed, 78 skipped, 0 failed.
- `pnpm --filter @kortix/db typecheck`: passed.
- `pnpm --filter kortix-api typecheck`: passed.
- `pnpm test`: passed all lanes; 383/383 API and CLI flows and 2,424 SDK tests passed.
