### PR TITLE
fix(triggers): validate webhook secret delivery

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,18 @@ linked, not inlined.
 
 ## Register
 
+### Webhook signing secrets must use connector delivery (2026-08-23)
+
+**When:** creating, updating, or diagnosing a webhook trigger. A stored secret
+is not sufficient. Its delivery policy must authorize the `connector` consumer:
+use `broker` strategy with `connector` consumer, then rotate after narrowing a
+secret that previously reached a sandbox. Reject invalid policy during trigger
+create/update, and return distinct runtime codes for missing, inactive, and
+delivery-mismatched secrets. *Incident:* production `test-webhook` returned 409
+because `SECRET` existed with `runtime`/`sandbox` delivery; the same manifest
+also named an undeclared agent. *Enforcer:* `e2e-project-triggers.test.ts` and
+`secret-consumer-access.test.ts`.
+
 ### Assert monotonic timestamps when later writes can advance one field (2026-08-22)
 
 **When:** a test reads two timestamps written by one statement after asynchronous

--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -101,6 +101,7 @@ function resetState() {
   modelDefaults = { account: null, agents: {}, projects: {} };
   projectRow.metadata = {};
   secretValues.clear();
+  secretConsumerConfigurationStates.clear();
   secretConsumerReads.length = 0;
 }
 
@@ -354,6 +355,10 @@ mock.module('../billing/repositories/credit-accounts', () => ({
 // Stub secrets so webhook tests can resolve the trigger's signing secret.
 // Tests can read/override `secretValues` to drive specific behaviors.
 const secretValues = new Map<string, string>();
+const secretConsumerConfigurationStates = new Map<
+  string,
+  'configured' | 'missing' | 'inactive' | 'delivery_mismatch'
+>();
 const secretConsumerReads: Array<Record<string, unknown>> = [];
 const realProjectSecrets = await import('../projects/secrets');
 mock.module('../projects/secrets', () => ({
@@ -367,9 +372,17 @@ mock.module('../projects/secrets', () => ({
   listProjectSecretNamesForConsumer: async () => [],
   listProjectSecretsSnapshotForUser: async () => ({ env: {}, names: [], revision: 'empty' }),
   projectSecretsRevision: async () => 'empty',
+  getProjectSecretConsumerConfigurationStatus: async (input: { name: string }) =>
+    secretConsumerConfigurationStates.get(input.name) ??
+    (secretValues.has(input.name) ? 'configured' : 'missing'),
   getProjectSecretValueForConsumer: async (input: { name: string; consumer: string }) => {
     secretConsumerReads.push(input);
-    return input.consumer === 'connector' ? (secretValues.get(input.name) ?? null) : null;
+    const configuration =
+      secretConsumerConfigurationStates.get(input.name) ??
+      (secretValues.has(input.name) ? 'configured' : 'missing');
+    return input.consumer === 'connector' && configuration === 'configured'
+      ? (secretValues.get(input.name) ?? null)
+      : null;
   },
 }));
 
@@ -918,6 +931,7 @@ describe('git-backed triggers — CRUD', () => {
   });
 
   test('POST /triggers commits a webhook trigger and exposes the URL on listing', async () => {
+    secretValues.set('SLACK_WEBHOOK_SECRET', 'configured-test-value');
     const app = createApp();
     const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
       method: 'POST',
@@ -939,6 +953,62 @@ describe('git-backed triggers — CRUD', () => {
       secret_env: 'SLACK_WEBHOOK_SECRET',
     });
     expect(body.triggers[0].webhook_url).toContain(`/v1/webhooks/projects/${PROJECT_ID}/slack-hook`);
+  });
+
+  test('POST /triggers rejects a webhook whose secret is missing or has sandbox delivery', async () => {
+    const app = createApp();
+    const body = {
+      name: 'Slack hook',
+      type: 'webhook',
+      secret_env: 'SLACK_WEBHOOK_SECRET',
+      prompt_template: 'New event',
+    };
+
+    const missing = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(missing.status).toBe(409);
+    expect(await missing.json()).toMatchObject({ code: 'webhook_secret_missing' });
+    expect(commitCalls).toHaveLength(0);
+
+    secretValues.set('SLACK_WEBHOOK_SECRET', 'configured-test-value');
+    secretConsumerConfigurationStates.set('SLACK_WEBHOOK_SECRET', 'delivery_mismatch');
+    const mismatched = await app.request(`/v1/projects/${PROJECT_ID}/triggers`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    expect(mismatched.status).toBe(409);
+    expect(await mismatched.json()).toMatchObject({
+      code: 'webhook_secret_delivery_mismatch',
+    });
+    expect(commitCalls).toHaveLength(0);
+  });
+
+  test('PATCH /triggers/:slug rejects an existing webhook with sandbox secret delivery', async () => {
+    seedManifest(webhookEntry({
+      slug: 'hook',
+      name: 'Hook',
+      secretEnv: 'HOOK_SECRET',
+      prompt: 'New event',
+    }));
+    secretValues.set('HOOK_SECRET', 'configured-test-value');
+    secretConsumerConfigurationStates.set('HOOK_SECRET', 'delivery_mismatch');
+    const app = createApp();
+
+    const res = await app.request(`/v1/projects/${PROJECT_ID}/triggers/hook`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Renamed hook' }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: 'webhook_secret_delivery_mismatch',
+    });
+    expect(commitCalls).toHaveLength(0);
   });
 
   test('POST /triggers reloads and retries one manifest revision conflict', async () => {
@@ -1459,6 +1529,34 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(repeated.status).toBe(401);
     expect(mirrorInvalidationCalls).toBe(1);
     expect(manifestReadCalls).toBe(2);
+  });
+
+  test('webhook reports a connector delivery mismatch without creating a session', async () => {
+    seedManifest(webhookEntry({
+      slug: 'hook',
+      name: 'Hook',
+      secretEnv: 'HOOK_SECRET',
+      prompt: 'New event',
+    }));
+    secretValues.set('HOOK_SECRET', 'shhh');
+    secretConsumerConfigurationStates.set('HOOK_SECRET', 'delivery_mismatch');
+    const app = createApp();
+    const rawBody = JSON.stringify({ action: 'opened' });
+
+    const res = await app.request(`/v1/webhooks/projects/${PROJECT_ID}/hook`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Kortix-Signature': sign(rawBody, 'shhh'),
+      },
+      body: rawBody,
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      code: 'webhook_secret_delivery_mismatch',
+    });
+    expect(sandboxProvisionCalls).toBe(0);
   });
 
   test('webhook fires with a valid HMAC spawn a session', async () => {

--- a/apps/api/src/connectors/manifest-mutation.ts
+++ b/apps/api/src/connectors/manifest-mutation.ts
@@ -2,11 +2,23 @@ import { commitManifest, loadManifestForEdit } from '../projects/lib/triggers';
 
 export type ManifestMutationResult =
   | { ok: true; commitMessage: string | null }
-  | { ok: false; error: string; status: number };
+  | {
+      ok: false;
+      error: string;
+      status: number;
+      code?: string;
+      remediation?: string;
+    };
 
 export type ManifestCommitResult =
   | { ok: true }
-  | { ok: false; error: string; status: number };
+  | {
+      ok: false;
+      error: string;
+      status: number;
+      code?: string;
+      remediation?: string;
+    };
 
 type EditableManifest = Awaited<ReturnType<typeof loadManifestForEdit>>;
 type ManifestProject = Parameters<typeof loadManifestForEdit>[0];

--- a/apps/api/src/projects/lib/webhook-secret-policy.ts
+++ b/apps/api/src/projects/lib/webhook-secret-policy.ts
@@ -1,0 +1,65 @@
+import {
+  getProjectSecretConsumerConfigurationStatus,
+  type ProjectSecretConsumerConfigurationStatus,
+} from "../secrets";
+
+export type WebhookSecretErrorCode =
+  | "webhook_secret_missing"
+  | "webhook_secret_inactive"
+  | "webhook_secret_delivery_mismatch"
+  | "webhook_secret_unavailable";
+
+export interface WebhookSecretConfigurationError {
+  error: string;
+  code: WebhookSecretErrorCode;
+  remediation: string;
+}
+
+export function webhookSecretConfigurationError(
+  status:
+    | Exclude<ProjectSecretConsumerConfigurationStatus, "configured">
+    | "unavailable",
+): WebhookSecretConfigurationError {
+  if (status === "missing") {
+    return {
+      error: "Webhook secret is not configured",
+      code: "webhook_secret_missing",
+      remediation:
+        "Create the referenced secret, then set its delivery to broker with consumer connector.",
+    };
+  }
+  if (status === "inactive") {
+    return {
+      error: "Webhook secret is disabled",
+      code: "webhook_secret_inactive",
+      remediation:
+        "Set the referenced secret value, then set its delivery to broker with consumer connector.",
+    };
+  }
+  if (status === "delivery_mismatch") {
+    return {
+      error: "Webhook secret is not available to the connector consumer",
+      code: "webhook_secret_delivery_mismatch",
+      remediation: "Set the secret delivery to broker with consumer connector.",
+    };
+  }
+  return {
+    error: "Webhook secret is unavailable",
+    code: "webhook_secret_unavailable",
+    remediation: "Rotate the secret value and retry the request.",
+  };
+}
+
+export async function validateWebhookSecretConfiguration(input: {
+  projectId: string;
+  secretEnv: string;
+}): Promise<WebhookSecretConfigurationError | null> {
+  const status = await getProjectSecretConsumerConfigurationStatus({
+    projectId: input.projectId,
+    name: input.secretEnv,
+    consumer: "connector",
+  });
+  return status === "configured"
+    ? null
+    : webhookSecretConfigurationError(status);
+}

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -31,6 +31,10 @@ import { registerGitHubLinkedProject } from '../lib/project-registration';
 import { UUID_V4_REGEX, deriveProjectName, normalizeRepoUrl, normalizeString, readBody, requestAuditContext, serializeGitHubInstallation, serializeGitHubInstallations, serializeProject } from '../lib/serializers';
 import { extractWebhookToken, fireGitTrigger, markGitTriggerFired, renderPromptTemplate, triggerFilterMatches, triggersPausedForProject, verifyWebhookSignature, verifyWebhookToken, webhookPayload } from '../lib/triggers';
 import {
+  validateWebhookSecretConfiguration,
+  webhookSecretConfigurationError,
+} from '../lib/webhook-secret-policy';
+import {
   consumeProjectWebhookManifestRefreshBudget,
   createProjectWebhookRateLimitMiddleware,
 } from '../../shared/rate-limit';
@@ -80,16 +84,21 @@ projectWebhooksApp.post('/projects/:projectId/:slug', async (c) => {
   }
 
   const rawBody = await c.req.text();
-  const secret = spec.secretEnv
-    ? await getProjectSecretValueForConsumer({
-        projectId: project.projectId,
-        accountId: project.accountId,
-        name: spec.secretEnv,
-        consumer: 'connector',
-      })
-    : null;
+  if (!spec.secretEnv) {
+    return c.json(webhookSecretConfigurationError('missing'), 409);
+  }
+  const secret = await getProjectSecretValueForConsumer({
+    projectId: project.projectId,
+    accountId: project.accountId,
+    name: spec.secretEnv,
+    consumer: 'connector',
+  });
   if (!secret) {
-    return c.json({ error: 'Webhook secret is not configured' }, 409);
+    const configurationError = await validateWebhookSecretConfiguration({
+      projectId: project.projectId,
+      secretEnv: spec.secretEnv,
+    });
+    return c.json(configurationError ?? webhookSecretConfigurationError('unavailable'), 409);
   }
 
   // Primary auth: HMAC-SHA256 signature over the raw body (GitHub-compatible).

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -151,6 +151,7 @@ import {
   triggersPausedForProject,
   upsertTriggerInManifest,
 } from '../lib/triggers';
+import { validateWebhookSecretConfiguration } from '../lib/webhook-secret-policy';
 import { childIdleGraceMs } from '../sandbox-deadline';
 import { generateSessionTitleFromFirstPrompt } from '../session-title-generate';
 import { listProjectSecretNamesForConsumer } from '../secrets';
@@ -1132,6 +1133,13 @@ projectsApp.openapi(
 
     const draft = parseTriggerDraft(body, { existingSlug: null });
     if ('error' in draft) return c.json({ error: draft.error }, 400);
+    if (draft.type === 'webhook' && draft.secretEnv) {
+      const configurationError = await validateWebhookSecretConfiguration({
+        projectId,
+        secretEnv: draft.secretEnv,
+      });
+      if (configurationError) return c.json(configurationError, 409);
+    }
     const parsedAccess =
       body.session_access === undefined
         ? { ok: true as const, access: PRIVATE_TRIGGER_SESSION_ACCESS }
@@ -1332,6 +1340,15 @@ projectsApp.openapi(
         if (patchesKey && !patchesMode) delete base.session_mode;
         const draft = parseTriggerDraft({ ...base, ...body, slug: slug }, { existingSlug: slug });
         if ('error' in draft) return { ok: false, error: draft.error, status: 400 };
+        if (draft.type === 'webhook' && draft.secretEnv) {
+          const configurationError = await validateWebhookSecretConfiguration({
+            projectId,
+            secretEnv: draft.secretEnv,
+          });
+          if (configurationError) {
+            return { ok: false, status: 409, ...configurationError };
+          }
+        }
         effectivePinnedSessionId = draft.pinnedSessionId;
 
         // A `pinned` trigger may only target a session that belongs to THIS project.
@@ -1362,7 +1379,14 @@ projectsApp.openapi(
       },
     );
     if (!result.ok) {
-      return c.json({ error: result.error }, result.status as 400 | 404 | 409 | 502);
+      return c.json(
+        {
+          error: result.error,
+          ...(result.code ? { code: result.code } : {}),
+          ...(result.remediation ? { remediation: result.remediation } : {}),
+        },
+        result.status as 400 | 404 | 409 | 502,
+      );
     }
     if (touchesManifest) {
       if (!committedManifest) throw new Error('trigger update completed without a manifest');

--- a/apps/api/src/projects/secret-consumer-access.test.ts
+++ b/apps/api/src/projects/secret-consumer-access.test.ts
@@ -22,6 +22,7 @@ mock.module('../shared/audit', () => ({
 const {
   decryptProjectSecret,
   encryptProjectSecret,
+  getProjectSecretConsumerConfigurationStatus,
   getProjectSecretValueForConsumer,
   listProjectSecretNamesForConsumer,
   resolveProjectSecretsForConsumer,
@@ -84,6 +85,26 @@ describe('getProjectSecretValueForConsumer', () => {
       },
     });
     expect(JSON.stringify(audits)).not.toContain('plaintext-test-value');
+  });
+
+  test('distinguishes missing, inactive, mismatched, and configured connector secrets', async () => {
+    const status = () =>
+      getProjectSecretConsumerConfigurationStatus({
+        projectId: PROJECT_ID,
+        name: 'provider_key',
+        consumer: 'connector',
+      });
+
+    expect(await status()).toBe('missing');
+
+    rows = [secret({ strategy: 'broker', consumer: 'connector', active: false })];
+    expect(await status()).toBe('inactive');
+
+    rows = [secret({ strategy: 'runtime', consumer: 'sandbox' })];
+    expect(await status()).toBe('delivery_mismatch');
+
+    rows = [secret({ strategy: 'broker', consumer: 'connector' })];
+    expect(await status()).toBe('configured');
   });
 
   test('does not decrypt or audit fallback identifiers when the first value resolves', async () => {

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -877,11 +877,39 @@ export interface ProjectSecretConsumerValue {
   value: string;
 }
 
-export async function projectSecretIsConfiguredForConsumer(input: {
+type ServerSecretConsumer = Exclude<SecretConsumer, 'sandbox' | 'network' | 'http_broker'>;
+
+export type ProjectSecretConsumerConfigurationStatus =
+  | 'configured'
+  | 'missing'
+  | 'inactive'
+  | 'delivery_mismatch';
+
+function secretPolicyAllowsConsumer(
+  row: {
+    scope: string;
+    strategy: SecretStrategy;
+    consumer: SecretConsumer | null;
+  },
+  consumer: ServerSecretConsumer,
+): boolean {
+  return consumer === 'connector'
+    ? (row.strategy === 'broker' && row.consumer === 'connector') ||
+        (row.scope === 'connector' &&
+          (row.consumer === 'connector' || row.consumer === 'sandbox'))
+    : row.strategy === 'broker' && row.consumer === consumer;
+}
+
+/**
+ * Read whether a named shared secret can cross one server-consumer boundary.
+ * This does not decrypt the value. Callers can distinguish a missing secret
+ * from an existing secret whose delivery policy denies the consumer.
+ */
+export async function getProjectSecretConsumerConfigurationStatus(input: {
   projectId: string;
   name: string;
-  consumer: Exclude<SecretConsumer, 'sandbox' | 'network' | 'http_broker'>;
-}): Promise<boolean> {
+  consumer: ServerSecretConsumer;
+}): Promise<ProjectSecretConsumerConfigurationStatus> {
   const normalizedName = input.name.trim().toUpperCase();
   const rows = await db
     .select({
@@ -898,14 +926,20 @@ export async function projectSecretIsConfiguredForConsumer(input: {
         isNull(projectSecrets.ownerUserId),
       ),
     );
-  return rows.some(
-    (row) =>
-      row.active &&
-      (input.consumer === 'connector'
-        ? row.scope === 'connector' ||
-          (row.strategy === 'broker' && row.consumer === 'connector')
-        : row.strategy === 'broker' && row.consumer === input.consumer),
-  );
+  if (rows.length === 0) return 'missing';
+  if (rows.some((row) => row.active && secretPolicyAllowsConsumer(row, input.consumer))) {
+    return 'configured';
+  }
+  if (rows.some((row) => row.active)) return 'delivery_mismatch';
+  return 'inactive';
+}
+
+export async function projectSecretIsConfiguredForConsumer(input: {
+  projectId: string;
+  name: string;
+  consumer: ServerSecretConsumer;
+}): Promise<boolean> {
+  return (await getProjectSecretConsumerConfigurationStatus(input)) === 'configured';
 }
 
 export async function listProjectSecretNamesForConsumer(input: {
@@ -950,12 +984,7 @@ export async function listProjectSecretNamesForConsumer(input: {
     const selected = slot.personal?.active ? slot.personal : slot.shared;
     if (!selected?.active || selected.name.toUpperCase().startsWith('KORTIX_')) continue;
     const policy = slot.shared ?? selected;
-    const configured =
-      input.consumer === 'connector'
-        ? (policy.strategy === 'broker' && policy.consumer === 'connector') ||
-          (policy.scope === 'connector' &&
-            (policy.consumer === 'connector' || policy.consumer === 'sandbox'))
-        : policy.strategy === 'broker' && policy.consumer === input.consumer;
+    const configured = secretPolicyAllowsConsumer(policy, input.consumer);
     if (configured) names.add(selected.name.toUpperCase());
   }
   return [...names].sort();
@@ -1046,13 +1075,7 @@ async function resolveProjectSecretValuesForConsumer(
 
   const resolved: ProjectSecretConsumerValue[] = [];
   for (const { row, policyRow } of selectedRows) {
-    const allowed =
-      row.active &&
-      (input.consumer === 'connector'
-        ? (policyRow.strategy === 'broker' && policyRow.consumer === 'connector') ||
-          (policyRow.scope === 'connector' &&
-            (policyRow.consumer === 'connector' || policyRow.consumer === 'sandbox'))
-        : policyRow.strategy === 'broker' && policyRow.consumer === input.consumer);
+    const allowed = row.active && secretPolicyAllowsConsumer(policyRow, input.consumer);
     if (!allowed) {
       await recordAuditEvent({
         accountId,

--- a/apps/web/content/docs/connect/triggers.mdx
+++ b/apps/web/content/docs/connect/triggers.mdx
@@ -224,7 +224,7 @@ Legacy `kortix.toml` uses the same fields in a different container; see [legacy 
 | `type` | yes | — | `cron`, `webhook`, or `monitor`. |
 | `prompt` | yes | — | Template string. Renders as the session's first message. |
 | `name` | no | `slug` | Human label. |
-| `agent` | no | `default` | Must name a key in `agents:`, or fall back to `default_agent`. |
+| `agent` | no | `default_agent` | Must name a key in `agents:`. Omit it to use `default_agent`; do not write the literal `default`. |
 | `model` | no | resolves at fire time | Wire form `provider/model`, for example `anthropic/claude-sonnet-4-5`. |
 | `enabled` | no | `true` | When `false`, the scheduler and the webhook receiver skip the entry. |
 | `session_mode` | no | `fresh`, or `reuse` on a monitor | See [Session strategy](#session-strategy). |
@@ -234,13 +234,24 @@ Legacy `kortix.toml` uses the same fields in a different container; see [legacy 
 | `cron` | one of `cron`/`run_at`, on `type: cron` | — | 6-field expression: second minute hour day month weekday. |
 | `run_at` | one of `cron`/`run_at`, on `type: cron` | — | ISO-8601 timestamp. Fires once, then stays dormant. |
 | `timezone` | no, cron only | `UTC` | IANA name. |
-| `secret_env` | required, webhook only | — | Name of a project secret holding the webhook signing key. |
+| `secret_env` | required, webhook only | — | Name of a project secret holding the signing key. The secret must use `broker` delivery with the `connector` consumer. |
 | `run` | required, monitor only | — | Repo-relative command whose stdout lines are the events. One line, at most 1024 characters. |
 | `mode` | required, monitor only | — | `poll` re-runs `run` every `interval`; `stream` runs it once and keeps it alive. |
 | `interval` | required for `mode: poll` | — | Duration literal (`30s`, `5m`, `24h`, `7d`), minimum `30s`. Invalid on `mode: stream`. |
 | `expect_event_within` | no, monitor only | — | Duration literal, minimum `5m`. Silence longer than this fires a lifecycle event. |
 
 A cron trigger needs `cron` or `run_at`, never both. A webhook trigger without `secret_env` is rejected — there is no unauthenticated webhook. A monitor needs `run` and `mode`, and rejects `cron`, `run_at`, `timezone`, and `secret_env` outright — a manifest that claims a schedule the monitor runner never reads is a lie.
+
+Configure the signing secret before you create or update a webhook trigger:
+
+```bash
+kortix secrets set WEBHOOK_SECRET=-
+kortix secrets delivery WEBHOOK_SECRET broker --consumer connector
+```
+
+Pass the value to the first command on standard input. If the secret previously
+used sandbox delivery, rotate it after the delivery change because an existing
+sandbox can retain the previous value.
 
 ## Session strategy
 
@@ -315,7 +326,7 @@ Fires on `POST /v1/webhooks/projects/{projectId}/{slug}`. Kortix checks the requ
 | 400 | Malformed project ID or slug in the URL. |
 | 401 | Signature and token both missing or wrong. |
 | 404 | Trigger not found, disabled, not a webhook, or the project is not active. |
-| 409 | `secret_env` has no value set. |
+| 409 | The signing secret is missing, inactive, unavailable, or does not authorize the `connector` consumer. The response includes a `webhook_secret_*` code and remediation. |
 | 500 | Auth passed, but the session failed to fire. |
 
 ## Endpoints

--- a/apps/web/content/docs/project/manifest.mdx
+++ b/apps/web/content/docs/project/manifest.mdx
@@ -223,13 +223,13 @@ triggers:
 | `type`         | yes                   | —                     | `cron`, `webhook`, or `monitor` (experimental).                                                       |
 | `prompt`       | yes                   | —                     | Non-empty. Supports templating.                                                                       |
 | `name`         | no                    | slug                  | Human label.                                                                                          |
-| `agent`        | no                    | `default`             | Must name a key in `agents:`, or fall back to `default_agent`.                                        |
+| `agent`        | no                    | `default_agent`       | Must name a key in `agents:`. Omit it to use `default_agent`; do not write the literal `default`.      |
 | `enabled`      | no                    | `true`                | `false` skips the entry.                                                                              |
 | `model`        | no                    | resolves at fire time | Wire form `provider/model`. Pins the fired session to that model. See [Models](/docs/project/models). |
 | `session_mode` | no                    | `fresh`               | `fresh`, `reuse`, `pinned`, or `keyed`.                                                               |
 | `session_id`   | required for `pinned` | —                     | Exact session to re-prompt.                                                                           |
 
-Cron triggers need exactly one of `cron` (a 6-field expression) or `run_at` (a one-off ISO-8601 timestamp), plus `timezone` as an IANA name. Webhook triggers need `secret_env`, the name of a secret holding the HMAC signing key. Monitor triggers need `run` (a repo-relative command) and `mode` (`poll` or `stream`), and reject every cron and webhook field. Full field reference, payload templating, endpoints, and session strategy: see [Triggers](/docs/connect/triggers).
+Cron triggers need exactly one of `cron` (a 6-field expression) or `run_at` (a one-off ISO-8601 timestamp), plus `timezone` as an IANA name. Webhook triggers need `secret_env`, the name of a secret that uses `broker` delivery with the `connector` consumer. Monitor triggers need `run` (a repo-relative command) and `mode` (`poll` or `stream`), and reject every cron and webhook field. Full field reference, credential setup, payload templating, endpoints, and session strategy: see [Triggers](/docs/connect/triggers).
 
 ## `connectors:`
 


### PR DESCRIPTION
## Problem

Webhook triggers accepted secrets that existed but used runtime/sandbox delivery. The public endpoint then returned a generic 409 and created no session. A literal `agent: default` also passed through project edits even though the manifest validator rejects it when no `default` agent exists.

## Change

- classify webhook secrets as configured, missing, inactive, or delivery-mismatched without decrypting values
- reject invalid secret policy during trigger create and update
- return machine-readable `webhook_secret_*` runtime errors with remediation
- keep denied consumer reads audited
- document broker/connector setup and correct `default_agent` fallback usage
- record the incident learning

## Verification

- `bun test --isolate --env-file=apps/api/scripts/test.env apps/api/src/__tests__/e2e-project-triggers.test.ts apps/api/src/projects/secret-consumer-access.test.ts` — 47 passed, 221 assertions
- `pnpm --filter kortix-api typecheck` — passed
- `pnpm --filter kortix-api test` — 8,278 passed, 78 skipped, 0 failed, 29,321 assertions
- production project E2E before this platform change: no signature 401; invalid signature 401; valid HMAC 202; one new session completed on `kortix/deepseek-v4-flash`
