### PR TITLE
fix(gateway): wire API proxy to standalone service

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1691,3 +1691,24 @@ unbounded allocation path.
 `502 Bad Gateway`. Enforcement: `readAdmittedBody` allocation-order tests,
 response-lifetime lease tests, one-dispatch tests, and a mounted 28 MiB request
 test that asserts one provider call and an intact response.
+
+## A standalone service needs explicit caller wiring in every environment
+
+2026-08-22. The API stopped hosting an in-process gateway and became a reverse
+proxy. Self-host Compose configured `LLM_GATEWAY_PROXY_TARGET`. Dev ECS did not.
+The gateway deployed healthy at the correct SHA, but the API returned
+`gateway_unavailable` for every LLM route. The edge converted that origin `503`
+into `MAINTENANCE_MODE`, which hid the missing environment variable.
+
+**The rule.** A service extraction is incomplete until every caller in every
+deployment topology has an explicit target. Configure local, self-host, dev,
+staging, production, and shadow environments in the same change. Verify through
+the caller route. A healthy callee does not prove that its caller can reach it.
+
+**The enforcement.** Terraform now injects `LLM_GATEWAY_PROXY_TARGET` into each
+cloud API task. The end-to-end verification calls `/v1/llm/health` through the
+API origin and requires the standalone gateway health response.
+
+*Incident:* dev API returned `gateway_unavailable` after gateway PR #6737.
+The public edge surfaced it as blocking maintenance. Direct origin inspection
+identified the missing target before user traffic resumed.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -109,10 +109,12 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image                   = var.api_image
-  container_port          = var.container_port
-  certificate_arn         = one(module.acm[*].certificate_arn)
-  environment             = var.api_environment
+  image           = var.api_image
+  container_port  = var.container_port
+  certificate_arn = one(module.acm[*].certificate_arn)
+  environment = merge(var.api_environment, {
+    LLM_GATEWAY_PROXY_TARGET = "https://gateway-dev-ecs-fargate.kortix.com"
+  })
   secrets                 = var.api_secrets
   secrets_blob_arn        = data.aws_secretsmanager_secret.env.arn
   ses_send_region         = "us-east-2"

--- a/infra/terraform/environments/prod-us-east-2-shadow/main.tf
+++ b/infra/terraform/environments/prod-us-east-2-shadow/main.tf
@@ -74,7 +74,8 @@ module "api" {
   health_check_path = "/health/ready"
   certificate_arn   = module.certificate.certificate_arn
   environment = {
-    KORTIX_VERSION = "0.10.14"
+    KORTIX_VERSION           = "0.10.14"
+    LLM_GATEWAY_PROXY_TARGET = "https://${var.gateway_shadow_hostname}"
   }
   secrets                 = local.secrets
   secrets_blob_arn        = var.secret_arn

--- a/infra/terraform/environments/prod-us-east-2-shadow/variables.tf
+++ b/infra/terraform/environments/prod-us-east-2-shadow/variables.tf
@@ -67,3 +67,9 @@ variable "api_shadow_hostname" {
   type        = string
   default     = "api-use2-shadow.kortix.com"
 }
+
+variable "gateway_shadow_hostname" {
+  description = "SNI hostname used for direct shadow gateway access. Terraform does not create DNS."
+  type        = string
+  default     = "gateway-use2-shadow.kortix.com"
+}

--- a/infra/terraform/environments/prod/main.tf
+++ b/infra/terraform/environments/prod/main.tf
@@ -100,11 +100,13 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image                   = var.api_image
-  container_port          = var.container_port
-  certificate_arn         = module.acm.certificate_arn
-  health_check_path       = "/health/ready"
-  environment             = var.api_environment
+  image             = var.api_image
+  container_port    = var.container_port
+  certificate_arn   = module.acm.certificate_arn
+  health_check_path = "/health/ready"
+  environment = merge(var.api_environment, {
+    LLM_GATEWAY_PROXY_TARGET = "https://${var.gateway_domain}"
+  })
   secrets                 = var.api_secrets
   secrets_blob_arn        = data.aws_secretsmanager_secret.env.arn
   ses_send_region         = "us-east-2"

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -83,10 +83,12 @@ module "api" {
   ]
   private_subnet_ids = module.network.private_subnet_ids
 
-  image                   = var.api_image
-  container_port          = var.container_port
-  certificate_arn         = var.wildcard_certificate_arn
-  environment             = var.api_environment
+  image           = var.api_image
+  container_port  = var.container_port
+  certificate_arn = var.wildcard_certificate_arn
+  environment = merge(var.api_environment, {
+    LLM_GATEWAY_PROXY_TARGET = "https://gateway-staging-ecs-fargate.kortix.com"
+  })
   secrets                 = var.api_secrets
   secrets_blob_arn        = data.aws_secretsmanager_secret.env.arn
   ses_send_region         = "us-east-2"


### PR DESCRIPTION
## Incident

The standalone gateway deployed healthy, but cloud API tasks had no `LLM_GATEWAY_PROXY_TARGET`. Every `/v1/llm/*` request returned `gateway_unavailable`. The edge presented that origin 503 as `MAINTENANCE_MODE`.

## Fix

Inject the environment-specific standalone gateway origin into API tasks in dev, staging, production, and the US East 2 shadow stack.

## Evidence

- Before: `GET https://dev-api-ecs-fargate.kortix.com/v1/llm/health` returned `503 {code: gateway_unavailable}`.
- Gateway: `GET https://gateway-dev.kortix.com/health` returned healthy at merge SHA `4fd71b3a`.
- `terraform fmt -check` passes for all four changed environments.
- Checkov and Terraform validation run in CI.