### PR TITLE
refactor: gateway-only residue — daemon refuses to leave gateway mode; drop dead non-kortix branches

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -1664,7 +1664,7 @@ describe('daemon proxy auth gate', () => {
     }
   })
 
-  it('flips the provider-key deny-list with llm gateway mode (BYOK works when off)', async () => {
+  it('sets the gateway key + provider-key deny-list, and refuses to leave gateway mode on llmGatewayEnabled=false', async () => {
     const saved = {
       key: process.env.KORTIX_LLM_API_KEY,
       base: process.env.KORTIX_LLM_BASE_URL,
@@ -1707,7 +1707,10 @@ describe('daemon proxy auth gate', () => {
       expect(process.env.KORTIX_LLM_API_KEY as string | undefined).toBe('kortix_pat_exec')
       expect(process.env.KORTIX_OPENCODE_DENY_ENV as string | undefined).toBe('ANTHROPIC_API_KEY,OPENAI_API_KEY')
 
-      // DIRECT off: deny-list cleared so opencode sees native BYOK keys again.
+      // Gateway mode is the ONLY mode. `llmGatewayEnabled: false` is what an
+      // OLDER API could still send for a moment during a mixed-version rollout;
+      // the daemon answers 200 (no 4xx storm) but REFUSES to leave gateway mode:
+      // the gateway key and the native-key deny list stay exactly as they were.
       const off = await app.request('/kortix/env', {
         method: 'POST',
         headers: { Authorization: `Bearer ${TEST_TOKEN}`, 'Content-Type': 'application/json' },
@@ -1721,8 +1724,8 @@ describe('daemon proxy auth gate', () => {
         }),
       })
       expect(off.status).toBe(200)
-      expect(process.env.KORTIX_LLM_API_KEY).toBeUndefined()
-      expect(process.env.KORTIX_OPENCODE_DENY_ENV).toBeUndefined()
+      expect(process.env.KORTIX_LLM_API_KEY as string | undefined).toBe('kortix_pat_exec')
+      expect(process.env.KORTIX_OPENCODE_DENY_ENV as string | undefined).toBe('ANTHROPIC_API_KEY,OPENAI_API_KEY')
     } finally {
       for (const [k, v] of Object.entries({
         KORTIX_LLM_API_KEY: saved.key,

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -94,12 +94,14 @@ function applyLlmGatewayMode(enabled: unknown, baseUrl: unknown, denyEnv: unknow
   if (enabled === undefined) return { changed: false, names: [] }
   if (typeof enabled !== 'boolean') throw new Error('llmGatewayEnabled must be a boolean')
   if (!enabled) {
-    return setOpencodeRuntimeEnv({
-      KORTIX_LLM_API_KEY: null,
-      KORTIX_LLM_BASE_URL: null,
-      // DIRECT/BYOK: stop withholding native provider keys from opencode.
-      KORTIX_OPENCODE_DENY_ENV: null,
-    })
+    // Gateway mode is the ONLY mode: OpenCode is a proxy to the one `kortix`
+    // provider and never sees native provider keys. No current API sends
+    // `false`; an OLDER API still can for a moment during a mixed-version
+    // rollout. Answer 200 (no 4xx storm on every prompt's env sync) but refuse
+    // to leave gateway mode — the gateway key and the deny list stay as they
+    // are. Clearing them here used to be the one runtime path back to native.
+    console.warn('[env] llmGatewayEnabled=false ignored — gateway mode is the only mode')
+    return { changed: false, names: [] }
   }
   if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
     throw new Error('llmGatewayBaseUrl is required when llmGatewayEnabled is true')

--- a/apps/web/src/features/session/model-grouping.ts
+++ b/apps/web/src/features/session/model-grouping.ts
@@ -27,9 +27,8 @@ const MANAGED_MODEL_IDS = new Set<string>(DEFAULT_MANAGED_MODEL_IDS);
 // that over parsing the wire id at all. String-splitting `modelID` remains
 // ONLY as a fallback for a stale/older baked catalog that predates the field.
 export function pickerGroupId(model: FlatModel): string {
-  if (model.providerID !== 'kortix') {
-    return model.providerID;
-  }
+  // Gateway mode is the only mode, so every model here is under `kortix`; a
+  // foreign providerID (no `provider`, no `/`) falls through to itself below.
   if (MANAGED_MODEL_IDS.has(model.modelID)) return model.provider ?? model.providerID;
   if (model.provider) return model.provider;
   const slash = model.modelID.indexOf('/');

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -36,6 +36,14 @@ follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `KortixMasterProject` — the kortix-master daemon's board project.
 - `@kortix/sdk/internal/*` for the zustand stores. Not covered by semver.
 
+### Changed
+- Gateway mode is the only mode, and two helpers now say so: `hasUsableModel`
+  returns `false` for a model under any provider other than `kortix` (the
+  old "native/direct provider → usable" branch described a mode that no
+  longer exists), and `modelKeyToWire` has no `opencode` special case — only
+  `kortix` is bare, everything else is `provider/model`. Both branches were
+  unreachable from live data (inputs are source-filtered to `kortix`).
+
 ### Deprecated
 - The 20 legacy subpaths (`/projects-client`, `/turns`, `/files`, `/session`,
   `/event-stream`, the stores, …). They still work. Import from the root.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12200,3 +12200,18 @@ this branch (no export/entry change since).
 
 **Shippable to production: YES.**
 
+### 2026-08-22 (same session, follow-up 2) — gateway-only residue (branch `chore/gateway-only-residue`)
+Adversarial lens on #6744 flagged inert-but-real remnants of native mode.
+Removed: `hasUsableModel` non-kortix → `true` branch (now `false`),
+`modelKeyToWire` `'opencode'` special case; web `pickerGroupId` non-kortix early
+return (redundant); daemon `applyLlmGatewayMode(false)` no longer clears
+`KORTIX_LLM_*`/deny list (200 + warn, refuses to leave gateway mode — mixed-
+version tolerant). Tests rewritten where they encoded the old mode (stated in
+the commit), new gateway-only tests RED → GREEN.
+
+**Evidence** — SDK `use-model-store.test.ts` 9/0, full suite + typecheck in the
+commit body; daemon `proxy-auth.test.ts` 49/0 + tsc clean; web
+`model-grouping.test.ts` 25/0 + eslint clean.
+
+**Shippable to production: YES.**
+

--- a/packages/sdk/src/react/use-model-store.test.ts
+++ b/packages/sdk/src/react/use-model-store.test.ts
@@ -3,7 +3,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import type { FlatModel } from './model-flatten';
-import { hasUsableModel, useModelStore, type ModelKey } from './use-model-store';
+import { hasUsableModel, modelKeyToWire, useModelStore, type ModelKey } from './use-model-store';
 
 // Regression coverage for connection-gating (`hasUsableModel`/`isVisible`)
 // preferring the explicit `provider` field the gateway now serves per model
@@ -182,3 +182,29 @@ describe('useModelStore — `isVisible` is independent of the calling surface (c
     }
   });
 });
+
+// Gateway mode is the only mode: every model OpenCode can use is registered
+// under the one `kortix` provider. A FlatModel under any other providerID is a
+// stale/foreign catalog entry, not a usable route — the old "native/direct
+// provider → usable" branch described a mode that no longer exists.
+describe('gateway-only: non-kortix providers are not usable routes', () => {
+  test('hasUsableModel is false for a model under a non-kortix providerID', () => {
+    const models = [
+      {
+        providerID: 'anthropic',
+        providerName: 'Anthropic',
+        modelID: 'claude-opus-4-8',
+        modelName: 'Claude Opus 4.8',
+      },
+    ] as never;
+    expect(hasUsableModel(models, { connectedProviderIds: new Set(['anthropic']) })).toBe(false);
+  });
+
+  test('modelKeyToWire has no `opencode` special case — only `kortix` is bare', () => {
+    expect(modelKeyToWire({ providerID: 'kortix', modelID: 'glm-5.2' })).toBe('glm-5.2');
+    expect(modelKeyToWire({ providerID: 'opencode', modelID: 'big-pickle' })).toBe(
+      'opencode/big-pickle',
+    );
+  });
+});
+

--- a/packages/sdk/src/react/use-model-store.ts
+++ b/packages/sdk/src/react/use-model-store.ts
@@ -46,10 +46,11 @@ export type ModelKey = {
 // ── Gateway wire-model ⟷ ModelKey conversion ───────────────────────────────
 // The LLM gateway identifies a model by its "wire model" — what opencode sends
 // as `body.model`. Under the kortix gateway provider that is just the modelID
-// (a bare managed id like 'glm-5.2', or a BYOK 'provider/model'). A direct
-// provider model uses 'provider/model'.
+// (a bare managed id like 'glm-5.2', or a BYOK 'provider/model'). Gateway mode
+// is the only mode, so `kortix` is the only bare provider; anything else is
+// spelled out as 'provider/model' verbatim.
 export function modelKeyToWire(model: ModelKey): string {
-  if (model.providerID === 'kortix' || model.providerID === 'opencode') return model.modelID;
+  if (model.providerID === 'kortix') return model.modelID;
   return `${model.providerID}/${model.modelID}`;
 }
 
@@ -246,11 +247,10 @@ export function hasUsableModel(
   const connectedProviderIds = opts.connectedProviderIds;
   const freeTier = opts.freeTier ?? false;
   return allModels.some((m) => {
-    if (m.providerID !== MANAGED_GATEWAY_PROVIDER_ID) {
-      // Native/direct provider models: flattenModels only includes models
-      // from CONNECTED providers, so presence here already means usable.
-      return true;
-    }
+    // Gateway mode is the only mode: every usable model is registered under
+    // the one `kortix` provider. Anything else is a stale/foreign catalog
+    // entry, not a route OpenCode can take.
+    if (m.providerID !== MANAGED_GATEWAY_PROVIDER_ID) return false;
     if (MANAGED_MODEL_IDS.has(m.modelID)) return !freeTier;
     const sub = subProviderOf(m.modelID, m.provider);
     return sub === SUBSCRIPTION_PROVIDER_ID


### PR DESCRIPTION
The adversarial lens on the gateway-mode-only refactor flagged code that still
described native mode. Inert from live data, but "remove the possibility" is
the principle:

- agent-server routes/env.ts applyLlmGatewayMode(false): no longer clears
  KORTIX_LLM_*/KORTIX_OPENCODE_DENY_ENV. Answers 200 + warn and keeps gateway
  mode — tolerant of an OLDER API sending false during a mixed-version
  rollout, with no runtime path back to native. The proxy-auth test that
  asserted the old "DIRECT off" behaviour encoded the retired mode; rewritten
  (deliberately, not to reach green) to assert the key and deny list survive.
- packages/sdk use-model-store.ts: hasUsableModel → false for any non-kortix
  providerID (was true, "native/direct → usable"); modelKeyToWire drops the
  'opencode' special case. Documented under CHANGELOG ### Changed. New tests
  RED → GREEN.
- apps/web model-grouping.ts pickerGroupId: the non-kortix early return was
  redundant with the fall-through; removed, existing test still passes.

Evidence: daemon 837 pass / 0 fail + tsc clean; SDK 2515 pass / 0 fail +
typecheck clean; web session tests 2475 pass / 0 fail; eslint clean.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW