### PR TITLE
fix(deploy): persist gateway target in ECS revisions

### DIFF
--- a/infra/scripts/ecs-deploy.sh
+++ b/infra/scripts/ecs-deploy.sh
@@ -94,6 +94,16 @@ merge_environment_overrides() {
   '
 }
 
+gateway_target_for_env() {
+  case "$1" in
+    dev) printf '%s' 'https://gateway-dev-ecs-fargate.kortix.com' ;;
+    staging) printf '%s' 'https://gateway-staging-ecs-fargate.kortix.com' ;;
+    prod) printf '%s' 'https://gateway-ecs-fargate.kortix.com' ;;
+    prod-use2-shadow) printf '%s' 'https://gateway-use2-shadow.kortix.com' ;;
+    *) echo "unknown gateway environment: $1" >&2; return 2 ;;
+  esac
+}
+
 fast_cold_boot_requires_atomic_admission() {
   local overrides_json="${1:-}" secret_json="${2:-}"
   local enabled providers
@@ -257,6 +267,11 @@ CURRENT_TD_JSON="$(aws ecs describe-task-definition --region "$REGION" \
 
 ENVIRONMENT_OVERRIDES_JSON="${KORTIX_ECS_ENV_OVERRIDES:-}"
 [ -n "$ENVIRONMENT_OVERRIDES_JSON" ] || ENVIRONMENT_OVERRIDES_JSON='{}'
+if [ "$SVC_KIND" = "api" ]; then
+  GATEWAY_TARGET="$(gateway_target_for_env "$ENV")"
+  ENVIRONMENT_OVERRIDES_JSON="$(printf '%s' "$ENVIRONMENT_OVERRIDES_JSON" | jq -c \
+    --arg target "$GATEWAY_TARGET" '. + {LLM_GATEWAY_PROXY_TARGET: $target}')"
+fi
 CURRENT_ENVIRONMENT_JSON="$(printf '%s' "$CURRENT_TD_JSON" | jq -c --arg c "$CONTAINER" \
   '[.containerDefinitions[] | select(.name == $c) | (.environment // [])][0] // []')"
 MERGED_ENVIRONMENT_JSON="$(merge_environment_overrides "$CURRENT_ENVIRONMENT_JSON" "$ENVIRONMENT_OVERRIDES_JSON")"

--- a/infra/scripts/ecs-fast-cold-boot-gate.test.mjs
+++ b/infra/scripts/ecs-fast-cold-boot-gate.test.mjs
@@ -21,6 +21,21 @@ function runFunction(name, ...args) {
 }
 
 describe('fast cold boot deployment gate', () => {
+  test('maps every permanent API environment to its standalone gateway origin', () => {
+    const targets = {
+      dev: 'https://gateway-dev-ecs-fargate.kortix.com',
+      staging: 'https://gateway-staging-ecs-fargate.kortix.com',
+      prod: 'https://gateway-ecs-fargate.kortix.com',
+      'prod-use2-shadow': 'https://gateway-use2-shadow.kortix.com',
+    };
+    for (const [environment, target] of Object.entries(targets)) {
+      const result = runFunction('gateway_target_for_env', environment);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(target);
+    }
+    expect(runFunction('gateway_target_for_env', 'unknown').status).toBe(2);
+  });
+
   test('requires the capability only for a flag-on deployment that can use Platinum', () => {
     expect(runFunction(
       'fast_cold_boot_requires_atomic_admission',


### PR DESCRIPTION
## Root cause

Terraform owns only the initial ECS task definition. The ECS module ignores later `container_definitions` changes. `infra/scripts/ecs-deploy.sh` rebuilds each live revision from the current task plus explicit overrides. The Terraform-only fix in #6738 therefore could not update an existing API task.

## Fix

The deploy renderer now injects the environment-specific `LLM_GATEWAY_PROXY_TARGET` for every API revision in dev, staging, production, and the US East 2 shadow stack.

## Verification

`bun test infra/scripts/ecs-fast-cold-boot-gate.test.mjs`: 3 passed, including exact target mapping for all four environments.