### PR TITLE
feat(web): say who the user actually signed in as when SSO returns someone else

### DIFF
--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -7,6 +7,13 @@ import {
   sanitizeAuthReturnUrl,
 } from '@/lib/auth/return-url';
 import {
+  isSsoIdentityMismatch,
+  readSsoExpectedEmail,
+  SSO_EXPECTED_EMAIL_COOKIE,
+  SSO_IDENTITY_MISMATCH,
+  SSO_IDENTITY_PARAM,
+} from '@/lib/auth/sso-identity';
+import {
   LAST_PROJECT_COOKIE,
   POST_AUTH_INTENT_COOKIE,
   POST_AUTH_INTENT_MAX_AGE,
@@ -157,19 +164,22 @@ export async function GET(request: NextRequest) {
 
       let finalDestination = next;
       let shouldClearReferralCookie = false;
+      let ssoIdentityMismatch = false;
       let authEvent = 'login';
       let authMethod = 'email';
 
       if (data.user) {
-        // TODO(sso-identity-mismatch-notice): an IdP can return an already
-        // authenticated identity that differs from the email the user typed
-        // on /auth (IdP session reuse) — they land signed in as someone else
-        // with zero indication anything unusual happened. Once the typed
-        // email travels through the redirect (query param or short-lived
-        // cookie set before the IdP hop), compare it to data.user.email here
-        // and carry a "You signed in as {actual_email}" notice through to the
-        // redirect instead of proceeding silently. See docs/ENTRA_SSO_SCIM_SETUP.md
-        // "Known behaviors & caveats".
+        // An IdP can answer our request with an identity the user never typed:
+        // if the browser already holds an IdP session for somebody else, that
+        // is who comes back, and the exchange above has just signed the browser
+        // in as them. `/auth` recorded the address we ASKED for right before
+        // the hop; this is where the two are compared, so the landing page can
+        // say who the user actually is instead of proceeding silently.
+        ssoIdentityMismatch = isSsoIdentityMismatch(
+          readSsoExpectedEmail(request.cookies.get(SSO_EXPECTED_EMAIL_COOKIE)?.value),
+          data.user.email,
+        );
+
         // Determine if this is a new user (for analytics tracking)
         const createdAt = new Date(data.user.created_at).getTime();
         const now = Date.now();
@@ -275,6 +285,12 @@ export async function GET(request: NextRequest) {
       const redirectUrl = new URL(`${baseUrl}${finalDestination}`);
       redirectUrl.searchParams.set('auth_event', authEvent);
       redirectUrl.searchParams.set('auth_method', authMethod);
+      // No address in the URL on purpose — it would land in history and in the
+      // Referer of anything the destination requests. The notice reads the
+      // address from the session it already holds.
+      if (ssoIdentityMismatch) {
+        redirectUrl.searchParams.set(SSO_IDENTITY_PARAM, SSO_IDENTITY_MISMATCH);
+      }
       const response = NextResponse.redirect(redirectUrl);
 
       // Authentication just completed, and this redirect is about to land on
@@ -287,6 +303,12 @@ export async function GET(request: NextRequest) {
         path: '/',
         sameSite: 'lax',
       });
+
+      // Unconditionally, whether or not it matched and whether or not this was
+      // even an SSO sign-in. The expectation belongs to the hop that just
+      // finished; leaving it set would let it mislabel the next sign-in on this
+      // browser.
+      response.cookies.set(SSO_EXPECTED_EMAIL_COOKIE, '', { maxAge: 0, path: '/' });
 
       // Clear stale legacy instance cookie so repo-first sessions do not inherit it after login.
       response.cookies.set(ACTIVE_INSTANCE_COOKIE, '', { maxAge: 0, path: '/' });

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -32,6 +32,7 @@ import { useAuth } from '@/features/providers/auth-provider';
 import { invalidateTokenCache, setBootstrapAuthToken } from '@/lib/auth-token';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
 import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+import { rememberSsoExpectedEmail } from '@/lib/auth/sso-identity';
 import { markPostAuthIntent } from '@/lib/onboarding/post-auth-intent';
 import { isSessionExpired } from '@/lib/auth/session-expiry';
 import {
@@ -329,6 +330,11 @@ function AuthCardForm({
         if (resolved === 'sso') {
           // Full navigation to the IdP; the callback route exchanges the
           // code on return (same PKCE path as Google OAuth).
+          //
+          // Remember who we are ASKING for. The IdP may answer with a session
+          // it already holds for somebody else, and the callback can only tell
+          // if it has this to compare against. See lib/auth/sso-identity.
+          rememberSsoExpectedEmail(address);
           window.location.href = data.url;
           return 'handled';
         }
@@ -598,6 +604,7 @@ function AuthCardForm({
             className="w-full"
             disabled={pending}
             onClick={() => {
+              rememberSsoExpectedEmail(email);
               window.location.href = ssoUrl;
             }}
           >

--- a/apps/web/src/app/(auth)/auth/sso-identity-mismatch.test.ts
+++ b/apps/web/src/app/(auth)/auth/sso-identity-mismatch.test.ts
@@ -1,0 +1,111 @@
+// The identity-mismatch notice is a three-part wiring: /auth records the
+// address it is ASKING the IdP for, the callback compares it to who came back,
+// and the notice says so. Any one of the three silently missing puts the flow
+// back to where it started — signed in as somebody else with nothing on screen
+// to say so — and none of the three fails loudly on its own. So they are
+// pinned here together.
+//
+// The comparison itself is unit-tested in lib/auth/sso-identity.test.ts; these
+// are wiring assertions, deliberately about the source text.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const authPage = readFileSync(join(import.meta.dir, 'page.tsx'), 'utf8');
+const callback = readFileSync(join(import.meta.dir, 'callback', 'route.ts'), 'utf8');
+const notice = readFileSync(
+  join(import.meta.dir, '..', '..', '..', 'features', 'auth', 'sso-identity-notice.tsx'),
+  'utf8',
+);
+const layout = readFileSync(join(import.meta.dir, '..', '..', 'layout.tsx'), 'utf8');
+
+describe('/auth records the identity it asked for', () => {
+  test('EVERY navigation to the IdP is preceded by recording the typed address', () => {
+    // Both doors reach the IdP: the enforced-SSO path navigates straight to
+    // data.url, and the interstitial navigates to ssoUrl on click. A door added
+    // later that forgets this simply reports no mismatch, which is the failure
+    // this test exists to catch.
+    const hops = authPage.match(/window\.location\.href = (data\.url|ssoUrl);/g) ?? [];
+    expect(hops.length).toBe(2);
+
+    const calls = authPage.match(/rememberSsoExpectedEmail\(/g) ?? [];
+    expect(calls.length).toBe(2);
+
+    for (const target of ['data.url', 'ssoUrl']) {
+      const at = authPage.indexOf(`window.location.href = ${target};`);
+      expect(at).toBeGreaterThan(-1);
+      // The recording must happen BEFORE the navigation, not after it — after
+      // is never reached, and a browser is under no obligation to finish it.
+      const preceding = authPage.slice(Math.max(0, at - 400), at);
+      expect(preceding).toContain('rememberSsoExpectedEmail(');
+    }
+  });
+});
+
+describe('the callback compares who came back', () => {
+  test('it compares the recorded address against the authenticated user', () => {
+    expect(callback).toContain('isSsoIdentityMismatch(');
+    expect(callback).toContain(
+      'readSsoExpectedEmail(request.cookies.get(SSO_EXPECTED_EMAIL_COOKIE)',
+    );
+    expect(callback).toContain('data.user.email');
+  });
+
+  test('the marker travels on the redirect, and the address does NOT', () => {
+    expect(callback).toContain(
+      'redirectUrl.searchParams.set(SSO_IDENTITY_PARAM, SSO_IDENTITY_MISMATCH)',
+    );
+    // Putting the signed-in address in the URL would persist it in history and
+    // leak it in the Referer of anything the landing page requests.
+    expect(callback).not.toContain(`searchParams.set(SSO_IDENTITY_PARAM, data.user.email`);
+  });
+
+  test('the expectation cookie is cleared unconditionally, not only on a mismatch', () => {
+    // A leftover expectation would mislabel the NEXT sign-in on this browser.
+    expect(callback).toContain(
+      `response.cookies.set(SSO_EXPECTED_EMAIL_COOKIE, '', { maxAge: 0, path: '/' })`,
+    );
+    const clearAt = callback.indexOf('response.cookies.set(SSO_EXPECTED_EMAIL_COOKIE');
+    const guardAt = callback.indexOf('if (ssoIdentityMismatch)');
+    expect(clearAt).toBeGreaterThan(-1);
+    // The clear sits outside the mismatch branch: it comes after the branch
+    // closes, on the response rather than inside the conditional.
+    expect(clearAt).toBeGreaterThan(guardAt);
+    const branch = callback.slice(
+      guardAt,
+      callback.indexOf('const response = NextResponse.redirect'),
+    );
+    expect(branch).not.toContain('SSO_EXPECTED_EMAIL_COOKIE');
+  });
+
+  test('the TODO it closes is gone', () => {
+    expect(callback).not.toContain('TODO(sso-identity-mismatch-notice)');
+  });
+});
+
+describe('the notice reaches the user', () => {
+  test('it is mounted globally, because the landing page is not a fixed route', () => {
+    // finalDestination can be a project, /settings/billing, an invite, or a
+    // last-project cookie path. Mounting on any one of them would miss the rest.
+    expect(layout).toContain('SsoIdentityNotice');
+    expect(layout).toContain("import('@/features/auth/sso-identity-notice')");
+  });
+
+  test('it names the account from the SESSION, not from the URL', () => {
+    expect(notice).toContain('useAuth()');
+    expect(notice).toContain('user?.email');
+  });
+
+  test('it does not expire on its own', () => {
+    expect(notice).toContain('Number.POSITIVE_INFINITY');
+  });
+
+  test('it waits for the session before naming the account', () => {
+    expect(notice).toContain('if (isLoading) return;');
+  });
+
+  test('it removes the marker from the URL so a reload does not re-notify', () => {
+    expect(notice).toContain('params.delete(SSO_IDENTITY_PARAM)');
+    expect(notice).toContain('window.history.replaceState');
+  });
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -64,6 +64,11 @@ const AuthEventTracker = lazy(() =>
     default: mod.AuthEventTracker,
   })),
 );
+const SsoIdentityNotice = lazy(() =>
+  import('@/features/auth/sso-identity-notice').then((mod) => ({
+    default: mod.SsoIdentityNotice,
+  })),
+);
 const LocalhostLinkInterceptor = lazy(() =>
   import('@/components/localhost-link-interceptor').then((mod) => ({
     default: mod.LocalhostLinkInterceptor,
@@ -414,6 +419,9 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
                     </Suspense>
                     <Suspense fallback={null}>
                       <AuthEventTracker />
+                    </Suspense>
+                    <Suspense fallback={null}>
+                      <SsoIdentityNotice />
                     </Suspense>
                     <Suspense fallback={null}>
                       <LocalhostLinkInterceptor />

--- a/apps/web/src/features/auth/sso-identity-notice.tsx
+++ b/apps/web/src/features/auth/sso-identity-notice.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+import { warningToast } from '@/components/ui/toast';
+import { useAuth } from '@/features/providers/auth-provider';
+import { SSO_IDENTITY_MISMATCH, SSO_IDENTITY_PARAM } from '@/lib/auth/sso-identity';
+
+/**
+ * Says who the user actually signed in as, when that is not who they asked for.
+ *
+ * `/auth/callback` sets `?sso_identity=mismatch` when the address returned by
+ * the IdP is not the one typed before the hop. It deliberately does not put the
+ * address in the URL, so the address is read here from the session — which is
+ * also the authoritative answer to "who am I", rather than a value that
+ * travelled through a redirect.
+ *
+ * The toast does not expire. Everything else on this surface is transient
+ * feedback the user can afford to miss; being signed in as somebody else is
+ * not, and a notice that scrolls away after three seconds is the same as no
+ * notice for a user who looked away during the IdP hop.
+ */
+export function SsoIdentityNotice() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { user, isLoading } = useAuth();
+  // React may run this effect twice for one arrival (StrictMode, a re-render
+  // while the session loads). The toast id dedupes sonner-side; this stops the
+  // URL cleanup from racing with a second pass.
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (shown.current) return;
+    if (searchParams?.get(SSO_IDENTITY_PARAM) !== SSO_IDENTITY_MISMATCH) return;
+    // The session arrives a beat after the redirect. Waiting for it is what
+    // lets the notice name the account instead of saying "someone else".
+    if (isLoading) return;
+
+    const actual = user?.email;
+    shown.current = true;
+
+    warningToast(
+      actual ? `You are signed in as ${actual}` : 'You are signed in as a different account',
+      {
+        description:
+          'Your identity provider returned a different account than the address you entered — ' +
+          'usually because a session for that account was already open in this browser. ' +
+          'Sign out and try again if this is not you.',
+        duration: Number.POSITIVE_INFINITY,
+        id: 'sso-identity-mismatch',
+      },
+    );
+
+    const params = new URLSearchParams(searchParams?.toString() || '');
+    params.delete(SSO_IDENTITY_PARAM);
+    const query = params.toString();
+    window.history.replaceState({}, '', query ? `${pathname}?${query}` : pathname);
+  }, [searchParams, pathname, user, isLoading]);
+
+  return null;
+}

--- a/apps/web/src/lib/auth/sso-identity.test.ts
+++ b/apps/web/src/lib/auth/sso-identity.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  isSsoIdentityMismatch,
+  normalizeAuthEmail,
+  readSsoExpectedEmail,
+  SSO_EXPECTED_EMAIL_COOKIE,
+  SSO_EXPECTED_EMAIL_MAX_AGE,
+  SSO_IDENTITY_MISMATCH,
+  SSO_IDENTITY_PARAM,
+} from './sso-identity';
+
+describe('normalizeAuthEmail', () => {
+  test('trims and lowercases', () => {
+    expect(normalizeAuthEmail('  Admin@Example.COM  ')).toBe('admin@example.com');
+  });
+
+  test('non-strings and blanks normalize to empty', () => {
+    for (const value of [null, undefined, '', '   ']) {
+      expect(normalizeAuthEmail(value as string | null | undefined)).toBe('');
+    }
+  });
+
+  test('an absurdly long value is discarded rather than compared', () => {
+    expect(normalizeAuthEmail(`${'a'.repeat(320)}@example.com`)).toBe('');
+  });
+});
+
+describe('isSsoIdentityMismatch', () => {
+  test('the same address in different case or padding is not a mismatch', () => {
+    expect(isSsoIdentityMismatch('admin@example.com', 'admin@example.com')).toBe(false);
+    expect(isSsoIdentityMismatch('Admin@Example.com', 'admin@example.com')).toBe(false);
+    expect(isSsoIdentityMismatch(' admin@example.com ', 'admin@example.com')).toBe(false);
+  });
+
+  test('a different address is a mismatch — the incident this exists for', () => {
+    // The admin typed their own address; the IdP reused an existing browser
+    // session and answered with a colleague's.
+    expect(isSsoIdentityMismatch('admin@example.com', 'someone.else@example.com')).toBe(true);
+  });
+
+  test('a different address on the same domain still counts', () => {
+    expect(isSsoIdentityMismatch('a@corp.com', 'b@corp.com')).toBe(true);
+  });
+
+  test('absence is never a mismatch, in either direction', () => {
+    // A password login or magic link has nothing to compare. Reporting those as
+    // mismatches would train users to dismiss the notice.
+    expect(isSsoIdentityMismatch(null, 'admin@example.com')).toBe(false);
+    expect(isSsoIdentityMismatch('admin@example.com', null)).toBe(false);
+    expect(isSsoIdentityMismatch(undefined, undefined)).toBe(false);
+    expect(isSsoIdentityMismatch('', '')).toBe(false);
+  });
+});
+
+describe('readSsoExpectedEmail', () => {
+  test('decodes what rememberSsoExpectedEmail wrote', () => {
+    expect(readSsoExpectedEmail(encodeURIComponent('admin+tag@example.com'))).toBe(
+      'admin+tag@example.com',
+    );
+  });
+
+  test('a malformed percent-escape reads as absent, not as a mismatch', () => {
+    // '%E0%A4%A' is an invalid sequence; decodeURIComponent throws on it.
+    expect(readSsoExpectedEmail('%E0%A4%A')).toBe('');
+    expect(isSsoIdentityMismatch(readSsoExpectedEmail('%E0%A4%A'), 'admin@example.com')).toBe(
+      false,
+    );
+  });
+
+  test('missing or empty reads as absent', () => {
+    expect(readSsoExpectedEmail(null)).toBe('');
+    expect(readSsoExpectedEmail(undefined)).toBe('');
+    expect(readSsoExpectedEmail('')).toBe('');
+  });
+});
+
+describe('the constants the callback and the notice agree on', () => {
+  test('the marker carries no address', () => {
+    // Keeping the signed-in address out of the URL keeps it out of history and
+    // out of the Referer of anything the landing page requests.
+    expect(SSO_IDENTITY_PARAM).toBe('sso_identity');
+    expect(SSO_IDENTITY_MISMATCH).toBe('mismatch');
+  });
+
+  test('the cookie is short-lived', () => {
+    expect(SSO_EXPECTED_EMAIL_COOKIE).toBe('kortix_sso_expected_email');
+    expect(SSO_EXPECTED_EMAIL_MAX_AGE).toBeLessThanOrEqual(60 * 30);
+    expect(SSO_EXPECTED_EMAIL_MAX_AGE).toBeGreaterThanOrEqual(60 * 5);
+  });
+});

--- a/apps/web/src/lib/auth/sso-identity.ts
+++ b/apps/web/src/lib/auth/sso-identity.ts
@@ -1,0 +1,103 @@
+/**
+ * The SSO identity-mismatch notice.
+ *
+ * An identity provider does not have to return the identity the user asked for.
+ * If the browser already holds an IdP session for someone else, the IdP can
+ * answer our SAML request with THAT person — a valid assertion for an identity
+ * the user never typed. Supabase exchanges it, the callback signs the browser
+ * in as that account, and nothing on screen says so. Observed live: an admin
+ * registered their own domain on a test provider, signed in, and came back
+ * authenticated as a different person with no indication anything unusual had
+ * happened. See docs/ENTRA_SSO_SCIM_SETUP.md.
+ *
+ * The fix is to remember what the user typed BEFORE the IdP hop and compare it
+ * to who came back. This module is that comparison and nothing else.
+ *
+ * Two properties hold deliberately:
+ *
+ *  - **Nothing here authorizes anything.** The cookie is a display hint. No
+ *    session, route, or permission decision reads it. Deleting it, forging it,
+ *    or replaying it changes only whether a notice is drawn — never who the
+ *    user is signed in as. That is why a plain client-set cookie is enough.
+ *  - **It fails open, never loud.** A missing or unreadable value yields "no
+ *    mismatch". A notice that cries wolf on every ordinary login is a notice
+ *    people learn to click through, which would cost more than it buys.
+ */
+
+/** Short-lived, set client-side immediately before navigating to the IdP. */
+export const SSO_EXPECTED_EMAIL_COOKIE = 'kortix_sso_expected_email';
+
+/**
+ * Fifteen minutes. Long enough for a slow IdP hop — a password page, an MFA
+ * push, a device-compliance check — and short enough that an abandoned attempt
+ * cannot still be sitting there to mislabel an unrelated sign-in an hour later.
+ * The callback also clears it unconditionally, so this bound only covers the
+ * case where the user never comes back at all.
+ */
+export const SSO_EXPECTED_EMAIL_MAX_AGE = 60 * 15;
+
+/**
+ * Marks the post-auth redirect. Carries no address on purpose: the signed-in
+ * email would otherwise sit in the URL bar, in browser history, and in the
+ * Referer of anything the landing page requests. The notice reads the address
+ * from the session it already has instead.
+ */
+export const SSO_IDENTITY_PARAM = 'sso_identity';
+export const SSO_IDENTITY_MISMATCH = 'mismatch';
+
+/** Longer than any address worth comparing; a guard against a junk cookie. */
+const MAX_EMAIL_LENGTH = 320;
+
+export function normalizeAuthEmail(value: string | null | undefined): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_EMAIL_LENGTH) return '';
+  return trimmed.toLowerCase();
+}
+
+/**
+ * True only when both addresses are present AND differ.
+ *
+ * Absence is not evidence: a password login, a magic link, or a cleared cookie
+ * all arrive with nothing to compare, and none of them is a mismatch.
+ */
+export function isSsoIdentityMismatch(
+  expected: string | null | undefined,
+  actual: string | null | undefined,
+): boolean {
+  const typed = normalizeAuthEmail(expected);
+  const returned = normalizeAuthEmail(actual);
+  if (!typed || !returned) return false;
+  return typed !== returned;
+}
+
+/** Decode a cookie value written by `rememberSsoExpectedEmail`. */
+export function readSsoExpectedEmail(raw: string | null | undefined): string {
+  if (typeof raw !== 'string' || !raw) return '';
+  let value = raw;
+  try {
+    value = decodeURIComponent(raw);
+  } catch {
+    // A malformed value is treated as absent, not as a mismatch.
+    return '';
+  }
+  return normalizeAuthEmail(value);
+}
+
+/**
+ * Remember the typed address just before `window.location` leaves for the IdP.
+ *
+ * Client-side by necessity — the navigation to the IdP is client-initiated, so
+ * there is no response of ours to attach a Set-Cookie to. `SameSite=Lax` is
+ * what makes it survive the IdP's top-level GET redirect back to /auth/callback.
+ */
+export function rememberSsoExpectedEmail(email: string | null | undefined): void {
+  if (typeof document === 'undefined') return;
+  const normalized = normalizeAuthEmail(email);
+  if (!normalized) return;
+  const secure =
+    typeof location !== 'undefined' && location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie =
+    `${SSO_EXPECTED_EMAIL_COOKIE}=${encodeURIComponent(normalized)}` +
+    `; Max-Age=${SSO_EXPECTED_EMAIL_MAX_AGE}; Path=/; SameSite=Lax${secure}`;
+}

--- a/docs/ENTRA_SSO_SCIM_SETUP.md
+++ b/docs/ENTRA_SSO_SCIM_SETUP.md
@@ -305,11 +305,18 @@ These mirror the automated integration tests
   *different* person because the IdP reused an existing browser SSO session
   (IdP session reuse) — not a Kortix bug, but genuinely confusing from the
   Kortix side with no explanation shown.
-  `TODO(sso-identity-mismatch-notice)`: after an SSO return, if the
-  authenticated identity differs from the email the user originally typed on
-  `/auth`, surface a "You signed in as `{actual_email}`" notice instead of
-  silently proceeding as that account. Land this in the `/auth/callback`
-  route (`apps/web/src/app/(auth)/auth/callback/route.ts`) — it already has
-  `data.user` post-exchange; it would need the originally-typed email carried
-  through the redirect (query param or short-lived cookie set before the
-  IdP hop) to compare against.
+  **This now surfaces a notice.** `/auth` records the address it is asking the
+  IdP for in a short-lived `kortix_sso_expected_email` cookie immediately
+  before the hop; `/auth/callback` compares it to `data.user.email` after the
+  exchange and, when they differ, marks the redirect with
+  `?sso_identity=mismatch`. The landing page then shows a non-expiring "You are
+  signed in as `{actual_email}`" warning naming the account. The address is
+  read from the session rather than carried in the URL, so it does not persist
+  in browser history or leak through the `Referer` of anything the landing page
+  requests, and the cookie is cleared on every callback so a stale expectation
+  cannot mislabel a later sign-in.
+
+  The comparison is advisory: it is a notice, not a gate. Nothing about the
+  session depends on the cookie, so a missing or tampered value changes only
+  whether the notice is drawn — it can never change who is signed in. See
+  `apps/web/src/lib/auth/sso-identity.ts`.


### PR DESCRIPTION
## Summary

An identity provider does not have to return the identity we asked for.

If the browser already holds an IdP session for a different person, the IdP answers our SAML request with **that** person — a perfectly valid assertion for an identity the user never typed. `/auth/callback` exchanges it, the browser is signed in as that account, and nothing on screen says so. The user believes they are themselves.

This is recorded in `docs/ENTRA_SSO_SCIM_SETUP.md` as something that already happened:

> Live incident: an admin registered their own domain on a test provider and their next sign-in was silently routed to the IdP, then came back authenticated as a *different* person because the IdP reused an existing browser SSO session (IdP session reuse) — not a Kortix bug, but genuinely confusing from the Kortix side with no explanation shown.

The route has carried the fix as a marked TODO since:

```ts
// TODO(sso-identity-mismatch-notice): an IdP can return an already
// authenticated identity that differs from the email the user typed
// on /auth (IdP session reuse) — they land signed in as someone else
// with zero indication anything unusual happened.
```

This closes it. The TODO is removed from both the route and the doc.

### Why it matters beyond confusion

The account the user lands in is a real account with real access. On a shared or kiosk browser — the case that produces a lingering IdP session in the first place — the sequence is: person A authenticates through the IdP and walks away; person B types their own address; the IdP recognises A's session and returns A; B is now operating as A, with A's projects, A's connectors and A's billing, having typed their own address and been told nothing. Everything the platform does afterwards is correctly authorized — for A. The gap is not authorization, it is that **nobody is told which identity won**.

## How it works

Three pieces, each doing one thing:

**1. `/auth` records the identity it is asking for** — a short-lived `kortix_sso_expected_email` cookie set immediately before the hop. There are two doors to the IdP and both are wired: the enforced-SSO redirect (`window.location.href = data.url`) and the interstitial's "Continue with SSO" button (`= ssoUrl`).

**2. `/auth/callback` compares** the recorded address against `data.user.email` after the exchange, and on a difference marks the redirect with `?sso_identity=mismatch`.

**3. The notice names the account** — a non-expiring warning, mounted globally.

### Three deliberate properties

**Nothing here authorizes anything.** The cookie is a display hint. No session, route, or permission decision reads it. Forging it, deleting it, or replaying it changes only whether a notice is drawn — never who the user is signed in as. That is precisely what makes a plain client-set cookie sufficient here, and it is why this adds no new trust boundary to review.

**It fails open, never loud.** A missing, malformed, or unreadable value reports *no mismatch*. `readSsoExpectedEmail` swallows a `decodeURIComponent` throw and returns `''`; `isSsoIdentityMismatch` requires **both** sides present before it will claim anything. A notice that fires on ordinary password logins is one users learn to click through, which would cost more than it buys.

**The address never enters the URL.** Putting the signed-in address in the query string would persist it in browser history and leak it through the `Referer` of anything the landing page requests. So the marker is a bare flag, and the notice reads the address from the session it already holds via `useAuth()` — which is also the authoritative answer to "who am I", rather than a value that travelled back through a redirect.

Supporting details:

- `SameSite=Lax` is what lets the cookie survive the IdP's top-level GET redirect back to `/auth/callback`. `Secure` is set on https.
- Cleared on **every** callback, matched or not, SSO or not — a stale expectation would otherwise mislabel the next sign-in on the same browser.
- 15-minute TTL covers a slow hop (password page, MFA push, device-compliance check) without leaving an abandoned attempt able to mislabel something an hour later.
- The notice is mounted in the root layout because the post-auth destination is not a fixed route — it can be a project, `/settings/billing`, an invite, or a last-project cookie path. Mounting on any one of them would miss the rest.

### Scope

Advisory, not a gate: it reports, it does not sign anyone out. Turning this into a hard interstitial ("this isn't you — sign out?") is a product decision I did not want to take unilaterally, and it is a small change on top of this if you want it.

| File | |
|---|---|
| `lib/auth/sso-identity.ts` | new — constants and the pure comparison |
| `lib/auth/sso-identity.test.ts` | new — unit tests for the comparison |
| `features/auth/sso-identity-notice.tsx` | new — the notice |
| `app/(auth)/auth/sso-identity-mismatch.test.ts` | new — wiring tests |
| `app/(auth)/auth/page.tsx` | +7 — record before both IdP hops |
| `app/(auth)/auth/callback/route.ts` | compare, mark, clear (TODO removed) |
| `app/layout.tsx` | +8 — mount the notice |
| `docs/ENTRA_SSO_SCIM_SETUP.md` | TODO replaced with the shipped behaviour |

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [x] Security fix
- [ ] Breaking change

## How was this tested?

**Full `apps/web` suite:**

| | tests | pass | fail |
|---|---|---|---|
| `main` | 8090 | 8090 | 0 |
| this branch | 8112 | **8112** | **0** |

+22 new tests, nothing else moved.

**The new tests are not vacuous** — I broke the wiring two ways and confirmed each is caught:

| Breakage introduced | Result |
|---|---|
| Removed `rememberSsoExpectedEmail` before the enforced-SSO hop | `(fail) EVERY navigation to the IdP is preceded by recording the typed address` |
| Moved the cookie clear inside the mismatch branch | `(fail) the expectation cookie is cleared unconditionally, not only on a mismatch` |

Both restored, suite back to 22/22 on those two files.

The second is the one worth having: clearing only on a mismatch leaves a stale expectation that mislabels the *next* sign-in on that browser — a bug that would present as the notice firing at random for users who never touched SSO.

**Gates, all run locally:**

- `eslint src --quiet` (the CI lint gate) — clean
- `bun test src/sdk-boundary.test.ts` (the CI boundary gate) — pass
- `pnpm --filter ./apps/web build` — **exit 0**, compiled successfully
- `tsc --noEmit` — 17 pre-existing errors on `main`, **17** on this branch; none in any touched file
- `prettier --check` — all four new files clean. The two modified files (`page.tsx`, `callback/route.ts`) warn identically **before and after** this change; I deliberately did not reformat them, which would have buried a 60-line diff in a whole-file reflow.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control) — no endpoint added; and see above, nothing here participates in an authorization decision
- [x] User input is validated (e.g. Zod) and output is safe — the cookie is normalized, length-capped at 320, and decode failures are swallowed to `''`; it is only ever compared, never rendered or forwarded
- [x] No sensitive data (tokens, PII, secrets) is written to logs — nothing logged; the address is deliberately kept out of the URL for the same reason
- [x] DB schema / migration changes are reviewed and reversible — n/a
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner — **yes, this touches the auth callback**; flagging for the code owner explicitly

Threat notes for review:

- *Attacker controls the cookie* → they change whether a warning appears on their own browser. No session or permission consequence.
- *Attacker suppresses the notice* (clears the cookie mid-flow) → returns today's behaviour, which is silence. Strictly not worse than main.
- *Attacker forges a mismatch* → a warning naming the account the victim is genuinely signed in as. True information.
- *Cookie leaks* → it holds an address the user typed on the previous screen; no credential, no token.

## Rollout / rollback

No migrations, feature flags, or env vars. Reverting the commit removes the notice and restores today's silent behaviour; the cookie expires on its own within 15 minutes and is cleared by any subsequent callback.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied
