### PR TITLE
fix(web): an App card names the App, not its hostname

### DIFF
--- a/apps/web/src/features/apps/apps-feature-gate.test.ts
+++ b/apps/web/src/features/apps/apps-feature-gate.test.ts
@@ -134,10 +134,35 @@ test('an App card shows the App, not a stock glyph standing in for it', () => {
   // filled because that is what a media control looks like — an unrelated
   // control failing a card assertion is the assertion being wrong, not the UI.
   expect(view).not.toContain('size-9');
-  // Status is the house dot, and the host loses the scheme every App shares.
+  // Status is the house dot.
   expect(view).toContain("dot: live ? 'bg-kortix-green'");
-  expect(view).toContain('{appHost(app.url)}');
-  expect(view).not.toContain('{app.url}</p>');
+});
+
+test('a card caption is the App\'s name and its state — not its hostname', () => {
+  const view = readFileSync(resolve(root, 'features/apps/apps-view.tsx'), 'utf8');
+  const card = view.slice(view.indexOf('function AppCard('), view.indexOf('function AppDetailModal('));
+
+  // Every App's URL is the same `<key>.apps.<domain>` shape, so a column of
+  // them differs only in a random token nobody reads or types — a third of the
+  // caption's height spent on noise, on the surface whose job is to show the
+  // App. Neither the derived host nor the raw URL belongs on a tile.
+  expect(card).not.toContain('appHost(');
+  expect(card).not.toContain('{app.url}');
+  expect(card).not.toContain('font-mono');
+
+  // The caption is ONE row now, not a stack — a leftover `space-y` wrapper
+  // would keep reserving the line the host used to occupy.
+  expect(card).toContain('className="mt-3 flex items-center gap-2"');
+  expect(card).not.toContain('mt-3 space-y-1');
+
+  // …and the skeleton loses its second bar with it, or the grid shifts the
+  // moment real data lands.
+  const skeleton = view.slice(view.indexOf('function AppGridSkeleton('));
+  expect(skeleton.slice(0, skeleton.indexOf('\n}'))).not.toContain('space-y-1');
+
+  // The URL is not gone from the product — the detail layer still names it on
+  // the control that opens the App.
+  expect(view).toContain('appHost(app.url)');
 });
 
 test('the Apps row matches the row contract of the group it sits in', () => {
@@ -285,7 +310,7 @@ test('the Apps grid is a gallery: bordered thumbnails, captions hanging below', 
   expect(card).toContain('relative overflow-hidden rounded-lg border');
   expect(card).not.toContain('bg-popover');
   expect(card).not.toContain('border-b');
-  expect(card).toContain('className="mt-3 space-y-1"');
+  expect(card).toContain('className="mt-3 flex items-center gap-2"');
 
   // Still exactly one control per card — a hover overflow button inside the
   // card button would be invalid HTML and a nested hit area.

--- a/apps/web/src/features/apps/apps-view.tsx
+++ b/apps/web/src/features/apps/apps-view.tsx
@@ -873,9 +873,13 @@ export function AppsView({ projectId }: { projectId: string }) {
 }
 
 /**
- * Shape-matched placeholder: same grid, same 16:9 tile, same two-line caption
+ * Shape-matched placeholder: same grid, same 16:9 tile, same ONE-line caption
  * hanging below it as `AppCard`. Four tiles, because four is the widest row any
  * density reaches — fewer would reflow the grid the moment real data lands.
+ *
+ * The second caption bar went when the card's hostname line did. A skeleton
+ * taller than the thing it stands in for is a layout shift dressed as a
+ * loading state.
  */
 function AppGridSkeleton({ columns }: { columns: string }) {
   return (
@@ -883,10 +887,7 @@ function AppGridSkeleton({ columns }: { columns: string }) {
       {Array.from({ length: 4 }).map((_, index) => (
         <li key={index}>
           <Skeleton className={cn(PREVIEW_TILE_ASPECT, 'w-full rounded-lg')} />
-          <div className="mt-3 space-y-1">
-            <Skeleton className="h-3.5 w-1/2 rounded-sm" />
-            <Skeleton className="h-3 w-3/4 rounded-sm" />
-          </div>
+          <Skeleton className="mt-3 h-3.5 w-1/2 rounded-sm" />
         </li>
       ))}
     </ul>
@@ -953,19 +954,24 @@ function AppCard({ projectId, app, onOpen }: { projectId: string; app: App; onOp
           />
         </div>
 
-        {/* The caption. Title and status share a baseline row; the host sits
-            under it, quieter. No padding of its own — it is page text now, not
-            the inside of a panel. */}
-        <div className="mt-3 space-y-1">
-          <div className="flex items-center gap-2">
-            <h3 className="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
-              {app.name}
-            </h3>
-            <Badge size="xs" variant={status.live ? 'success' : 'muted'} className="shrink-0">
-              {status.label}
-            </Badge>
-          </div>
-          <p className="text-muted-foreground truncate font-mono text-xs">{appHost(app.url)}</p>
+        {/* The caption: the App's name and whether it is up. One line.
+            No padding of its own — it is page text, not the inside of a panel.
+
+            The hostname used to sit under the name in monospace. It is the
+            same `<generated-key>.apps.<domain>` shape on every card, so a
+            column of them is a column of near-identical strings that differ in
+            a random token nobody reads or types — noise measured in a third of
+            the caption's height, on the surface whose whole job is to show the
+            App. The full URL is still one click away in the detail layer,
+            beside the control that opens it, which is where someone who wants
+            to copy it is already going. */}
+        <div className="mt-3 flex items-center gap-2">
+          <h3 className="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
+            {app.name}
+          </h3>
+          <Badge size="xs" variant={status.live ? 'success' : 'muted'} className="shrink-0">
+            {status.label}
+          </Badge>
         </div>
       </button>
     </li>

--- a/tests/e2e/specs/18-apps-ui.spec.ts
+++ b/tests/e2e/specs/18-apps-ui.spec.ts
@@ -12,6 +12,9 @@ import {
 import { dismissOnboarding, featureFlagRow, selectAccountForUi } from '../helpers/ui';
 
 const apiBase = process.env.E2E_API_URL || 'http://localhost:8008/v1';
+
+/** A hostname is full of dots; a raw interpolation into a RegExp would match too much. */
+const escapeRe = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const supabaseUrl = process.env.E2E_SUPABASE_URL || 'http://127.0.0.1:54321';
 const databaseUrl = process.env.KE2E_DATABASE_URL || process.env.E2E_DATABASE_URL;
 const password = 'E2eAppsUi123!';
@@ -225,8 +228,12 @@ test.describe('18 — Kortix Apps UI', () => {
       // Same assertions as before — they just live where the controls do.
       const seededCard = page.getByRole('button', { name: 'Open Seed App' });
       await expect(seededCard).toBeVisible();
-      await expect(seededCard.getByText(seededUrl.host, { exact: true })).toBeVisible();
       await expect(seededCard.getByText('Deploy to see a live preview.')).toBeVisible();
+      // The hostname is NOT on the tile. Every App's URL is the same
+      // `<generated-key>.apps.<domain>` shape, so a column of them differs only
+      // in a token nobody reads — a third of the caption spent on noise. It
+      // moved to the control that opens the App, asserted below.
+      await expect(seededCard.getByText(seededUrl.host, { exact: true })).toHaveCount(0);
       // Never deployed, so it must not claim to be running.
       await expect(seededCard.getByText('Not deployed', { exact: true })).toBeVisible();
 
@@ -238,7 +245,15 @@ test.describe('18 — Kortix Apps UI', () => {
       await expect(
         appModal.getByRole('button', { name: 'Put this App to sleep' }),
       ).toBeDisabled();
-      await expect(appModal.getByRole('link', { name: 'Open in a new tab' })).toBeVisible();
+      // …and this is where the URL went: the control that opens the App names
+      // the host it will open, so the tile can stay a picture of the App.
+      const openInNewTab = appModal.getByRole('link', { name: 'Open in a new tab' });
+      await expect(openInNewTab).toBeVisible();
+      // Containment, not an exact shape: this App has no deployment, so the
+      // href is the App's own URL rather than a signed session URL, and the two
+      // differ in query and trailing slash. What must hold either way is that
+      // the control points at THIS App's host.
+      await expect(openInNewTab).toHaveAttribute('href', new RegExp(escapeRe(seededUrl.host)));
 
       await appModal.getByRole('button', { name: 'More actions' }).click();
       await page.getByRole('menuitem', { name: 'Earlier versions' }).click();


### PR DESCRIPTION
Follow-up to #6764.

## The problem

Every App's URL is the same `<generated-key>.apps.<domain>` shape, so a column of tiles is a column of near-identical monospace strings differing only in a random token nobody reads, types, or recognises. It took a third of the caption's height on the one surface whose entire job is to show the App.

## The fix

Drop the host line from the tile. The full URL is still in the detail layer, on the control that opens the App, which is where someone who wants to copy it is already headed.

- Caption collapses from a two-line stack to one row: `mt-3 space-y-1` → `mt-3 flex items-center gap-2`.
- `AppGridSkeleton` loses its second bar to match — a skeleton taller than the thing it stands in for is a layout shift dressed as a loading state.
- `appHost()` stays; only the card stops calling it.

## Verification — real page, four seeded Apps, default density

| Check | Result |
| --- | --- |
| Grid rendered text | no `apps.localhost`, no `agkey0000*` anywhere |
| Captions | `Essentia Dashboards \| Running` — 0 `<p>`, no `font-mono` |
| Tile ratio | `1.7778` = 16/9, unchanged |
| Detail layer | `href="http://agkey0000001.apps.localhost:17808/"`, Hint reads `Open agkey0000001.apps.localhost:17808 in a new tab` |

Gates: `bun test src/features/apps` → **52 pass, 0 fail**; `eslint src/features/apps` clean; `tsc --noEmit` no errors in `features/apps`.

A new test pins the contract so the host cannot drift back onto a tile: the card body must not contain `appHost(`, `{app.url}`, or `font-mono`, and the skeleton must not carry `space-y-1`.
