### PR TITLE
fix(worktree): warn at start when another stack is live on the shared DB (worker cross-talk)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1741,3 +1741,33 @@ API origin and requires the standalone gateway health response.
 *Incident:* dev API returned `gateway_unavailable` after gateway PR #6737.
 The public edge surfaced it as blocking maintenance. Direct origin inspection
 identified the missing target before user traffic resumed.
+
+## Two dev stacks on one shared DB share one work queue
+
+2026-08-22. A `timeline-parity` worktree session's first prompt died inside
+OpenCode with `Cannot connect to API …
+subdivision-marine-acne-shorter.trycloudflare.com/v1/llm-gateway/v1/chat/completions`.
+That host belonged to a different worktree (`mw-perf`) whose quick tunnel had
+rotted. Both worktrees reuse the primary local Supabase, so prompt-inbox
+delivery, session-lifecycle commands, and sandbox env sync form ONE queue.
+`mw-perf`'s API grabbed the job, pushed its `KORTIX_URL`-derived gateway URL
+into the other worktree's sandbox, and forwarded the prompt. The owning
+worktree's log showed no env sync and no prompt POST, so nothing local
+explained the failure.
+
+**The rule.** A sandbox's gateway URL and credentials must come from the
+instance that owns the sandbox, never from whichever instance dequeues work.
+In local development, run one stack against the shared DB, or create the
+worktree with `--db`. When an OpenCode error names a host, grep EVERY stack
+log on the machine for that host before suspecting the branch.
+
+**The enforcement.** `pnpm worktree start` (`scripts/worktree/cli.ts`,
+`warnOnSharedDbCrosstalk`) now warns at start when another stack — a worktree
+in `shared` DB mode or the primary `pnpm dev` on `:8008` — is live on the
+same database, names it, and states the remedy. The product fix (persist the
+provisioning API origin on `session_sandboxes` and make env sync / delivery
+use it, or scope workers by instance) is an open follow-up.
+
+*Incident:* session `b090016e…` on worktree `timeline-parity`, first prompt
+`APIError` to a dead tunnel; prompts 2–3 succeeded after the owning instance's
+env sync rewrote the URL.

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -100,6 +100,32 @@ function warnOnStackPressure(current: string, reg: Registry): void {
   sub(`each holds ~19 processes and a few GB — free them with ${pc.cyan('pnpm worktree stop --all')}`);
 }
 
+/**
+ * Two stacks on the SHARED primary Supabase share one work queue — prompt-inbox
+ * delivery, session-lifecycle commands, sandbox env sync. Whichever API instance
+ * grabs a job pushes ITS `KORTIX_URL`-derived gateway URL into the box. If that
+ * other stack's tunnel has rotted (quick tunnels do, every few hours), the next
+ * prompt it picks up dies inside OpenCode with
+ * `Cannot connect to API … <other-stack>.trycloudflare.com/v1/llm-gateway`, and
+ * nothing in THIS stack's log explains it. 2026-08-22: `mw-perf`'s dead tunnel
+ * was pushed into a `timeline-parity` box this way. Say it at start, where the
+ * decision (one stack, or `--db`) is still cheap.
+ */
+const PRIMARY_API_PORT = 8008;
+function warnOnSharedDbCrosstalk(current: string, reg: Registry): void {
+  const me = reg.slots[current];
+  if (!me || dbModeOf(me) !== 'shared') return;
+  const others = Object.entries(reg.slots)
+    .filter(([n, e]) => n !== current && dbModeOf(e) === 'shared' && portInUse(e.ports.api).inUse)
+    .map(([n, e]) => `${n} (api :${e.ports.api})`);
+  if (portInUse(PRIMARY_API_PORT).inUse) others.unshift(`primary pnpm dev (api :${PRIMARY_API_PORT})`);
+  if (others.length === 0) return;
+  warn(`${plural(others.length, 'other stack is', 'other stacks are')} live on the SAME shared DB: ${others.join(', ')}`);
+  sub('they share one work queue (prompt delivery, session lifecycle, env sync) — whichever API grabs a job pushes ITS KORTIX_URL into the sandbox;');
+  sub(`a rotted tunnel over there surfaces HERE as OpenCode "Cannot connect to API …trycloudflare.com/v1/llm-gateway" on the first prompt.`);
+  sub(`run one stack at a time (${pc.cyan('pnpm worktree stop <name>')}), or recreate this worktree with ${pc.cyan('--db')} for an isolated database.`);
+}
+
 async function stopStack(e: SlotEntry, opts: { quiet?: boolean } = {}): Promise<KillResult> {
   const roots = stackRoots(e.path, e.ports);
   const res = await killTree(roots);
@@ -502,6 +528,7 @@ async function cmdStart(a: Args) {
       die('the shared primary Supabase DB does not have the kortix schema. Run the primary stack once to initialize it, or recreate this worktree with `--db` for an isolated database.');
     }
     sub(`${creds.supabaseUrl} · ${creds.dbUrl}`);
+    warnOnSharedDbCrosstalk(name, reg);
   }
   step('Building runtime artifacts');
   if (await ensureRuntimeArtifacts(e.path) !== 0) die('runtime artifact build failed');


### PR DESCRIPTION
Two stacks on the shared primary Supabase share one work queue — prompt-inbox
delivery, session-lifecycle commands, sandbox env sync. Whichever API grabs a
job pushes ITS KORTIX_URL-derived gateway URL into the sandbox. When that other
stack's quick tunnel has rotted, the next prompt it picks up dies inside
OpenCode with "Cannot connect to API … <other>.trycloudflare.com/v1/llm-gateway"
and nothing in the owning stack's log explains it.

2026-08-22: mw-perf's dead tunnel was pushed into a timeline-parity box this
way (mw-perf log: title-generate + env-sync push for the other worktree's
session/sandbox; owning log: no env sync, no prompt POST).

- scripts/worktree/cli.ts: warnOnSharedDbCrosstalk() runs right after "Using
  shared primary Supabase": lists other shared-mode slots whose api port is
  listening plus the primary pnpm dev on :8008, states the mechanism and the
  remedy (one stack at a time, or recreate with --db).
- learnings: rule + enforcement + open product follow-up (persist the
  provisioning API origin on session_sandboxes / scope workers by instance).

Proof: probe against the live registry returned
["primary pnpm dev (api :8008)", "mw-perf (api :16408)"]; scripts/worktree
tsc clean; `bun scripts/worktree/cli.ts --help` runs.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW