### PR TITLE
test(release): require Apps list after enabling flag

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,15 @@ linked, not inlined.
 
 ## Register
 
+### Prove the gated query ran after enabling its feature (2026-08-22)
+
+**When:** enabling a feature on one page, then navigating to its data page in a
+browser test. A route render does not prove the gated query ran. Wait for the
+exact API response around an explicit reload before asserting its empty state.
+*Near-miss:* release PR #6746 browser shard 2 failed twice with a permanent Apps
+skeleton after a `200` feature PATCH and zero `GET /apps` requests. *Enforcer:*
+`18-apps-ui.spec.ts` requires the Apps list response before the empty state.
+
 ### Assert an asynchronous timestamp write on its own row (2026-08-22)
 
 **When:** proving that one request advances a row timestamp while asynchronous

--- a/tests/e2e/specs/18-apps-ui.spec.ts
+++ b/tests/e2e/specs/18-apps-ui.spec.ts
@@ -158,6 +158,17 @@ test.describe('18 — Kortix Apps UI', () => {
       await page.goto(`/projects/${project.id}/apps`, {
         waitUntil: 'domcontentloaded',
       });
+      // A feature mutation can leave this client route mounted without starting
+      // its newly-enabled query. Reload and require the exact list response
+      // before asserting the empty state.
+      const emptyListResponse = page.waitForResponse(
+        (response) =>
+          response.request().method() === 'GET' &&
+          response.url().endsWith(`/v1/projects/${project.id}/apps`),
+      );
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      expect((await emptyListResponse).status()).toBe(200);
+      await dismissOnboarding(page);
       await expect(page.getByText('No Apps yet', { exact: true })).toBeVisible();
 
       const seeded = await api<AppResponse>(


### PR DESCRIPTION
## Problem

Release PR #6746 browser shard 2 failed twice after the Apps feature PATCH returned `200`. Both traces contained zero `GET /apps` requests, so the page remained on its loading skeleton.

## Change

- Reload the Apps route after enabling the flag.
- Require the exact `GET /apps` response to return `200` before asserting the empty state.
- Record the release-gate learning.

## Verification

- `pnpm --dir tests typecheck` — exit 0.
- `pnpm --dir tests exec playwright test -c playwright.config.ts e2e/specs/18-apps-ui.spec.ts --list` — 1 test discovered.
- The release gate will run the deployed browser journey against staging after merge.