### PR TITLE
feat(sdk): reconcile every loaded transcript on stream reconnect (server.connected)

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,12 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Unreleased
 
 ### Added
+- `SessionSyncReason` gains `'reconnect'`: on every `server.connected` frame
+  after the initial connect, the event handler re-reads the tail of EVERY
+  loaded session (busy or idle) — the OpenCode desktop app's re-bootstrap on
+  reconnect. Closes the "turn ended inside a short disconnect, transcript
+  short until hard refresh" hole the `> 5s`/busy-only gap path and the
+  turn-end path both miss.
 - Typed unified session-cost reads through
   `billing.sessionCosts.{list,get}` and `session(pid,sid).cost()`. The response
   combines finalized LLM and compute costs, model usage, and ledger entries.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12116,3 +12116,27 @@ assistant-turn-open 10 pass / 0 fail; `tsc --noEmit` 15 lines, all the known
 on both touched web files.
 
 **Shippable to production: YES.**
+
+### 2026-08-22 — `server.connected` reconnect resync (branch `feat/sse-reconnect-resync`, stacks on `timeline-parity`)
+Parity gap vs the OpenCode desktop app: `packages/app/src/context/server-sync.tsx`
+re-bootstraps every active directory on each `server.connected`; ours only
+re-read BUSY sessions after a `> 5s` gap. A turn that ended inside the
+disconnect is idle by reconnect time → never reconciled → short transcript
+until remount.
+
+Change: `handle-event.ts` `case 'server.connected'` — first frame per handler
+is the initial connect (skipped; mount `hydrateCore()` covers it); every later
+one reconciles every session in `useSyncStore.messages` with the new reason
+`'reconnect'` (additive member of `SessionSyncReason`).
+
+TDD: test written first, run RED for the right reason (`Expected
+[[busy,'reconnect'],[idle,'reconnect']], Received []`), then GREEN 58/58 in
+`handle-event.test.ts`.
+
+**Evidence** — `pnpm -s typecheck` clean; `bun test --isolate src` → 2510 tests,
+0 fail, 162 files (baseline on `timeline-parity`: 2505/0); smoke:install in the
+commit body.
+
+**Shippable to production: YES** (SDK-only, additive, behind an event the
+runtime already emits on every connection).
+

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -59,6 +59,12 @@ export type SessionSyncReason =
   // short — cured only by a remount. Turn end is the one moment the tail is
   // both final and cheap to verify, so it is reconciled there.
   | 'turn-end'
+  // The event stream reconnected. Every loaded session is re-read, busy or
+  // idle — a turn that ended INSIDE the disconnect left the session idle by
+  // the time the stream was back, so neither the gap path (busy-only) nor
+  // the turn-end path (never saw the transition) would reconcile it. This is
+  // the OpenCode desktop app's `server.connected` → re-bootstrap behaviour.
+  | 'reconnect'
   | 'compaction'
   | 'session-error'
   | 'send-recovery'

--- a/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.test.ts
@@ -1350,3 +1350,79 @@ describe('a turn ending reconciles the transcript tail', () => {
     expect(calls).toEqual([]);
   });
 });
+
+// ── the transcript is reconciled when the stream RECONNECTS ─────────────────
+// The OpenCode desktop app re-bootstraps every active directory on each
+// `server.connected` frame (packages/app/src/context/server-sync.tsx: the
+// event pushes every active directory onto the sync queue, guarded only by a
+// 1.5s "just booted" window). Ours re-read busy sessions after a > 5s gap and
+// nothing else. A turn that ENDS inside a short disconnect leaves the session
+// idle by the time the stream is back — the gap path skips it, the turn-end
+// path never saw the transition, and the tail stays short until a remount.
+describe('a reconnect (server.connected) reconciles every loaded session', () => {
+  const connected = (n: number) =>
+    ({ id: `evt_conn_${n}`, type: 'server.connected', properties: {} }) as never;
+  const load = (sessionID: string) =>
+    useSyncStore
+      .getState()
+      .hydrate(sessionID, [
+        {
+          info: {
+            id: `msg_${sessionID}`,
+            sessionID,
+            role: 'user',
+            time: { created: 1 },
+            agent: 'build',
+            model: { providerID: 'kortix', modelID: 'm' },
+          } as never,
+          parts: [],
+        },
+      ]);
+
+  test('the FIRST server.connected is the initial connect — nothing to reconcile', async () => {
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    load('ses_rc1');
+    handleEvent(connected(1));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls).toEqual([]);
+  });
+
+  test('a LATER server.connected re-reads every loaded session, busy or idle', async () => {
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    load('ses_rc2_idle');
+    load('ses_rc2_busy');
+    useSyncStore.getState().setStatus('ses_rc2_idle', { type: 'idle' });
+    useSyncStore.getState().setStatus('ses_rc2_busy', { type: 'busy' });
+    handleEvent(connected(1));
+    handleEvent(connected(2));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls.sort()).toEqual([
+      ['ses_rc2_busy', 'reconnect'],
+      ['ses_rc2_idle', 'reconnect'],
+    ]);
+  });
+
+  test('a session that was never loaded is not fetched on reconnect', async () => {
+    const calls: Array<[string, string]> = [];
+    const { handleEvent } = buildHandler({
+      reconcileSessionTail: async (sessionID, reason) => {
+        calls.push([sessionID, reason]);
+      },
+    });
+    useSyncStore.getState().setStatus('ses_rc3_status_only', { type: 'busy' });
+    handleEvent(connected(1));
+    handleEvent(connected(2));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(calls).toEqual([]);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/handle-event.ts
+++ b/packages/sdk/src/react/use-opencode-events/handle-event.ts
@@ -91,6 +91,11 @@ export function createEventHandler(deps: {
       if (result.data) useSyncStore.getState().hydrate(sessionID, result.data);
     });
 
+  // `server.connected` is the first frame of EVERY stream connection. The
+  // first one this handler sees is the initial connect — `hydrateCore()` ran
+  // at mount and covers it. Each later one is a reconnect.
+  let serverConnects = 0;
+
   // Helper: look up a session title from the React Query cache for notifications
   function getSessionTitle(sessionID: string): string | undefined {
     const sessions = queryClient.getQueryData<Session[]>(opencodeKeys.sessions());
@@ -547,6 +552,23 @@ export function createEventHandler(deps: {
       }
 
       // ---- Server disposed ----
+      // ---- Stream reconnect — re-read every loaded transcript ----
+      // The desktop app (packages/app/src/context/server-sync.tsx) pushes every
+      // active directory onto its sync queue on each `server.connected`. The
+      // > 5s gap path below only re-reads BUSY sessions: a turn that ended
+      // during the disconnect is idle by now, its turn-end transition was
+      // never delivered, and the tail stays short until a remount. So on a
+      // reconnect, every session with messages loaded is reconciled, busy or
+      // idle — one bounded tail read each, deduped in-flight by its controller.
+      case 'server.connected': {
+        serverConnects += 1;
+        if (serverConnects === 1) break;
+        for (const sid of Object.keys(useSyncStore.getState().messages)) {
+          void reconcileTail(sid, 'reconnect');
+        }
+        break;
+      }
+
       case 'server.instance.disposed': {
         for (const [sessionID, status] of Object.entries(useSyncStore.getState().sessionStatus)) {
           if (status?.type !== 'idle') {


### PR DESCRIPTION
Stacks on `timeline-parity` (#6734). SDK-only, additive.

## Problem

A turn that ends inside a short SSE disconnect leaves the transcript short until a hard refresh. Two existing paths both miss it:

- the gap path (`onGapRehydrate`) fires only after a **> 5s** gap and re-reads **busy** sessions only — the session is idle by reconnect time;
- the turn-end path (#6725) needs the busy→idle **transition frame** — which was the frame that got lost.

## What the OpenCode desktop app does

`packages/app/src/context/server-sync.tsx` (upstream `3a31c4e`): on every `server.connected` it pushes every active directory onto the sync queue and re-bootstraps, guarded only by a 1.5s "just booted" window.

## Change

- `handle-event.ts` — `case 'server.connected'`: the first frame per handler is the initial connect (skipped; mount `hydrateCore()` already covers it). Every later one reconciles **every session with messages loaded, busy or idle**, one bounded tail read each, deduped in-flight by its sync controller.
- `SessionSyncReason` gains `'reconnect'` (additive union member; no export renamed).

## TDD

Test written first and run RED for the right reason:
```
- [["ses_rc2_busy","reconnect"],["ses_rc2_idle","reconnect"]]
+ []
```
then GREEN. Guards also asserted: the first `server.connected` reconciles nothing; a session with only a status (never loaded) is not fetched.

## Gates

| | |
|---|---|
| `handle-event.test.ts` | 58 pass / 0 fail |
| `bun test --isolate src` (full SDK) | **2510 pass / 0 fail**, 162 files (baseline on `timeline-parity`: 2505/0) |
| `pnpm -s typecheck` | clean |
| `smoke:install` | passed |

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW

---

## Second commit — a parked stream hands over to the probe loop

`openEventStream` parks after **8** consecutive hard failures on `/event`, and `onParked` was never subscribed. The stream is opened from an effect keyed on `runtimeHealthy`; the probe behind that flag addresses the **daemon** port. So OpenCode can crash and restart (the "opencode is borderline crashing" session) behind a daemon that passes every probe — `healthy` never flips, nothing re-opens the stream, transcript frozen until hard refresh. The desktop app never parks (retries forever); ours parks on purpose for dead sandboxes, so the park has to hand control to something that can re-arm it.

- `react/use-opencode-events/parked.ts` — `handleEventStreamParked(info)` → `setOpenCodeHealth(false, undefined, 'event stream parked after N consecutive failures (…)')`. Sandbox `status` untouched.
- `index.ts` — wired as `onParked`.
- Cadence if `/event` stays dead behind a healthy daemon: 8 failed connects with 1s→30s backoff (~2 min) → unhealthy → probe at 150 ms → healthy → **fresh** stream. 8 attempts per ~2 min; UI truthfully "reconnecting" meanwhile.

TDD: `parked.test.ts` RED first (`Cannot find module './parked'`), then GREEN 3/3. Full SDK suite **2513 pass / 0 fail**, 163 files; typecheck clean.

---

## What is and is not proven

- **Unit level:** both behaviours pinned (RED→GREEN above). `reconcile()` in `SessionSyncController` has no freshness gate — only in-flight dedupe — so a `'reconnect'` always reads the tail.
- **Browser level — NOT exercised, honestly:** I tried to sever a live stream on the `suna-timeline-parity` worktree (logged-in session `2138f835…`). CDP network-offline emulation (63 s) failed the health probes (`status 0` ×2) but left the established `/global/event` socket alive (no new `/global/event`, no `/message?limit=50` read in the resource-timing buffer); `bun --hot` reload of the API (`touch src/index.ts`) also kept it alive. The only lever left is killing the API process, which tears down the shared stack the user is testing on — not done. A real OpenCode restart inside the sandbox (the daemon's `opencode.restart()` seam, no HTTP route) is the scenario this targets.
