### PR TITLE
fix(api,dev): instance-scoped background work on a shared local DB (KORTIX_INSTANCE_ID)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1782,16 +1782,40 @@ In local development, run one stack against the shared DB, or create the
 worktree with `--db`. When an OpenCode error names a host, grep EVERY stack
 log on the machine for that host before suspecting the branch.
 
-**The enforcement.** `pnpm worktree start` (`scripts/worktree/cli.ts`,
-`warnOnSharedDbCrosstalk`) now warns at start when another stack — a worktree
-in `shared` DB mode or the primary `pnpm dev` on `:8008` — is live on the
-same database, names it, and states the remedy. The product fix (persist the
-provisioning API origin on `session_sandboxes` and make env sync / delivery
-use it, or scope workers by instance) is an open follow-up.
+**Second incident, same night (~23:00 UTC).** Same worktree, same symptom,
+different culprit: the PRIMARY `pnpm dev` stack on `:8008`. Its quick tunnel
+(`patches-….trycloudflare.com`) had died; its 1 s lifecycle drain tick still
+claimed the worktree's queued prompt, its env sync pushed the dead
+`patches…/v1/llm-gateway` URL into the worktree's sandbox, and OpenCode failed
+the turn with `Cannot connect to API`. The worktree's log again showed no env
+sync and no prompt POST. Two instances in one evening proves this is the
+default failure mode of a shared DB, not a one-off.
 
-*Incident:* session `b090016e…` on worktree `timeline-parity`, first prompt
-`APIError` to a dead tunnel; prompts 2–3 succeeded after the owning instance's
-env sync rewrote the URL.
+**The enforcement.** Two layers, both shipped:
+1. `pnpm worktree start` (`scripts/worktree/cli.ts`, `warnOnSharedDbCrosstalk`)
+   warns at start when another stack is live on the same database, names it,
+   and states the remedy.
+2. **Instance scoping is the product fix.** `KORTIX_INSTANCE_ID`
+   (`apps/api/src/config.ts`, optional, unset in every deployed env) is set by
+   the launchers only: `scripts/dev-local.sh` exports `primary`,
+   `scripts/worktree/lib/launch-env.ts` exports the worktree name.
+   `provisionSessionSandbox` stamps `session_sandboxes.metadata.instanceId`;
+   `sandboxBelongsToThisInstance()` (`apps/api/src/projects/instance-scope.ts`)
+   is consulted by the lifecycle drain (`drainSessionLifecycleQueue` RELEASES a
+   claimed command whose sandbox another instance owns — `queued`, due in 2 s,
+   attempt given back, never dead-lettered), by the env-sync project fan-out
+   (`propagateProjectSecretsToActiveSandboxes` skips foreign boxes), by the box
+   reaper (`reapAndReconcileSandboxes` skips them) and by Platinum's
+   `listManagedRunningSandboxes` (`kortix.instance` marker beside `kortix.env`).
+   Unset id, or a row with no stamp (legacy), means "mine" — a strict no-op in
+   production and never a stranded sandbox. HTTP-path work (proxy, `/start`,
+   `prompt_async`) is deliberately unscoped: the browser talks to one stack on
+   purpose.
+
+*Incidents:* session `b090016e…` on worktree `timeline-parity` (20:16 UTC,
+`mw-perf`'s dead `subdivision-marine-acne-shorter` tunnel) and the same
+worktree at ~23:00 UTC (primary `pnpm dev`'s dead `patches…` tunnel); in both,
+prompts after the owning instance's own env sync succeeded.
 
 ## Every stack launcher needs the tunnel watchdog, not only `pnpm dev`
 

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -1541,7 +1541,7 @@ describe('git-backed triggers — runtime fire paths', () => {
 
     provisioningSessionCount = 0;
     const drained = await drainSessionLifecycleQueue({ workerId: 'test-worker', limit: 1 });
-    expect(drained).toEqual({ claimed: 1, succeeded: 1, failed: 0, queued: 0 });
+    expect(drained).toEqual({ claimed: 1, succeeded: 1, failed: 0, queued: 0, released: 0 });
     await new Promise((r) => setTimeout(r, 0));
     expect(sandboxProvisionCalls).toBe(1);
     expect(lastProvisionEnv?.KORTIX_INITIAL_PROMPT).toBeUndefined();

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -144,6 +144,14 @@ const envSchema = z.object({
   // `preview` = ephemeral per-PR API on EKS (shares the dev data plane, never
   // migrates it, workers off, allows preview frontends in CORS). See ensure-schema.ts + the CORS block in index.ts.
   INTERNAL_KORTIX_ENV: z.enum(['dev', 'staging', 'prod', 'preview']).optional().default('dev'),
+  // Instance scope for BACKGROUND work on a shared database (local dev only:
+  // worktrees + the primary `pnpm dev` share one Supabase, so the lifecycle
+  // queue, env-sync fan-outs and the box reaper are one queue across every
+  // running API). Set by the launchers (`scripts/dev-local.sh` → `primary`,
+  // `scripts/worktree/lib/launch-env.ts` → the worktree name). Unset in every
+  // deployed environment → every scope check is a no-op.
+  // See projects/instance-scope.ts.
+  KORTIX_INSTANCE_ID: z.string().trim().optional(),
 
   // Wildcard domain every preview ORIGIN sits under
   // (`{env}-p{port}-{sandbox}.{domain}`). Unset on managed cloud, where it is
@@ -991,6 +999,9 @@ export const config = {
 
   // ─── Internal Deployment Controls ─────────────────────────────────────────
   INTERNAL_KORTIX_ENV: env.INTERNAL_KORTIX_ENV as InternalKortixEnv,
+  // Empty string reads as unset: the launchers always export the var, and a
+  // blank value must not turn into an instance called "".
+  KORTIX_INSTANCE_ID: env.KORTIX_INSTANCE_ID || undefined,
   KORTIX_PREVIEW_BASE_DOMAIN: env.KORTIX_PREVIEW_BASE_DOMAIN,
   // Single master switch — see schema docstring above.
   KORTIX_BILLING_INTERNAL_ENABLED: env.KORTIX_BILLING_INTERNAL_ENABLED,

--- a/apps/api/src/platform/providers/platinum-list-managed.test.ts
+++ b/apps/api/src/platform/providers/platinum-list-managed.test.ts
@@ -11,14 +11,15 @@
 
 import { beforeEach, expect, mock, test } from 'bun:test';
 
+const platinumConfig: Record<string, unknown> = {
+  PLATINUM_API_KEY: 'pt_test',
+  PLATINUM_API_URL: 'https://platinum.example.test',
+  KORTIX_URL: 'https://api.example.test',
+  INTERNAL_KORTIX_ENV: 'dev',
+  PLATINUM_TEMPLATE: 'kortix-computer',
+};
 mock.module('../../config', () => ({
-  config: {
-    PLATINUM_API_KEY: 'pt_test',
-    PLATINUM_API_URL: 'https://platinum.example.test',
-    KORTIX_URL: 'https://api.example.test',
-    INTERNAL_KORTIX_ENV: 'dev',
-    PLATINUM_TEMPLATE: 'kortix-computer',
-  },
+  config: platinumConfig,
   SANDBOX_VERSION: 'test-version',
 }));
 
@@ -110,4 +111,46 @@ test('a box with no readable creation time reports createdAt null so the reaper 
   const listed = await new PlatinumProvider().listManagedRunningSandboxes();
 
   expect(listed).toEqual([{ externalId: 'sbx_undated', createdAt: null }]);
+});
+
+test('INSTANCE SCOPE: with KORTIX_INSTANCE_ID set, another instance’s box is skipped; own and unstamped boxes are listed', async () => {
+  // Shared Platinum org + shared local DB: instance A must never stop instance
+  // B's boxes (projects/instance-scope.ts). Boxes created before the stamp
+  // carry no `kortix.instance` and stay everyone's — the safe direction.
+  platinumConfig.KORTIX_INSTANCE_ID = 'wt-a';
+  try {
+    pages = [
+      {
+        rows: [
+          { id: 'sbx_mine', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'wt-a' }, created_at: '2026-08-12T00:00:00Z' },
+          { id: 'sbx_other', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'primary' }, created_at: '2026-08-12T00:00:00Z' },
+          { id: 'sbx_unstamped', state: 'running', metadata: MANAGED, created_at: '2026-08-12T00:00:00Z' },
+        ],
+        has_more: false,
+      },
+    ];
+
+    const { PlatinumProvider } = await import('./platinum');
+    const listed = await new PlatinumProvider().listManagedRunningSandboxes();
+
+    expect(listed.map((box) => box.externalId)).toEqual(['sbx_mine', 'sbx_unstamped']);
+  } finally {
+    delete platinumConfig.KORTIX_INSTANCE_ID;
+  }
+});
+
+test('INSTANCE SCOPE off (unset): a stamped box from any instance is listed as before', async () => {
+  pages = [
+    {
+      rows: [
+        { id: 'sbx_other', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'primary' }, created_at: '2026-08-12T00:00:00Z' },
+      ],
+      has_more: false,
+    },
+  ];
+
+  const { PlatinumProvider } = await import('./platinum');
+  const listed = await new PlatinumProvider().listManagedRunningSandboxes();
+
+  expect(listed.map((box) => box.externalId)).toEqual(['sbx_other']);
 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -41,6 +41,7 @@
 
 import { createHash } from 'node:crypto';
 import { SANDBOX_VERSION, config } from '../../config';
+import { currentInstanceId, sandboxBelongsToThisInstance } from '../../projects/instance-scope';
 import { isOpencodePort } from '../../shared/opencode-ports';
 import { platinumJson } from '../../shared/platinum';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
@@ -315,6 +316,10 @@ export class PlatinumProvider implements SandboxProvider {
         'kortix.env': config.INTERNAL_KORTIX_ENV,
         'kortix.workload': workloadType,
         ...(opts.sandboxId ? { 'kortix.sandbox_id': opts.sandboxId } : {}),
+        // Instance scope for local dev on a shared DB (projects/instance-scope.ts):
+        // `listManagedRunningSandboxes` skips another instance's boxes. Absent
+        // in deployed environments.
+        ...(currentInstanceId() ? { 'kortix.instance': currentInstanceId()! } : {}),
       },
     };
     if (dedup) {
@@ -551,6 +556,10 @@ export class PlatinumProvider implements SandboxProvider {
         const metadata = sandbox.metadata ?? {};
         if (String(metadata['kortix.managed'] ?? '') !== 'true') continue;
         if (String(metadata['kortix.env'] ?? '') !== config.INTERNAL_KORTIX_ENV) continue;
+        // Instance scope beside the env scope: another local instance's box is
+        // not ours to stop. Unstamped boxes stay everyone's. No-op when
+        // KORTIX_INSTANCE_ID is unset.
+        if (!sandboxBelongsToThisInstance({ instanceId: metadata['kortix.instance'] })) continue;
         if (String(sandbox.state ?? '').toLowerCase() !== 'running') continue;
         const rawCreatedAt = sandbox.created_at ?? sandbox.createdAt ?? null;
         const createdAt = rawCreatedAt ? new Date(rawCreatedAt) : null;

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -542,6 +542,42 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(finishCall?.updates.config).toMatchObject({ serviceKey: 'exec-tok-1' });
   });
 
+  test('stamps metadata.instanceId from KORTIX_INSTANCE_ID on the row it creates, and the finish write keeps it', async () => {
+    // Instance scoping for background work on a shared DB (projects/instance-scope.ts).
+    // The stamp is what lets another local API instance recognise this box as
+    // not its own and hand its queued work back.
+    (testConfig as Record<string, unknown>).KORTIX_INSTANCE_ID = 'wt-instance-a';
+    try {
+      const opened = waitFor((resolve) => {
+        onComputeOpened = resolve;
+      });
+      await provisionSessionSandbox(baseOpts());
+      await opened;
+
+      const finishCall = updateCalls.find(
+        (call) =>
+          call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
+      );
+      expect((finishCall?.updates.metadata as Record<string, unknown>).instanceId).toBe('wt-instance-a');
+    } finally {
+      delete (testConfig as Record<string, unknown>).KORTIX_INSTANCE_ID;
+    }
+  });
+
+  test('no KORTIX_INSTANCE_ID → no instanceId stamp (deployed environments are untouched)', async () => {
+    const opened = waitFor((resolve) => {
+      onComputeOpened = resolve;
+    });
+    await provisionSessionSandbox(baseOpts());
+    await opened;
+
+    const finishCall = updateCalls.find(
+      (call) =>
+        call.table === sessionSandboxes && 'externalId' in call.updates && 'config' in call.updates,
+    );
+    expect((finishCall?.updates.metadata as Record<string, unknown>).instanceId).toBeUndefined();
+  });
+
   test('the fast flag keeps the standard image so the edge optimization stays isolated', async () => {
     process.env.KORTIX_FAST_COLD_BOOT_ENABLED = 'true';
     const opened = waitFor((resolve) => {

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -61,6 +61,7 @@ import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
 import { resolveLlmGatewayBaseUrl } from '../../llm-gateway/sandbox-base-url';
 import { RuntimeIdentityConflictError } from '../../projects/runtime-identity-error';
 import { grantWarmPoolLifetime } from '../../projects/sandbox-deadline';
+import { instanceStampMetadata } from '../../projects/instance-scope';
 import { withTimeout, configuredTimeoutMs } from '../../shared/with-timeout';
 import { classifySandboxProvisioningFailure } from './sandbox-provisioning-error';
 import { platformMetaAgentGrant } from '../../projects/lib/platform-meta-agent';
@@ -406,6 +407,9 @@ export async function provisionSessionSandbox(opts: {
         config: {},
         metadata: {
           ...(opts.metadata ?? {}),
+          // Instance scope for background work on a shared DB — see
+          // projects/instance-scope.ts. `{}` when KORTIX_INSTANCE_ID is unset.
+          ...instanceStampMetadata(),
           ...(opts.initialTurn
             ? {
                 activeTurns: {
@@ -438,7 +442,7 @@ export async function provisionSessionSandbox(opts: {
         // out. Consume their authorization marker atomically so at most one
         // allocator can claim the row and call provider.create(). New code never
         // creates this marker because established identities are fail-closed.
-        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'identityRecoveryAuthorizedAt'`,
+        metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) - 'identityRecoveryAuthorizedAt') || ${JSON.stringify(instanceStampMetadata())}::jsonb`,
         updatedAt: new Date(),
       })
       .where(

--- a/apps/api/src/projects/instance-scope.test.ts
+++ b/apps/api/src/projects/instance-scope.test.ts
@@ -1,0 +1,56 @@
+// Instance scoping for background work on a SHARED database.
+//
+// 2026-08-22, twice in one night: two local API stacks (worktrees + the primary
+// `pnpm dev`) shared one Supabase, so prompt-inbox delivery, lifecycle commands
+// and env-sync formed ONE queue. Whichever instance dequeued a job pushed ITS
+// `KORTIX_URL`-derived gateway URL into the other instance's sandbox; when that
+// instance's quick tunnel was dead, the box got a dead URL and the next prompt
+// failed with OpenCode `Cannot connect to API …trycloudflare.com/v1/llm-gateway`
+// while the OWNING instance's log showed nothing.
+//
+// The helper is the one rule every background path consults. It must be a
+// strict NO-OP when `KORTIX_INSTANCE_ID` is unset (production: one URL), and it
+// must treat rows that predate the stamp as everyone's (legacy rows).
+import { afterEach, describe, expect, test } from 'bun:test';
+import { config } from '../config';
+import { sandboxBelongsToThisInstance } from './instance-scope';
+
+const ORIGINAL = (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID;
+const setInstance = (value: string | undefined) => {
+  (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID = value;
+};
+
+afterEach(() => setInstance(ORIGINAL));
+
+describe('sandboxBelongsToThisInstance', () => {
+  test('unset KORTIX_INSTANCE_ID → every sandbox belongs to this instance (prod no-op)', () => {
+    setInstance(undefined);
+    expect(sandboxBelongsToThisInstance({ instanceId: 'wt-a' })).toBe(true);
+    expect(sandboxBelongsToThisInstance({})).toBe(true);
+    expect(sandboxBelongsToThisInstance(null)).toBe(true);
+  });
+
+  test('set, and the row carries no instanceId (legacy row) → belongs to this instance', () => {
+    setInstance('wt-a');
+    expect(sandboxBelongsToThisInstance({})).toBe(true);
+    expect(sandboxBelongsToThisInstance({ instanceId: null })).toBe(true);
+    expect(sandboxBelongsToThisInstance(null)).toBe(true);
+    expect(sandboxBelongsToThisInstance(undefined)).toBe(true);
+  });
+
+  test('set, and the row carries the SAME id → belongs to this instance', () => {
+    setInstance('wt-a');
+    expect(sandboxBelongsToThisInstance({ instanceId: 'wt-a' })).toBe(true);
+  });
+
+  test('set, and the row carries ANOTHER id → foreign, this instance must not touch it', () => {
+    setInstance('wt-a');
+    expect(sandboxBelongsToThisInstance({ instanceId: 'primary' })).toBe(false);
+    expect(sandboxBelongsToThisInstance({ instanceId: 'mw-perf' })).toBe(false);
+  });
+
+  test('empty-string KORTIX_INSTANCE_ID reads as unset', () => {
+    setInstance('');
+    expect(sandboxBelongsToThisInstance({ instanceId: 'primary' })).toBe(true);
+  });
+});

--- a/apps/api/src/projects/instance-scope.ts
+++ b/apps/api/src/projects/instance-scope.ts
@@ -1,0 +1,59 @@
+/**
+ * Instance scoping for BACKGROUND work on a shared database.
+ *
+ * Local development runs several API instances (worktrees + the primary
+ * `pnpm dev`) against ONE Supabase. Prompt-inbox delivery, session-lifecycle
+ * commands, env-sync fan-outs and the box reaper read the same tables, so they
+ * form one work queue across every running instance. Each instance has its own
+ * `KORTIX_URL` (its own quick tunnel): whichever instance dequeues a job pushes
+ * ITS gateway URL into the sandbox. When that instance's tunnel is dead the box
+ * gets a dead URL, and the OWNING instance's log shows nothing (2026-08-22,
+ * twice: `mw-perf` at 20:16 UTC, the primary `pnpm dev` at ~23:00 UTC).
+ *
+ * The rule: a sandbox is touched by background work ONLY from the instance
+ * that provisioned it. `provisionSessionSandbox` stamps
+ * `session_sandboxes.metadata.instanceId = config.KORTIX_INSTANCE_ID`; every
+ * background path asks this helper before acting on a row.
+ *
+ * Deployed environments never set `KORTIX_INSTANCE_ID` (one `KORTIX_URL`), so
+ * the helper is a strict no-op there. Rows that predate the stamp belong to
+ * everyone — the safe direction: never strand a legacy sandbox.
+ *
+ * HTTP-path work (the proxy, `/start`, `prompt_async` through the proxy) is
+ * deliberately NOT scoped: the user's browser talks to one stack on purpose.
+ */
+import { config } from '../config';
+
+export const SANDBOX_INSTANCE_METADATA_KEY = 'instanceId';
+
+/** This instance's id, or undefined when scoping is off (deployed envs). */
+export function currentInstanceId(): string | undefined {
+  const raw = (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID;
+  return typeof raw === 'string' && raw.trim() !== '' ? raw : undefined;
+}
+
+/**
+ * True when background work on this sandbox may run here:
+ *  - `KORTIX_INSTANCE_ID` is unset (scoping off), or
+ *  - the row carries no `instanceId` (legacy row), or
+ *  - the row's `instanceId` equals ours.
+ */
+export function sandboxBelongsToThisInstance(metadata: unknown): boolean {
+  const mine = currentInstanceId();
+  if (!mine) return true;
+  const theirs = sandboxInstanceId(metadata);
+  return theirs === null || theirs === mine;
+}
+
+/** The `instanceId` stamped on a sandbox row, or null when absent. */
+export function sandboxInstanceId(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return null;
+  const raw = (metadata as Record<string, unknown>)[SANDBOX_INSTANCE_METADATA_KEY];
+  return typeof raw === 'string' && raw !== '' ? raw : null;
+}
+
+/** Metadata fragment to merge into a sandbox row at creation. `{}` when scoping is off. */
+export function instanceStampMetadata(): Record<string, string> {
+  const mine = currentInstanceId();
+  return mine ? { [SANDBOX_INSTANCE_METADATA_KEY]: mine } : {};
+}

--- a/apps/api/src/projects/lib/sandbox-env-sync.instance-scope.test.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.instance-scope.test.ts
@@ -1,0 +1,160 @@
+// Instance scope on the project-wide env-sync fan-out.
+//
+// `propagateProjectSecretsToActiveSandboxes` enumerates EVERY active box of a
+// project and pushes this instance's env — including its `KORTIX_URL`-derived
+// gateway URL — into each one. On a shared local DB that is how one worktree's
+// dead tunnel ended up inside another worktree's sandbox (2026-08-22, twice).
+// With `KORTIX_INSTANCE_ID` set, boxes stamped by another instance are skipped
+// and not counted as targets; legacy rows (no stamp) and own rows are pushed.
+// With it unset, nothing changes.
+//
+// Same `mock.module` + `globalThis.fetch` pattern as the sibling
+// `sandbox-env-sync.refresh-models.test.ts` (runs isolated per file).
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+import * as realSecrets from '../secrets';
+import * as realSecretGrant from './secret-grant';
+
+const PROJECT_ROW = {
+  repoUrl: 'https://example.test/acme/repo.git',
+  defaultBranch: 'main',
+  manifestPath: 'kortix.yaml',
+  metadata: null as Record<string, unknown> | null,
+};
+const SESSION_ROW = {
+  createdBy: 'user-1',
+  agentName: 'support',
+  secretsAllowlist: null as string[] | null,
+};
+
+type SandboxRow = {
+  externalId: string | null;
+  sessionId: string;
+  provider: string;
+  config: Record<string, unknown> | null;
+  metadata: Record<string, unknown> | null;
+};
+let sandboxRows: SandboxRow[] = [];
+
+mock.module('../../shared/db', () => ({
+  hasDatabase: true,
+  db: {
+    select: (columns: Record<string, unknown>) => ({
+      from: () => ({
+        where: () => {
+          const wantsSandboxes = 'externalId' in columns && 'sessionId' in columns;
+          const wantsSession = 'createdBy' in columns;
+          const rows = wantsSandboxes ? sandboxRows : wantsSession ? [SESSION_ROW] : [PROJECT_ROW];
+          return {
+            limit: async () => rows,
+            then: (resolve: (value: typeof rows) => unknown, reject?: (reason: unknown) => unknown) =>
+              Promise.resolve(rows).then(resolve, reject),
+          };
+        },
+      }),
+    }),
+    update: () => ({ set: () => ({ where: async () => undefined }) }),
+  },
+}));
+
+mock.module('./secret-grant', () => ({
+  ...realSecretGrant,
+  resolveSessionSecretGrant: async () => 'all' as const,
+}));
+mock.module('../secrets', () => ({
+  ...realSecrets,
+  listProjectSecretsSnapshotForUser: async () => ({
+    env: { EXAMPLE: 'v1' },
+    names: ['EXAMPLE'],
+    revision: 'rev-1',
+    capabilitiesJson: '{"version":1,"capabilities":[]}',
+  }),
+}));
+mock.module('./network-secret-boundary', () => ({
+  resolveSessionNetworkBoundary: async () => [],
+}));
+mock.module('../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async (externalId: string) => ({
+    url: `https://daemon.test/${externalId}`,
+    headers: {},
+  }),
+}));
+
+/** External ids whose daemon received an env push, in order. */
+let pushed: string[] = [];
+const ORIGINAL_FETCH = globalThis.fetch;
+(globalThis as { fetch: unknown }).fetch = async (url: unknown, init?: { body?: string }) => {
+  const href = String(url);
+  const externalId = new URL(href).pathname.split('/')[1]!;
+  pushed.push(externalId);
+  const body = init?.body ? (JSON.parse(init.body) as { revision?: unknown }) : {};
+  return Response.json({
+    ok: true,
+    revision: body.revision,
+    exported: 1,
+    managed: 1,
+    withheld: 0,
+    agent_env_written: true,
+    opencode: 'ok',
+  });
+};
+
+const { propagateProjectSecretsToActiveSandboxes } = await import('./sandbox-env-sync');
+const { config } = await import('../../config');
+const ORIGINAL_INSTANCE = (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID;
+const setInstance = (value: string | undefined) => {
+  (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID = value;
+};
+
+function row(externalId: string, metadata: Record<string, unknown> | null): SandboxRow {
+  return {
+    externalId,
+    sessionId: `sess-${externalId}`,
+    provider: 'daytona',
+    config: { serviceKey: `svc-${externalId}` },
+    metadata,
+  };
+}
+
+let projectSeq = 0;
+/** A fresh project id per call: the runner is coalesced PER PROJECT, and a
+ *  second call within its cooldown would wait on the first. */
+const nextProject = () => `proj-scope-${++projectSeq}`;
+
+afterAll(() => {
+  (globalThis as { fetch: unknown }).fetch = ORIGINAL_FETCH;
+});
+beforeEach(() => {
+  pushed = [];
+  sandboxRows = [
+    row('ext-mine', { instanceId: 'wt-a' }),
+    row('ext-legacy', null),
+    row('ext-foreign', { instanceId: 'primary' }),
+  ];
+});
+afterEach(() => setInstance(ORIGINAL_INSTANCE));
+
+describe('propagateProjectSecretsToActiveSandboxes — instance scope', () => {
+  test('KORTIX_INSTANCE_ID set → pushes to own + legacy boxes, skips another instance’s box', async () => {
+    setInstance('wt-a');
+
+    const report = await propagateProjectSecretsToActiveSandboxes(nextProject());
+
+    expect(pushed.sort()).toEqual(['ext-legacy', 'ext-mine']);
+    expect(report.targeted).toBe(2);
+    expect(report.synced).toBe(2);
+    expect(report.failed).toBe(0);
+    // The foreign box is neither a target nor a failure: it is simply not ours.
+    expect(report.results.map((r) => r.sandbox_id).sort()).toEqual(['ext-legacy', 'ext-mine']);
+  });
+
+  test('KORTIX_INSTANCE_ID unset → every active box is pushed (deployed envs unchanged)', async () => {
+    setInstance(undefined);
+
+    const report = await propagateProjectSecretsToActiveSandboxes(nextProject());
+
+    expect(pushed.sort()).toEqual(['ext-foreign', 'ext-legacy', 'ext-mine']);
+    expect(report.targeted).toBe(3);
+    expect(report.synced).toBe(3);
+  });
+});

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -28,6 +28,7 @@ import {
   workspaceModeFromSessionMetadata,
 } from './session-sandbox-metadata';
 import { resolveSessionNetworkBoundary } from './network-secret-boundary';
+import { sandboxBelongsToThisInstance } from '../instance-scope';
 import type { NetworkBoundarySecretBinding } from '../../secrets/network-boundary';
 
 /** Resolve the LLM gateway URL used by every supported remote provider. */
@@ -807,15 +808,20 @@ async function runProjectSecretPropagation(
     results: [],
   };
   try {
-    const rows = await db
+    const allRows = await db
       .select({
         externalId: sessionSandboxes.externalId,
         sessionId: sessionSandboxes.sessionId,
         provider: sessionSandboxes.provider,
         config: sessionSandboxes.config,
+        metadata: sessionSandboxes.metadata,
       })
       .from(sessionSandboxes)
       .where(and(eq(sessionSandboxes.projectId, projectId), eq(sessionSandboxes.status, 'active')));
+    // INSTANCE SCOPE (shared local DB — ../instance-scope.ts): a box another
+    // API instance provisioned must not receive THIS instance's env (its
+    // `KORTIX_URL`-derived gateway URL). No-op when KORTIX_INSTANCE_ID is unset.
+    const rows = allRows.filter((r) => sandboxBelongsToThisInstance(r.metadata));
 
     report.active_sandboxes = rows.length;
     const targets = rows.filter((r): r is typeof r & { externalId: string } => !!r.externalId);

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -37,6 +37,7 @@ import { markComputeSessionAlive } from '../../billing/services/compute-metering
 import { type SandboxProvider, type SandboxStatus, getProvider } from '../../platform/providers';
 import { invalidateProviderCache } from '../../sandbox-proxy';
 import { REAP_CONCURRENCY } from '../reaper-constants';
+import { sandboxBelongsToThisInstance } from '../instance-scope';
 import { preserveEstablishedRuntime } from '../runtime-identity';
 import { extendUnconfirmedTurnDeadline } from '../sandbox-deadline';
 import { turnDeliveryGraceMs, turnGrantMs } from '../sandbox-deadline-policy';
@@ -223,6 +224,11 @@ export async function reapAndReconcileSandboxes(
   const worker = async () => {
     while (cursor < rows.length) {
       const row = rows[cursor++];
+      // INSTANCE SCOPE (shared local DB — ../instance-scope.ts): instance A
+      // never probes or stops a box instance B provisioned. Sits beside the
+      // provider-level `kortix.env` filter in listManagedRunningSandboxes.
+      // No-op when KORTIX_INSTANCE_ID is unset.
+      if (!sandboxBelongsToThisInstance(row.metadata)) continue;
       try {
         const provider = getProvider(row.provider);
         const providerStatus: SandboxStatus = await provider.getStatus(row.externalId);

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -190,13 +190,15 @@ const visitStamps = () => updateCalls.filter(isVisitStamp);
 // `mock.module` is process-global in bun, so a factory returning only `{ config }`
 // strips every other named export (e.g. SANDBOX_VERSION) for every sibling suite
 // in the same process — which is what made this whole directory unrunnable.
-mock.module('../config', () =>
-  mockConfigModule({
-    KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15,
-    KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5,
-    ALLOWED_SANDBOX_PROVIDERS: ['daytona', 'e2b'],
-  }),
-);
+// Hoisted so a test can flip `KORTIX_INSTANCE_ID` at call time (the
+// instance-scope helper reads config per call, never at import).
+const reaperConfigModule = mockConfigModule({
+  KORTIX_SANDBOX_AUTOSTOP_MINUTES: 15,
+  KORTIX_SANDBOX_TRIGGER_AUTOSTOP_MINUTES: 5,
+  ALLOWED_SANDBOX_PROVIDERS: ['daytona', 'e2b'],
+});
+const reaperConfig = reaperConfigModule.config as Record<string, unknown>;
+mock.module('../config', () => reaperConfigModule);
 
 mock.module('../shared/db', () => ({
   db: {
@@ -757,6 +759,69 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     expect(
       updateCalls.some((c) => c.table === projectSessions && c.updates.status === 'stopped'),
     ).toBe(true);
+  });
+
+  test('INSTANCE SCOPE: a box stamped by ANOTHER API instance is never probed or stopped here', async () => {
+    // Shared local DB (projects/instance-scope.ts): instance A must never stop
+    // instance B's boxes, however expired they look from here.
+    reaperConfig.KORTIX_INSTANCE_ID = 'wt-a';
+    try {
+      candidates = [
+        candidate({
+          deadlineAt: new Date(NOW.getTime() - 1),
+          metadata: { instanceId: 'primary' },
+        }),
+      ];
+      statusByExternal['ext-1'] = 'running';
+
+      const r = await reapAndReconcileSandboxes(NOW);
+
+      expect(statusCalls).toEqual([]);
+      expect(stops).toEqual([]);
+      expect(r.stopped).toBe(0);
+      expect(
+        updateCalls.some((c) => c.table === sessionSandboxes && c.updates.status === 'stopped'),
+      ).toBe(false);
+    } finally {
+      delete reaperConfig.KORTIX_INSTANCE_ID;
+    }
+  });
+
+  test('INSTANCE SCOPE: own-stamped and legacy (unstamped) boxes are reaped as before', async () => {
+    reaperConfig.KORTIX_INSTANCE_ID = 'wt-a';
+    try {
+      candidates = [
+        candidate({ deadlineAt: new Date(NOW.getTime() - 1), metadata: { instanceId: 'wt-a' } }),
+        candidate({
+          sandboxId: 'sb-2',
+          sessionId: 'sess-2',
+          externalId: 'ext-2',
+          deadlineAt: new Date(NOW.getTime() - 1),
+          metadata: null,
+        }),
+      ];
+      statusByExternal['ext-1'] = 'running';
+      statusByExternal['ext-2'] = 'running';
+
+      const r = await reapAndReconcileSandboxes(NOW);
+
+      expect(stops.sort()).toEqual(['ext-1', 'ext-2']);
+      expect(r.stopped).toBe(2);
+    } finally {
+      delete reaperConfig.KORTIX_INSTANCE_ID;
+    }
+  });
+
+  test('INSTANCE SCOPE off (unset): a foreign-looking stamp changes nothing', async () => {
+    candidates = [
+      candidate({ deadlineAt: new Date(NOW.getTime() - 1), metadata: { instanceId: 'primary' } }),
+    ];
+    statusByExternal['ext-1'] = 'running';
+
+    const r = await reapAndReconcileSandboxes(NOW);
+
+    expect(stops).toEqual(['ext-1']);
+    expect(r.stopped).toBe(1);
   });
 
   test('a box with an observed turn SURVIVES — its deadline is still ahead', async () => {

--- a/apps/api/src/projects/session-lifecycle/__tests__/instance-scope-release.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/instance-scope-release.test.ts
@@ -1,0 +1,304 @@
+// Instance-scoped lifecycle drain on a SHARED database.
+//
+// 2026-08-22, twice: two local API stacks shared one Supabase, so the
+// lifecycle queue was one queue. The instance that dequeued a prompt pushed its
+// own (dead) `KORTIX_URL` gateway URL into the OTHER instance's sandbox, and the
+// owner's log showed nothing. The drain must hand a claimed command whose
+// sandbox belongs to another instance BACK (queued, due in ~2s, never
+// dead-lettered, never executed) so the owning instance takes it. With
+// `KORTIX_INSTANCE_ID` unset (every deployed env) nothing changes — not even
+// the metadata lookup runs.
+//
+// Same mocking caveat as the sibling engine.ts test files: `mock.module` is
+// process-global in bun:test, so this file runs on its own under `--isolate`.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectSessions, projects, sessionLifecycleCommands, sessionSandboxes } from '@kortix/db';
+import type { SessionLifecycleCommandRow } from '../store';
+import { mintWireMessageId } from '../../wire-message-id';
+
+const SESSION_ID = 'sess-scope-1';
+const ACCOUNT_ID = 'acct-1';
+const PROJECT_ID = 'proj-1';
+const EXTERNAL_ID = 'sandbox-1';
+const OC_SESSION_ID = 'oc-1';
+const NOW_MS = Date.now();
+const WIRE_ID = mintWireMessageId({ nowMs: NOW_MS - 10 * 60_000, random: () => 0.5 }).id;
+
+/** Mutable config the engine + instance-scope helper read at call time. */
+const cfg: { KORTIX_URL: string; KORTIX_INSTANCE_ID?: string } = { KORTIX_URL: 'https://api.test' };
+
+let sessionRow: Record<string, unknown> | null = null;
+let boxRow: { status: string; metadata: Record<string, unknown> | null } | null = null;
+/** What `loadSandboxMetadataForSessions` answers, and whether it was asked. */
+let ownerMetadataBySession: Map<string, Record<string, unknown> | null> = new Map();
+let ownerLookups: string[][] = [];
+let releases: Array<{ commandId: string; availableAt: Date; owner: string | null }> = [];
+let capturedBodies: Array<Record<string, unknown>> = [];
+let succeededCalls: string[] = [];
+let forwardedCalls: string[] = [];
+let failedCalls: Array<{ commandId: string; message: string }> = [];
+let claimed: SessionLifecycleCommandRow[] = [];
+
+mock.module('../../../config', () => ({
+  config: cfg,
+  SANDBOX_VERSION: 'test',
+}));
+
+mock.module('../../../shared/db', () => ({
+  hasDatabase: () => true,
+  db: {
+    select: (projection?: Record<string, unknown>) => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async () => {
+            if (table === projectSessions) return sessionRow ? [sessionRow] : [];
+            if (table === projects) return [{ projectId: PROJECT_ID, accountId: ACCOUNT_ID }];
+            if (table === sessionSandboxes) return boxRow ? [boxRow] : [];
+            if (table === sessionLifecycleCommands && projection && 'newest' in projection) {
+              return [{ newest: null }];
+            }
+            return [];
+          },
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({ where: async () => {} }),
+    }),
+  },
+}));
+
+mock.module('../../session-title-generate', () => ({
+  generateSessionTitleFromFirstPrompt: async () => {},
+}));
+mock.module('../../routes/shared', () => ({
+  openSession: async () => ({
+    stage: 'ready',
+    sandbox: { external_id: EXTERNAL_ID, provider: 'daytona' },
+    opencode_session_id: OC_SESSION_ID,
+  }),
+}));
+mock.module('../../../sandbox-proxy/routes/preview', () => ({
+  forwardToSandbox: async (
+    _externalId: string,
+    _port: number,
+    _access: unknown,
+    _method: string,
+    _path: string,
+    _query: string,
+    _headers: Headers,
+    body: ArrayBuffer,
+  ) => {
+    capturedBodies.push(JSON.parse(new TextDecoder().decode(body)));
+    return new Response(null, { status: 204 });
+  },
+}));
+mock.module('../../lib/sessions', () => ({
+  // The create test only asserts that the scope step ignores a session-less
+  // row; the create itself is allowed to fail into `markCommandFailed`.
+  createProjectSession: async () => ({ error: { status: 400, body: { error: 'stub' } } }),
+}));
+mock.module('../actor', () => ({
+  resolveProjectAutomationActor: async () => 'automation-user-1',
+  resolveAgentRunAttribution: async () => null,
+}));
+mock.module('../backpressure', () => ({
+  sessionBackpressureState: async () => ({ shouldQueue: false, reason: null }),
+}));
+mock.module('../store', () => ({
+  promoteNextInboxRow: async () => null,
+  requeueForAdmission: async () => {},
+  claimCreateSessionCommand: async () => {
+    throw new Error('not expected');
+  },
+  claimDueLifecycleCommands: async () => claimed,
+  enqueueContinueSessionCommand: async () => {
+    throw new Error('not expected');
+  },
+  markCommandFailed: async (commandId: string, message: string) => {
+    failedCalls.push({ commandId, message });
+  },
+  markCommandQueued: async () => {
+    throw new Error('not expected');
+  },
+  markCommandForwarded: async (commandId: string) => {
+    forwardedCalls.push(commandId);
+  },
+  markCommandSucceeded: async (commandId: string) => {
+    succeededCalls.push(commandId);
+  },
+  withNextDeliveryAttempt: (payload: unknown) => payload,
+  resultFromExistingCommand: () => {
+    throw new Error('not expected');
+  },
+}));
+mock.module('../instance-release', () => ({
+  loadSandboxMetadataForSessions: async (sessionIds: string[]) => {
+    ownerLookups.push(sessionIds);
+    return ownerMetadataBySession;
+  },
+  releaseCommandToOwningInstance: async (
+    commandId: string,
+    opts: { availableAt: Date; owner: string | null },
+  ) => {
+    releases.push({ commandId, availableAt: opts.availableAt, owner: opts.owner });
+  },
+}));
+mock.module('../../opencode-mapping', () => ({
+  sandboxOpencodeEndpoint: async () => ({ url: 'https://sandbox.test', headers: {} }),
+}));
+mock.module('../../../platform/service-key', () => ({
+  serviceKeyForExternalId: async () => 'svc-key-1',
+}));
+mock.module('../../../sandbox-proxy/backend', () => ({
+  resolveSandboxIngress: async () => ({ url: 'https://daemon.test', headers: {} }),
+}));
+mock.module('../../lib/sandbox-env-sync', () => ({
+  syncSandboxEnvForPrompt: async () => {},
+}));
+
+const { drainSessionLifecycleQueue } = await import('../engine');
+
+function row(overrides: Partial<SessionLifecycleCommandRow> = {}): SessionLifecycleCommandRow {
+  const now = new Date(NOW_MS);
+  return {
+    commandId: 'cmd-1',
+    commandType: 'continue_session',
+    source: 'ui',
+    status: 'running',
+    projectId: PROJECT_ID,
+    sessionId: SESSION_ID,
+    accountId: ACCOUNT_ID,
+    actorUserId: null,
+    idempotencyKey: null,
+    payload: {
+      text: 'say hi',
+      clientMessageId: 'q_1',
+      wireMessageId: WIRE_ID,
+      parts: [{ type: 'text', text: 'say hi' }],
+    },
+    result: {},
+    attempts: 1,
+    availableAt: now,
+    lockedBy: 'worker-x',
+    lockedUntil: new Date(NOW_MS + 5 * 60_000),
+    lastError: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  } as SessionLifecycleCommandRow;
+}
+
+beforeEach(() => {
+  delete cfg.KORTIX_INSTANCE_ID;
+  sessionRow = {
+    accountId: ACCOUNT_ID,
+    projectId: PROJECT_ID,
+    status: 'running',
+    metadata: {},
+    sandboxProvider: 'daytona',
+    baseRef: 'main',
+    agentName: 'agent',
+    opencodeSessionId: OC_SESSION_ID,
+    sandboxUrl: `https://sandbox.test/p/${EXTERNAL_ID}/8000/`,
+  };
+  boxRow = { status: 'active', metadata: {} };
+  ownerMetadataBySession = new Map();
+  ownerLookups = [];
+  releases = [];
+  capturedBodies = [];
+  succeededCalls = [];
+  forwardedCalls = [];
+  failedCalls = [];
+  claimed = [row()];
+  globalThis.fetch = (async (url: string | URL) => {
+    const href = String(url);
+    if (href.includes('/message')) return new Response(JSON.stringify([]), { status: 200 });
+    return new Response(JSON.stringify({ id: OC_SESSION_ID }), { status: 200 });
+  }) as typeof fetch;
+});
+
+describe('drainSessionLifecycleQueue — instance scope', () => {
+  test('a command whose sandbox belongs to ANOTHER instance is released, not executed', async () => {
+    cfg.KORTIX_INSTANCE_ID = 'wt-a';
+    ownerMetadataBySession = new Map([[SESSION_ID, { instanceId: 'primary' }]]);
+
+    const result = await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(ownerLookups).toEqual([[SESSION_ID]]);
+    expect(releases).toHaveLength(1);
+    expect(releases[0]!.commandId).toBe('cmd-1');
+    expect(releases[0]!.owner).toBe('primary');
+    // Back on the queue ~2s out: long enough not to spin, short enough that the
+    // owner's 1s drain tick takes it on its next pass.
+    const delay = releases[0]!.availableAt.getTime() - Date.now();
+    expect(delay).toBeGreaterThan(500);
+    expect(delay).toBeLessThanOrEqual(5_000);
+    // Never executed, never failed, never dead-lettered.
+    expect(capturedBodies).toEqual([]);
+    expect(succeededCalls).toEqual([]);
+    expect(forwardedCalls).toEqual([]);
+    expect(failedCalls).toEqual([]);
+    expect(result).toMatchObject({ claimed: 1, released: 1, succeeded: 0, failed: 0, queued: 0 });
+  });
+
+  test('a command whose sandbox carries the SAME instance id is executed', async () => {
+    cfg.KORTIX_INSTANCE_ID = 'wt-a';
+    ownerMetadataBySession = new Map([[SESSION_ID, { instanceId: 'wt-a' }]]);
+
+    const result = await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(releases).toEqual([]);
+    expect(capturedBodies).toHaveLength(1);
+    expect(failedCalls).toEqual([]);
+    expect(result.released).toBe(0);
+  });
+
+  test('a command whose sandbox row carries NO instance id (legacy row) is executed', async () => {
+    cfg.KORTIX_INSTANCE_ID = 'wt-a';
+    ownerMetadataBySession = new Map([[SESSION_ID, {}]]);
+
+    await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(releases).toEqual([]);
+    expect(capturedBodies).toHaveLength(1);
+  });
+
+  test('a session with no sandbox row yet is executed (nothing to be foreign to)', async () => {
+    cfg.KORTIX_INSTANCE_ID = 'wt-a';
+    ownerMetadataBySession = new Map();
+
+    await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(releases).toEqual([]);
+    expect(capturedBodies).toHaveLength(1);
+  });
+
+  test('KORTIX_INSTANCE_ID unset → no lookup at all, foreign-looking rows execute (prod no-op)', async () => {
+    ownerMetadataBySession = new Map([[SESSION_ID, { instanceId: 'primary' }]]);
+
+    const result = await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(ownerLookups).toEqual([]);
+    expect(releases).toEqual([]);
+    expect(capturedBodies).toHaveLength(1);
+    expect(result.released).toBe(0);
+  });
+
+  test('a create_session command (no session yet) is never scoped', async () => {
+    cfg.KORTIX_INSTANCE_ID = 'wt-a';
+    claimed = [
+      row({
+        commandId: 'cmd-create',
+        commandType: 'create_session',
+        sessionId: null,
+        payload: { source: 'ui', body: {} } as unknown as SessionLifecycleCommandRow['payload'],
+      }),
+    ];
+
+    await drainSessionLifecycleQueue({ limit: 10 });
+
+    expect(ownerLookups).toEqual([]);
+    expect(releases).toEqual([]);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -20,6 +20,12 @@ import { serviceKeyForExternalId } from '../../platform/service-key';
 import type { ProviderName } from '../../platform/providers';
 import { sandboxOpencodeEndpoint } from '../opencode-mapping';
 import { sandboxRuntimeRequestHeaders } from '../sandbox-fetch';
+import {
+  currentInstanceId,
+  sandboxBelongsToThisInstance,
+  sandboxInstanceId,
+} from '../instance-scope';
+import { loadSandboxMetadataForSessions, releaseCommandToOwningInstance } from './instance-release';
 import { db } from '../../shared/db';
 import { connectorBindingPayloadConflicts } from '../lib/session-connector-bindings';
 import { secretsAllowlistPayloadConflicts } from '../secrets';
@@ -585,6 +591,9 @@ export async function continueSession(
   });
 }
 
+/** How far out a released foreign command is re-queued; the owner's drain ticks every 1s. */
+const INSTANCE_RELEASE_DELAY_MS = 2_000;
+
 export async function drainSessionLifecycleQueue(
   input: {
     workerId?: string;
@@ -594,7 +603,7 @@ export async function drainSessionLifecycleQueue(
     /** Only drain commands due before this instant — see claimDueLifecycleCommands. */
     availableBefore?: Date;
   } = {},
-): Promise<{ claimed: number; succeeded: number; failed: number; queued: number }> {
+): Promise<{ claimed: number; succeeded: number; failed: number; queued: number; released: number }> {
   const workerId = input.workerId ?? `session-lifecycle:${process.pid}:${Date.now()}`;
   // COALESCE a burst before claiming. A targeted kick fires per POST, and the
   // composer sends a burst's POSTs concurrently — their arrival order is the
@@ -623,7 +632,44 @@ export async function drainSessionLifecycleQueue(
       rows.push(...siblings.filter((sib) => !rows.some((r) => r.commandId === sib.commandId)));
     }
   }
-  const out = { claimed: rows.length, succeeded: 0, failed: 0, queued: 0 };
+  const out = { claimed: rows.length, succeeded: 0, failed: 0, queued: 0, released: 0 };
+
+  // INSTANCE SCOPE (local dev on a shared DB — projects/instance-scope.ts).
+  // A command whose session's sandbox was provisioned by ANOTHER API instance
+  // goes back on the queue for that instance: executing it here would push
+  // this instance's `KORTIX_URL` (its tunnel) into a box that is not ours.
+  // Gated on `KORTIX_INSTANCE_ID`, so deployed environments never run the
+  // lookup. Done here, after the claim and the sibling sweep, so every
+  // command type and every claim path is covered.
+  const mine = currentInstanceId();
+  if (mine && rows.length > 0) {
+    const sessionIds = [...new Set(rows.map((r) => r.sessionId).filter((v): v is string => !!v))];
+    const metadataBySession =
+      sessionIds.length > 0 ? await loadSandboxMetadataForSessions(sessionIds) : new Map();
+    const availableAt = new Date(Date.now() + INSTANCE_RELEASE_DELAY_MS);
+    for (let i = rows.length - 1; i >= 0; i -= 1) {
+      const row = rows[i];
+      if (!row.sessionId) continue;
+      const metadata = metadataBySession.get(row.sessionId);
+      if (metadata === undefined || sandboxBelongsToThisInstance(metadata)) continue;
+      const owner = sandboxInstanceId(metadata);
+      await releaseCommandToOwningInstance(row.commandId, { availableAt, owner }).catch((err) => {
+        logger.warn('[session-lifecycle] instance-scope release failed; lock expiry will reclaim', {
+          commandId: row.commandId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+      logger.info('[session-lifecycle] command belongs to another instance — released', {
+        commandId: row.commandId,
+        sessionId: row.sessionId,
+        commandType: row.commandType,
+        owner,
+        instance: mine,
+      });
+      rows.splice(i, 1);
+      out.released += 1;
+    }
+  }
 
   // ONE LANE PER SESSION, and the lanes run concurrently.
   //

--- a/apps/api/src/projects/session-lifecycle/instance-release.ts
+++ b/apps/api/src/projects/session-lifecycle/instance-release.ts
@@ -1,0 +1,63 @@
+/**
+ * Instance-scope plumbing for the lifecycle drain (projects/instance-scope.ts).
+ *
+ * Lives beside `store.ts` rather than in it on purpose: the engine's test
+ * harnesses replace `./store` WHOLESALE with `mock.module`, and every new
+ * named export there breaks each of them at import time. A module of its own
+ * keeps the existing harnesses byte-identical and lets the one test that cares
+ * mock exactly this.
+ */
+import { sessionLifecycleCommands, sessionSandboxes } from '@kortix/db';
+import { eq, inArray, sql } from 'drizzle-orm';
+import { db } from '../../shared/db';
+
+/**
+ * The `session_sandboxes.metadata` of each session's box, keyed by session id.
+ * Sessions with no box row are absent from the map.
+ *
+ * Read by the drain's instance-scope step (projects/instance-scope.ts) and
+ * only when `KORTIX_INSTANCE_ID` is set — deployed environments never pay for
+ * this query.
+ */
+export async function loadSandboxMetadataForSessions(
+  sessionIds: string[],
+): Promise<Map<string, Record<string, unknown> | null>> {
+  const out = new Map<string, Record<string, unknown> | null>();
+  if (sessionIds.length === 0) return out;
+  const rows = await db
+    .select({ sessionId: sessionSandboxes.sessionId, metadata: sessionSandboxes.metadata })
+    .from(sessionSandboxes)
+    .where(inArray(sessionSandboxes.sessionId, sessionIds));
+  for (const row of rows) {
+    out.set(row.sessionId, (row.metadata as Record<string, unknown> | null) ?? null);
+  }
+  return out;
+}
+
+/**
+ * Hand a claimed command BACK because its sandbox belongs to another API
+ * instance (shared local DB — see projects/instance-scope.ts). The row goes
+ * `queued`, due at `availableAt` (~2s: the owner's 1s drain tick takes it on
+ * its next pass), with the claim's attempt increment given back so a foreign
+ * instance polling the queue never spends the row's dead-letter budget. The
+ * owner is stamped into `result.deferred_to_instance` so `GET /prompts` can
+ * say why a row is still queued.
+ */
+export async function releaseCommandToOwningInstance(
+  commandId: string,
+  opts: { availableAt: Date; owner: string | null },
+): Promise<void> {
+  await db
+    .update(sessionLifecycleCommands)
+    .set({
+      status: 'queued',
+      availableAt: opts.availableAt,
+      lockedBy: null,
+      lockedUntil: null,
+      attempts: sql`GREATEST(${sessionLifecycleCommands.attempts} - 1, 0)`,
+      result: sql`COALESCE(${sessionLifecycleCommands.result}, '{}'::jsonb)
+        || ${JSON.stringify({ deferred_to_instance: opts.owner })}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(eq(sessionLifecycleCommands.commandId, commandId));
+}

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -29,6 +29,16 @@ for _arg in "$@"; do
   esac
 done
 
+# Instance identity for BACKGROUND work on the shared local Supabase. Worktrees
+# (`pnpm worktree`, scripts/worktree/lib/launch-env.ts) export their worktree
+# name; this primary stack is `primary`. With it set, the lifecycle drain hands
+# back commands whose sandbox another instance provisioned, env-sync fan-outs
+# skip foreign boxes, and the box reaper leaves them alone — so this stack's
+# quick-tunnel URL never lands in a worktree's sandbox (2026-08-22 incidents).
+# Launcher-only: deployed environments never set it (one KORTIX_URL) and every
+# scope check is then a no-op. See apps/api/src/projects/instance-scope.ts.
+export KORTIX_INSTANCE_ID="${KORTIX_INSTANCE_ID:-primary}"
+
 load_local_env() {
   # pnpm --filter runs each package from its own directory, where Bun/Next may
   # auto-load package .env files. Be explicit here: use the app env files for

--- a/scripts/worktree/__tests__/pure.test.ts
+++ b/scripts/worktree/__tests__/pure.test.ts
@@ -140,6 +140,16 @@ describe('launch envs', () => {
     expect(env.ALLOWED_SANDBOX_PROVIDERS).toBeUndefined();
   });
 
+  test('api carries the worktree name as KORTIX_INSTANCE_ID (instance-scoped background work on the shared DB)', () => {
+    const env = apiLaunchEnv(ports, creds, { instanceId: 'feat-x' });
+    expect(env.KORTIX_INSTANCE_ID).toBe('feat-x');
+  });
+
+  test('no instanceId → KORTIX_INSTANCE_ID is not set (scoping off)', () => {
+    const env = apiLaunchEnv(ports, creds);
+    expect(env.KORTIX_INSTANCE_ID).toBeUndefined();
+  });
+
   test('--stripe turns billing on and injects the webhook secret', () => {
     const env = apiLaunchEnv(ports, creds, { stripeWebhookSecret: 'whsec_x' });
     expect(env.KORTIX_BILLING_INTERNAL_ENABLED).toBe('true');

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -568,7 +568,7 @@ async function cmdStart(a: Args) {
   // The API's KORTIX_URL is baked at spawn, so a tunnel rotation has to
   // respawn it — keep the spawn in a function and the handle mutable.
   const spawnApi = (kortixUrl: string | undefined) =>
-    Bun.spawn(['pnpm', '--filter', API_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...apiLaunchEnv(e.ports, creds, { kortixUrl, stripeWebhookSecret: stripe?.secret, billing }) }, stdout: 'inherit', stderr: 'inherit' });
+    Bun.spawn(['pnpm', '--filter', API_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...apiLaunchEnv(e.ports, creds, { kortixUrl, stripeWebhookSecret: stripe?.secret, billing, instanceId: name }) }, stdout: 'inherit', stderr: 'inherit' });
   let api = spawnApi(tunnel?.url);
   let apiRestarting = false;
   const gateway = Bun.spawn(['pnpm', '--filter', GATEWAY_FILTER, 'dev'], { cwd: e.path, env: { ...process.env, ...gatewayLaunchEnv(e.ports) }, stdout: 'inherit', stderr: 'inherit' });

--- a/scripts/worktree/lib/launch-env.ts
+++ b/scripts/worktree/lib/launch-env.ts
@@ -11,6 +11,12 @@ export interface ApiLaunchOpts {
   stripeWebhookSecret?: string;
   /** Expose billing routes without requiring live Stripe webhook forwarding. */
   billing?: boolean;
+  /** This stack's identity for instance-scoped background work (the worktree
+   *  name). Worktrees share the primary Supabase by default, so the lifecycle
+   *  queue / env-sync / box reaper are one queue across every running API;
+   *  `KORTIX_INSTANCE_ID` is what keeps one stack's (possibly dead) tunnel URL
+   *  out of another stack's sandboxes. See apps/api/src/projects/instance-scope.ts. */
+  instanceId?: string;
 }
 
 export function apiLaunchEnv(ports: Ports, c: SlotCreds, opts: ApiLaunchOpts = {}): Record<string, string> {
@@ -21,6 +27,7 @@ export function apiLaunchEnv(ports: Ports, c: SlotCreds, opts: ApiLaunchOpts = {
     KORTIX_APPS_LOCAL: 'true',
     KORTIX_APPS_LOCAL_PORT: String(ports.api),
     KORTIX_URL: opts.kortixUrl || `http://localhost:${ports.api}`,
+    ...(opts.instanceId ? { KORTIX_INSTANCE_ID: opts.instanceId } : {}),
     NEXT_PUBLIC_BACKEND_URL: `http://localhost:${ports.api}/v1`,
     KORTIX_PUBLIC_BACKEND_URL: `http://localhost:${ports.api}/v1`,
     BACKEND_URL: `http://localhost:${ports.api}/v1`,


### PR DESCRIPTION
Two incidents on 2026-08-22: dev worktrees share the primary local Supabase,
so prompt-inbox delivery, session-lifecycle commands and sandbox env-sync are
ONE queue across every running API instance. Whichever instance dequeued a job
pushed ITS KORTIX_URL-derived gateway URL into the sandbox; when that instance's
quick tunnel was dead (mw-perf at 20:16 UTC, the primary pnpm dev stack at
~23:00 UTC) the box got a dead URL and the next prompt failed with OpenCode
"Cannot connect to API ...trycloudflare.com/v1/llm-gateway" while the OWNING
instance's log showed nothing.

Design (no-op when unconfigured; production sets no KORTIX_INSTANCE_ID):
- config.ts: optional KORTIX_INSTANCE_ID (empty reads as unset).
  scripts/dev-local.sh exports primary; scripts/worktree/lib/launch-env.ts
  exports the worktree name (cli.ts passes instanceId: name). Launcher-only.
- Stamp: provisionSessionSandbox writes metadata.instanceId on the row it
  creates or reclaims; the finish write keeps it. Per-project warm sessions go
  through the same insert. Platinum create adds kortix.instance beside
  kortix.env.
- Scope: projects/instance-scope.ts sandboxBelongsToThisInstance(metadata) =
  true when KORTIX_INSTANCE_ID is unset OR the row carries no instanceId
  (legacy) OR it equals ours. Used by:
  (a) drainSessionLifecycleQueue: a claimed command whose session sandbox
      belongs to another instance is RELEASED (queued, available_at now+2s,
      attempt given back, result.deferred_to_instance, never dead-lettered)
      so the owner's 1s drain tick takes it; new field released in the result.
      Helpers live in session-lifecycle/instance-release.ts so the engine test
      harnesses that mock ./store wholesale stay untouched.
  (b) propagateProjectSecretsToActiveSandboxes skips foreign boxes.
  (c) reapAndReconcileSandboxes skips foreign rows; Platinum
      listManagedRunningSandboxes skips foreign kortix.instance markers.
  HTTP-path work (proxy, /start, prompt_async) is deliberately unscoped.

Tests (RED first, then GREEN): instance-scope.test.ts (helper, all cases),
__tests__/instance-scope-release.test.ts (release vs execute vs no-op),
sandbox-env-sync.instance-scope.test.ts, sandbox-reaper.test.ts (3 cases),
platinum-list-managed.test.ts (2 cases), session-sandbox.test.ts (stamp kept
through the finish write), scripts/worktree pure.test.ts (launch env).

Learnings: second-incident paragraph + enforcement updated in
.claude/skills/learnings/SKILL.md.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW
(cherry picked from commit 6cdeb6fc768831411af8c1e7e8261945218012d4)

Cherry-pick of `6cdeb6fc76` from `timeline-parity` (adversarially verified there: no behaviour change when `KORTIX_INSTANCE_ID` is unset — every deployed env; set by `pnpm dev` / `pnpm worktree` → foreign lifecycle commands are released to their owning instance, env-sync fan-out and the reaper skip foreign boxes). Two incidents tonight where another dev stack's dead tunnel URL was pushed into a worktree's sandboxes motivated it; learnings updated.

https://claude.ai/code/session_01PEtDE4DeQAvRRz3xyxVMdW