### PR TITLE
fix(sdk): re-read the transcript when a turn ends

### DIFF
--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -51,7 +51,18 @@ export interface SessionSyncScheduler {
 }
 
 export type SessionSyncReason =
-  'initial' | 'poll' | 'sse-gap' | 'compaction' | 'session-error' | 'send-recovery' | 'manual';
+  | 'initial'
+  | 'poll'
+  | 'sse-gap'
+  // A turn just ended. The stream can stay CONNECTED and still lose a message
+  // event, so a gap-triggered resync never fires and the transcript is left
+  // short — cured only by a remount. Turn end is the one moment the tail is
+  // both final and cheap to verify, so it is reconciled there.
+  | 'turn-end'
+  | 'compaction'
+  | 'session-error'
+  | 'send-recovery'
+  | 'manual';
 
 export interface SessionSyncTelemetryEvent {
   operation: 'tail' | 'older';

--- a/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
@@ -1284,3 +1284,69 @@ describe('session.next.revert.committed → tail-reconcile wiring (F2 consumer)'
     expect(calls).toEqual([]);
   });
 });
+
+// ── the transcript is reconciled when a turn ENDS ───────────────────────────
+// Reported live 2026-08-22: the agent finished, the terminal showed the whole
+// answer, and the web transcript stopped mid-sentence. A hard refresh rendered
+// it correctly — which is the tell. The data was on the server the whole time;
+// only the browser was short.
+//
+// The turn-end branches already refreshed git status, diffs and the file list.
+// They never re-read the MESSAGES, on the assumption that every message event
+// arrives. They do not, and `onGapRehydrate` cannot save it: that fires on a
+// stream GAP > 5s, and the stream here stayed connected. So nothing reconciled
+// until the component remounted.
+describe('a turn ending reconciles the transcript tail', () => {
+  const busyThenIdle = (sessionID: string, kind: 'session.status' | 'session.idle') => {
+    useSyncStore.getState().setStatus(sessionID, { type: 'busy' });
+    return kind === 'session.status'
+      ? ({
+          id: `evt_${sessionID}`,
+          type: 'session.status',
+          properties: { sessionID, status: { type: 'idle' } },
+        } as never)
+      : ({ id: `evt_${sessionID}`, type: 'session.idle', properties: { sessionID } } as never);
+  };
+
+  test('session.status busy → idle re-reads the tail', async () => {
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    handleEvent(busyThenIdle('ses_te1', 'session.status'));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls).toEqual([['ses_te1', 'turn-end']]);
+  });
+
+  test('session.idle re-reads the tail', async () => {
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    handleEvent(busyThenIdle('ses_te2', 'session.idle'));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls).toEqual([['ses_te2', 'turn-end']]);
+  });
+
+  test('an idle→idle event does NOT re-read — only a real transition does', async () => {
+    // Otherwise every idle heartbeat costs a transcript fetch.
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    useSyncStore.getState().setStatus('ses_te3', { type: 'idle' });
+    handleEvent({
+      id: 'evt_te3',
+      type: 'session.idle',
+      properties: { sessionID: 'ses_te3' },
+    } as never);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/handle-event.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.ts
@@ -348,6 +348,14 @@ export function createEventHandler(deps: {
               queryKey: fileListKeys.all,
               type: 'active',
             });
+            // AND the transcript itself. Files and diffs were refreshed here
+            // for years while the messages were not, on the assumption that
+            // every message event arrives. They do not: the stream can stay
+            // CONNECTED and still drop one, so `onGapRehydrate` (> 5s gap)
+            // never fires and nothing reconciles. The tail then stays short
+            // until the page is remounted — the "hard refresh fixes it" bug.
+            // Turn end is exactly when the tail is final, so verify it once.
+            void reconcileTail(sessionID, 'turn-end');
           }
         }
         break;
@@ -374,6 +382,14 @@ export function createEventHandler(deps: {
               queryKey: fileListKeys.all,
               type: 'active',
             });
+            // AND the transcript itself. Files and diffs were refreshed here
+            // for years while the messages were not, on the assumption that
+            // every message event arrives. They do not: the stream can stay
+            // CONNECTED and still drop one, so `onGapRehydrate` (> 5s gap)
+            // never fires and nothing reconciles. The tail then stays short
+            // until the page is remounted — the "hard refresh fixes it" bug.
+            // Turn end is exactly when the tail is final, so verify it once.
+            void reconcileTail(sessionID, 'turn-end');
           }
         }
         break;


### PR DESCRIPTION
The agent finished, the terminal showed the whole answer, and the web transcript stopped mid-sentence. **A hard refresh rendered it correctly.**

That last detail is the entire diagnosis. I fetched the "missing" assistant messages straight through our own proxy — they were there the whole time, byte-identical to the terminal:

```
assistant msg_029a83e75001KwxAMeiObC :: "All 11 files are on disk. Reading them now."
assistant msg_029a8ecfd001f7po4wRzPh :: "Read all 11. Here's what's actually in them…"
```

The server was fine. Only the browser was short.

## The hole

The turn-end branches in `handle-event.ts` already refreshed three things:

```js
queryClient.invalidateQueries({ queryKey: gitStatusKeys.all })        // Changes panel
queryClient.invalidateQueries({ queryKey: opencodeKeys.vcsDiffAll() }) // diffs
queryClient.invalidateQueries({ queryKey: fileListKeys.all })          // file list
```

**Files and diffs — never the messages.** The transcript was assumed to be event-complete.

And `onGapRehydrate` can't cover it: that fires on a stream **gap > 5s**, and here the stream stayed **connected** — one event was lost, not the connection. So nothing reconciled, and the tail stayed short until the component remounted.

"Hard refresh fixes it" is a bug report, not a workaround.

## The fix

Turn end is the one moment the tail is both **final** and cheap to verify. Both transitions — `session.status` busy→idle and `session.idle` — now reconcile it, under a dedicated `'turn-end'` sync reason so telemetry can distinguish this from an `sse-gap` resync.

**Guarded against the obvious cost:** an idle→idle heartbeat is not a transition and does **not** fetch. Only a real busy→idle edge does — once per turn. There's a test pinning that.

## Verification

| | |
|---|---|
| `handle-event` | **55 pass / 0 fail** (3 new, incl. the idle→idle no-fetch guard) |
| SDK suite | **1947 pass**, failures identical to main's 480 baseline |
| `tsc --noEmit` | clean |

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW