### PR TITLE
docs(learnings): never resolve a merge inside a worktree whose API runs --hot

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1819,3 +1819,29 @@ watching the rotation (PR #6755).
 
 *Incident:* session `b090016e…` / `cbde77cf…` on worktree `timeline-parity`,
 three tunnel deaths, each surfaced as an OpenCode retry loop.
+
+## Never resolve a merge inside a worktree whose API runs `--hot`
+
+2026-08-22. `git merge origin/main` was run inside `suna-timeline-parity`, the
+worktree that served the user's live test stack (`bun --hot` API, Next dev
+web). The merge stopped on conflicts, the tree held conflict markers, and the
+hot-reloading API picked them up (`tsc`: `TS1185: Merge conflict marker
+encountered` in `r4.ts`) while the user was testing. `git merge --abort`
+restored it within a minute; no sandbox was lost.
+
+**The rule.** A worktree that serves a live stack is read-only to git
+operations that can leave the tree in a non-compiling state: merges with
+possible conflicts, rebases, cherry-picks, checkouts of other branches.
+Resolve in a scratch worktree on a sibling branch, run the gates there, then
+`git merge --ff-only` inside the live worktree so it only ever moves between
+two consistent trees. Fast-forward is the only git write a live worktree
+should see.
+
+**The enforcement.** The integration-branch memory note names the rule; the
+scratch-worktree-then-ff sequence is the procedure
+(`timeline-parity-main-merge` → `git merge --ff-only`). Candidate for a
+`pnpm worktree` guard: refuse `merge`/`rebase` in a slot whose API port is
+listening unless `--ff-only`.
+
+*Incident:* `timeline-parity` worktree, 2026-08-22 ~21:35 UTC, ~60 s of
+`tsc` errors on the live API; aborted, re-done in `tp-main-merge`, ff'd.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1835,7 +1835,13 @@ possible conflicts, rebases, cherry-picks, checkouts of other branches.
 Resolve in a scratch worktree on a sibling branch, run the gates there, then
 `git merge --ff-only` inside the live worktree so it only ever moves between
 two consistent trees. Fast-forward is the only git write a live worktree
-should see.
+should see — and a fast-forward that moves `apps/kortix-sandbox-agent-server`,
+`apps/cli`, or `apps/kortix-app-runtime` source must be followed by the same
+artifact builds the launcher runs at start (`pnpm --filter` build for the
+agent server and CLI, `bash apps/kortix-app-runtime/build.sh`), or every new
+session fails provisioning with `kortix-agent dist binary … is older than its
+source` (seen 2026-08-22 21:41 right after the ff; rebuilt, sessions booted
+again).
 
 **The enforcement.** The integration-branch memory note names the rule; the
 scratch-worktree-then-ff sequence is the procedure


### PR DESCRIPTION
Near-miss tonight: a conflicted `git merge origin/main` inside the live `timeline-parity` worktree put conflict markers under a `bun --hot` API for ~60 s. Rule + procedure (scratch worktree → gates → `git merge --ff-only`) recorded in the learnings register.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW