### PR TITLE
fix(release): bind Vercel runtime version per deployment

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,15 @@ linked, not inlined.
 
 ## Register
 
+### Bind public Vercel runtime metadata to the deployment, not the project environment (2026-08-22)
+
+**When:** passing public release metadata to a Vercel Production deployment.
+Use `vercel deploy --env KORTIX_PUBLIC_<NAME>=<value>`. Do not add a
+`NEXT_PUBLIC_*` Production project variable. Vercel CLI 59.4.0 infers secret
+visibility and rejects public framework prefixes. *Incident:* v0.13.3 left
+`kortix.com` on v0.13.2 after `env add NEXT_PUBLIC_KORTIX_VERSION` failed.
+*Enforcer:* `web-ecs-workflow.test.ts` pins the deployment-scoped runtime value.
+
 ### A selective capacity release must include the pool isolation it budgets (2026-08-22)
 
 **When:** selecting database-capacity commits for a release. Do not ship pool

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1328,26 +1328,15 @@ jobs:
             echo "::error::VERCEL_PROJECT_ID resolves to '$linked', not the suna project — refusing to deploy the wrong project."
             exit 1
           fi
-      - name: Pin the RUNTIME frontend version env
-        run: |
-          set -euo pipefail
-          VER="${{ needs.version.outputs.version }}"
-          # The frontend resolves its VERSION at RUNTIME:
-          # apps/web/src/lib/public-env-server.ts reads NEXT_PUBLIC_KORTIX_VERSION
-          # via Reflect.get(process.env, ...), which Next.js does NOT inline at
-          # build time. So `--build-env` below never overrides a STALE Production
-          # runtime var — v0.12.8 shipped an FE stuck on the prior 0.12.7 until
-          # this runtime var was corrected by hand. Overwrite the Production
-          # runtime var to the release version so the deploy binds it correctly.
-          npx --yes vercel@latest env rm NEXT_PUBLIC_KORTIX_VERSION production --yes --token="$VERCEL_TOKEN" 2>/dev/null || true
-          printf '%s' "$VER" | npx --yes vercel@latest env add NEXT_PUBLIC_KORTIX_VERSION production --token="$VERCEL_TOKEN"
       - name: Deploy the release frontend to production
         run: |
           set -euo pipefail
-          # Keep --build-env too (belt-and-braces for any build-time read); the
-          # RUNTIME var pinned in the step above is what actually drives
-          # /api/runtime-config and the frontend-auth-proof version guard.
+          # Bind the release version to this deployment at build time and runtime.
+          # KORTIX_PUBLIC_VERSION is the server-only alias that public-env-server
+          # exposes as VERSION. Vercel rejects NEXT_PUBLIC_* Production variables
+          # because its CLI treats them as secrets by default.
           npx --yes vercel@latest deploy --prod --yes --token="$VERCEL_TOKEN" \
+            --env "KORTIX_PUBLIC_VERSION=${{ needs.version.outputs.version }}" \
             --build-env "NEXT_PUBLIC_KORTIX_VERSION=${{ needs.version.outputs.version }}"
 
   frontend-note:

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -190,9 +190,18 @@ describe('web ECS migration', () => {
   it('deploys the prod Vercel frontend only after the API serves the release', () => {
     const workflow = read('.github/workflows/deploy-prod.yml');
     expect(workflow).toContain('deploy-web-vercel:');
-    expect(workflow).toMatch(/deploy-web-vercel:\s*\n\s*name:[^\n]*\n\s*needs: \[version, verify-live-version\]/);
+    expect(workflow).toMatch(
+      /deploy-web-vercel:\s*\n\s*name:[^\n]*\n\s*needs: \[version, verify-live-version\]/,
+    );
     expect(workflow).toContain('prj_SoUUSNJPvOTDneE0E7faWHFuWMAY');
-    expect(workflow).toMatch(/frontend-auth-proof:\s*\n\s*name:[^\n]*\n\s*needs: \[[^\]]*deploy-web-vercel\]/);
+    expect(workflow).toContain(
+      '--env "KORTIX_PUBLIC_VERSION=${{ needs.version.outputs.version }}"',
+    );
+    expect(workflow).not.toContain('env add NEXT_PUBLIC_KORTIX_VERSION production');
+    expect(workflow).not.toContain('env rm NEXT_PUBLIC_KORTIX_VERSION production');
+    expect(workflow).toMatch(
+      /frontend-auth-proof:\s*\n\s*name:[^\n]*\n\s*needs: \[[^\]]*deploy-web-vercel\]/,
+    );
   });
 
   it('carries both Basic auth credentials and the Vercel SSO bypass in QA', () => {


### PR DESCRIPTION
Selective release of main PR #6735.

Vercel CLI 59.4.0 rejects the current `NEXT_PUBLIC_*` Production project-variable write. This change binds `KORTIX_PUBLIC_VERSION` to the individual deployment through `vercel deploy --env`.

Files: 3.

Verification: `/Users/markokraemer/.bun/bin/bun test tests/unit/web-ecs-workflow.test.ts` → 11 passed, 0 failed.

Production webhook evidence after the database fix: external 202; one session; one user turn; one assistant turn; `kortix/deepseek-v4-flash`; complete cleanup.