### PR TITLE
fix(cli): replay manifest CAS 409 once; projects ls honors --host/--account

### DIFF
--- a/apps/cli/src/__tests__/client-cas-retry.test.ts
+++ b/apps/cli/src/__tests__/client-cas-retry.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+// Two things the dev e2e pass surfaced, both fixed in one place each:
+//  1. a manifest compare-and-swap 409 ("File "kortix.yaml" changed since it was
+//     read") right after a previous manifest commit — the CLI now replays the
+//     write once (apps/cli/src/api/client.ts).
+//  2. `kortix projects ls` ignored `--host`, so it always listed the ACTIVE
+//     host's account — now `--host` / `--account` are honored.
+
+const CLI_ROOT = resolve(import.meta.dir, '..', '..');
+const CLI_ENTRY = join(CLI_ROOT, 'src', 'index.ts');
+const ORIGINAL_ENV = { ...process.env };
+const PROJECT = 'proj_cas';
+
+let tmp: string;
+let server: ReturnType<typeof Bun.serve> | null = null;
+let hits: Array<{ method: string; path: string; query: string }> = [];
+
+function writeConfig(activeBase: string, otherBase: string): string {
+  const path = join(tmp, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      active: 'active-host',
+      hosts: {
+        'active-host': {
+          url: activeBase,
+          token: 'tok_active',
+          user_id: 'u1',
+          user_email: 'a@example.test',
+          account_id: 'acct_active',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+        'other-host': {
+          url: otherBase,
+          token: 'tok_other',
+          user_id: 'u1',
+          user_email: 'a@example.test',
+          account_id: 'acct_other',
+          logged_in_at: '2026-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+    'utf8',
+  );
+  return path;
+}
+
+function startServer(): string {
+  let scopePuts = 0;
+  server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      hits.push({ method: req.method, path: url.pathname, query: url.search });
+      if (url.pathname === `/v1/projects/${PROJECT}/agents/bot/scope` && req.method === 'PUT') {
+        scopePuts += 1;
+        if (scopePuts === 1) {
+          return Response.json({ error: 'File "kortix.yaml" changed since it was read' }, { status: 409 });
+        }
+        return Response.json({ ok: true, agent: 'bot', env: 'all', connectors: [], connectors_required: [] });
+      }
+      if (url.pathname === `/v1/projects/${PROJECT}/agents/bot/config` && req.method === 'GET') {
+        return Response.json({ agent: 'bot', schema_version: 2, editable: true, block: { secrets: 'all', connectors: [] } });
+      }
+      if (url.pathname === `/v1/projects/${PROJECT}/features` && req.method === 'PATCH') {
+        // A CAS-looking 409 on a NON-manifest route is replayed too (same
+        // message = same server contract), but a different 409 is not.
+        return Response.json({ error: 'enabled must be a boolean or null' }, { status: 409 });
+      }
+      if (url.pathname === '/v1/projects' && req.method === 'GET') {
+        const acct = url.searchParams.get('account_id');
+        return Response.json([
+          { project_id: `p_${acct}`, account_id: acct, name: `Project of ${acct}`, repo_url: '', default_branch: 'main', manifest_path: 'kortix.yaml', status: 'active', last_opened_at: null, created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
+        ]);
+      }
+      return Response.json({ error: 'not found' }, { status: 404 });
+    },
+  });
+  return `http://127.0.0.1:${server.port}`;
+}
+
+async function runCli(args: string[], configFile?: string) {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    KORTIX_NO_UPDATE_CHECK: '1',
+    NO_COLOR: '1',
+    FORCE_COLOR: '0',
+    KORTIX_DISABLE_SANDBOX_ENV_FILE: '1',
+    KORTIX_CONFIG_FILE: configFile,
+  };
+  for (const key of ['KORTIX_API_URL', 'KORTIX_CLI_TOKEN', 'KORTIX_FRONTEND_URL', 'KORTIX_PROJECT_ID', 'KORTIX_TOKEN', 'BASH_ENV']) delete env[key];
+  const proc = Bun.spawn({ cmd: [process.execPath, CLI_ENTRY, ...args], cwd: tmp, env, stdout: 'pipe', stderr: 'pipe' });
+  const timeout = setTimeout(() => proc.kill(), 20_000);
+  const [code, stdout, stderr] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]).finally(() => clearTimeout(timeout));
+  return { code, stdout, stderr };
+}
+
+describe('CLI client: manifest CAS 409 is replayed once', () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kortix-cas-'));
+    process.env = { ...ORIGINAL_ENV };
+    hits = [];
+  });
+  afterEach(() => {
+    server?.stop(true);
+    server = null;
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('agents scope: first PUT answers the CAS 409, the replay succeeds → exit 0', async () => {
+    const base = startServer();
+    const config = writeConfig(base, base);
+    const r = await runCli(['agents', 'scope', 'bot', '--secrets', 'all', '--connectors', 'none', '--project', PROJECT], config);
+    expect(r.code).toBe(0);
+    const puts = hits.filter((h) => h.method === 'PUT' && h.path.endsWith('/agents/bot/scope'));
+    expect(puts.length).toBe(2);
+    expect(r.stderr).not.toContain('changed since it was read');
+  });
+
+  test('a 409 with a different message is NOT replayed', async () => {
+    const base = startServer();
+    const config = writeConfig(base, base);
+    const r = await runCli(['projects', 'features', 'enable', 'apps', '--project', PROJECT], config);
+    expect(r.code).toBe(1);
+    const patches = hits.filter((h) => h.method === 'PATCH');
+    expect(patches.length).toBe(1);
+  });
+});
+
+describe('kortix projects ls honors --host / --account', () => {
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'kortix-ls-host-'));
+    process.env = { ...ORIGINAL_ENV };
+    hits = [];
+  });
+  afterEach(() => {
+    server?.stop(true);
+    server = null;
+    rmSync(tmp, { recursive: true, force: true });
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  test('--host other-host lists THAT host’s account, --account overrides it', async () => {
+    const base = startServer();
+    const config = writeConfig('http://127.0.0.1:9', base); // active host is unreachable on purpose
+    const r = await runCli(['projects', 'ls', '--host', 'other-host', '--json'], config);
+    expect(r.code).toBe(0);
+    expect(JSON.parse(r.stdout)[0].project_id).toBe('p_acct_other');
+    const r2 = await runCli(['projects', 'ls', '--host', 'other-host', '--account', 'acct_x', '--json'], config);
+    expect(r2.code).toBe(0);
+    expect(JSON.parse(r2.stdout)[0].project_id).toBe('p_acct_x');
+    expect(hits.filter((h) => h.path === '/v1/projects').map((h) => h.query)).toEqual(['?account_id=acct_other', '?account_id=acct_x']);
+  });
+
+  test('--host that is not logged in exits 1 with a login hint', async () => {
+    const base = startServer();
+    const config = writeConfig(base, base);
+    const r = await runCli(['projects', 'ls', '--host', 'nope-host'], config);
+    expect(r.code).toBe(1);
+    expect(r.stderr).toContain('not logged in');
+  });
+});

