### PR TITLE
fix(worktree): tunnel watchdog — rotate a dead quick tunnel and respawn the API with the new KORTIX_URL

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1783,3 +1783,30 @@ use it, or scope workers by instance) is an open follow-up.
 *Incident:* session `b090016e…` on worktree `timeline-parity`, first prompt
 `APIError` to a dead tunnel; prompts 2–3 succeeded after the owning instance's
 env sync rewrote the URL.
+
+## Every stack launcher needs the tunnel watchdog, not only `pnpm dev`
+
+2026-08-22. The `timeline-parity` worktree's quick tunnel died three times in
+one evening (30 min – 3 h after mint). The symptom in the session UI was
+OpenCode `Retrying in 81s · #1 · <none>` — Cloudflare's HTML 530 carries no
+message — or `Cannot connect to API …trycloudflare.com/v1/llm-gateway` on the
+first prompt. The local API was healthy each time. `scripts/dev-local.sh` had
+a watchdog that rotates a dead tunnel and bounces the API; the worktree
+launcher (`scripts/worktree/cli.ts`) did not, so every death needed a hand
+restart and a new `KORTIX_URL`.
+
+**The rule.** A component that bakes a public callback URL at spawn must own
+the liveness of that URL. Any launcher that mints a quick tunnel ships the
+watchdog with it: probe the URL while the local API is healthy; on death,
+mint a new tunnel and respawn the API with the new URL; say so in the log.
+Diagnose a `<none>` retry row by `curl $KORTIX_URL/v1/health` (530 = dead
+tunnel) and `pgrep -f 'cloudflared tunnel'`.
+
+**The enforcement.** `pnpm worktree start` now runs `startTunnelWatchdog`
+(60 s tick, two-probe confirmation, cloudflared exit detection, API respawn
+with the new `KORTIX_URL`). The worktree launcher gets the same tunnel
+watchdog as `pnpm dev`. Proven by killing cloudflared on a live stack and
+watching the rotation (PR #6755).
+
+*Incident:* session `b090016e…` / `cbde77cf…` on worktree `timeline-parity`,
+three tunnel deaths, each surfaced as an OpenCode retry loop.

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -21,7 +21,7 @@ import {
   STRIDE, BASE, computePorts, loadRegistry, saveRegistry, withLock, sanitizeName,
   lowestFreeSlot, sh, run, which, portInUse, repoRoot, defaultWorktreePath, branchExists, worktreeAddArgs,
   renderSupabaseProject, runMigrate, supa, supaStatusEnv, slotCredsFromStatus, apiLaunchEnv, webLaunchEnv, gatewayLaunchEnv,
-  writeMarker, ensureDeps, checkDeps, supaWorkdir, slotDir, startTunnel, startStripeListen, WT_HOME, REGISTRY_PATH,
+  writeMarker, ensureDeps, checkDeps, supaWorkdir, slotDir, startTunnel, tunnelAnswers, startStripeListen, WT_HOME, REGISTRY_PATH,
   startSupabaseDb, startSupabaseFullStack, hasKortixSchema, ensureRuntimeArtifacts, dbModeOf,
   ensurePrimarySupabase, primaryCredsFromStatus, SHARED_SUPABASE_PORTS,
   killTree, stackRoots, stackPids, listenersOn, psTable, cwdTable,
@@ -565,11 +565,58 @@ async function cmdStart(a: Args) {
   }
   console.log(pc.dim('   (Ctrl+C stops the dev servers cleanly)\n'));
 
-  const api = Bun.spawn(['pnpm', '--filter', API_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...apiLaunchEnv(e.ports, creds, { kortixUrl: tunnel?.url, stripeWebhookSecret: stripe?.secret, billing }) }, stdout: 'inherit', stderr: 'inherit' });
+  // The API's KORTIX_URL is baked at spawn, so a tunnel rotation has to
+  // respawn it — keep the spawn in a function and the handle mutable.
+  const spawnApi = (kortixUrl: string | undefined) =>
+    Bun.spawn(['pnpm', '--filter', API_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...apiLaunchEnv(e.ports, creds, { kortixUrl, stripeWebhookSecret: stripe?.secret, billing }) }, stdout: 'inherit', stderr: 'inherit' });
+  let api = spawnApi(tunnel?.url);
+  let apiRestarting = false;
   const gateway = Bun.spawn(['pnpm', '--filter', GATEWAY_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...gatewayLaunchEnv(e.ports) }, stdout: 'inherit', stderr: 'inherit' });
   const web = Bun.spawn(['pnpm', '--filter', WEB_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...webLaunchEnv(e.ports, creds, { billing }) }, stdout: 'inherit', stderr: 'inherit' });
   void waitForGateway(e.ports.gateway, gateway);
   let stopping = false;
+  // Quick tunnels die silently — cloudflared exits, or the URL starts answering
+  // 530 while the process lives. 2026-08-22: three deaths in one evening; each
+  // one surfaced as OpenCode "Retrying in 81s · <none>" (Cloudflare's HTML 530
+  // has no message) or "Cannot connect to API …trycloudflare.com" on the first
+  // prompt, and nothing local said why. Mirror scripts/dev-local.sh's watchdog:
+  // every 60s, if the LOCAL API is healthy but the tunnel is dead (process gone,
+  // or two consecutive probe failures), mint a new quick tunnel and respawn the
+  // API with the new KORTIX_URL. Existing boxes pick the new gateway URL up on
+  // their next prompt (env sync); their daemon callbacks stay on the old host.
+  const startTunnelWatchdog = () => {
+    if (!tunnel) return;
+    const localHealthy = () => tunnelAnswers(`http://localhost:${e.ports.api}`, '/v1/health', 2000);
+    void (async () => {
+      while (!stopping) {
+        await Bun.sleep(60_000);
+        if (stopping || !tunnel) return;
+        if (!(await localHealthy())) continue; // not the tunnel's fault
+        const procDead = tunnel.proc.exitCode !== null;
+        let dead = procDead || !(await tunnelAnswers(tunnel.url));
+        if (dead && !procDead) { await Bun.sleep(5000); dead = !(await tunnelAnswers(tunnel.url)); } // confirm, avoid a blip
+        if (!dead) continue;
+        warn(`tunnel ${tunnel.url} is DEAD (${procDead ? 'cloudflared exited' : 'URL answers no health'}) — rotating + restarting the API…`);
+        try { tunnel.proc.kill(); } catch {}
+        const next = await startTunnel(e.ports.api);
+        if (!next) { warn('tunnel rotation FAILED (cloudflared gave no URL) — will retry next minute'); continue; }
+        tunnel = next;
+        apiRestarting = true;
+        try { api.kill(); } catch {}
+        await Promise.race([api.exited, Bun.sleep(4000)]);
+        api = spawnApi(tunnel.url);
+        void watchApi();
+        apiRestarting = false;
+        ok(`tunnel rotated: KORTIX_URL → ${tunnel.url} (API restarted)`);
+      }
+    })();
+  };
+  // An API exit that WE did not cause (rotation) still tears the stack down.
+  const watchApi = async () => {
+    const mine = api;
+    await mine.exited;
+    if (!stopping && !apiRestarting && api === mine) await shutdown();
+  };
   const shutdown = async () => {
     if (stopping) return; stopping = true;
     console.log(`\n${pc.yellow('▸')} stopping…`);
@@ -595,7 +642,9 @@ async function cmdStart(a: Args) {
   };
   process.on('SIGINT', () => { void shutdown(); });
   process.on('SIGTERM', () => { void shutdown(); });
-  await Promise.race([api.exited, gateway.exited, web.exited]);
+  startTunnelWatchdog();
+  void watchApi();
+  await Promise.race([gateway.exited, web.exited]);
   await shutdown();
 }
 

--- a/scripts/worktree/lib/services.ts
+++ b/scripts/worktree/lib/services.ts
@@ -35,6 +35,9 @@ async function waitForOutputMatch(
     try {
       for await (const chunk of stream as unknown as AsyncIterable<Uint8Array>) {
         buf += dec.decode(chunk, { stream: true });
+        // The pumps outlive the match so the child's pipes stay drained for
+        // its whole life (a full pipe stalls cloudflared). Keep the tail only.
+        if (buf.length > 65_536) buf = buf.slice(-32_768);
       }
     } catch { /* stream closed when the process is killed */ }
   };
@@ -50,6 +53,16 @@ async function waitForOutputMatch(
 }
 
 export interface Tunnel { url: string; proc: ReturnType<typeof Bun.spawn>; }
+
+/** True when the quick tunnel's public URL answers the API health route. */
+export async function tunnelAnswers(url: string, apiPath = '/v1/health', timeoutMs = 8000): Promise<boolean> {
+  try {
+    const r = await fetch(`${url}${apiPath}`, { signal: AbortSignal.timeout(timeoutMs) });
+    return r.ok;
+  } catch {
+    return false;
+  }
+}
 
 export async function startTunnel(apiPort: number): Promise<Tunnel | null> {
   if (!which('cloudflared')) return null;


### PR DESCRIPTION
Quick tunnels die silently: cloudflared exits, or the URL starts answering
Cloudflare's HTML 530 while the process lives. 2026-08-22: three deaths in one
evening on the timeline-parity worktree (each ~30 min to 3 h after mint). Each
surfaced in the session UI as OpenCode "Retrying in 81s · <none>" (the 530
page carries no message) or "Cannot connect to API …trycloudflare.com" on the
first prompt; the local API was healthy the whole time and nothing local said
why. scripts/dev-local.sh has had a watchdog for this since the primary stack
hit it; the worktree launcher did not.

- cli.ts start(): the API spawn becomes spawnApi(kortixUrl) with a mutable
  handle. A watchdog ticks every 60s: if the LOCAL API answers /v1/health but
  the tunnel is dead (cloudflared exited, or two consecutive probe failures
  5s apart), it kills cloudflared, mints a new quick tunnel, kills + respawns
  the API with the new KORTIX_URL, and says so. watchApi() still tears the
  stack down on an API exit we did not cause. The final await no longer races
  on api.exited (a rotation is not a crash).
- services.ts: tunnelAnswers(url) probe; waitForOutputMatch caps its buffer
  (the pumps outlive the match so cloudflared's pipes stay drained).

Existing sandboxes pick the new gateway URL up on their next prompt (env
sync); their daemon callbacks stay on the old host — same caveat as
dev-local.sh.

Proof: scripts/worktree tsc clean; `bun scripts/worktree/cli.ts --help` runs.
Live rotation exercised on the timeline-parity worktree after cherry-pick
(see PR body for the log lines).

## Live rotation proof (timeline-parity worktree, 2026-08-22 21:03–21:05 UTC)

1. Stack up with the patched launcher: `KORTIX_URL=https://electric-secret-logistics-sin.trycloudflare.com` → `/v1/health` **200**.
2. `kill <cloudflared pid 21210>` at 21:03:55 → old URL answers **530** immediately.
3. Watchdog tick: new cloudflared (pid 28107) minted, API respawned — `started_at 2026-08-22T21:04:52Z`, pid 21466 → 29961 — with `KORTIX_URL=https://karaoke-bugs-pounds-importance.trycloudflare.com` in its env (read via `ps eww`).
4. New URL → `/v1/health` **200**; launcher (pid 20942) still supervising. Elapsed kill→healthy: ~60 s.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW
