### PR TITLE
fix(preview): make preview origins a MUST on a public domain, never a silent downgrade

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,71 @@ linked, not inlined.
 
 ## Register
 
+### A self-host has TWO version axes — the images and the CLI binary. Updating one never updates the other (2026-08-22)
+
+**When:** diagnosing a self-host that is "on latest", or shipping any feature
+whose config the CLI renders (Caddyfile, `.env` keys, compose services).
+
+Essentia ran API/gateway/frontend images from `main` while `/usr/local/bin/kortix`
+was **1565 commits stale**. The CLI renders the Caddyfile and owns the `.env`
+schema, so the box silently lacked every CLI-side feature that had shipped since:
+preview origins could not be configured (no such flag existed), and the Caddy
+half of the "Bad Gateway" retry fix (PR #6702) had never landed even though its
+API half was live in the image. **Check `kortix --version` before believing any
+self-host diagnosis.** Upgrade with `curl -fsSL https://kortix.com/install | bash`
+(needs `HOME` set under SSM, or it dies on `HOME: unbound variable`).
+
+**Three update-semantics traps found in the same box:**
+1. `resolveTag()` reads `KORTIX_CHANNEL`, **never** `KORTIX_VERSION`. A bare
+   `kortix self-host update` on a box pinned to `dev-latest` with
+   `KORTIX_CHANNEL=stable` rolled it **back 758 commits** to a 3-week-old
+   release. Always pass `--version <ref>` explicitly on a pinned box.
+2. `KORTIX_IMAGE_PULL=never` (set by a past `--local-images`) makes every update
+   a silent no-op against the local Docker cache — `status` still reports
+   "no drift", because drift compares config to running images, not to the registry.
+3. `status`/`version` say "up to date" while tracking a floating tag. Compare the
+   **registry manifest digest** to the local `RepoDigests`, or the `/health`
+   `commit` to `origin/main`. A version string is not evidence.
+
+*Incident:* no outage from the staleness itself; it hid a shipped fix for ~1 day
+and blocked a customer feature.
+
+### Validate a config offline before applying it, and never trust a probe whose SNI you did not choose (2026-08-22)
+
+**When:** enabling a wildcard site block, or writing any "did it come back up?"
+check against a server doing on-demand TLS.
+
+Enabling preview origins on Essentia crash-looped Caddy for ~4 minutes:
+`subject does not qualify for certificate: '*.'`. A wildcard site address and the
+env var it interpolates are **two separate writes** — the Caddyfile gained
+`*.{$KORTIX_PREVIEW_BASE_DOMAIN}` while the running container's baked env still
+had that var empty, and Caddy refuses to adapt a config containing a bare `*.`.
+
+**Rules.**
+1. Render the target config and run `caddy validate --config … --adapter caddyfile`
+   in a throwaway container with the exact env **before** touching the live stack.
+   The failing and passing cases both reproduce in seconds, with no blast radius.
+2. After a config write, `--force-recreate` the container so its env is rebuilt
+   from `.env`. A plain restart reuses the env baked at creation time.
+3. **A probe to `https://localhost` is not a health check** against on-demand TLS:
+   it presents SNI `localhost`, the issuance `ask` gate correctly rejects it, and
+   TLS fails — so the probe returns `000` whether the service is healthy or not.
+   It fired a needless rollback here. Use `--resolve <real-host>:443:127.0.0.1`.
+   Prove any guard by running it against the *known-good* state first.
+4. **Never infer "no DNS" from a bare-label lookup when the record is a wildcard.**
+   `dig apps.essentia.kortix.cloud` returns nothing while `*.apps.essentia…`
+   exists and serves live traffic. That inference led to clearing a live
+   `KORTIX_APPS_BASE_DOMAIN` and taking deployed Apps down for ~25 min. Confirm
+   with the *authoritative* NS and a synthesized name, and prefer an empirical
+   before/after test to any reasoning about config intent.
+5. Querying a name before its record exists poisons public resolvers for the
+   SOA negative TTL (1800s here). Create the record first, then resolve.
+
+*Incident:* Essentia self-host, 2026-08-22. Two self-inflicted outages (~4 min
+API, ~25 min Apps), both caused by the operator's own verification, not by the
+change. Enforcer: `kortix self-host doctor` now fails on a domain-mode instance
+with no preview base domain (PR #6732).
+
 ### A selective capacity release must include the pool isolation it budgets (2026-08-22)
 
 **When:** selecting database-capacity commits for a release. Do not ship pool

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -55,7 +55,7 @@ import {
 } from './shared/daytona-transient';
 import { GitOperationError, isGitOperationError } from './projects/git/mirror';
 import { resolvePrefixEscape } from './sandbox-proxy/prefix-escape';
-import { previewBaseDomain } from './sandbox-proxy/preview-hosts';
+import { previewBaseDomain, warnIfPreviewOriginsMissing } from './sandbox-proxy/preview-hosts';
 // Statically imported (NOT await import() in the handlers): on a long-running
 // `bun --hot` dev process, dynamic import() can wedge permanently after enough
 // hot reloads — the promise never settles, the handler hangs, and Bun's
@@ -1400,6 +1400,7 @@ async function startReplicaServices() {
     '[snapshots] project image rollout',
     projectImageRolloutDiagnostic(),
   );
+  warnIfPreviewOriginsMissing(appLogger);
   startAccessControlCache();
   startTunnelService();
   // Warm the runtime-settings cache BEFORE serving traffic so the admin-panel

--- a/apps/api/src/sandbox-proxy/preview-hosts.test.ts
+++ b/apps/api/src/sandbox-proxy/preview-hosts.test.ts
@@ -8,8 +8,14 @@ const configState: Record<string, unknown> = {
 };
 mock.module('../config', () => ({ config: configState }));
 
-const { previewBaseDomain, previewOriginFor, previewUrlTemplate, resolvePreviewHost, sandboxHostLabel } =
-  await import('./preview-hosts');
+const {
+  previewBaseDomain,
+  previewOriginFor,
+  previewUrlTemplate,
+  resolvePreviewHost,
+  sandboxHostLabel,
+  warnIfPreviewOriginsMissing,
+} = await import('./preview-hosts');
 
 const SBX = 'sbx_01M0G4HXCM32BX5R1GPYZDYC1H';
 const LABEL = 'sbx-01m0g4hxcm32bx5r1gpyzdyc1h';
@@ -158,5 +164,56 @@ describe('previewOriginFor', () => {
       sandboxLabel: LABEL,
       local: false,
     });
+  });
+});
+
+describe('warnIfPreviewOriginsMissing', () => {
+  /** Collects the warnings a boot would emit. */
+  const spy = () => {
+    const calls: Array<{ message: string; meta?: Record<string, unknown> }> = [];
+    return {
+      calls,
+      warn: (message: string, meta?: Record<string, unknown>) => calls.push({ message, meta }),
+    };
+  };
+
+  test('warns on a public deployment with no preview domain — the silent-downgrade case', () => {
+    configState.KORTIX_URL = 'https://api.essentia.kortix.cloud';
+    configState.KORTIX_PREVIEW_BASE_DOMAIN = undefined;
+    const log = spy();
+    warnIfPreviewOriginsMissing(log);
+    expect(log.calls).toHaveLength(1);
+    expect(log.calls[0]!.message).toContain('no KORTIX_PREVIEW_BASE_DOMAIN');
+    expect(log.calls[0]!.meta?.kortix_url).toBe('https://api.essentia.kortix.cloud');
+  });
+
+  test('silent once a preview domain is configured', () => {
+    configState.KORTIX_URL = 'https://api.essentia.kortix.cloud';
+    configState.KORTIX_PREVIEW_BASE_DOMAIN = 'p.essentia.kortix.cloud';
+    const log = spy();
+    warnIfPreviewOriginsMissing(log);
+    expect(log.calls).toEqual([]);
+  });
+
+  test.each([
+    ['localhost', 'https://localhost:8008'],
+    ['a *.localhost host', 'https://api.my-worktree.localhost:8008'],
+    ['a quick cloudflared tunnel', 'https://random-words-here.trycloudflare.com'],
+    ['plain http', 'http://api.example.com'],
+    ['an unset KORTIX_URL', ''],
+  ])('stays silent for %s — the path form is correct there', (_label, url) => {
+    configState.KORTIX_URL = url;
+    configState.KORTIX_PREVIEW_BASE_DOMAIN = undefined;
+    const log = spy();
+    warnIfPreviewOriginsMissing(log);
+    expect(log.calls).toEqual([]);
+  });
+
+  test('never throws — a warning must never become an outage', () => {
+    configState.KORTIX_URL = 'not a url';
+    configState.KORTIX_PREVIEW_BASE_DOMAIN = undefined;
+    const log = spy();
+    expect(() => warnIfPreviewOriginsMissing(log)).not.toThrow();
+    expect(log.calls).toEqual([]);
   });
 });

--- a/apps/api/src/sandbox-proxy/preview-hosts.ts
+++ b/apps/api/src/sandbox-proxy/preview-hosts.ts
@@ -176,3 +176,57 @@ export function previewCorsHeaders(origin: string): Record<string, string> {
     Vary: 'Origin',
   };
 }
+
+/**
+ * Whether this deployment serves browsers on a public origin — the only case
+ * where a missing preview domain is a misconfiguration rather than the correct
+ * setup.
+ *
+ * A laptop and a worktree are excluded deliberately. Their clients build
+ * `p{port}-{sandbox}.localhost:{apiPort}` themselves (see previewUrlTemplate's
+ * null contract), and a quick cloudflared tunnel has no wildcard DNS and no
+ * certificate a preview origin could ever use — warning there would train
+ * operators to ignore the warning that matters.
+ */
+function servesPublicBrowsers(): boolean {
+  const raw = (config.KORTIX_URL || '').trim();
+  if (!raw) return false;
+  let host: string;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== 'https:') return false;
+    host = url.hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (host === 'localhost' || host.endsWith('.localhost')) return false;
+  if (host === '127.0.0.1' || host === '::1') return false;
+  // Ephemeral quick tunnels: public, but nothing durable to anchor an origin to.
+  if (host.endsWith('.trycloudflare.com')) return false;
+  return true;
+}
+
+/**
+ * Say — once, at boot, at WARN — that this deployment hands browsers path
+ * previews. Nothing fails when KORTIX_PREVIEW_BASE_DOMAIN is unset: the path
+ * proxy answers 200 and the app inside it quietly loses every root-absolute
+ * link. That silence is the whole problem, and it is why this is a startup log
+ * rather than a health check: an operator reading boot logs after a deploy is
+ * the earliest moment anyone can notice.
+ *
+ * Deliberately never throws and never blocks startup. Refusing to boot would
+ * turn a degraded preview into an outage for every instance that has not set
+ * the variable yet — trading a broken stylesheet for a dead API.
+ */
+export function warnIfPreviewOriginsMissing(
+  log: { warn: (message: string, meta?: Record<string, unknown>) => void },
+): void {
+  if (previewBaseDomain() || !servesPublicBrowsers()) return;
+  log.warn(
+    '[preview] no KORTIX_PREVIEW_BASE_DOMAIN — browsers get /v1/p/ path previews, which break root-absolute links',
+    {
+      kortix_url: config.KORTIX_URL,
+      fix: 'point *.p.<your domain> at this deployment, then set KORTIX_PREVIEW_BASE_DOMAIN (self-host: `kortix self-host doctor`)',
+    },
+  );
+}

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -657,7 +657,7 @@ function selfHostDoctor(flags: GlobalFlags): number {
     // KORTIX_PREVIEW_BASE_DOMAIN the API hands browsers the `/v1/p/{sandbox}/
     // {port}/` path form, which is a correct transport for programmatic callers
     // and a broken one for a browser: the app escapes the prefix the moment it
-    // emits anything root-absolute (`<a href="/learn">`, `fetch('/api')`,
+    // emits anything root-absolute (`<a href="/learn">`, an XHR to `/api`,
     // pushState, a service worker, `new WebSocket('/hmr')`). Nothing in the
     // running stack fails when this is unset — previews just silently degrade,
     // which is exactly how one instance served path previews for weeks before

--- a/apps/cli/src/commands/self-host.ts
+++ b/apps/cli/src/commands/self-host.ts
@@ -652,6 +652,36 @@ function selfHostDoctor(flags: GlobalFlags): number {
       });
     }
   }
+  if (existsSync(envPath(flags.instance))) {
+    // Sandbox previews on a PUBLIC domain must have their own origins. Without
+    // KORTIX_PREVIEW_BASE_DOMAIN the API hands browsers the `/v1/p/{sandbox}/
+    // {port}/` path form, which is a correct transport for programmatic callers
+    // and a broken one for a browser: the app escapes the prefix the moment it
+    // emits anything root-absolute (`<a href="/learn">`, `fetch('/api')`,
+    // pushState, a service worker, `new WebSocket('/hmr')`). Nothing in the
+    // running stack fails when this is unset — previews just silently degrade,
+    // which is exactly how one instance served path previews for weeks before
+    // anyone noticed. So `doctor` is where it becomes loud and non-zero.
+    //
+    // Scoped to domain mode on purpose. A tunnel or laptop instance has no
+    // wildcard DNS and no certificate to put previews behind, and its client
+    // builds `p{port}-{sandbox}.localhost:{apiPort}` itself — the path form is
+    // the right answer there, not a misconfiguration.
+    const env = loadEnv(flags.instance);
+    if (env && reachabilityMode(env) === 'domain') {
+      const previewDomain = env.KORTIX_PREVIEW_BASE_DOMAIN?.trim() ?? '';
+      const suggested = `p.${(env.KORTIX_DOMAIN ?? '').trim()}`;
+      checks.push({
+        name: 'preview-origins',
+        ok: Boolean(previewDomain),
+        detail: previewDomain
+          ? previewDomain
+          : `domain mode but KORTIX_PREVIEW_BASE_DOMAIN is empty — browsers get /v1/p/ path previews, which break root-absolute links. `
+            + `Point a *.${suggested} DNS record at this instance, then: `
+            + `kortix self-host env set KORTIX_PREVIEW_BASE_DOMAIN=${suggested} KORTIX_PREVIEW_ALLOW_DIRECT_EDGE=true`,
+      });
+    }
+  }
   const ok = checks.every((check) => check.ok);
   if (flags.json) {
     process.stdout.write(`${JSON.stringify({ instance: flags.instance, ok, checks }, null, 2)}\n`);
@@ -1215,6 +1245,19 @@ function selfHostStatus(flags: GlobalFlags): number {
     }
   } else if (report.drift) {
     process.stdout.write(`\n  ${status.ok('no drift')}${C.dim} — running images match the rendered config${C.reset}\n`);
+  }
+
+  // Preview origins, on the same screen as drift and the update outcome. An
+  // unset preview domain never makes anything fail — the path proxy answers 200
+  // — so the only way an operator learns about it is if a status screen they
+  // already read says so. `doctor` is the non-zero gate; this is the glance.
+  if (reachabilityMode(env) === 'domain') {
+    const previewDomain = env.KORTIX_PREVIEW_BASE_DOMAIN?.trim() ?? '';
+    process.stdout.write(
+      previewDomain
+        ? `  ${status.ok('preview origins')}${C.dim} — *.${previewDomain}${C.reset}\n`
+        : `  ${status.err('preview origins NOT configured')}${C.dim} — browsers get /v1/p/ path previews, which break root-absolute links. Run \`kortix self-host doctor\`${C.reset}\n`,
+    );
   }
   process.stdout.write('\n');
   return 0;
@@ -1828,24 +1871,39 @@ async function configureConnections(env: SelfHostEnv, flags: GlobalFlags): Promi
     }
   }
 
-  // Sandbox preview origins (optional, default skip): serves every sandbox port
-  // a browser can open on its OWN hostname,
-  // <env>-p<port>-<sandbox>.<preview base domain>. Without it previews use the
-  // path proxy (/v1/p/<sandbox>/<port>/), which works for tools but not for a
-  // browser: an app that emits <a href="/learn">, an XHR to /api, pushState, a
-  // service worker or a WebSocket resolves those against the API origin and
-  // escapes the prefix. Same mechanics as Apps above — a *.<domain> DNS record
-  // plus per-hostname on-demand certificates, no wildcard certificate needed.
+  // Sandbox preview origins: serves every sandbox port a browser can open on
+  // its OWN hostname, <env>-p<port>-<sandbox>.<preview base domain>. Without it
+  // previews use the path proxy (/v1/p/<sandbox>/<port>/), which works for
+  // tools but not for a browser: an app that emits <a href="/learn">, an XHR to
+  // /api, pushState, a service worker or a WebSocket resolves those against the
+  // API origin and escapes the prefix. Same mechanics as Apps above — a
+  // *.<domain> DNS record plus per-hostname on-demand certificates, no wildcard
+  // certificate needed.
+  //
+  // On a PUBLIC domain this defaults to "configure", not "skip": the path form
+  // is a silent downgrade — everything keeps answering 200, so nobody discovers
+  // it until a user reports a preview that lost its stylesheet. `doctor` fails
+  // on the same condition (see selfHostDoctor). The default VALUE is only
+  // suggested, never assumed: an operator who has not pointed *.p.<domain> at
+  // this box must be able to say so, because advertising an origin with no DNS
+  // is worse than the path form, which always works. On a tunnel/laptop
+  // instance the prompt keeps defaulting to skip — there is no wildcard DNS to
+  // put previews behind and the client builds *.localhost origins itself.
   if (shouldPrompt(flags)) {
+    const domainMode = reachabilityMode(env) === 'domain';
+    const suggestedPreviewDomain = env.KORTIX_PREVIEW_BASE_DOMAIN
+      || (domainMode ? `p.${(env.KORTIX_DOMAIN ?? '').trim()}` : '');
     const previewMode = await selectFrom(
-      'Sandbox preview origins (optional, makes browser previews of sandbox ports work like a real site): configure/skip',
-      ['skip', 'configure'] as const,
-      env.KORTIX_PREVIEW_BASE_DOMAIN ? 'configure' : 'skip',
+      domainMode
+        ? 'Sandbox preview origins (STRONGLY recommended — without them browser previews break root-absolute links): configure/skip'
+        : 'Sandbox preview origins (makes browser previews of sandbox ports work like a real site): configure/skip',
+      ['configure', 'skip'] as const,
+      env.KORTIX_PREVIEW_BASE_DOMAIN || domainMode ? 'configure' : 'skip',
     );
     if (previewMode === 'configure') {
       env.KORTIX_PREVIEW_BASE_DOMAIN = await prompt(
         'Preview base domain (needs a *.<domain> DNS record pointing at this instance; Caddy issues per-preview certificates on demand)',
-        env.KORTIX_PREVIEW_BASE_DOMAIN,
+        suggestedPreviewDomain,
       );
       env.KORTIX_PREVIEW_ALLOW_DIRECT_EDGE = 'true';
     }

--- a/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
+++ b/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
@@ -568,7 +568,7 @@ describe('kortix self-host (generic Docker CLI)', () => {
       .find((c) => c.name === 'preview-origins');
     expect(setCheck?.ok).toBe(true);
     expect(setCheck?.detail).toBe('p.kortix.example.com');
-  });
+  }, 60_000);
 
   test('doctor does NOT raise preview-origins on a domain-less (laptop) instance — the path form is correct there', async () => {
     await run(['init', '--yes']);
@@ -577,16 +577,29 @@ describe('kortix self-host (generic Docker CLI)', () => {
     expect(checks.find((c) => c.name === 'preview-origins')).toBeUndefined();
   });
 
+  // Sets the preview domain by editing .env directly rather than via `env set`.
+  // `env set` restarts the services the key touches (caddy + kortix-api), and
+  // two `status` renders on top of that docker work blew the 15s default in CI.
+  // The `env set` path is already covered black-box by the doctor test above;
+  // what this one asserts is the STATUS WORDING, which only needs the file.
   test('status shows preview origins as NOT configured on a domain instance, and names the domain once set', async () => {
     await run(['init', '--yes', '--domain', 'kortix.example.com']);
     const missing = await run(['status']);
     expect(missing.stdout).toContain('preview origins NOT configured');
 
-    await run(['env', 'set', 'KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com']);
+    const envFile = join(configRoot, instance, '.env');
+    writeFileSync(
+      envFile,
+      readFileSync(envFile, 'utf8').replace(
+        /^KORTIX_PREVIEW_BASE_DOMAIN=.*$/m,
+        'KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com',
+      ),
+    );
+
     const set = await run(['status']);
     expect(set.stdout).toContain('*.p.kortix.example.com');
     expect(set.stdout).not.toContain('NOT configured');
-  });
+  }, 60_000);
 
   // `connect-github` is deprecated: managed git is now configured in the web
   // dashboard (Settings → Git), not by this CLI — the App-manifest flow it

--- a/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
+++ b/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
@@ -543,6 +543,51 @@ describe('kortix self-host (generic Docker CLI)', () => {
     expect(staleCheck?.detail).toContain('stale');
   });
 
+  // Sandbox preview origins are a MUST on a public domain, and their absence is
+  // invisible at runtime: the /v1/p/ path proxy answers 200 and the app inside
+  // it quietly loses every root-absolute link. `doctor` is the gate that turns
+  // that silence into a non-zero exit. It stays silent on a laptop instance,
+  // where the path form (and the client-built *.localhost origin) is correct.
+  test('doctor FAILS when a domain instance has no preview base domain, and passes once it is set', async () => {
+    await run(['init', '--yes', '--domain', 'kortix.example.com']);
+
+    const missing = await run(['doctor', '--json']);
+    const missingCheck = (JSON.parse(missing.stdout).checks as Array<{ name: string; ok: boolean; detail: string }>)
+      .find((c) => c.name === 'preview-origins');
+    expect(missingCheck?.ok).toBe(false);
+    expect(missingCheck?.detail).toContain('KORTIX_PREVIEW_BASE_DOMAIN');
+    // The whole point: a degraded preview setup must make `doctor` exit non-zero.
+    expect(JSON.parse(missing.stdout).ok).toBe(false);
+    expect(missing.code).not.toBe(0);
+    // And it must hand the operator the exact command, not just a complaint.
+    expect(missingCheck?.detail).toContain('kortix self-host env set KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com');
+
+    await run(['env', 'set', 'KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com']);
+    const set = await run(['doctor', '--json']);
+    const setCheck = (JSON.parse(set.stdout).checks as Array<{ name: string; ok: boolean; detail: string }>)
+      .find((c) => c.name === 'preview-origins');
+    expect(setCheck?.ok).toBe(true);
+    expect(setCheck?.detail).toBe('p.kortix.example.com');
+  });
+
+  test('doctor does NOT raise preview-origins on a domain-less (laptop) instance — the path form is correct there', async () => {
+    await run(['init', '--yes']);
+    const { stdout } = await run(['doctor', '--json']);
+    const checks = JSON.parse(stdout).checks as Array<{ name: string }>;
+    expect(checks.find((c) => c.name === 'preview-origins')).toBeUndefined();
+  });
+
+  test('status shows preview origins as NOT configured on a domain instance, and names the domain once set', async () => {
+    await run(['init', '--yes', '--domain', 'kortix.example.com']);
+    const missing = await run(['status']);
+    expect(missing.stdout).toContain('preview origins NOT configured');
+
+    await run(['env', 'set', 'KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com']);
+    const set = await run(['status']);
+    expect(set.stdout).toContain('*.p.kortix.example.com');
+    expect(set.stdout).not.toContain('NOT configured');
+  });
+
   // `connect-github` is deprecated: managed git is now configured in the web
   // dashboard (Settings → Git), not by this CLI — the App-manifest flow it
   // used to run never worked reliably from a laptop (GitHub rejects


### PR DESCRIPTION
## Problem

An instance with a public domain and no `KORTIX_PREVIEW_BASE_DOMAIN` hands browsers the `/v1/p/{sandbox}/{port}/` path form.

**Nothing fails when it does.** The path proxy answers `200`, and the app inside it quietly loses every root-absolute link — `<a href="/learn">`, `fetch('/api')`, `pushState`, CSS `url()`, service workers, `new WebSocket('/hmr')`. That silence is the defect.

Found on a live self-host: it served path previews for weeks. Nobody noticed, because every surface reported healthy. It was only caught by opening a preview by hand and seeing `/v1/p/...` in the address bar.

## Approach: loud on every surface, fail closed on none

| Surface | Before | After |
|---|---|---|
| `self-host doctor` | no preview check | **`preview-origins` check FAILS, non-zero exit**, prints the exact fix command |
| `self-host status` | no preview line | shows preview state next to drift + update outcome |
| Guided setup | prompt defaulted to `skip` | defaults to `configure` on a public domain, suggests `p.<domain>` |
| API boot | silent | one `WARN` when serving public browsers with no preview domain |

The API warning matters because it is the **only** signal for deployments the CLI does not manage (dev/staging/prod on ECS).

## What this deliberately does NOT do

**No hard boot failure.** Refusing to start would turn a degraded preview into an outage for every instance that has not set the variable yet — trading a broken stylesheet for a dead API.

**No auto-derived default.** The value is suggested, never assumed. Advertising an origin whose wildcard DNS does not exist yet is *worse* than the path form, which always works. (Same trap as the earlier draft that derived from `KORTIX_URL` and had a worktree advertising `p.trycloudflare.com`.)

**Local/tunnel instances stay silent.** A laptop, a worktree, and a quick cloudflared tunnel have no wildcard DNS to anchor an origin to, and their clients build `p{port}-{sandbox}.localhost:{apiPort}` themselves. The path form is correct there, not a misconfiguration — warning would train operators to ignore the warning that matters.

The `/v1/p/` control transport is untouched. Per the 5-surface audit it stays for `runtime_url`, `/v1/p/auth|share|config|public-share`, and durable `base_url` rows.

## Verification

Real CLI, black box, not a unit test on an unexported function:

```
$ kortix self-host init --yes --domain kortix.example.com
$ kortix self-host doctor
  ✓  docker / docker-compose / compose-config / instance-dir
  ✗  preview-origins domain mode but KORTIX_PREVIEW_BASE_DOMAIN is empty — browsers get
     /v1/p/ path previews, which break root-absolute links. Point a *.p.kortix.example.com
     DNS record at this instance, then: kortix self-host env set
     KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com KORTIX_PREVIEW_ALLOW_DIRECT_EDGE=true
  >>> EXIT CODE: 1

$ kortix self-host env set KORTIX_PREVIEW_BASE_DOMAIN=p.kortix.example.com ...
$ kortix self-host doctor
  ✓  preview-origins p.kortix.example.com
  >>> EXIT CODE: 0
```

Tests:
- `apps/cli` self-host suite: **189 pass, 0 fail** (3 new black-box tests: doctor fails then passes, doctor silent on a domain-less instance, status wording both ways)
- `apps/api` preview-hosts: **30 pass, 0 fail** (8 new: warns on public, silent once configured, silent for localhost / `*.localhost` / trycloudflare / http / unset, never throws on a malformed URL)
- `apps/cli` `tsc --noEmit`: clean. `apps/api` `tsc --noEmit`: clean on touched files.

Pre-existing and unrelated: `apps/api/src/sandbox-proxy/` + `src/edge/` have **44 failures on clean `main`** (confirmed by stashing this branch's changes and re-running). This PR takes that suite 173 → 181 pass with the same 44 failures.

https://claude.ai/code/session_01VvTyMHRdfg7pMeEgy5bjp7