### PR TITLE
test(browser): await account render before retry

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### A selective capacity release must include the pool isolation it budgets (2026-08-22)
+
+**When:** selecting database-capacity commits for a release. Do not ship pool
+arithmetic without every pool and writer that arithmetic assumes. Verify the
+release tree, not `main`, contains the dedicated pool and its call sites.
+*Incident:* staging release `2e01bad2` included the bounded connection budget
+but omitted PR #6702. All 6 API shards returned `503` while 14-23 slow audit
+inserts occupied the shared pools. *Enforcer:* `database-capacity.test.ts`
+reads `audit-db.ts` and every high-volume writer from the release tree.
+
 ### A browser retry must wait for the result it is retrying (2026-08-22)
 
 **When:** retrying a client-rendered page after an eventually consistent write.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### A browser retry must wait for the result it is retrying (2026-08-22)
+
+**When:** retrying a client-rendered page after an eventually consistent write.
+`domcontentloaded` does not mean that React consumed the API response. Wait for
+the exact response and the final DOM state before the next navigation. A poll
+that reloads immediately can abort every successful render itself.
+*Near-miss:* PR #6724 failed browser-1 twice while every repeated account read
+returned `200`. *Enforcer:* `08-accounts-project-access.spec.ts` waits for the
+exact account response and the visible `Members` heading on each attempt.
+
 ### Mint every OpenCode message id with the native sortable codec (2026-08-22)
 
 **When:** delivering an initial, queued, retried, or imported OpenCode prompt.

--- a/apps/api/src/shared/database-capacity.test.ts
+++ b/apps/api/src/shared/database-capacity.test.ts
@@ -20,6 +20,21 @@ describe('production database connection capacity', () => {
     expect(SCHEMA_CHECK_POOL_MAX).toBe(1);
   });
 
+  test('keeps high-volume audit writers on the bounded audit pool', () => {
+    const auditDb = readFileSync(new URL('./audit-db.ts', import.meta.url), 'utf8');
+    expect(auditDb).toContain("import { DEFAULT_AUDIT_POOL_MAX } from './database-capacity'");
+    expect(auditDb).toContain("intFromEnv('DB_AUDIT_POOL_MAX', DEFAULT_AUDIT_POOL_MAX)");
+
+    for (const relativePath of [
+      '../projects/routes/project-audit.ts',
+      './audit.ts',
+      './gateway-logs.ts',
+    ]) {
+      const writer = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+      expect(writer).toContain('auditDb()');
+    }
+  });
+
   test('keeps a maximum rolling deployment below the usable PostgreSQL limit', () => {
     expect(PROD_API_MAX_TASKS).toBe(10);
     expect(ROLLING_TASK_OVERLAP).toBe(2);

--- a/tests/e2e/specs/08-accounts-project-access.spec.ts
+++ b/tests/e2e/specs/08-accounts-project-access.spec.ts
@@ -859,15 +859,32 @@ test.describe("08 — Accounts, invites, and project access", { tag: "@quarantin
     // (see IAM_PROPAGATION_MS). A task that has not seen it answers
     // `GET /accounts/:id` with 403, and the hub then sits on its loading
     // skeleton forever rather than erroring — so reload until it renders.
+    const invitedMembersHeading = page.getByRole("heading", {
+      name: "Members",
+      exact: true,
+    });
     await expect
       .poll(
         async () => {
+          const accountResponse = page
+            .waitForResponse(
+              (response) => {
+                const url = new URL(response.url());
+                return (
+                  response.request().method() === "GET" &&
+                  url.pathname === `/v1/accounts/${account.account_id}`
+                );
+              },
+              { timeout: 5_000 },
+            )
+            .catch(() => null);
           await page.goto(`/accounts/${account.account_id}`, {
             waitUntil: "domcontentloaded",
           });
-          return page
-            .getByRole("heading", { name: "Members", exact: true })
-            .isVisible()
+          if ((await accountResponse)?.status() !== 200) return false;
+          return invitedMembersHeading
+            .waitFor({ state: "visible", timeout: 5_000 })
+            .then(() => true)
             .catch(() => false);
         },
         { timeout: IAM_PROPAGATION_MS },


### PR DESCRIPTION
## Incidents

1. The deployed account-access journey reloaded after `domcontentloaded`. React had not consumed the successful account response yet.
2. The selective staging release included the database budget from #6722 but omitted audit isolation from #6702. All 6 API shards returned `503` while slow audit inserts occupied shared pools.

## Change

- Wait for the exact account detail response and HTTP 200.
- Wait for the visible `Members` heading before another retry.
- Pin the dedicated audit pool and every high-volume audit writer in `database-capacity.test.ts`.
- Record both incident rules in the append-only learning register.

## Verification

- Browser source commit: 8 passed, 3 skipped, 0 failed.
- Database capacity, audit queue, and OpenCode ingestion: 30 passed, 0 failed.
- Project audit ingestion: 4 passed, 0 failed.
- API typecheck: passed.
- Self-host compose assets: 57 passed, 0 failed.

This PR carries release-only tests and incident rules back to `main`. Production fixes #6702, #6715, and #6722 are already on `main`.