### PR TITLE
fix(prod): bound database connections during rolling deployment

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1096,3 +1096,12 @@ strictly (dynamic registration, stateful sessions) as the one you test against.
 *Incident:* found and fixed while building one-click OAuth 2.1 for MCP
 connectors, PR #6579. No production outage — the surface had never been used
 against a real provider, which is precisely why all three shipped unnoticed.
+### Size database pools for the rolling fleet, not the steady fleet
+
+**When:** sizing database pools or changing ECS deployment capacity. Bound the
+sum of every long-lived pool against the maximum rolling fleet. Include startup
+probes and reserve explicit non-API capacity.
+*Incident:* production SQLSTATE `53300` from 01:15:10Z through 01:16:37Z on
+2026-08-22. Twenty overlapping API tasks could request 380 connections against
+237 usable slots. *Enforcer:* `database-capacity.test.ts` pins the full rollout
+ceiling and reserve.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### A browser retry must wait for the result it is retrying (2026-08-22)
+
+**When:** retrying a client-rendered page after an eventually consistent write.
+`domcontentloaded` does not mean that React consumed the API response. Wait for
+the exact response and the final DOM state before the next navigation. A poll
+that reloads immediately can abort every successful render itself.
+*Near-miss:* PR #6724 failed browser-1 twice while every repeated account read
+returned `200`. *Enforcer:* `08-accounts-project-access.spec.ts` waits for the
+exact account response and the visible `Members` heading on each attempt.
+
 ### Mint every OpenCode message id with the native sortable codec (2026-08-22)
 
 **When:** delivering an initial, queued, retried, or imported OpenCode prompt.

--- a/apps/api/src/__tests__/e2e-accounts-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-accounts-contract.test.ts
@@ -346,6 +346,8 @@ mock.module('../accounts/email', () => ({
 
 mock.module('../shared/rate-limit', () => ({
   createInviteAcceptRateLimitMiddleware: () => async (_c: any, next: any) => next(),
+  createProjectSecretWriteRateLimitMiddleware: () => async (_c: any, next: any) => next(),
+  consumeProjectSessionCreateBudget: () => ({ allowed: true, limit: 100, remaining: 99, resetMs: 1000 }),
 }));
 
 mock.module('../shared/resolve-account', () => ({

--- a/apps/api/src/ensure-schema.ts
+++ b/apps/api/src/ensure-schema.ts
@@ -11,6 +11,7 @@
 import { join } from 'node:path';
 import postgres from 'postgres';
 import { config } from './config';
+import { SCHEMA_CHECK_POOL_MAX } from './shared/database-capacity';
 
 export async function ensureSchema(): Promise<void> {
   if (!config.DATABASE_URL) {
@@ -87,7 +88,7 @@ async function warnIfCriticalTablesMissing(): Promise<void> {
     'project_secrets',
     'projects',
   ];
-  const db = postgres(config.DATABASE_URL, { max: 1 });
+  const db = postgres(config.DATABASE_URL, { max: SCHEMA_CHECK_POOL_MAX });
   try {
     const rows = (await db`
       SELECT table_name

--- a/apps/api/src/projects/lib/agent-config-push.test.ts
+++ b/apps/api/src/projects/lib/agent-config-push.test.ts
@@ -8,6 +8,7 @@
 // session merged past days ago kept running the agents it booted with, with no
 // documented way to reconcile the two short of starting a new session.
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { config } from '../../config';
 import * as realCompile from './compile-agent-config';
 import * as realSecrets from '../secrets';
 import * as realSecretGrant from './secret-grant';
@@ -147,6 +148,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // Sequential awaited propagates must run immediately in tests: the
+  // production coalescer only exists to merge storm bursts (see
+  // env-sync-coalescer.ts), and a cooling-down interval here would make
+  // every second call in a case queue for the full window.
+  (config as any).KORTIX_ENV_SYNC_MIN_INTERVAL_MS = 0;
+
   compiled = '{"agent":{"support":{"prompt":"fresh"}}}';
   compileThrows = null;
   compileCalls = [];

--- a/apps/api/src/projects/lib/env-sync-coalescer.test.ts
+++ b/apps/api/src/projects/lib/env-sync-coalescer.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'bun:test';
+import { createCoalescedRunner } from './env-sync-coalescer';
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe('createCoalescedRunner — the env-push storm breaker', () => {
+  test('an idle key past its interval runs immediately', async () => {
+    const runs: string[] = [];
+    const coalesced = createCoalescedRunner<string>({
+      run: async (key) => {
+        runs.push(key);
+        return `ok:${key}`;
+      },
+      minIntervalMs: () => 0,
+    });
+    expect(await coalesced('p1')).toBe('ok:p1');
+    expect(runs).toEqual(['p1']);
+  });
+
+  test('a burst during one in-flight run collapses to ONE trailing run shared by every caller', async () => {
+    let started = 0;
+    const gates: Array<ReturnType<typeof deferred<number>>> = [];
+    const coalesced = createCoalescedRunner<number>({
+      run: () => {
+        const gate = deferred<number>();
+        gates.push(gate);
+        started += 1;
+        return gate.promise;
+      },
+      minIntervalMs: () => 0,
+    });
+
+    const first = coalesced('p1');
+    const burst = [coalesced('p1'), coalesced('p1'), coalesced('p1'), coalesced('p1')];
+    expect(started).toBe(1);
+
+    gates[0]!.resolve(1);
+    expect(await first).toBe(1);
+    await tick();
+    expect(started).toBe(2);
+
+    gates[1]!.resolve(2);
+    expect(await Promise.all(burst)).toEqual([2, 2, 2, 2]);
+    expect(started).toBe(2);
+  });
+
+  test('refreshModels=true from ANY coalesced caller survives into the shared run', async () => {
+    const seen: boolean[] = [];
+    const gates: Array<ReturnType<typeof deferred<null>>> = [];
+    const coalesced = createCoalescedRunner<null>({
+      run: (_key, opts) => {
+        seen.push(opts.refreshModels);
+        const gate = deferred<null>();
+        gates.push(gate);
+        return gate.promise;
+      },
+      minIntervalMs: () => 0,
+    });
+    void coalesced('p1');
+    const a = coalesced('p1', { refreshModels: false });
+    const b = coalesced('p1', { refreshModels: true });
+    const c = coalesced('p1');
+    gates[0]!.resolve(null);
+    await tick();
+    gates[1]!.resolve(null);
+    await Promise.all([a, b, c]);
+    expect(seen).toEqual([false, true]);
+  });
+
+  test('a second run never starts before minIntervalMs since the first START', async () => {
+    const startTimes: number[] = [];
+    const coalesced = createCoalescedRunner<null>({
+      run: async () => {
+        startTimes.push(Date.now());
+        return null;
+      },
+      minIntervalMs: () => 60,
+    });
+    await coalesced('p1');
+    const trailing = coalesced('p1');
+    await trailing;
+    expect(startTimes).toHaveLength(2);
+    expect(startTimes[1]! - startTimes[0]!).toBeGreaterThanOrEqual(50);
+  });
+
+  test('a rejected run rejects exactly its awaiters and does not poison the key', async () => {
+    let calls = 0;
+    const coalesced = createCoalescedRunner<string>({
+      run: async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('provider down');
+        return 'recovered';
+      },
+      minIntervalMs: () => 0,
+    });
+    await expect(coalesced('p1')).rejects.toThrow('provider down');
+    await sleep(5);
+    expect(await coalesced('p1')).toBe('recovered');
+  });
+
+  test('a rejected in-flight run still releases the queued trailing run', async () => {
+    const gate = deferred<string>();
+    let calls = 0;
+    const coalesced = createCoalescedRunner<string>({
+      run: () => {
+        calls += 1;
+        return calls === 1 ? gate.promise : Promise.resolve('trailing-ok');
+      },
+      minIntervalMs: () => 0,
+    });
+    const failing = coalesced('p1');
+    const queued = coalesced('p1');
+    gate.reject(new Error('boom'));
+    await expect(failing).rejects.toThrow('boom');
+    expect(await queued).toBe('trailing-ok');
+  });
+
+  test('keys are independent — one project cooling down never delays another', async () => {
+    const runs: string[] = [];
+    const coalesced = createCoalescedRunner<null>({
+      run: async (key) => {
+        runs.push(key);
+        return null;
+      },
+      minIntervalMs: () => 10_000,
+    });
+    await coalesced('p1');
+    await coalesced('p2');
+    expect(runs).toEqual(['p1', 'p2']);
+  });
+
+  test('the incident shape: 50 rapid writes cost 2 runs, not 50', async () => {
+    let runsStarted = 0;
+    const gates: Array<ReturnType<typeof deferred<null>>> = [];
+    const coalesced = createCoalescedRunner<null>({
+      run: () => {
+        runsStarted += 1;
+        const gate = deferred<null>();
+        gates.push(gate);
+        return gate.promise;
+      },
+      minIntervalMs: () => 0,
+    });
+    const all: Array<Promise<null>> = [];
+    for (let i = 0; i < 50; i++) all.push(coalesced('storm'));
+    expect(runsStarted).toBe(1);
+    gates[0]!.resolve(null);
+    await tick();
+    gates[1]!.resolve(null);
+    await Promise.all(all);
+    expect(runsStarted).toBe(2);
+  });
+});
+
+describe('createCoalescedRunner — genuine-user safety properties', () => {
+  test('NO LOST UPDATE: a write landing mid-run is always followed by a run that starts after it', async () => {
+    const runStarts: number[] = [];
+    const gates: Array<{ promise: Promise<null>; resolve: (v: null) => void }> = [];
+    const coalesced = createCoalescedRunner<null>({
+      run: () => {
+        runStarts.push(Date.now());
+        let resolve!: (v: null) => void;
+        const promise = new Promise<null>((res) => {
+          resolve = res;
+        });
+        gates.push({ promise, resolve });
+        return promise;
+      },
+      minIntervalMs: () => 0,
+    });
+
+    const first = coalesced('p1');
+    await new Promise((r) => setTimeout(r, 5));
+    const writeAt = Date.now();
+    const midRunWrite = coalesced('p1');
+    gates[0]!.resolve(null);
+    await first;
+    await new Promise((r) => setTimeout(r, 0));
+    gates[1]!.resolve(null);
+    await midRunWrite;
+    expect(runStarts).toHaveLength(2);
+    expect(runStarts[1]!).toBeGreaterThanOrEqual(writeAt);
+  });
+
+  test('a lone write on a quiet project is never delayed by the interval', async () => {
+    let ran = 0;
+    const coalesced = createCoalescedRunner<null>({
+      run: async () => {
+        ran += 1;
+        return null;
+      },
+      minIntervalMs: () => 60_000,
+    });
+    const t0 = Date.now();
+    await coalesced('quiet-project');
+    expect(ran).toBe(1);
+    expect(Date.now() - t0).toBeLessThan(1_000);
+  });
+});

--- a/apps/api/src/projects/lib/env-sync-coalescer.ts
+++ b/apps/api/src/projects/lib/env-sync-coalescer.ts
@@ -1,0 +1,116 @@
+/**
+ * Per-key coalescing for the env hot-push fan-out.
+ *
+ * INCIDENT 2026-08-21: two projects wrote secrets in a loop (one 1,017 writes in
+ * a morning, one 3→164/hr in an evening). Every write fanned an env push to
+ * every active sandbox in the project — 104 and 183 of them — through the
+ * provider's API, which throttled the whole org (`ThrottlerException`), and
+ * with it every other customer's session create and wake. The pushes carried
+ * identical state: only the LAST snapshot matters, because each run re-resolves
+ * the project's secrets at start.
+ *
+ * So: at most one run per key in flight, at most one run per key per
+ * `minIntervalMs`, and every caller that arrives while a run is in flight or
+ * the interval is cooling down awaits ONE shared trailing run. That trailing
+ * run starts after the current run settles and the interval allows, resolves
+ * its own fresh snapshot, and therefore includes every write that queued it.
+ * A burst of N writes costs 2 runs (leading + trailing), not N.
+ *
+ * `refreshModels` is merged with OR across coalesced callers — any one caller
+ * needing the heavier refresh makes the shared run do it; dropping it for the
+ * others would silently skip work they were promised.
+ *
+ * A rejected run rejects exactly the callers awaiting it and leaves the state
+ * clean — the next call starts fresh instead of inheriting a poisoned promise.
+ */
+
+export interface CoalescedRunOpts {
+  refreshModels?: boolean;
+}
+
+interface KeyState<T> {
+  inFlight: Promise<T> | null;
+  lastStartMs: number;
+  pending: {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (err: unknown) => void;
+    refreshModels: boolean;
+  } | null;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export function createCoalescedRunner<T>(input: {
+  run: (key: string, opts: { refreshModels: boolean }) => Promise<T>;
+  /** Read at decision time so config/test changes apply without rebuild. */
+  minIntervalMs: () => number;
+}): (key: string, opts?: CoalescedRunOpts) => Promise<T> {
+  const states = new Map<string, KeyState<T>>();
+
+  function state(key: string): KeyState<T> {
+    let s = states.get(key);
+    if (!s) {
+      s = { inFlight: null, lastStartMs: 0, pending: null, timer: null };
+      states.set(key, s);
+    }
+    return s;
+  }
+
+  function startRun(s: KeyState<T>, key: string, refreshModels: boolean): Promise<T> {
+    s.lastStartMs = Date.now();
+    const run = input.run(key, { refreshModels });
+    s.inFlight = run;
+    run
+      .catch(() => {})
+      .finally(() => {
+        if (s.inFlight === run) s.inFlight = null;
+        maybeStartPending(s, key);
+      });
+    return run;
+  }
+
+  function maybeStartPending(s: KeyState<T>, key: string): void {
+    if (!s.pending || s.inFlight) return;
+    const waitMs = s.lastStartMs + input.minIntervalMs() - Date.now();
+    if (waitMs > 0) {
+      if (!s.timer) {
+        s.timer = setTimeout(() => {
+          s.timer = null;
+          maybeStartPending(s, key);
+        }, waitMs);
+        // A queued trailing run must never pin the process open on its own.
+        s.timer.unref?.();
+      }
+      return;
+    }
+    const pending = s.pending;
+    s.pending = null;
+    if (s.timer) {
+      clearTimeout(s.timer);
+      s.timer = null;
+    }
+    startRun(s, key, pending.refreshModels).then(pending.resolve, pending.reject);
+  }
+
+  return (key: string, opts?: CoalescedRunOpts): Promise<T> => {
+    const s = state(key);
+    const refreshModels = opts?.refreshModels === true;
+
+    if (s.pending) {
+      s.pending.refreshModels ||= refreshModels;
+      return s.pending.promise;
+    }
+    if (!s.inFlight && Date.now() - s.lastStartMs >= input.minIntervalMs()) {
+      return startRun(s, key, refreshModels);
+    }
+    let resolve!: (value: T) => void;
+    let reject!: (err: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    s.pending = { promise, resolve, reject, refreshModels };
+    maybeStartPending(s, key);
+    return promise;
+  };
+}

--- a/apps/api/src/projects/lib/sandbox-env-sync.boundary.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.boundary.test.ts
@@ -17,6 +17,7 @@
 // fan-out is the caller that does NOT fail soft — a refusal reaches its report
 // verbatim, which is the only place the decision is observable as a message.
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { config } from '../../config';
 
 import * as realSecrets from '../secrets';
 import * as realSecretGrant from './secret-grant';
@@ -114,6 +115,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // Sequential awaited propagates must run immediately in tests: the
+  // production coalescer only exists to merge storm bursts (see
+  // env-sync-coalescer.ts), and a cooling-down interval here would make
+  // every second call in a case queue for the full window.
+  (config as any).KORTIX_ENV_SYNC_MIN_INTERVAL_MS = 0;
+
   __resetNetworkBoundaryArmCacheForTests();
   envPushes = [];
   sandboxProvider = 'daytona';

--- a/apps/api/src/projects/lib/sandbox-env-sync.prompt.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.prompt.test.ts
@@ -14,6 +14,7 @@
 // re-pushed, and resolving the binding set stays FAIL-CLOSED — it re-reads the
 // agent's grant, and a grant we cannot prove must refuse the turn.
 import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { config } from '../../config';
 
 import * as realSecrets from '../secrets';
 import * as realSecretGrant from './secret-grant';
@@ -134,6 +135,12 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  // Sequential awaited propagates must run immediately in tests: the
+  // production coalescer only exists to merge storm bursts (see
+  // env-sync-coalescer.ts), and a cooling-down interval here would make
+  // every second call in a case queue for the full window.
+  (config as any).KORTIX_ENV_SYNC_MIN_INTERVAL_MS = 0;
+
   __resetNetworkBoundaryArmCacheForTests();
   __resetPromptModelSignatureCacheForTests();
   events = [];

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -22,6 +22,7 @@ import {
   resolveSelectedAgentConfigForSession,
 } from './compile-agent-config';
 import { waitForDaemonOpencodeReady } from './sandbox-daemon-ready';
+import { createCoalescedRunner } from './env-sync-coalescer';
 import { SECRET_CAPABILITIES_ENV_NAME } from '../secret-capabilities';
 import {
   workspaceModeAllowsFullRepository,
@@ -781,7 +782,29 @@ export async function syncSandboxEnvForPrompt(args: {
   console.log(`[env-sync] timing sandbox=${args.externalId} push=sent refreshModels=${refreshModels} ${JSON.stringify(timing)}`);
 }
 
-export async function propagateProjectSecretsToActiveSandboxes(
+/**
+ * The coalesced public entry — see env-sync-coalescer.ts for the incident this
+ * exists for (2026-08-21: looping secret writers × per-write fan-out throttled
+ * the whole Daytona org). Callers keep their await semantics: an awaited call
+ * returns a report from a run that STARTED after their write, so the report
+ * covers it; a burst shares one trailing run instead of stacking N fan-outs.
+ */
+export const propagateProjectSecretsToActiveSandboxes = createCoalescedRunner<
+  ProjectSecretPropagationResult
+>({
+  run: (projectId, opts) => runProjectSecretPropagation(projectId, opts),
+  // 3s, not more: single-flight + burst-collapse are what break a storm (50
+  // writes → 2 runs regardless of this value); the interval only paces a
+  // slow-drip loop. The two AWAITED callers (secret-broker rotation and
+  // POST /secrets/sync) sit behind this cooldown too, so it must stay small
+  // enough that a human never notices it on those endpoints.
+  minIntervalMs: () => {
+    const configured = Number((config as any).KORTIX_ENV_SYNC_MIN_INTERVAL_MS);
+    return Number.isFinite(configured) && configured >= 0 ? Math.floor(configured) : 3_000;
+  },
+});
+
+async function runProjectSecretPropagation(
   projectId: string,
   opts?: { refreshModels?: boolean },
 ): Promise<ProjectSecretPropagationResult> {

--- a/apps/api/src/projects/lib/session-caps.test.ts
+++ b/apps/api/src/projects/lib/session-caps.test.ts
@@ -1,0 +1,100 @@
+// Boundary proof for the 2026-08-21 per-project session controls, at the seam
+// where they live: checkConcurrentSessionCap with its DB counts and account
+// limit mocked, the REAL rate-limit bucket underneath. Heavier dependencies of
+// lib/sessions are stubbed so its top-level imports resolve, and `mock.module`
+// is process-global, so this file must be run on its own (--isolate).
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let activeInAccount = 0;
+let activeInProject = 0;
+
+mock.module('../../shared/account-limits', () => ({
+  resolveAccountSessionLimit: async () => ({ tier: 'enterprise', limit: 10_000, source: 'tier' }),
+  resolveAccountTier: async () => 'enterprise',
+  accountUsesLlmGateway: async () => false,
+  maxProjectsForAccount: async () => 10_000,
+}));
+mock.module('../../shared/audit', () => ({
+  recordAuditEvent: async () => {},
+  inferAuditSource: () => 'test',
+  runAuditedTransaction: async (_ctx: unknown, fn: () => unknown) => fn(),
+  requestAuditContext: () => ({}),
+}));
+
+// The two count queries share one shape (select→from→where→limit → one row of
+// {activeCount}); the account count always runs first, the project count only
+// when a projectId is passed. The stub answers by call order per invocation.
+let dbCalls = 0;
+mock.module('../../shared/db', () => ({
+  hasDatabase: () => true,
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            dbCalls += 1;
+            return [{ activeCount: dbCalls % 2 === 1 ? activeInAccount : activeInProject }];
+          },
+        }),
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => {} }) }),
+  },
+}));
+
+import { config } from '../../config';
+import { resetRateLimiters } from '../../shared/rate-limit';
+import { checkConcurrentSessionCap } from './sessions';
+
+describe('per-project session controls at the create seam', () => {
+  beforeEach(() => {
+    resetRateLimiters();
+    dbCalls = 0;
+    activeInAccount = 0;
+    activeInProject = 0;
+    (config as any).KORTIX_PROJECT_ACTIVE_SESSION_LIMIT = 2;
+    (config as any).KORTIX_PROJECT_SESSION_CREATES_PER_HOUR = 1;
+  });
+
+  test('at the active cap the create refuses with project_session_limit', async () => {
+    activeInProject = 2;
+    const result = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-cap');
+    expect(result.error?.status).toBe(429);
+    expect((result.error?.body as any)?.code).toBe('project_session_limit');
+  });
+
+  test('ORDERING: cap refusals never burn the create budget', async () => {
+    activeInProject = 2;
+    for (let i = 0; i < 5; i++) {
+      const refused = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-order');
+      expect((refused.error?.body as any)?.code).toBe('project_session_limit');
+    }
+    activeInProject = 0;
+    const afterCleanup = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-order');
+    expect(afterCleanup.error).toBeUndefined();
+  });
+
+  test('under the cap, the hourly budget refuses with project_session_create_limit', async () => {
+    const first = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-budget');
+    expect(first.error).toBeUndefined();
+    const second = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-budget');
+    expect(second.error?.status).toBe(429);
+    expect((second.error?.body as any)?.code).toBe('project_session_create_limit');
+    expect((second.error?.body as any)?.retry_after_seconds).toBeGreaterThan(0);
+  });
+
+  test('speculative warm pre-creates (reserveSlots=1) never consume the budget', async () => {
+    for (let i = 0; i < 5; i++) {
+      const warm = await checkConcurrentSessionCap('acc', 'user', undefined, 1, 'proj-warm');
+      expect(warm.error).toBeUndefined();
+    }
+    const real = await checkConcurrentSessionCap('acc', 'user', undefined, 0, 'proj-warm');
+    expect(real.error).toBeUndefined();
+  });
+
+  test('a create with no projectId (legacy caller) still passes the account path untouched', async () => {
+    const result = await checkConcurrentSessionCap('acc', 'user', undefined, 0);
+    expect(result.error).toBeUndefined();
+    expect(result.headers['X-RateLimit-Limit']).toBe('10000');
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -12,6 +12,7 @@ import { isMetaAgentName, META_AGENT_NAME, META_SANDBOX_SLUG } from '@kortix/sha
 import { checkBillingActive } from '../../billing/services/billing-gate';
 import { accountMayUseManagedModels } from '../../billing/services/entitlements';
 import { type SandboxProviderName, config } from '../../config';
+import { consumeProjectSessionCreateBudget } from '../../shared/rate-limit';
 import { agentMayUseConnector } from '../../iam/agent-scope';
 import {
   loadSessionGrants,
@@ -162,6 +163,37 @@ export async function countActiveProjectSessions(accountId: string): Promise<num
   return Number(row?.activeCount ?? 0);
 }
 
+export async function countActiveSessionsInProject(projectId: string): Promise<number> {
+  const [row] = await db
+    .select({ activeCount: sql<number>`count(*)::int` })
+    .from(projectSessions)
+    .where(
+      and(
+        eq(projectSessions.projectId, projectId),
+        inArray(projectSessions.status, [...ACTIVE_SESSION_STATUSES]),
+      ),
+    )
+    .limit(1);
+
+  return Number(row?.activeCount ?? 0);
+}
+
+/**
+ * Hard per-PROJECT ceiling on active sessions, independent of account tier.
+ *
+ * INCIDENT 2026-08-21: a per-minute trigger in one project spawned a fresh
+ * session every tick and never cleaned up — 104 active sandboxes in one
+ * project, 183 in another. The account-level concurrent-session limit never
+ * fired because those accounts were entitled to be big; no single PROJECT has
+ * a legitimate reason to hold 100+ live sandboxes, and each one multiplies
+ * every env fan-out and provider call the project makes. Deliberately generous
+ * so no real team ever sees it; it exists to clip runaway automation.
+ */
+export function projectActiveSessionLimit(): number {
+  const configured = Number((config as any).KORTIX_PROJECT_ACTIVE_SESSION_LIMIT);
+  return Number.isFinite(configured) && configured > 0 ? Math.floor(configured) : 100;
+}
+
 export async function countProvisioningProjectSessions(projectId: string): Promise<number> {
   const [row] = await db
     .select({ provisioningCount: sql<number>`count(*)::int` })
@@ -239,6 +271,7 @@ export async function checkConcurrentSessionCap(
   userId: string,
   request?: RequestAuditContext,
   reserveSlots = 0,
+  projectId?: string,
 ): Promise<{
   error?: SessionCreateError;
   headers: Record<string, string>;
@@ -250,6 +283,102 @@ export async function checkConcurrentSessionCap(
     'X-RateLimit-Limit': String(limit),
     'X-RateLimit-Remaining': String(remainingAfterCreate),
   };
+
+  // The per-project ceilings run before the account-tier check: they are the
+  // more specific refusals, and an account big enough to pass the tier check
+  // is exactly the account whose runaway project these exist to clip.
+  if (projectId) {
+    const projectLimit = projectActiveSessionLimit();
+    const activeInProject = await countActiveSessionsInProject(projectId);
+    if (activeInProject >= projectLimit) {
+      recordAuditEvent({
+        accountId,
+        actorUserId: userId,
+        action: `RATE_LIMIT ${request?.method ?? 'SYSTEM'} ${request?.path ?? 'project_session'}`,
+        resourceType: 'project_session',
+        resourceId: projectId,
+        ip: request?.ip ?? null,
+        userAgent: request?.userAgent ?? null,
+        metadata: {
+          limiter: 'project_active_sessions',
+          limit: projectLimit,
+          active_sessions_in_project: activeInProject,
+        },
+      }).catch((error) => {
+        console.error('[projects] Failed to record project session cap audit event:', error);
+      });
+      const message = `This project already has ${activeInProject} active sessions (limit ${projectLimit}). Stop or delete finished sessions before starting more — a trigger or automation that never cleans up its sessions is usually what hits this.`;
+      return {
+        headers: {
+          'X-RateLimit-Limit': String(projectLimit),
+          'X-RateLimit-Remaining': '0',
+        },
+        error: {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(projectLimit),
+            'X-RateLimit-Remaining': '0',
+          },
+          body: {
+            error: message,
+            message,
+            code: 'project_session_limit',
+            limit: projectLimit,
+            active_sessions: activeInProject,
+          },
+        },
+      };
+    }
+  }
+
+  // The hourly create budget runs AFTER the active-session cap and only
+  // charges REAL creates (reserveSlots === 0). Two genuine-user protections
+  // live in that ordering: a speculative warm pre-create is page-view-driven
+  // and must not drain the budget, and a user retrying against the cap must
+  // not burn budget on refusals — otherwise they clean up their sessions and
+  // find themselves locked out for the rest of the hour anyway.
+  if (projectId && reserveSlots === 0) {
+    const budget = consumeProjectSessionCreateBudget(projectId);
+    if (!budget.allowed) {
+      recordAuditEvent({
+        accountId,
+        actorUserId: userId,
+        action: `RATE_LIMIT ${request?.method ?? 'SYSTEM'} ${request?.path ?? 'project_session'}`,
+        resourceType: 'project_session',
+        resourceId: projectId,
+        ip: request?.ip ?? null,
+        userAgent: request?.userAgent ?? null,
+        metadata: {
+          limiter: 'project_session_creates',
+          limit: budget.limit,
+          retry_after_ms: budget.retryAfterMs ?? null,
+        },
+      }).catch((error) => {
+        console.error('[projects] Failed to record session create budget audit event:', error);
+      });
+      const message = `This project has hit its hourly session-create limit (${budget.limit}/hour). A trigger or automation creating a session on every tick is usually what hits this — reuse sessions instead of spawning new ones.`;
+      return {
+        headers: {
+          'X-RateLimit-Limit': String(budget.limit),
+          'X-RateLimit-Remaining': '0',
+        },
+        error: {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(budget.limit),
+            'X-RateLimit-Remaining': '0',
+          },
+          body: {
+            error: message,
+            message,
+            code: 'project_session_create_limit',
+            limit: budget.limit,
+            retry_after_seconds: Math.ceil((budget.retryAfterMs ?? budget.resetMs) / 1000),
+          },
+        },
+      };
+    }
+  }
 
   if (activeSessions < limit - reserveSlots) return { headers };
 
@@ -1220,6 +1349,7 @@ export async function createProjectSession(input: {
           userId,
           input.request,
           input.reserveConcurrentSlots ?? 0,
+          projectId,
         )
       : Promise.resolve(null),
     checkBillingActive(accountId),

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -4,6 +4,7 @@ import { agentMayUseEnv, getAgentGrant } from '../../iam/agent-scope';
 import { auth, errors, json } from '../../openapi';
 import { createAccountToken, listAccountTokens, revokeAccountToken } from '../../repositories/account-tokens';
 import { inferAuditSource, recordAuditEvent, runAuditedTransaction } from '../../shared/audit';
+import { createProjectSecretWriteRateLimitMiddleware } from '../../shared/rate-limit';
 import { db } from '../../shared/db';
 import { kickRoutedPreBuild, templateBuildProviders } from '../../snapshots/builder';
 import { getTemplateById } from '../../snapshots/templates';
@@ -154,6 +155,14 @@ async function connectorSecretBindings(projectId: string, identifier: string): P
     );
   return rows.map((row) => row.slug).sort();
 }
+
+// Registered before this file's routes so it runs for every secret WRITE
+// (including /broker and /sync) and for nothing else. See the middleware's
+// doc comment for the 2026-08-21 storm it exists to stop. The pattern is
+// concatenated because unit-iam-gate-codemod-pin.test.ts strips block comments
+// with a regex, and a literal slash-star inside this string would read as a
+// comment-opener and swallow the next hundred lines of this file from its view.
+projectsApp.use('/:projectId/secrets/' + '*', createProjectSecretWriteRateLimitMiddleware());
 
 projectsApp.openapi(
   createRoute({

--- a/apps/api/src/setup-links/public-app.test.ts
+++ b/apps/api/src/setup-links/public-app.test.ts
@@ -37,6 +37,8 @@ mock.module('../shared/db', () => ({
 mock.module('../shared/rate-limit', () => ({
   TokenBucketRateLimiter: class {},
   enforceRateLimit: async () => null,
+  createProjectSecretWriteRateLimitMiddleware: () => async (_c: any, next: any) => next(),
+  consumeProjectSessionCreateBudget: () => ({ allowed: true, limit: 100, remaining: 99, resetMs: 1000 }),
 }));
 
 const propagated: string[] = [];

--- a/apps/api/src/shared/database-capacity.test.ts
+++ b/apps/api/src/shared/database-capacity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import {
+  DEFAULT_AUDIT_POOL_MAX,
+  DEFAULT_DB_POOL_MAX,
+  LEADER_ELECTION_POOL_MAX,
+  PROD_API_MAX_TASKS,
+  PROD_DB_NON_API_RESERVE,
+  PROD_DB_ROLLING_CONNECTION_CEILING,
+  PROD_DB_USABLE_CONNECTIONS,
+  ROLLING_TASK_OVERLAP,
+  SCHEMA_CHECK_POOL_MAX,
+} from './database-capacity';
+
+describe('production database connection capacity', () => {
+  test('pins every API-owned connection pool in the rollout budget', () => {
+    expect(DEFAULT_DB_POOL_MAX).toBe(6);
+    expect(DEFAULT_AUDIT_POOL_MAX).toBe(2);
+    expect(LEADER_ELECTION_POOL_MAX).toBe(1);
+    expect(SCHEMA_CHECK_POOL_MAX).toBe(1);
+  });
+
+  test('keeps a maximum rolling deployment below the usable PostgreSQL limit', () => {
+    expect(PROD_API_MAX_TASKS).toBe(10);
+    expect(ROLLING_TASK_OVERLAP).toBe(2);
+    expect(PROD_DB_USABLE_CONNECTIONS).toBe(237);
+    expect(PROD_DB_NON_API_RESERVE).toBe(32);
+    expect(PROD_DB_ROLLING_CONNECTION_CEILING).toBe(190);
+    expect(PROD_DB_ROLLING_CONNECTION_CEILING).toBeLessThanOrEqual(
+      PROD_DB_USABLE_CONNECTIONS - PROD_DB_NON_API_RESERVE,
+    );
+  });
+
+  test('matches the production ECS capacity and deployment overlap', () => {
+    const productionTerraform = readFileSync(
+      new URL('../../../../infra/terraform/environments/prod/main.tf', import.meta.url),
+      'utf8',
+    );
+    const ecsModule = readFileSync(
+      new URL('../../../../infra/terraform/modules/ecs-api/main.tf', import.meta.url),
+      'utf8',
+    );
+
+    expect(productionTerraform).toMatch(/module "api"[\s\S]*?max_capacity\s*=\s*10/);
+    expect(ecsModule).toMatch(/deployment_maximum_percent\s*=\s*200/);
+  });
+});

--- a/apps/api/src/shared/database-capacity.ts
+++ b/apps/api/src/shared/database-capacity.ts
@@ -1,0 +1,39 @@
+import { DEFAULT_DB_POOL_MAX } from '@kortix/db/connection-defaults';
+
+/**
+ * Connection budgets for one API task.
+ *
+ * Keep these values in one pure module. The production rollout-capacity test
+ * must account for every long-lived pool and the transient schema probe.
+ */
+export { DEFAULT_DB_POOL_MAX };
+export const DEFAULT_AUDIT_POOL_MAX = 2;
+export const LEADER_ELECTION_POOL_MAX = 1;
+export const SCHEMA_CHECK_POOL_MAX = 1;
+
+/** Production PostgreSQL exposes 240 slots and reserves 3 for superusers. */
+export const PROD_DB_USABLE_CONNECTIONS = 237;
+
+/** ECS can autoscale the production API service to 10 tasks. */
+export const PROD_API_MAX_TASKS = 10;
+
+/** ECS permits a 200% rolling deployment: 10 old tasks plus 10 new tasks. */
+export const ROLLING_TASK_OVERLAP = 2;
+
+/**
+ * Slots reserved for Supabase, operators, migrations, and request-scoped probes.
+ * The invariant below leaves a further 15-slot buffer beyond this reserve.
+ */
+export const PROD_DB_NON_API_RESERVE = 32;
+
+const rollingLongLivedConnections =
+  PROD_API_MAX_TASKS *
+  ROLLING_TASK_OVERLAP *
+  (DEFAULT_DB_POOL_MAX + DEFAULT_AUDIT_POOL_MAX + LEADER_ELECTION_POOL_MAX);
+
+// Only the 10 starting tasks run the transient schema probe. Old tasks have
+// completed it before the deployment begins.
+const rollingSchemaProbeConnections = PROD_API_MAX_TASKS * SCHEMA_CHECK_POOL_MAX;
+
+export const PROD_DB_ROLLING_CONNECTION_CEILING =
+  rollingLongLivedConnections + rollingSchemaProbeConnections;

--- a/apps/api/src/shared/leader-election.ts
+++ b/apps/api/src/shared/leader-election.ts
@@ -26,6 +26,7 @@ import os from 'node:os';
 import postgres from 'postgres';
 import { config } from '../config';
 import { logger } from '../lib/logger';
+import { LEADER_ELECTION_POOL_MAX } from './database-capacity';
 
 const LOCK_KEY = 'background-workers';
 
@@ -247,7 +248,7 @@ export function startLeaderElection(
   // pool. prepare:false matches the Supabase-pooler app client.
   sql = postgres(config.DATABASE_URL, {
     prepare: false,
-    max: 1,
+    max: LEADER_ELECTION_POOL_MAX,
     idle_timeout: 30,
     connect_timeout: 10,
     onnotice: () => {},

--- a/apps/api/src/shared/rate-limit.test.ts
+++ b/apps/api/src/shared/rate-limit.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
 
-import { TokenBucketRateLimiter } from './rate-limit';
+import {
+  TokenBucketRateLimiter,
+  consumeProjectSessionCreateBudget,
+  createProjectSecretWriteRateLimitMiddleware,
+  resetRateLimiters,
+} from './rate-limit';
+import { config } from '../config';
 
 describe('TokenBucketRateLimiter bounded buckets', () => {
   test('a flood of unique keys never grows the internal Map without bound', () => {
@@ -20,5 +27,83 @@ describe('TokenBucketRateLimiter bounded buckets', () => {
     expect(limiter.check('same', policy).allowed).toBe(true);
     expect(limiter.check('same', policy).allowed).toBe(true);
     expect(limiter.check('same', policy).allowed).toBe(false);
+  });
+});
+
+describe('createProjectSecretWriteRateLimitMiddleware — the 2026-08-21 storm breaker', () => {
+  function appWithLimit(limit: number) {
+    resetRateLimiters();
+    (config as any).KORTIX_PROJECT_SECRET_WRITES_PER_HOUR = limit;
+    const app = new Hono();
+    app.use('/:projectId/secrets/*', createProjectSecretWriteRateLimitMiddleware());
+    app.post('/:projectId/secrets', (c) => c.json({ ok: true }));
+    app.post('/:projectId/secrets/:name/broker', (c) => c.json({ ok: true }));
+    app.get('/:projectId/secrets', (c) => c.json({ ok: true }));
+    return app;
+  }
+
+  test('writes past the budget 429 with the loop-explaining code', async () => {
+    const app = appWithLimit(3);
+    for (let i = 0; i < 3; i++) {
+      const res = await app.request('/proj-a/secrets', { method: 'POST' });
+      expect(res.status).toBe(200);
+    }
+    const blocked = await app.request('/proj-a/secrets', { method: 'POST' });
+    expect(blocked.status).toBe(429);
+    const body = (await blocked.json()) as { code?: string };
+    expect(body.code).toBe('project_secret_write_limit');
+    expect(blocked.headers.get('Retry-After')).toBeTruthy();
+    delete (config as any).KORTIX_PROJECT_SECRET_WRITES_PER_HOUR;
+    resetRateLimiters();
+  });
+
+  test('nested write routes (broker) draw from the same project budget', async () => {
+    const app = appWithLimit(2);
+    expect((await app.request('/proj-b/secrets', { method: 'POST' })).status).toBe(200);
+    expect(
+      (await app.request('/proj-b/secrets/TELEGRAM_BOT_TOKEN/broker', { method: 'POST' })).status,
+    ).toBe(200);
+    expect(
+      (await app.request('/proj-b/secrets/TELEGRAM_BOT_TOKEN/broker', { method: 'POST' })).status,
+    ).toBe(429);
+    delete (config as any).KORTIX_PROJECT_SECRET_WRITES_PER_HOUR;
+    resetRateLimiters();
+  });
+
+  test('reads are never throttled and projects are independent', async () => {
+    const app = appWithLimit(1);
+    expect((await app.request('/proj-c/secrets', { method: 'POST' })).status).toBe(200);
+    expect((await app.request('/proj-c/secrets', { method: 'POST' })).status).toBe(429);
+    for (let i = 0; i < 5; i++) {
+      expect((await app.request('/proj-c/secrets', { method: 'GET' })).status).toBe(200);
+    }
+    expect((await app.request('/proj-d/secrets', { method: 'POST' })).status).toBe(200);
+    delete (config as any).KORTIX_PROJECT_SECRET_WRITES_PER_HOUR;
+    resetRateLimiters();
+  });
+});
+
+describe('consumeProjectSessionCreateBudget — hourly create ceiling', () => {
+  test('the default budget admits exactly 100 creates then refuses with retry timing', () => {
+    resetRateLimiters();
+    for (let i = 0; i < 100; i++) {
+      expect(consumeProjectSessionCreateBudget('proj-x').allowed).toBe(true);
+    }
+    const denied = consumeProjectSessionCreateBudget('proj-x');
+    expect(denied.allowed).toBe(false);
+    expect(denied.limit).toBe(100);
+    expect(denied.retryAfterMs).toBeGreaterThan(0);
+    resetRateLimiters();
+  });
+
+  test('projects never share a budget — one runaway cannot starve a neighbor', () => {
+    resetRateLimiters();
+    (config as any).KORTIX_PROJECT_SESSION_CREATES_PER_HOUR = 2;
+    expect(consumeProjectSessionCreateBudget('runaway').allowed).toBe(true);
+    expect(consumeProjectSessionCreateBudget('runaway').allowed).toBe(true);
+    expect(consumeProjectSessionCreateBudget('runaway').allowed).toBe(false);
+    expect(consumeProjectSessionCreateBudget('innocent').allowed).toBe(true);
+    delete (config as any).KORTIX_PROJECT_SESSION_CREATES_PER_HOUR;
+    resetRateLimiters();
   });
 });

--- a/apps/api/src/shared/rate-limit.ts
+++ b/apps/api/src/shared/rate-limit.ts
@@ -167,7 +167,65 @@ const voiceTranscriptPollLimiter = new TokenBucketRateLimiter('voice_transcript_
 const checkEmailLimiter = new TokenBucketRateLimiter('check_email');
 const projectWebhookLimiter = new TokenBucketRateLimiter('project_webhook');
 const projectWebhookManifestRefreshLimiter = new TokenBucketRateLimiter('project_webhook_manifest_refresh');
+const projectSecretWriteLimiter = new TokenBucketRateLimiter('project_secret_write');
+const projectSessionCreateLimiter = new TokenBucketRateLimiter('project_session_create');
 export const sessionLlmLimiter = new TokenBucketRateLimiter('session_llm');
+
+/**
+ * Per-project budget on session CREATES (the 2026-08-21 storm's other half: a
+ * per-minute trigger created a session every tick, forever — 60 provider
+ * provisions an hour from one project, none ever cleaned up). Checked from the
+ * session-create path (lib/sessions.ts), not a route mount, because creates
+ * arrive through several routes (UI, triggers, channels, KaaB).
+ *
+ * In-process bucket — same replica-multiplied honesty as the secret-write
+ * budget above, and the same verdict: this stops runaway loops, it does not
+ * meter exact quotas.
+ */
+export function consumeProjectSessionCreateBudget(projectId: string): RateLimitResult {
+  return projectSessionCreateLimiter.check(projectId, {
+    limit: positiveInt((config as any).KORTIX_PROJECT_SESSION_CREATES_PER_HOUR, 100),
+    windowMs: 60 * 60_000,
+  });
+}
+
+/**
+ * Per-project budget on secret WRITES (POST/PUT/PATCH/DELETE under
+ * /:projectId/secrets*). Reads pass untouched.
+ *
+ * INCIDENT 2026-08-21: agents in two projects used secrets as a config store
+ * and wrote them in loops (one made 1,017 writes in a morning). Every write
+ * fans an env push to every active sandbox in the project, so the loops became
+ * a provider-API storm that got the whole Daytona org rate-limited — failing
+ * session creates and wakes for every other customer. No human workflow writes
+ * secrets 100 times in an hour; an agent loop does.
+ *
+ * In-process buckets, so the effective ceiling is limit × API replicas when a
+ * loop happens to spread across pods. That is accepted: the goal is stopping
+ * hundreds-per-hour runaways, not metering exact quotas.
+ */
+export function createProjectSecretWriteRateLimitMiddleware() {
+  return async (c: Context, next: Next) => {
+    const method = c.req.method.toUpperCase();
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') return next();
+    const projectId = c.req.param('projectId') || 'unknown';
+    const result = projectSecretWriteLimiter.check(projectId, {
+      limit: positiveInt((config as any).KORTIX_PROJECT_SECRET_WRITES_PER_HOUR, 100),
+      windowMs: 60 * 60_000,
+    });
+    setHeaders(c, result);
+    if (!result.allowed) {
+      return c.json({
+        error: 'rate_limit_exceeded',
+        message:
+          'This project has hit its secret-write limit. Secrets are for credentials, not fast-changing state — store loop data elsewhere, or retry later.',
+        code: 'project_secret_write_limit',
+        retry_after_seconds: Math.ceil((result.retryAfterMs ?? result.resetMs) / 1000),
+      }, 429);
+    }
+    await next();
+  };
+}
 
 export function createInviteAcceptRateLimitMiddleware() {
   return async (c: Context, next: Next) => {
@@ -423,5 +481,7 @@ export function resetRateLimiters() {
   checkEmailLimiter.reset();
   projectWebhookLimiter.reset();
   projectWebhookManifestRefreshLimiter.reset();
+  projectSecretWriteLimiter.reset();
+  projectSessionCreateLimiter.reset();
   sessionLlmLimiter.reset();
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -177,6 +177,12 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   const requestHeaders = await headers();
   const isDesktopApp = requestHeaders.get('user-agent')?.includes(DESKTOP_UA_TOKEN) ?? false;
 
+  // The visitor pixel below loads ONLY on the production site host — never on
+  // localhost (CI, local dev) or preview hosts. Host-based rather than
+  // NODE_ENV so a production BUILD run locally or in CI still skips it.
+  const requestHost = (requestHeaders.get('host') ?? '').toLowerCase().split(':')[0] ?? '';
+  const isKortixSiteHost = requestHost === 'kortix.com' || requestHost.endsWith('.kortix.com');
+
   // Locale-routed marketing pages (/de, /fr, …) are rewritten onto the
   // unprefixed route by the middleware, which records the locale in x-locale.
   const requestLocale = requestHeaders.get('x-locale');
@@ -317,8 +323,12 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         />
 
         {/* Domain integration — script tag verification.
-            Skipped in the desktop app (visitor de-anonymization pixel). */}
-        {!isDesktopApp && (
+            Skipped in the desktop app (visitor de-anonymization pixel), and
+            loaded only on the real site: on localhost it fires anyway and the
+            vendor 400s the beacon, which failed every PR's browser lane at the
+            admin console's "no bad responses" guard — a tracking pixel has no
+            business in CI, local dev, or preview deploys to begin with. */}
+        {!isDesktopApp && isKortixSiteHost && (
           <script
             src="https://d2mvefebd70kbz.cloudfront.net/scripts/019e82ba-9ec3-733e-8a8e-9ff5cc2e1d35.js"
             async

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./client": "./src/client.ts",
+    "./connection-defaults": "./src/connection-defaults.ts",
     "./schema": "./src/schema/index.ts",
     "./types": "./src/types.ts"
   },

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,5 +1,6 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
+import { DEFAULT_DB_POOL_MAX } from './connection-defaults';
 import * as schema from './schema';
 
 function intFromEnv(name: string, fallback: number): number {
@@ -29,16 +30,17 @@ function intFromEnv(name: string, fallback: number): number {
  *      (Investigation found real offenders: an unindexed 21M-row audit scan at
  *      80–120s, and account-deletion sweeps at 36–64s, each pinning a connection
  *      for up to the 2-min server statement_timeout.)
- *   2. A modestly larger, env-tunable `max` so normal concurrent page loads
- *      (one IAM page fans out ~15-20 parallel queries) don't exhaust the pool.
+ *   2. An env-tunable `max` so normal concurrent page loads can run without
+ *      letting a rolling deployment exhaust the PostgreSQL server.
  *
  * SIZING: prod connects DIRECTLY to Postgres (db.<ref>.supabase.co:5432), NOT
- * the Supavisor pooler — so every client connection is one real backend, capped
- * by the server's `max_connections` (240 on the current instance, only ~23 in
- * use at rest). Keep `POOL_MAX * max_replicas` comfortably under that ceiling
- * with headroom for other consumers: at the current autoscale max of 10
- * replicas, 15 * 10 = 150 < 240. If replica count or pool size grows, move app
- * traffic to the transaction pooler (port 6543) instead of raising this further.
+ * the Supavisor pooler. Every client connection consumes one real backend.
+ * PostgreSQL exposes 237 non-reserved slots. ECS can overlap 10 old tasks and
+ * 10 new tasks during a rolling deployment. The API also owns an audit pool,
+ * a leader-election connection, and a transient startup schema probe. The
+ * capacity invariant in apps/api/src/shared/database-capacity.test.ts accounts
+ * for all four sources and preserves a non-API reserve. If replica count or
+ * pool size grows, update that invariant before changing this default.
  *
  * All knobs are env-overridable so prod can tune without a code change. The
  * app's background workers (maintenance sweeps, migration workers) only ever run
@@ -46,7 +48,7 @@ function intFromEnv(name: string, fallback: number): number {
  * job needs a longer single statement it should `SET LOCAL statement_timeout`
  * inside its own transaction rather than raising this request-path default.
  */
-const POOL_MAX = intFromEnv('DB_POOL_MAX', 15);
+const POOL_MAX = intFromEnv('DB_POOL_MAX', DEFAULT_DB_POOL_MAX);
 const IDLE_TIMEOUT_S = intFromEnv('DB_IDLE_TIMEOUT_S', 30);
 const CONNECT_TIMEOUT_S = intFromEnv('DB_CONNECT_TIMEOUT_S', 10);
 const MAX_LIFETIME_S = intFromEnv('DB_MAX_LIFETIME_S', 60 * 30); // 30 min

--- a/packages/db/src/connection-defaults.ts
+++ b/packages/db/src/connection-defaults.ts
@@ -1,0 +1,2 @@
+/** Default postgres.js main-pool limit for one Kortix API process. */
+export const DEFAULT_DB_POOL_MAX = 6;

--- a/tests/README.md
+++ b/tests/README.md
@@ -151,9 +151,9 @@ Why six. On run 32240074477 four shards of 137 flows were all killed by the
 40-minute job cap while still passing what they ran (76/87 and 68/77). Measured
 from those logs, a shard completes 2.0–2.3 flows/min, so 137 flows needs 62–70
 minutes — more than a 60-minute cap allows. Six shards put 82 flows on each,
-which the same rates finish in 38–43 minutes. Each shard keeps
-`KE2E_API_WORKERS=2` and `KE2E_SANDBOX_WORKERS=1`: the throughput comes from
-fewer flows per shard, not from more workers inside one.
+which the same rates finish in 38–43 minutes. Each shard uses
+`KE2E_API_WORKERS=1` and `KE2E_SANDBOX_WORKERS=1` to stay below staging's
+proven concurrency ceiling.
 
 A final job named `full suite + quality gates` aggregates the shards. That exact
 name is the required status check on `prod` branch protection; renaming it

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -859,15 +859,32 @@ test.describe("08 — Accounts, invites, and project access", { tag: "@quarantin
     // (see IAM_PROPAGATION_MS). A task that has not seen it answers
     // `GET /accounts/:id` with 403, and the hub then sits on its loading
     // skeleton forever rather than erroring — so reload until it renders.
+    const invitedMembersHeading = page.getByRole("heading", {
+      name: "Members",
+      exact: true,
+    });
     await expect
       .poll(
         async () => {
+          const accountResponse = page
+            .waitForResponse(
+              (response) => {
+                const url = new URL(response.url());
+                return (
+                  response.request().method() === "GET" &&
+                  url.pathname === `/v1/accounts/${account.account_id}`
+                );
+              },
+              { timeout: 5_000 },
+            )
+            .catch(() => null);
           await page.goto(`/accounts/${account.account_id}`, {
             waitUntil: "domcontentloaded",
           });
-          return page
-            .getByRole("heading", { name: "Members", exact: true })
-            .isVisible()
+          if ((await accountResponse)?.status() !== 200) return false;
+          return invitedMembersHeading
+            .waitFor({ state: "visible", timeout: 5_000 })
+            .then(() => true)
             .catch(() => false);
         },
         { timeout: IAM_PROPAGATION_MS },

--- a/tests/src/flows/secrets.flow.ts
+++ b/tests/src/flows/secrets.flow.ts
@@ -80,6 +80,9 @@ flow(
         );
       primary.status([200, 201]);
       primary.body().has("identifier", "GMAPS-primary").has("name", "GOOGLE_MAPS_API_KEY");
+      // The per-project secret-write budget (2026-08-21 storm control) must be
+      // armed on this route: its limiter stamps every allowed write.
+      primary.headerEquals("X-RateLimit-Limit", /^\d+$/);
 
       const backup = await ctx.client
         .as(ctx.P.OWNER)

--- a/tests/unit/local-profile.test.ts
+++ b/tests/unit/local-profile.test.ts
@@ -86,12 +86,13 @@ describe("ke2e local profile", () => {
     expect(localRunExitCode({ failed: 0, skipped: 0, todo: 1 })).toBe(1);
   });
 
-  it("fails a strict deployed run when any flow is skipped or remains todo", () => {
-    expect(runExitCode({ failed: 0, skipped: 0, todo: 0 }, true)).toBe(0);
-    expect(runExitCode({ failed: 1, skipped: 0, todo: 0 }, false)).toBe(1);
-    expect(runExitCode({ failed: 0, skipped: 1, todo: 0 }, false)).toBe(0);
-    expect(runExitCode({ failed: 0, skipped: 1, todo: 0 }, true)).toBe(1);
-    expect(runExitCode({ failed: 0, skipped: 0, todo: 1 }, true)).toBe(1);
+  it("fails a strict deployed run when a flow skips without an assertion or remains todo", () => {
+    expect(runExitCode({ failed: 0, skipped: 0, skippedUnasserted: 0, todo: 0 }, true)).toBe(0);
+    expect(runExitCode({ failed: 1, skipped: 0, skippedUnasserted: 0, todo: 0 }, false)).toBe(1);
+    expect(runExitCode({ failed: 0, skipped: 1, skippedUnasserted: 1, todo: 0 }, false)).toBe(0);
+    expect(runExitCode({ failed: 0, skipped: 1, skippedUnasserted: 0, todo: 0 }, true)).toBe(0);
+    expect(runExitCode({ failed: 0, skipped: 1, skippedUnasserted: 1, todo: 0 }, true)).toBe(1);
+    expect(runExitCode({ failed: 0, skipped: 0, skippedUnasserted: 0, todo: 1 }, true)).toBe(1);
   });
 
   it("uses bounded CPU-aware concurrency", () => {

--- a/tests/unit/provisioning-perf.test.ts
+++ b/tests/unit/provisioning-perf.test.ts
@@ -153,7 +153,13 @@ async function loadProvisionMatrix(opts: {
       }
       async post() {
         await new Promise((resolve) => setTimeout(resolve, delay));
-        return { json: () => ({ secret_key: 'pat-secret' }), text: () => '' };
+        return {
+          status() {
+            return this;
+          },
+          json: () => ({ secret_key: 'pat-secret' }),
+          text: () => '',
+        };
       }
     },
   }));
@@ -239,7 +245,13 @@ describe('provisionMatrix parallelism (P1.7)', () => {
           return this;
         }
         async post() {
-          return { json: () => ({ secret_key: 's' }), text: () => '' };
+          return {
+            status() {
+              return this;
+            },
+            json: () => ({ secret_key: 's' }),
+            text: () => '',
+          };
         }
       },
     }));

--- a/tests/unit/sandbox-workflow.test.ts
+++ b/tests/unit/sandbox-workflow.test.ts
@@ -88,8 +88,8 @@ describe('sandbox test workflow', () => {
     // A cap is a hang detector, not a throttle. 40 minutes throttled: it killed
     // shards that were passing 76/87 and 68/77 of what they had run.
     expect(release).toMatch(/^ {4}timeout-minutes: 60$/m);
-    // The load each shard offers staging is unchanged by the extra shards.
-    expect(release).toContain("KE2E_API_WORKERS: '2'");
+    // Keep each shard below staging's proven concurrency ceiling.
+    expect(release).toContain("KE2E_API_WORKERS: '1'");
     expect(release).toContain("KE2E_SANDBOX_WORKERS: '1'");
     expect(release).toContain("KE2E_TIMEOUT_ATTEMPTS: '2'");
     // Dry run against staging without a release PR. `RELEASE_SOURCE_SHA` only


### PR DESCRIPTION
## Incident

Production PostgreSQL returned SQLSTATE 53300 during an ECS rolling deployment. Twenty overlapping API tasks could request more connections than PostgreSQL exposes. Webhook, authorization, audit, turn-stream, and lifecycle queries failed as collateral damage.

## Runtime changes

- Cherry-pick PR #6715 storm controls.
- Reduce the main database pool default from 15 to 6.
- Keep the 0.13.2 audit subsystem absent.
- Add a rolling-fleet capacity invariant.
- Model a 190-connection API ceiling against 237 usable slots.
- Preserve 32 explicit non-API slots plus 15 additional slots.
- Add the incident rule to the append-only learnings register.

## Test-only staging repairs

The staging branch already contained three stale assertions. This PR includes the existing main commits that align those assertions with staging behavior. No deployment workflow changes are included.

## Verification

- pnpm --filter kortix-api typecheck
- pnpm --filter kortix-api test: 7735 passed, 74 skipped, 0 failed
- pnpm --filter @kortix/db test: 249 passed, 18 skipped, 0 failed
- pnpm test: 381/381 API and CLI flows; all SDK, runner, route coverage, and worktree lanes passed
