### PR TITLE
fix(self-host): expose the public LLM gateway route

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Keep self-host sandbox gateway URLs aligned with the public proxy route (2026-08-23)
+
+**When:** changing `LLM_GATEWAY_PROXY_TARGET`, Caddy LLM matchers, or sandbox
+gateway URL resolution. Test the final public URL through the deployed proxy.
+Internal proxy mode does not prove that `/v1/llm-gateway/v1` is public.
+*Incident:* Essentia sessions received Caddy `404` because Compose selected that
+internal prefix while Caddy exposed `/v1/llm` directly to the gateway.
+*Enforcer:* `compose-assets.test.ts` pins `LLM_GATEWAY_BASE_URL` to the public
+`${KORTIX_URL}/v1/llm` route.
+
 ### Webhook signing secrets must use connector delivery (2026-08-23)
 
 **When:** creating, updating, or diagnosing a webhook trigger. A stored secret

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -246,6 +246,16 @@ describe('full self-host Docker distribution', () => {
     expect(document.services).not.toHaveProperty('caddy');
   });
 
+  test('the API gives remote sandboxes the public self-host gateway route', () => {
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { environment?: Record<string, string> }>;
+    };
+
+    expect(document.services['kortix-api']?.environment?.LLM_GATEWAY_BASE_URL).toBe(
+      '${KORTIX_URL}/v1/llm',
+    );
+  });
+
   test('the kortix-updater service is always present and mounts the docker socket', () => {
     const document = parse(renderFullDockerCompose('kortix-default')) as {
       services: Record<string, { volumes?: string[]; environment?: Record<string, string> }>;

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -88,19 +88,11 @@ services:
       # here no matter what .env said).
       LLM_GATEWAY_ENABLED: "true"
       LLM_GATEWAY_PROXY_TARGET: http://llm-gateway:8090
-      # Deliberately NOT set: LLM_GATEWAY_BASE_URL is what gets handed straight
-      # to sandboxes as KORTIX_LLM_BASE_URL (see session-sandbox.ts /
-      # sandbox-env-sync.ts). It used to be pinned here to the compose-internal
-      # `llm-gateway` service (http://llm-gateway:8090/v1/llm) — a hostname a
-      # remote Daytona sandbox VM can never resolve, so every BYOK model call
-      # failed with opencode's "Cannot connect to API: Was there a typo in the
-      # url or port?" the moment a session tried to actually run a turn. Left
-      # unset, the fallback in session-sandbox.ts correctly resolves to
-      # `${KORTIX_URL}/v1/llm` — kortix-api's own in-process gateway mount,
-      # already reachable through the SAME public tunnel/domain origin every
-      # other sandbox call already uses. The standalone `llm-gateway` container
-      # below still runs (control-plane RPC at /internal/gateway), it's just
-      # never the sandbox-facing base URL in self-host.
+      # KORTIX_LLM_BASE_URL must use the public Caddy route. The proxy target
+      # above is internal control-plane wiring. Without this explicit override,
+      # the API selects /v1/llm-gateway/v1. Caddy sends every /v1/llm* request
+      # directly to the standalone gateway, which does not expose that prefix.
+      LLM_GATEWAY_BASE_URL: ${KORTIX_URL}/v1/llm
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
     depends_on:


### PR DESCRIPTION
## Problem

Self-host API containers set `LLM_GATEWAY_PROXY_TARGET`. The sandbox URL resolver therefore injected `/v1/llm-gateway/v1`. Self-host Caddy routes `/v1/llm*` directly to the standalone gateway, where that prefixed path returns 404.

## Fix

- Pin `LLM_GATEWAY_BASE_URL` to `${KORTIX_URL}/v1/llm` in the self-host Compose asset.
- Add a rendered-Compose regression test.
- Add the incident rule to the learnings register.

## Verification

`bun test apps/cli/src/self-host/__tests__/compose-assets.test.ts`

Result: 63 pass, 0 fail.