--- a/apps/cli/src/api/client.ts
+++ b/apps/cli/src/api/client.ts
@@ -104,7 +104,41 @@ function captureIdentity(endpoint: string, token: string, data: unknown): void {
   }
 }
 
+/** The API commits manifest writes (kortix.yaml, agent .md) with a
+ *  compare-and-swap on the file sha. Two writes in quick succession — e.g.
+ *  `agents default` then `agents scope`, or a dashboard edit landing while the
+ *  CLI reads — answer 409 with this exact message. The write is safe to replay:
+ *  the server re-reads the file and applies the same mutation on top of the new
+ *  sha. Replay ONCE after a short pause; a second conflict is surfaced as-is. */
+const MANIFEST_CAS_CONFLICT = /changed since it was read/i;
+const MANIFEST_CAS_RETRY_DELAY_MS = 1500;
+function isManifestCasConflict(err: unknown): boolean {
+  if (!(err instanceof ApiError) || err.status !== 409) return false;
+  if (MANIFEST_CAS_CONFLICT.test(err.message)) return true;
+  // The SDK may keep the server's wording in the body rather than the message.
+  try {
+    return MANIFEST_CAS_CONFLICT.test(JSON.stringify(err.body ?? ''));
+  } catch {
+    return false;
+  }
+}
+
 async function request<T>(
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+  path: string,
+  body: unknown,
+  opts: { auth: Auth; accountId?: string },
+): Promise<T> {
+  try {
+    return await requestOnce<T>(method, path, body, opts);
+  } catch (err) {
+    if (method === 'GET' || !isManifestCasConflict(err)) throw err;
+    await new Promise((r) => setTimeout(r, MANIFEST_CAS_RETRY_DELAY_MS));
+    return requestOnce<T>(method, path, body, opts);
+  }
+}
+
+async function requestOnce<T>(
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   path: string,
   body: unknown,

--- a/apps/cli/src/api/types.ts
+++ b/apps/cli/src/api/types.ts
@@ -159,6 +159,8 @@ export interface ProjectTrigger {
   agent: string;
   enabled: boolean;
   cron: string | null;
+  /** One-off run instant (ISO); exclusive with cron. */
+  run_at?: string | null;
   timezone: string;
   secret_env: string | null;
   /** monitor only — the repo-relative command whose stdout lines are the events. */

--- a/apps/cli/src/commands/audit.ts
+++ b/apps/cli/src/commands/audit.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { downloadAccountAudit, type AuditEvent, type AuditEventList } from '@kortix/sdk';
-import { loadAuth } from '../api/auth.ts';
+import { loadAuth, loadAuthForHost } from '../api/auth.ts';
 import { activeAccount } from '../api/config.ts';
 import { clientFromAuth, type ApiClient } from '../api/client.ts';
 import { emitJson, surfaceApiError, takeFlagValue, takeFlagBool } from '../command-helpers.ts';
@@ -72,6 +72,7 @@ Options:
   --url <u>            webhooks add: the http(s) endpoint to POST events to.
   --action-prefix <p>  webhooks add: only deliver actions with this prefix.
   --account <id>       Operate on this account (default: active account).
+  --host <name>        Operate against a non-default Kortix host.
   --json               Machine-readable output.
   -h, --help           Show this help.
 
@@ -170,13 +171,19 @@ interface AuditContext {
   auth: NonNullable<ReturnType<typeof loadAuth>>;
 }
 
-function resolveAccountContext(accountArg?: string): AuditContext | null {
-  const auth = loadAuth();
+function resolveAccountContext(accountArg?: string, hostArg?: string): AuditContext | null {
+  // --host names a logged-in host other than the active one; its own stored
+  // account is the default scope there (never the global active account).
+  const auth = hostArg ? loadAuthForHost(hostArg) : loadAuth();
   if (!auth?.token) {
-    process.stderr.write(`${status.err('Not logged in. Run `kortix login`.')}\n`);
+    process.stderr.write(
+      hostArg
+        ? `${status.err(`Host "${hostArg}" is not logged in.`)} Run \`kortix login --host ${hostArg}\`.\n`
+        : `${status.err('Not logged in. Run `kortix login`.')}\n`,
+    );
     return null;
   }
-  const accountId = accountArg || activeAccount()?.id || auth.account_id || '';
+  const accountId = accountArg || (hostArg ? auth.account_id : activeAccount()?.id || auth.account_id) || '';
   if (!accountId) {
     process.stderr.write(
       `${status.err('No active account. Run `kortix accounts use` or pass --account <id>.')}\n`,
@@ -325,6 +332,7 @@ export async function runAudit(argv: string[]): Promise<number> {
   let all = false;
   try {
     f.account = takeFlagValue(rest, ['--account']);
+    f.host = takeFlagValue(rest, ['--host']);
     f.action = takeFlagValue(rest, ['--action']);
     f.actor = takeFlagValue(rest, ['--actor']);
     f.actorType = takeFlagValue(rest, ['--actor-type']);
@@ -354,7 +362,7 @@ export async function runAudit(argv: string[]): Promise<number> {
   }
   const positional = rest.filter((a) => !a.startsWith('-'));
 
-  const ctx = resolveAccountContext(f.account);
+  const ctx = resolveAccountContext(f.account, f.host);
   if (!ctx) return 1;
   const base = `/accounts/${ctx.accountId}/audit`;
 

--- a/apps/cli/src/commands/cr.ts
+++ b/apps/cli/src/commands/cr.ts
@@ -43,7 +43,7 @@ Subcommands:
   request-changes <cr> --message "<t>"   Ask the agent that opened it to revise.
   close <cr>                             Close an open CR without merging.
   reopen <cr>                            Reopen a closed CR.
-  version-diff --from <ver> --into <ver> Summarize one version against another
+  version-diff --from <head> --into <base> Summarize what merging <head> into <base>
                 [--json]                 before opening a CR.
 
 <cr> can be a CR number (e.g. 3) or a CR uuid.

--- a/apps/cli/src/commands/projects.ts
+++ b/apps/cli/src/commands/projects.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { isProjectGlyphColor, isProjectGlyphName, PROJECT_GLYPH_COLORS } from '@kortix/shared';
-import { loadAuth } from '../api/auth.ts';
+import { loadAuth, loadAuthForHost } from '../api/auth.ts';
 import {
   activeAccount,
   activeHostName,
@@ -118,13 +118,17 @@ export async function runProjects(argv: string[]): Promise<number> {
       const all = takeFlagBool(restCopy, ['--all', '-a']);
       const json = takeFlagBool(restCopy, ['--json']);
       let query: string | undefined;
+      let hostArg: string | undefined;
+      let accountArg: string | undefined;
       try {
         query = takeFlagValue(restCopy, ['--query', '-q']);
+        hostArg = takeFlagValue(restCopy, ['--host']);
+        accountArg = takeFlagValue(restCopy, ['--account']);
       } catch (err) {
         process.stderr.write(`${status.err((err as Error).message)}\n`);
         return 2;
       }
-      return projectsLs(json, all, query);
+      return projectsLs(json, all, query, hostArg, accountArg);
     }
     case 'set':
     case 'update':
@@ -1083,14 +1087,31 @@ function filterProjects(projects: ProjectSummary[], query?: string): ProjectSumm
   );
 }
 
-async function projectsLs(json = false, all = false, query?: string): Promise<number> {
-  const auth = requireAuth();
-  if (!auth) return 1;
+async function projectsLs(
+  json = false,
+  all = false,
+  query?: string,
+  hostArg?: string,
+  accountArg?: string,
+): Promise<number> {
+  // --host names a logged-in host other than the active one; --account picks
+  // the account within it (default: that host's active account).
+  const auth = hostArg ? loadAuthForHost(hostArg) : requireAuth();
+  if (!auth?.token) {
+    if (hostArg) {
+      process.stderr.write(
+        `${status.err(`Host "${hostArg}" is not logged in.`)} Run ${C.cyan}kortix login --host ${hostArg}${C.reset}.\n`,
+      );
+    }
+    return 1;
+  }
   if (all) return projectsLsAll(auth, json, query);
 
   // Scope to the active account so this lists exactly that account's projects
   // (not the server's earliest-joined-account default).
-  const client = clientFromAuth(auth, { accountId: scopeAccountId(auth) });
+  // --host: that host's own stored account (never the global active one).
+  const accountId = accountArg || (hostArg ? auth.account_id || undefined : scopeAccountId(auth));
+  const client = clientFromAuth(auth, { accountId });
   let projects: ProjectSummary[];
   try {
     projects = filterProjects(await client.get<ProjectSummary[]>('/projects'), query);

--- a/apps/cli/src/commands/triggers.ts
+++ b/apps/cli/src/commands/triggers.ts
@@ -775,6 +775,7 @@ async function triggersInfo(slug: string | undefined, opts: CtxOpts, json = fals
   ];
   if (t.type === 'cron') {
     rows.push(['cron', t.cron ?? '—'], ['timezone', t.timezone]);
+    if (t.run_at) rows.push(['run_at', String(t.run_at)]);
   } else if (t.type === 'monitor') {
     rows.push(['run', t.run ?? '—'], ['mode', t.mode ?? '—']);
     if (t.interval_seconds !== null && t.interval_seconds !== undefined) {


### PR DESCRIPTION
Two defects surfaced by the end-to-end pass of the parity commands against dev-api (throwaway account/project, every command run for real with read-back):

- **Manifest CAS 409 replayed once.** `kortix agents scope` right after `kortix agents default` answered `409 File "kortix.yaml" changed since it was read` (the API commits manifest writes with a compare-and-swap). The CLI client now replays a non-GET once after 1.5 s when the 409 carries that wording; other 409s are surfaced unchanged. Verified live: the same sequence now passes on dev.
- **`kortix projects ls --host <name> [--account <id>]`.** `ls` ignored `--host` and always listed the active host's account.

Tests: `apps/cli/src/__tests__/client-cas-retry.test.ts` (fake API answers the CAS 409 once → exactly 2 PUTs, exit 0; a different 409 → 1 request, exit 1; `--host` lists that host's account, `--account` overrides, unknown host → exit 1). `bun test` in apps/cli: 1232 pass / 0 fail.

https://claude.ai/code/session_016oVpyD5iwu78GoqefcYndL