### PR TITLE
fix(release): isolate audit writes from API database pool

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### A selective capacity release must include the pool isolation it budgets (2026-08-22)
+
+**When:** selecting database-capacity commits for a release. Do not ship pool
+arithmetic without every pool and writer that arithmetic assumes. Verify the
+release tree, not `main`, contains the dedicated pool and its call sites.
+*Incident:* staging release `2e01bad2` included the bounded connection budget
+but omitted PR #6702. All 6 API shards returned `503` while 14-23 slow audit
+inserts occupied the shared pools. *Enforcer:* `database-capacity.test.ts`
+reads `audit-db.ts` and every high-volume writer from the release tree.
+
 ### A browser retry must wait for the result it is retrying (2026-08-22)
 
 **When:** retrying a client-rendered page after an eventually consistent write.

--- a/apps/api/src/projects/routes/project-audit.ts
+++ b/apps/api/src/projects/routes/project-audit.ts
@@ -7,6 +7,7 @@ import { PROJECT_ACTIONS } from '../../iam';
 import { approvalPageUrl } from '../../setup-links/token';
 import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
+import { auditDb } from '../../shared/audit-db';
 import { createRoute, z } from '@hono/zod-openapi';
 import { auditEvents, connectors, connectorCalls, projectSessions, sessionSandboxes, serviceAccounts } from '@kortix/db';
 import { and, asc, desc, eq, gt, inArray, isNull, or } from 'drizzle-orm';
@@ -285,7 +286,7 @@ projectsApp.openapi(
       return c.json({ accepted: parsed.accepted, inserted: 0, duplicates: 0, suppressed });
     }
 
-    const inserted = await db
+    const inserted = await auditDb()
       .insert(auditEvents)
       .values(toInsert)
       .onConflictDoNothing()

--- a/apps/api/src/shared/audit-db.ts
+++ b/apps/api/src/shared/audit-db.ts
@@ -1,0 +1,65 @@
+import type { Database } from '@kortix/db';
+import { config } from '../config';
+import { DEFAULT_AUDIT_POOL_MAX } from './database-capacity';
+import { db } from './db';
+
+/**
+ * The dedicated audit-write pool.
+ *
+ * Why a SEPARATE pool (prod incident, Essentia box 2026-08-21): every audit
+ * insert serializes through a per-session `FOR UPDATE` row lock in the
+ * `audit_prepare_event` trigger; under a burst those inserts convoy for 4-24s
+ * each. On the SHARED `db` pool that pinned connections the gateway's auth query
+ * (and every app query) needed, so a slow audit write starved the hot path and
+ * the upstream closed the socket → Caddy "Bad Gateway" (EOF). Isolating audit
+ * writes onto their own small pool means the convoy can degrade audit
+ * completeness (best-effort by design) but can NEVER starve auth/app traffic.
+ * The shorter statement_timeout caps how long a blocked audit insert holds its
+ * backend, so this pool self-drains every ~10s instead of riding the main 25s.
+ *
+ * Use ONLY for the audit event queue flush, OpenCode audit ingestion, and
+ * gateway_request_logs writes (whose trigger fans out an audit row). Never route
+ * auth/app/billing queries here.
+ */
+function intFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+const AUDIT_POOL_MAX = intFromEnv('DB_AUDIT_POOL_MAX', DEFAULT_AUDIT_POOL_MAX);
+const AUDIT_STATEMENT_TIMEOUT_MS = intFromEnv('DB_AUDIT_STATEMENT_TIMEOUT_MS', 10_000);
+
+let dedicatedPool: Database | null = null;
+function dedicated(): Database {
+  if (!dedicatedPool) {
+    // Lazy require, NOT a top-level `import { createDb }`: dedicated() only runs
+    // in production (auditDb() returns `db` when NODE_ENV=test), and the ~3 unit
+    // tests that mock '@kortix/db' without createDb would SyntaxError on a
+    // load-time value import. Resolving it here keeps them untouched.
+    const { createDb } = require('@kortix/db') as typeof import('@kortix/db');
+    dedicatedPool = createDb(config.DATABASE_URL, {
+      max: AUDIT_POOL_MAX,
+      connection: { statement_timeout: AUDIT_STATEMENT_TIMEOUT_MS },
+    });
+  }
+  return dedicatedPool;
+}
+
+/**
+ * Resolve the audit client. In production (a real DATABASE_URL, NODE_ENV not
+ * `test`) this is the dedicated isolated pool. In unit tests it is the main
+ * `db` export — which the ~120 suites that `mock.module('../shared/db', …)`
+ * replace, so audit writes route to their mock with NO mock changes.
+ *
+ * Resolved PER CALL, never captured at module load: `db` is a live ESM binding
+ * and mock.module is applied AFTER a test's hoisted imports have already
+ * evaluated this module, so a load-time `const` would snapshot the real pool
+ * before the mock exists. This is also why we do NOT `import * as` the db module
+ * — a namespace import forces the real module to evaluate and defeats the mock
+ * for every importer.
+ */
+export function auditDb(): Database {
+  return config.DATABASE_URL && process.env.NODE_ENV !== 'test' ? dedicated() : db;
+}

--- a/apps/api/src/shared/audit-queue.test.ts
+++ b/apps/api/src/shared/audit-queue.test.ts
@@ -67,7 +67,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 describe('AuditQueue', () => {
   test('defaults match the documented tuning', () => {
     expect(AUDIT_FLUSH_MS_DEFAULT).toBe(250);
-    expect(AUDIT_FLUSH_MAX_DEFAULT).toBe(500);
+    expect(AUDIT_FLUSH_MAX_DEFAULT).toBe(100);
     expect(AUDIT_QUEUE_MAX_DEFAULT).toBe(5_000);
   });
 

--- a/apps/api/src/shared/audit-queue.ts
+++ b/apps/api/src/shared/audit-queue.ts
@@ -45,7 +45,11 @@ export interface AuditQueueOptions {
 }
 
 export const AUDIT_FLUSH_MS_DEFAULT = 250;
-export const AUDIT_FLUSH_MAX_DEFAULT = 500;
+// 100, lowered from 500 (Essentia convoy fix): each row's BEFORE INSERT trigger
+// takes a per-session FOR UPDATE lock held to the batch's COMMIT, so a large
+// batch holds every touched session's lock for the whole commit and cross-blocks
+// the other replica. Smaller batches commit sooner. Tunable via KORTIX_AUDIT_FLUSH_MAX.
+export const AUDIT_FLUSH_MAX_DEFAULT = 100;
 export const AUDIT_QUEUE_MAX_DEFAULT = 5_000;
 const DROP_LOG_INTERVAL_MS = 60_000;
 

--- a/apps/api/src/shared/audit.ts
+++ b/apps/api/src/shared/audit.ts
@@ -6,6 +6,7 @@ import type { AppEnv } from '../types';
 import { normalizeAuditClientSource } from './audit-client-source';
 import { type AuditRow, getAuditQueue } from './audit-queue';
 import { db } from './db';
+import { auditDb } from './audit-db';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const SKIPPED_PATHS = new Set(['/v1/health', '/v1/openapi.json', '/v1/docs']);
@@ -403,22 +404,22 @@ function auditWritesAreSynchronous(): boolean {
  */
 export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
   if (auditWritesAreSynchronous()) {
-    await insertAuditEvent(db, input);
+    await insertAuditEvent(auditDb(), input);
     return;
   }
-  getAuditQueue(db).enqueue(buildAuditRow(input));
+  getAuditQueue(auditDb()).enqueue(buildAuditRow(input));
 }
 
 /** Drain buffered audit events. Called on shutdown and by tests. */
 export async function flushAuditEvents(): Promise<void> {
   if (auditWritesAreSynchronous()) return;
-  await getAuditQueue(db).flush();
+  await getAuditQueue(auditDb()).flush();
 }
 
 /** Flush and stop the flush timer. Shutdown path only. */
 export async function shutdownAuditEvents(): Promise<void> {
   if (auditWritesAreSynchronous()) return;
-  await getAuditQueue(db).shutdown();
+  await getAuditQueue(auditDb()).shutdown();
 }
 
 /**

--- a/apps/api/src/shared/database-capacity.test.ts
+++ b/apps/api/src/shared/database-capacity.test.ts
@@ -20,6 +20,21 @@ describe('production database connection capacity', () => {
     expect(SCHEMA_CHECK_POOL_MAX).toBe(1);
   });
 
+  test('keeps high-volume audit writers on the bounded audit pool', () => {
+    const auditDb = readFileSync(new URL('./audit-db.ts', import.meta.url), 'utf8');
+    expect(auditDb).toContain("import { DEFAULT_AUDIT_POOL_MAX } from './database-capacity'");
+    expect(auditDb).toContain("intFromEnv('DB_AUDIT_POOL_MAX', DEFAULT_AUDIT_POOL_MAX)");
+
+    for (const relativePath of [
+      '../projects/routes/project-audit.ts',
+      './audit.ts',
+      './gateway-logs.ts',
+    ]) {
+      const writer = readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+      expect(writer).toContain('auditDb()');
+    }
+  });
+
   test('keeps a maximum rolling deployment below the usable PostgreSQL limit', () => {
     expect(PROD_API_MAX_TASKS).toBe(10);
     expect(ROLLING_TASK_OVERLAP).toBe(2);

--- a/apps/api/src/shared/gateway-logs.ts
+++ b/apps/api/src/shared/gateway-logs.ts
@@ -1,11 +1,14 @@
 import { gatewayRequestLogs } from '@kortix/db';
-import { db } from './db';
+// The gateway_request_logs write's AFTER-INSERT trigger fans out an audit row,
+// so route it through the isolated audit pool — its convoy must never starve the
+// gateway's own auth query (the "Bad Gateway"/EOF root cause). See audit-db.ts.
+import { auditDb } from './audit-db';
 import { buildGatewayTraceRow, type GatewayTraceInput } from './gateway-trace-row';
 
 export type { GatewayTraceInput };
 
 export async function recordGatewayTrace(input: GatewayTraceInput): Promise<void> {
-  await db
+  await auditDb()
     .insert(gatewayRequestLogs)
     .values(buildGatewayTraceRow(input))
     .onConflictDoNothing({ target: gatewayRequestLogs.requestId });

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -335,6 +335,28 @@ describe('full self-host Docker distribution', () => {
     expect(caddyfile).toContain('fail_duration');
   });
 
+  test('supabase-db gets tunable max_connections headroom (injected, not vendored) so the stack scales past ~4 api replicas', () => {
+    const rendered = renderFullDockerCompose('kortix-default', { domainConfigured: true });
+    // Rendered compose carries the override (injected in renderFullDockerCompose,
+    // NOT in the upstream-locked vendored docker-compose.yml — the separate
+    // upstream-lock test above guards that the vendored file stays pristine).
+    expect(rendered).toContain('max_connections=${POSTGRES_MAX_CONNECTIONS:-200}');
+    // It rides the postgres command, right after the config_file arg.
+    expect(rendered).toContain('config_file=/etc/postgresql/postgresql.conf');
+  });
+
+  test('every replicated upstream carries in-request retry so a recreate-window pick failure is retried, not 502ed', () => {
+    const caddyfile = kortixRuntimeAssets.Caddyfile;
+    // One lb_try_duration/lb_try_interval per replicated app upstream
+    // (api, gateway, frontend). Dial-level failures (connection refused / no
+    // upstreams available) are retried against the healthy replica — POST-safe
+    // because the upstream never received the request. See the Bad-Gateway fix.
+    expect((caddyfile.match(/lb_try_duration 5s/g) ?? []).length).toBe(3);
+    expect((caddyfile.match(/lb_try_interval 250ms/g) ?? []).length).toBe(3);
+    // No raw retry_match that would unsafely replay a non-idempotent POST.
+    expect(caddyfile).not.toContain('retry_match');
+  });
+
   test('Caddyfile sends a conservative HSTS header (no preload) on both site blocks', () => {
     const caddyfile = kortixRuntimeAssets.Caddyfile;
     const matches = [...caddyfile.matchAll(/Strict-Transport-Security "([^"]+)"/g)];

--- a/apps/cli/src/self-host/assets/Caddyfile.txt
+++ b/apps/cli/src/self-host/assets/Caddyfile.txt
@@ -17,6 +17,20 @@
 # until it starts passing; `fail_duration` additionally ejects a replica for a
 # few seconds after any failed proxy attempt (passive check) as a second line
 # of defense, e.g. mid-way through a container being stopped.
+#
+# In-request retry (Essentia "Bad Gateway" fix, 2026-08-21): every app upstream
+# carries `lb_try_duration`/`lb_try_interval` so a single failed pick during a
+# container recreate window — `dial tcp: connection refused` (an old/not-ready
+# IP) or `no upstreams available` (both replicas momentarily failing the active
+# check) — is retried against the healthy replica instead of returning 502 to
+# the client. Caddy retries these dial-level failures for EVERY method including
+# POST, because the upstream never received the request, so there is no
+# duplicate-turn risk. Write-side failures after bytes were sent (EOF/reset) are
+# still only retried for idempotent GET/HEAD by Caddy's default and are NOT
+# force-retried here — a re-sent chat/turn/prompt POST could double-charge.
+# Health/eject cadence is tightened (`health_interval 3s`, `refresh 2s`,
+# `fail_duration 30s`) so the recreate window that produces those failures is
+# small and a torn-down replica stays parked well past it.
 {
 	email {$KORTIX_ACME_EMAIL}
 }
@@ -39,13 +53,15 @@
 			dynamic a {
 				name llm-gateway
 				port 8090
-				refresh 5s
+				refresh 2s
 			}
 			lb_policy round_robin
-			fail_duration 10s
+			lb_try_duration 5s
+			lb_try_interval 250ms
+			fail_duration 30s
 			health_uri /health
-			health_interval 10s
-			health_timeout 5s
+			health_interval 3s
+			health_timeout 2s
 		}
 	}
 	handle {
@@ -53,13 +69,15 @@
 			dynamic a {
 				name kortix-api
 				port 8008
-				refresh 5s
+				refresh 2s
 			}
 			lb_policy round_robin
-			fail_duration 10s
+			lb_try_duration 5s
+			lb_try_interval 250ms
+			fail_duration 30s
 			health_uri /v1/health
-			health_interval 10s
-			health_timeout 5s
+			health_interval 3s
+			health_timeout 2s
 		}
 	}
 }
@@ -74,7 +92,7 @@
 	@supabase path /rest/v1* /auth/v1* /storage/v1* /realtime/v1* /functions/v1* /graphql/v1*
 	handle @supabase {
 		reverse_proxy supabase-kong:8000 {
-			fail_duration 10s
+			fail_duration 30s
 		}
 	}
 	handle {
@@ -82,13 +100,15 @@
 			dynamic a {
 				name frontend
 				port 3000
-				refresh 5s
+				refresh 2s
 			}
 			lb_policy round_robin
-			fail_duration 10s
+			lb_try_duration 5s
+			lb_try_interval 250ms
+			fail_duration 30s
 			health_uri /
-			health_interval 10s
-			health_timeout 5s
+			health_interval 3s
+			health_timeout 2s
 		}
 	}
 }

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -153,53 +153,6 @@ const APPS_SITE_BLOCK = `# *.<apps base domain>: every deployed Kortix App, serv
 	}
 }`;
 
-/**
- * The wildcard preview-serving site block. Every sandbox port a browser can
- * open publishes on <env>-p<port>-<sandbox-label>.{$KORTIX_PREVIEW_BASE_DOMAIN},
- * so the app is alone on its own origin and root-absolute links, XHR to `/api`,
- * `history.pushState`, service workers and WebSockets all resolve to the origin
- * the browser is already on — none of which survive a path prefix.
- *
- * The API matches the real Host header (KORTIX_PREVIEW_ALLOW_DIRECT_EDGE=true —
- * this reverse proxy is the trust boundary, there is no Cloudflare Worker to
- * sign the claim). Caddy preserves the inbound Host and sets X-Forwarded-Proto
- * by default, so resolvePreviewHost(Host) names the right sandbox and port with
- * no header_up override.
- *
- * TLS is issued PER HOSTNAME on first request; a 2nd-level wildcard certificate
- * is as impractical here as it is for Apps.
- *
- * Caddy's reverse_proxy passes WebSocket upgrades through unchanged, which the
- * API needs — a dev server's hot reload opens one, and it is the only
- * credential-carrying request an app's own code can make.
- */
-const PREVIEW_SITE_BLOCK = `# *.<preview base domain>: one origin per sandbox port, served over
-# per-hostname on-demand TLS. Only present when KORTIX_PREVIEW_BASE_DOMAIN is
-# configured — see renderCaddyfile() in compose-assets.ts. The global
-# on_demand_tls \`ask\` above bounds certificate issuance to real preview hosts.
-*.{$KORTIX_PREVIEW_BASE_DOMAIN} {
-	header Strict-Transport-Security "max-age=2592000"
-
-	tls {
-		on_demand
-	}
-
-	reverse_proxy {
-		dynamic a {
-			name kortix-api
-			port 8008
-			refresh 2s
-		}
-		lb_policy round_robin
-		lb_try_duration 5s
-		lb_try_interval 250ms
-		fail_duration 30s
-		health_uri /v1/health
-		health_interval 3s
-		health_timeout 2s
-	}
-}`;
-
 export interface RenderCaddyfileOptions {
   /**
    * Whether Apps hosting is configured (KORTIX_APPS_BASE_DOMAIN is set). When

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -141,13 +141,62 @@ const APPS_SITE_BLOCK = `# *.<apps base domain>: every deployed Kortix App, serv
 		dynamic a {
 			name kortix-api
 			port 8008
-			refresh 5s
+			refresh 2s
 		}
 		lb_policy round_robin
-		fail_duration 10s
+		lb_try_duration 5s
+		lb_try_interval 250ms
+		fail_duration 30s
 		health_uri /v1/health
-		health_interval 10s
-		health_timeout 5s
+		health_interval 3s
+		health_timeout 2s
+	}
+}`;
+
+/**
+ * The wildcard preview-serving site block. Every sandbox port a browser can
+ * open publishes on <env>-p<port>-<sandbox-label>.{$KORTIX_PREVIEW_BASE_DOMAIN},
+ * so the app is alone on its own origin and root-absolute links, XHR to `/api`,
+ * `history.pushState`, service workers and WebSockets all resolve to the origin
+ * the browser is already on — none of which survive a path prefix.
+ *
+ * The API matches the real Host header (KORTIX_PREVIEW_ALLOW_DIRECT_EDGE=true —
+ * this reverse proxy is the trust boundary, there is no Cloudflare Worker to
+ * sign the claim). Caddy preserves the inbound Host and sets X-Forwarded-Proto
+ * by default, so resolvePreviewHost(Host) names the right sandbox and port with
+ * no header_up override.
+ *
+ * TLS is issued PER HOSTNAME on first request; a 2nd-level wildcard certificate
+ * is as impractical here as it is for Apps.
+ *
+ * Caddy's reverse_proxy passes WebSocket upgrades through unchanged, which the
+ * API needs — a dev server's hot reload opens one, and it is the only
+ * credential-carrying request an app's own code can make.
+ */
+const PREVIEW_SITE_BLOCK = `# *.<preview base domain>: one origin per sandbox port, served over
+# per-hostname on-demand TLS. Only present when KORTIX_PREVIEW_BASE_DOMAIN is
+# configured — see renderCaddyfile() in compose-assets.ts. The global
+# on_demand_tls \`ask\` above bounds certificate issuance to real preview hosts.
+*.{$KORTIX_PREVIEW_BASE_DOMAIN} {
+	header Strict-Transport-Security "max-age=2592000"
+
+	tls {
+		on_demand
+	}
+
+	reverse_proxy {
+		dynamic a {
+			name kortix-api
+			port 8008
+			refresh 2s
+		}
+		lb_policy round_robin
+		lb_try_duration 5s
+		lb_try_interval 250ms
+		fail_duration 30s
+		health_uri /v1/health
+		health_interval 3s
+		health_timeout 2s
 	}
 }`;
 
@@ -370,6 +419,26 @@ export function renderFullDockerCompose(composeProject: string, options: RenderC
       retries: 20,
       start_period: '10s',
     };
+    // Connection headroom for horizontal scaling (Essentia scale work,
+    // 2026-08-21). Each kortix-api replica opens DB_POOL_MAX (15) main +
+    // DB_AUDIT_POOL_MAX (3) audit = 18 DIRECT Postgres backends; the Supabase
+    // data plane adds ~30. The image default of 100 caps the stack at ~4 api
+    // replicas; 200 (each backend ~10 MiB → ~2 GiB, fine on a typical box)
+    // lifts that to ~8-9. Injected here, NOT in the upstream-locked vendored
+    // docker-compose.yml, so it survives a Supabase bump. We keep the api on
+    // DIRECT connections rather than the supavisor transaction pooler because
+    // supavisor does NOT propagate the per-connection statement_timeout
+    // (verified on the box: a stuck query is never killed) — that timeout is the
+    // anti-cascade lever in packages/db/src/client.ts. Scale further by raising
+    // POSTGRES_MAX_CONNECTIONS (needs a db restart) and DB_POOL_MAX per replica.
+    if (Array.isArray(database.command)) {
+      const cmd = database.command as string[];
+      if (!cmd.some((arg) => String(arg).startsWith('max_connections='))) {
+        const cfgIdx = cmd.findIndex((arg) => String(arg).startsWith('config_file='));
+        const insertAt = cfgIdx >= 0 ? cfgIdx + 1 : cmd.length;
+        cmd.splice(insertAt, 0, '-c', 'max_connections=${POSTGRES_MAX_CONNECTIONS:-200}');
+      }
+    }
   }
   const supavisor = services['supabase-supavisor'];
   if (supavisor) {


### PR DESCRIPTION
## Incident

Release gate `32580245708` failed all 6 API shards during bootstrap. Every `POST /v1/accounts/tokens` returned `503` or timed out.

A live staging database probe showed 14-23 concurrent `audit_events` inserts running for up to 21 seconds. The selective release included the pool budget from #6722 but omitted the audit-pool isolation from main PR #6702. Slow audit inserts therefore occupied the shared API pools and blocked authorization and token writes.

## Change

- Carry merged main PR #6702 into the selective release.
- Bind `DB_AUDIT_POOL_MAX` to the `DEFAULT_AUDIT_POOL_MAX=2` capacity budget from #6722.
- Add a release-tree test that pins the dedicated audit pool and all high-volume writer call sites.
- Record the selective-release dependency rule in the incident register.

## Verification

- API typecheck: passed.
- Database capacity, audit queue, and OpenCode ingestion: 30 passed, 0 failed.
- Project audit ingestion: 4 passed, 0 failed.
- Audit transaction and wiring: 3 passed, 0 failed when isolated from Bun global mock state.
- Self-host compose assets: 57 passed, 0 failed.
- Failed staging gate was cancelled after the common failure was proven.

After merge, staging must redeploy the exact SHA and pass a fresh full release gate before production promotion.