### PR TITLE
fix(web): the model dialog IS the Models page, not a second copy of it

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/gateway-view.tsx
@@ -48,6 +48,25 @@
  * This view reads `useSettingsNav()`, never a store directly, so it mounts
  * under either the legacy Customize panel or the new Settings panel — see
  * `features/workspace/shared/settings-nav-context.tsx`.
+ *
+ * ## This module is also the dialog
+ *
+ * `ProjectProviderModal` — the quick version the session model picker and the
+ * Secrets tab open — renders THESE components, not copies of them. It used to
+ * be a second implementation with its own tab root, its own underline strip at
+ * `text-xs`, its own labels ("API keys" for what this page calls "Providers"),
+ * no project-default control, and a scroll body with no horizontal padding, so
+ * the model rows ran into the modal's clipped edge. Four exports ended that:
+ *
+ *   - `LlmTabStrip` — takes an optional `tabs` SUBSET (`QUICK_LLM_TABS`), so
+ *     the dialog draws three of the same pills, not three different ones.
+ *   - `ProjectDefaultPicker` — the one page-level control, both places.
+ *   - `LlmSections` — the section bodies, chosen by the host's `tab`.
+ *   - `MODELS_PAGE_TITLE` / `MODELS_PAGE_DESCRIPTION` — the same two lines.
+ *
+ * None of them carries horizontal padding: the host column supplies it
+ * (`CapabilityPageShell` here, `px-5` in the dialog). Adding one back here
+ * double-indents the page.
  */
 
 import { useEffect, useState } from 'react';
@@ -72,9 +91,21 @@ import { useIsMutating } from '@tanstack/react-query';
 export const MODELS_PAGE_TITLE = 'Models';
 export const MODELS_PAGE_DESCRIPTION = 'Which providers and models this project can use.';
 
-type LlmTab = 'providers' | 'models' | 'custom' | 'gateway' | 'routing' | 'overview' | 'logs';
+export type LlmTab =
+  | 'providers'
+  | 'models'
+  | 'custom'
+  | 'gateway'
+  | 'routing'
+  | 'overview'
+  | 'logs';
 
-export const LLM_TABS: { id: LlmTab; label: string }[] = [
+export interface LlmTabEntry {
+  id: LlmTab;
+  label: string;
+}
+
+export const LLM_TABS: LlmTabEntry[] = [
   // The keys you bring IN. Only the provider list — it was called "API keys"
   // and also carried the gateway key and its reference, which point the other
   // way; see `gateway-access-tab.tsx`.
@@ -95,6 +126,28 @@ export const LLM_TABS: { id: LlmTab; label: string }[] = [
   { id: 'overview', label: 'Costs' },
   { id: 'logs', label: 'Logs' },
 ];
+
+/**
+ * The three tabs the QUICK version carries — `ProjectProviderModal`, the
+ * dialog the session model picker and the Secrets tab open.
+ *
+ * It is a slice of `LLM_TABS`, not a second list: same ids, same labels, same
+ * order, same pills, and it renders through the same `LlmTabStrip` and the
+ * same `LlmSections`. What the dialog drops is the four tabs that are project
+ * administration rather than "let me use a model right now" — Gateway (the key
+ * you hand out), Routing, Costs and Logs. Those live on the full page, which
+ * has the width and the height for a log table.
+ */
+export type QuickLlmTab = 'providers' | 'models' | 'custom';
+
+export const QUICK_LLM_TABS: LlmTabEntry[] = LLM_TABS.filter((t) =>
+  (['providers', 'models', 'custom'] as string[]).includes(t.id),
+);
+
+/** True when `tab` is one of the quick version's three. */
+export function isQuickLlmTab(tab: string): tab is QuickLlmTab {
+  return QUICK_LLM_TABS.some((t) => t.id === tab);
+}
 
 /**
  * The legacy Customize overlay's `llm-*` `CustomizeSection` ids. The new
@@ -139,18 +192,25 @@ const TAB_BY_SECTION: Partial<Record<LegacyLlmSubTab, LlmTab>> = {
  * `size` or a className — the whole point of this component is that Models and
  * Connectors draw the same control, and a prop added on one side is how they
  * stop.
+ *
+ * `tabs` is a SUBSET, never a different list: the modal passes
+ * `QUICK_LLM_TABS` and gets the same pills, the same labels and the same order
+ * as the page. It is the only knob, and it selects entries out of `LLM_TABS` —
+ * it cannot introduce one.
  */
 export function LlmTabStrip({
   value,
   onValueChange,
+  tabs = LLM_TABS,
 }: {
   value: string;
   onValueChange: (next: string) => void;
+  tabs?: readonly LlmTabEntry[];
 }) {
   return (
     <Tabs value={value} onValueChange={onValueChange}>
       <TabsList>
-        {LLM_TABS.map((t) => (
+        {tabs.map((t) => (
           <TabsTrigger key={t.id} value={t.id}>
             {t.label}
           </TabsTrigger>
@@ -160,15 +220,20 @@ export function LlmTabStrip({
   );
 }
 
-export function LlmManagementView({ projectId }: { projectId: string }) {
-  const { isOpen: open, activeTab: section } = useSettingsNav();
-  const [tab, setTab] = useState<LlmTab>(
-    () => TAB_BY_SECTION[section as LegacyLlmSubTab] ?? 'providers',
-  );
-
-  // The project default is the single model authority for this project. Account
-  // and platform defaults are display-only inheritance when no project value is
-  // configured; choosing here always writes project scope.
+/**
+ * The project-default model picker — the ONE page-level control, rendered by
+ * the page in `CapabilityPageShell`'s `action` slot and by the modal in the
+ * same place beside its title.
+ *
+ * The project default is the single model authority for this project. Account
+ * and platform defaults are display-only inheritance when no project value is
+ * configured; choosing here always writes project scope.
+ *
+ * Callers gate it on write access — a role with the LLM section's READ leaf
+ * (`project.read`) but not `project.write` sees the gateway read-only, and the
+ * one mutating control in this bar is hidden rather than left to 403.
+ */
+export function ProjectDefaultPicker({ projectId }: { projectId: string }) {
   const models = useProjectModels(projectId);
   const modelDefaults = useModelDefaults(projectId);
   const routingMutationCount = useIsMutating({ mutationKey: gatewayRoutingPolicyKey(projectId) });
@@ -177,10 +242,117 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
     modelDefaults.accountDefault ??
     (modelDefaults.freeTier ? undefined : modelDefaults.platformDefault) ??
     null;
-  // A role with the LLM section's READ leaf (project.read) but not project.write
-  // sees the gateway read-only: logs/overview/spend stay visible, but the
-  // project-default model picker — the one mutating control in this bar — is
-  // hidden so a read-only user cannot trigger a forbidden write.
+
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      <span className="text-muted-foreground hidden text-xs sm:inline">Project default</span>
+      <ModelSelector
+        models={models}
+        selectedModel={effectiveDefault}
+        unsetLabel="Project default"
+        disabled={modelDefaults.isLoading || modelDefaults.isUpdating || routingMutationCount > 0}
+        onSelect={(m) => {
+          if (!m) return;
+          void modelDefaults
+            .setProjectDefault(m)
+            .catch(() => errorToast('Could not update the project default'));
+        }}
+      />
+    </div>
+  );
+}
+
+/**
+ * The selected section — the page's body and the modal's, character for
+ * character.
+ *
+ * One section at a time, by the caller's state — NOT seven `TabsContent`
+ * panels. Radix keeps every panel in the tree and each one used to open its
+ * own `overflow-y-auto`, which is how this page ended up with three nested
+ * scroll containers under a shell that already had one.
+ *
+ * It renders NO padding of its own: the host column supplies it
+ * (`CapabilityPageShell`'s `max-w-5xl px-4` on the page, the modal's `px-5`),
+ * which is what makes the model list line up under the heading in both.
+ */
+export function LlmSections({
+  projectId,
+  tab,
+  onTabChange,
+  canWrite,
+  enabled,
+}: {
+  projectId: string;
+  tab: LlmTab;
+  /** Sections that hand the reader on — the custom form's "Done", the gateway
+   *  tab's "view models" — move the host's tab, so it has to come back up. */
+  onTabChange: (next: LlmTab) => void;
+  canWrite: boolean;
+  /** Gates the provider list's fetch. False while the host is closed. */
+  enabled: boolean;
+}) {
+  const modelDefaults = useModelDefaults(projectId);
+
+  return (
+    <>
+      {tab === 'providers' && (
+        /* JAY-510: this path mounts `ProviderConnect` DIRECTLY — no nested
+           dialog, so connecting Anthropic here opens nothing on top of what
+           you are already looking at. `p-0` because the host column already
+           carries the padding. */
+        <ProviderConnect
+          projectId={projectId}
+          canWrite={canWrite}
+          enabled={enabled}
+          className="gap-4 p-0"
+        />
+      )}
+      {/* The model-visibility list used to sit one level deeper, inside the
+          provider modal's own "Models" tab. Flattened to a sibling here so it
+          keeps a home now that `ProviderConnect` has no tabs of its own. */}
+      {tab === 'models' && <ModelsTab projectId={projectId} />}
+      {/* A saved custom provider gets a key like any other and a row on the
+          provider list, so a "Done" that leaves you on the form you just
+          submitted is not done. */}
+      {tab === 'custom' && (
+        <CustomProviderPanel
+          projectId={projectId}
+          canWrite={canWrite}
+          onDone={() => onTabChange('providers')}
+        />
+      )}
+      {tab === 'gateway' && (
+        <GatewayAccessTab
+          projectId={projectId}
+          canWrite={canWrite}
+          onViewModels={() => onTabChange('models')}
+        />
+      )}
+      {tab === 'routing' && (
+        <GatewayRouting
+          projectId={projectId}
+          canWrite={canWrite}
+          projectDefaultPending={modelDefaults.isUpdating}
+        />
+      )}
+      {/* Stats + the spend cap. `canWrite` reaches the budget controls that
+          used to live one tab over. */}
+      {tab === 'overview' && <GatewayOverview projectId={projectId} canWrite={canWrite} />}
+      {tab === 'logs' && <GatewayLogs projectId={projectId} />}
+    </>
+  );
+}
+
+export function LlmManagementView({ projectId }: { projectId: string }) {
+  const { isOpen: open, activeTab: section } = useSettingsNav();
+  const [tab, setTab] = useState<LlmTab>(
+    () => TAB_BY_SECTION[section as LegacyLlmSubTab] ?? 'providers',
+  );
+
+  // A role with the LLM section's READ leaf (project.read) but not
+  // project.write sees the gateway read-only: logs/overview/spend stay
+  // visible, but the project-default model picker is hidden so a read-only
+  // user cannot trigger a forbidden write.
   const canWrite =
     useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE).allowed === true;
 
@@ -201,68 +373,17 @@ export function LlmManagementView({ projectId }: { projectId: string }) {
            beside the tabs: a bordered dropdown opposite a filled pill strip
            reads as a second tab strip, and the row that has to look identical
            to Connectors / Agents / Skills is exactly that one. */
-        canWrite ? (
-          <div className="flex shrink-0 items-center gap-1.5">
-            <span className="text-muted-foreground hidden text-xs sm:inline">Project default</span>
-            <ModelSelector
-              models={models}
-              selectedModel={effectiveDefault}
-              unsetLabel="Project default"
-              disabled={
-                modelDefaults.isLoading || modelDefaults.isUpdating || routingMutationCount > 0
-              }
-              onSelect={(m) => {
-                if (!m) return;
-                void modelDefaults
-                  .setProjectDefault(m)
-                  .catch(() => errorToast('Could not update the project default'));
-              }}
-            />
-          </div>
-        ) : undefined
+        canWrite ? <ProjectDefaultPicker projectId={projectId} /> : undefined
       }
       filters={<LlmTabStrip value={tab} onValueChange={(v) => setTab(v as LlmTab)} />}
     >
-      {/* One section at a time, by local state — NOT six `TabsContent` panels.
-          Radix keeps every panel in the tree and each one used to open its own
-          `overflow-y-auto`, which is how this page ended up with three nested
-          scroll containers under a shell that already had one. */}
-      {tab === 'providers' && (
-        /* JAY-510: this path mounts `ProviderConnect` DIRECTLY — no Modal, no
-           dialog, so connecting Anthropic here opens nothing. The modal shell
-           (`ProjectProviderModal`) is only for the model selector and the
-           Secrets tab, which are dialogs by construction. `p-0` because the
-           shell's column already carries the page padding. */
-        <ProviderConnect
-          projectId={projectId}
-          canWrite={canWrite}
-          enabled={open}
-          className="gap-4 p-0"
-        />
-      )}
-      {/* The model-visibility list used to sit one level deeper, inside the
-          provider modal's own "Models" tab. Flattened to a sibling here so it
-          keeps a home now that `ProviderConnect` has no tabs of its own. */}
-      {tab === 'models' && <ModelsTab projectId={projectId} />}
-      {tab === 'custom' && <CustomProviderPanel projectId={projectId} canWrite={canWrite} />}
-      {tab === 'gateway' && (
-        <GatewayAccessTab
-          projectId={projectId}
-          canWrite={canWrite}
-          onViewModels={() => setTab('models')}
-        />
-      )}
-      {tab === 'routing' && (
-        <GatewayRouting
-          projectId={projectId}
-          canWrite={canWrite}
-          projectDefaultPending={modelDefaults.isUpdating}
-        />
-      )}
-      {/* Stats + the spend cap. `canWrite` reaches the budget controls that
-          used to live one tab over. */}
-      {tab === 'overview' && <GatewayOverview projectId={projectId} canWrite={canWrite} />}
-      {tab === 'logs' && <GatewayLogs projectId={projectId} />}
+      <LlmSections
+        projectId={projectId}
+        tab={tab}
+        onTabChange={setTab}
+        canWrite={canWrite}
+        enabled={open}
+      />
     </CapabilityPageShell>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-panel.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/custom-provider-panel.tsx
@@ -68,7 +68,7 @@ export function customProviderIdsFromSecrets(names: string[]): string[] {
   return [...ids].sort();
 }
 
-/** One added custom provider — same row grid as the API keys list. */
+/** One added custom provider — same row grid as the provider list. */
 function CustomProviderRow({ id }: { id: string }) {
   return (
     <div className="grid gap-1.5 py-1.5 sm:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] sm:items-center sm:gap-4">
@@ -127,7 +127,7 @@ export function CustomProviderPanel({
 }: {
   projectId: string;
   canWrite?: boolean;
-  /** Called on a successful save — hosts send the reader back to the API keys
+  /** Called on a successful save — hosts send the reader back to the Providers
    *  list, where the new provider now has a row. */
   onDone?: () => void;
 }) {
@@ -148,7 +148,7 @@ export function CustomProviderPanel({
           its own — this tab is for the endpoint the catalog does not carry. */}
       <p className="text-muted-foreground px-0.5 text-xs text-pretty">
         Point this project at any OpenAI-compatible endpoint — self-hosted, on-prem, or a provider
-        that isn't in the catalog. Everything the catalog does carry belongs on the API keys tab.
+        that isn't in the catalog. Everything the catalog does carry belongs on the Providers tab.
       </p>
 
       <AddedCustomProviders projectId={projectId} />

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import {
+  LLM_TABS,
+  MODELS_PAGE_DESCRIPTION,
+  MODELS_PAGE_TITLE,
+  QUICK_LLM_TABS,
+} from '../gateway-view';
+
 /**
  * Comments stripped first — a `toContain` over a whole file otherwise matches
  * the file's own doc comment rather than its code.
@@ -9,62 +16,118 @@ import { join } from 'node:path';
 function code(path: string): string {
   return readFileSync(path, 'utf8')
     .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/^\s*\/\/.*$/gm, '');
+    .replace(/^\s*\/\/.*$/gm, '')
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '');
 }
 
 const modalSource = code(join(import.meta.dir, 'llm-provider-modal.tsx'));
 
+/**
+ * `ProjectProviderModal` is the QUICK version of the Models page — the same
+ * components in a dialog, not a second implementation of them.
+ *
+ * It used to be the second implementation, and every difference between the
+ * two screens was a bug someone had to notice: an underline strip at `text-xs`
+ * against the page's pills, "API keys" against the page's "Providers", no
+ * project-default control, and a scroll body with no horizontal padding, so
+ * the search field and every model row ran into the modal's clipped edge under
+ * a heading indented 20px.
+ *
+ * What is pinned below is that the dialog OWNS none of that any more.
+ */
 describe('LLM provider modal shell', () => {
-  /**
-   * JAY-510 replaced the old three tabs (Add provider / Connected / Models)
-   * with `ProviderConnect`'s four sections plus the model-visibility list. The
-   * predecessor test pinned `catalog` before `connected` before `models`; that
-   * ordering is exactly what the ticket inverted (Connected is now section 1
-   * INSIDE Providers), so it is replaced, not deleted — the fact worth pinning
-   * is that Providers comes before Models and that nothing else remains.
-   */
-  /**
-   * Three tabs now. `custom` is third and last because it is the rarest job
-   * on this modal — it was a fourth SECTION stacked under the provider list,
-   * where everyone who was not connecting a self-hosted endpoint had to scroll
-   * past a form they would never fill.
-   */
-  test('has exactly three tabs: API keys, then Models, then Custom', () => {
-    const providers = modalSource.indexOf('<TabsTrigger value="providers"');
-    const models = modalSource.indexOf('<TabsTrigger value="models"');
-    const custom = modalSource.indexOf('<TabsTrigger value="custom"');
-
-    expect(providers).toBeGreaterThan(-1);
-    expect(models).toBeGreaterThan(providers);
-    expect(custom).toBeGreaterThan(models);
-    expect(modalSource.match(/<TabsTrigger/g)).toHaveLength(3);
-    expect(modalSource).not.toContain('value="catalog"');
-    expect(modalSource).not.toContain('value="connected"');
+  test('renders the page’s components — it declares no chrome of its own', () => {
+    expect(modalSource).toContain(
+      "from '@/features/workspace/customize/sections/gateway-view'",
+    );
+    for (const shared of [
+      '<LlmTabStrip',
+      '<LlmSections',
+      '<ProjectDefaultPicker',
+      'MODELS_PAGE_TITLE',
+      'MODELS_PAGE_DESCRIPTION',
+    ]) {
+      expect(modalSource).toContain(shared);
+    }
+    // Not one tab, section or label built here. Each of these coming back is a
+    // second implementation coming back with it.
+    for (const forbidden of [
+      '<TabsTrigger',
+      '<TabsList',
+      '<TabsContent',
+      '<Tabs ',
+      '<ProviderConnect',
+      '<ModelsTab',
+      '<CustomProviderPanel',
+      '<ModelSelector',
+      'API keys',
+      'InputGroupSearch',
+      'underline',
+    ]) {
+      expect(modalSource).not.toContain(forbidden);
+    }
   });
 
   /**
-   * The Custom tab has to be able to hand the reader back: a saved custom
-   * provider now has a key like any other and a row on the API keys list, so
-   * a "Done" that leaves you on the form you just submitted is not done.
+   * The dialog's tabs come from `QUICK_LLM_TABS` — a slice of the page's seven,
+   * shipped by the page's own module. It cannot name a tab the page does not
+   * have, and it cannot relabel one.
    */
-  test('finishing the custom form returns to the API keys tab', () => {
-    expect(modalSource).toContain('<CustomProviderPanel');
-    expect(modalSource).toContain("onDone={() => setTab('providers')}");
+  test('its tabs are the page’s first three, by reference not by copy', () => {
+    expect(modalSource).toContain('tabs={QUICK_LLM_TABS}');
+    expect(QUICK_LLM_TABS).toEqual(LLM_TABS.slice(0, 3));
+    expect(QUICK_LLM_TABS.map((t) => t.id)).toEqual(['providers', 'models', 'custom']);
+    expect(QUICK_LLM_TABS.map((t) => t.label)).toEqual(['Providers', 'Models', 'Custom']);
+    // Gateway / Routing / Costs / Logs are project administration and stay on
+    // the page, which has the width and height for a log table.
+    for (const pageOnly of LLM_TABS.slice(3)) {
+      expect(QUICK_LLM_TABS).not.toContainEqual(pageOnly);
+    }
   });
 
-  test('owns no connect UI of its own — it delegates to the one shared component', () => {
-    expect(modalSource).toContain("import { ProviderConnect } from '@/features/providers/provider-connect'");
-    expect(modalSource).toContain('<ProviderConnect projectId={projectId}');
-    // The always-on search bar above the tabs is gone; search now lives inside
-    // the More-providers disclosure in `provider-connect.tsx`.
-    expect(modalSource).not.toContain('InputGroupSearch');
-    expect(modalSource).not.toContain('Search providers');
+  test('it shows the page’s heading, not a second wording of it', () => {
+    expect(MODELS_PAGE_TITLE).toBe('Models');
+    expect(MODELS_PAGE_DESCRIPTION).toBe('Which providers and models this project can use.');
+    expect(modalSource).toContain('<ModalTitle className="text-base font-medium">{MODELS_PAGE_TITLE}</ModalTitle>');
+    expect(modalSource).toContain('<ModalDescription>{MODELS_PAGE_DESCRIPTION}</ModalDescription>');
+    expect(modalSource).not.toContain('Connect your own AI accounts');
   });
 
   /**
-   * The width moved from `600px` to `lg:max-w-3xl` (768px) when the API-keys
-   * tab became a two-column grid: at 600px the 13rem identity column left the
-   * key field under ~28ch, which is narrower than every key it has to hold.
+   * THE bug in the screenshot. `LlmSections` carries no horizontal padding —
+   * on the page `CapabilityPageShell` supplies the column — so the dialog has
+   * to, or the model rows run edge to edge and the row card's rounded border
+   * is clipped away by `ModalContent`'s `overflow-hidden`.
+   */
+  test('the scroll column is padded, so the rows line up under the heading', () => {
+    const column = modalSource.slice(modalSource.indexOf('overflow-y-auto'));
+    expect(column).toContain('px-5');
+    expect(column.indexOf('<LlmSections')).toBeGreaterThan(-1);
+    // One scroller, and it is this one.
+    expect(modalSource.match(/overflow-y-auto/g)).toHaveLength(1);
+  });
+
+  /**
+   * The picker is the header's right-hand control, like the page's. The modal's
+   * close button is `absolute top-3 right-3` at `size-8`, so 44px of the right
+   * edge is spoken for and the header has to stop short of it.
+   */
+  test('the project-default picker sits in the header and clears the close button', () => {
+    const header = modalSource.slice(
+      modalSource.indexOf('<ModalHeader'),
+      modalSource.indexOf('</ModalHeader>'),
+    );
+    expect(header).toContain('<ProjectDefaultPicker projectId={projectId} />');
+    // Write-gated: a read-only member sees the list, not the one control that
+    // POSTs from this bar.
+    expect(header).toContain('canWrite ? <ProjectDefaultPicker');
+    expect(modalSource).toContain('sm:pr-11');
+  });
+
+  /**
+   * The width moved from `600px` to a named `lg:max-w-*` step when the
+   * providers tab became a two-column grid: at 600px the 13rem identity column
+   * left the key field under ~28ch, narrower than every key it has to hold.
    * The height is unchanged.
    */
   test('keeps the 680px height and is wide enough for the two-column key grid', () => {
@@ -77,11 +140,19 @@ describe('LLM provider modal shell', () => {
     expect(modalSource).toContain('h-(--provider-modal-h)');
     expect(modalSource).toContain('lg:min-h-(--provider-modal-h)');
     expect(modalSource).toContain('lg:max-h-(--provider-modal-h)');
-    // A named `lg:max-w-*` step, deliberately not pinned to which one — the
-    // width is still being tuned. What must not come back is a fixed pixel
-    // cap: at 600px the 13rem identity column left the key field under ~28ch,
-    // narrower than every key it has to hold.
     expect(modalSource).toMatch(/lg:max-w-\d?xl/);
     expect(modalSource).not.toMatch(/max-w-\[\d+px\]/);
+  });
+
+  /**
+   * Reopening still lands on the requested tab: the shell's
+   * `key={`${open}-${defaultTab}`}` remounts the body, whose `useState`
+   * initializer runs once per mount — no `setState` in an effect body
+   * (`react-hooks/set-state-in-effect`).
+   */
+  test('reopening re-seeds the tab by remount, not by an effect', () => {
+    expect(modalSource).toContain("key={`${open}-${defaultTab ?? ''}`}");
+    expect(modalSource).toContain('useState<ActiveTab>(() => pickInitialTab(defaultTab))');
+    expect(modalSource).not.toContain('useEffect');
   });
 });

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/llm-provider-modal.tsx
@@ -1,24 +1,46 @@
 'use client';
 
 /**
- * `ProjectProviderModal` — the `Modal` SHELL around `provider-connect.tsx`.
- * It owns no connect UI of its own any more: JAY-510 collapsed the old
- * "Add provider" and "Connected" tabs into `ProviderConnect`'s four sections
- * (Connected / Add a provider / More providers / Custom provider), and deleted
- * the always-on search bar that used to sit above the tab row — the search now
- * lives inside the More-providers disclosure where it belongs.
+ * `ProjectProviderModal` — the QUICK version of the Models page, and nothing
+ * else.
  *
- * Two tabs remain, because they are two different questions:
- *   - **Providers** — `ProviderConnect`: which providers this project can call.
- *   - **Models**    — `ModelsTab`: which of the connected providers' models the
- *                     picker offers. Kept as its own tab rather than nested one
- *                     level deeper, which is where it used to live.
+ * ## It is the same screen, or it is wrong
  *
- * Two live mounts, both dialogs: the model selector's connect dialog
- * (`use-model-connection-gate.tsx:138`) and the Secrets tab's "Manage
- * providers" button (`secrets-view.tsx:353`). The Models settings tab mounts
- * `ProviderConnect` DIRECTLY (`gateway-view.tsx`) — connecting a provider there
- * opens no dialog at all, which is JAY-510's first acceptance criterion.
+ * This dialog used to be a second implementation of model management: its own
+ * `Tabs` root, its own underline tab row at `text-xs`, its own labels ("API
+ * keys" where the page says "Providers"), no project-default control, and — the
+ * visible bug — a scroll body with NO horizontal padding, so the search field
+ * and every model row ran edge to edge under a heading indented 20px, and the
+ * row card's rounded border was clipped away by the modal's `overflow-hidden`.
+ * Beside the page it read as a different, older product.
+ *
+ * There is one implementation now. Every part below is imported from
+ * `gateway-view.tsx`, the Customize page's own module:
+ *
+ *   - `MODELS_PAGE_TITLE` / `MODELS_PAGE_DESCRIPTION` — the same two lines.
+ *   - `ProjectDefaultPicker` — the same one page-level control, in the same
+ *     place relative to the heading.
+ *   - `QUICK_LLM_TABS` + `LlmTabStrip` — the same pill strip, the same labels,
+ *     the same order. A slice of `LLM_TABS`, never a second list.
+ *   - `LlmSections` — the same section bodies, chosen the same way.
+ *
+ * This file contributes the dialog chrome and the padded column, full stop. It
+ * declares no `TabsTrigger`, no section, and no label of its own; a change to
+ * any of those has exactly one place to be made.
+ *
+ * ## Why three tabs and not seven
+ *
+ * The page carries Providers / Models / Custom / Gateway / Routing / Costs /
+ * Logs. This dialog opens from the session model picker's connect gate
+ * (`use-model-connection-gate.tsx`) and the Secrets tab's "Manage providers"
+ * (`secrets-view.tsx`) — both are "let me use a model right now" moments. It
+ * carries the three tabs that answer that and drops the four that are project
+ * administration; a log table wants the page's width and height, not 680px of
+ * dialog. `QUICK_LLM_TABS` is that decision, expressed once.
+ *
+ * The Models settings tab mounts `LlmManagementView` DIRECTLY — connecting a
+ * provider there opens no dialog at all, which is JAY-510's first acceptance
+ * criterion.
  */
 
 import {
@@ -28,11 +50,16 @@ import {
   ModalHeader,
   ModalTitle,
 } from '@/components/ui/modal';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ProviderConnect } from '@/features/providers/provider-connect';
+import {
+  isQuickLlmTab,
+  LlmSections,
+  LlmTabStrip,
+  MODELS_PAGE_DESCRIPTION,
+  MODELS_PAGE_TITLE,
+  ProjectDefaultPicker,
+  QUICK_LLM_TABS,
+} from '@/features/workspace/customize/sections/gateway-view';
 import { useState } from 'react';
-import { CustomProviderPanel } from './custom-provider-panel';
-import { ModelsTab } from './models-tab';
 import type { ActiveTab, ProjectProviderModalProps } from './types';
 import { pickInitialTab } from './utils';
 
@@ -56,17 +83,7 @@ export function ProjectProviderModal({
           form). `lg:min-h` + `lg:max-h` clamp that `h-auto` to a constant.
           The unprefixed mobile sheet keeps its own `max-h-[90%]` cap. */}
       <ModalContent className="flex h-(--provider-modal-h) w-[calc(100vw-2rem)] flex-col gap-0 overflow-hidden p-0 [--provider-modal-h:min(680px,calc(100dvh-2rem))] lg:max-h-(--provider-modal-h) lg:min-h-(--provider-modal-h) lg:max-w-4xl">
-        <ModalHeader className="shrink-0">
-          <ModalTitle>AI models</ModalTitle>
-          {/* One line. Each tab states its own rule beside its own controls,
-              so repeating "everyone on this project can use it" up here only
-              makes the reader read it twice on the way to the same field. */}
-          <ModalDescription>
-            Connect your own AI accounts, and choose which models this project can use.
-          </ModalDescription>
-        </ModalHeader>
-
-        <ProviderModalTabs
+        <ProviderModalBody
           key={`${open}-${defaultTab ?? ''}`}
           projectId={projectId}
           open={open}
@@ -79,7 +96,7 @@ export function ProjectProviderModal({
 }
 
 /**
- * The tab strip, below the `key` boundary the shell owns.
+ * The body, below the `key` boundary the shell owns.
  *
  * CONTROLLED, but with no effect and no re-seeding: `useState`'s initializer
  * runs once per mount, and the parent's `key={`${open}-${defaultTab}`}`
@@ -87,12 +104,11 @@ export function ProjectProviderModal({
  * exactly as the uncontrolled version did, with no `setState` in an effect
  * body (`react-hooks/set-state-in-effect`).
  *
- * Controlled at all because the Custom tab has to be able to hand the reader
- * back: saving a custom provider gives it a key like any other, and the API
- * keys list is where it now has a row. A "Done" that leaves you on the form
- * you just submitted is not done.
+ * Controlled at all because `LlmSections` hands the reader on: saving a custom
+ * provider gives it a key like any other and a row on the provider list, so a
+ * "Done" that leaves you on the form you just submitted is not done.
  */
-function ProviderModalTabs({
+function ProviderModalBody({
   projectId,
   open,
   canWrite,
@@ -106,46 +122,44 @@ function ProviderModalTabs({
   const [tab, setTab] = useState<ActiveTab>(() => pickInitialTab(defaultTab));
 
   return (
-    <Tabs
-      value={tab}
-      onValueChange={(next) => setTab(next as ActiveTab)}
-      className="flex min-h-0 flex-1 flex-col gap-0"
-    >
-      <div className="flex items-center gap-3 px-5 pb-3">
-        <TabsList className="flex w-full shrink-0 items-center justify-start" type="underline">
-          {/* "API keys", not "Providers" — the tab is named after what you do
-              on it. Everything on that tab is a field you paste a key into,
-              and "API key" is the phrase every provider's own site uses on the
-              page you copy it from. */}
-          <TabsTrigger value="providers" className="w-auto flex-none text-xs" size="sm">
-            API keys
-          </TabsTrigger>
-          <TabsTrigger value="models" className="w-auto flex-none text-xs" size="sm">
-            Models
-          </TabsTrigger>
-          {/* Third, and last, because it is the rarest. "Custom" rather than
-              "Advanced": it names WHAT is on the tab, where "Advanced" only
-              warns you off it. */}
-          <TabsTrigger value="custom" className="w-auto flex-none text-xs" size="sm">
-            Custom
-          </TabsTrigger>
-        </TabsList>
+    <>
+      {/* The page's header, in a dialog: heading and description on the left,
+          the one page-level control on the right. `pr-11` is the modal's close
+          button — `absolute top-3 right-3` at `size-8`, so 44px of the right
+          edge is spoken for and the picker has to stop short of it. */}
+      <ModalHeader className="shrink-0 gap-3 sm:flex-row sm:items-start sm:justify-between sm:pr-11">
+        <div className="space-y-1">
+          <ModalTitle className="text-base font-medium">{MODELS_PAGE_TITLE}</ModalTitle>
+          <ModalDescription>{MODELS_PAGE_DESCRIPTION}</ModalDescription>
+        </div>
+        {canWrite ? <ProjectDefaultPicker projectId={projectId} /> : null}
+      </ModalHeader>
+
+      <div className="shrink-0 px-5 pt-5 pb-4">
+        <LlmTabStrip
+          value={tab}
+          tabs={QUICK_LLM_TABS}
+          onValueChange={(next) => {
+            if (isQuickLlmTab(next)) setTab(next);
+          }}
+        />
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <TabsContent value="providers" className="mt-0">
-          <ProviderConnect projectId={projectId} canWrite={canWrite} enabled={open} />
-        </TabsContent>
-        <TabsContent value="models" className="mt-0">
-          <ModelsTab projectId={projectId} />
-        </TabsContent>
-        <TabsContent value="custom" className="mt-0">
-          <CustomProviderPanel
-            projectId={projectId}
-            canWrite={canWrite}
-            onDone={() => setTab('providers')}
-          />
-        </TabsContent>
+
+      {/* The column. `px-5` is the whole reason the model rows now line up
+          under the heading instead of running into the modal's clipped edge —
+          `LlmSections` carries no horizontal padding of its own, because on
+          the page `CapabilityPageShell` supplies it. */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
+        <LlmSections
+          projectId={projectId}
+          tab={tab}
+          onTabChange={(next) => {
+            if (isQuickLlmTab(next)) setTab(next);
+          }}
+          canWrite={canWrite}
+          enabled={open}
+        />
       </div>
-    </Tabs>
+    </>
   );
 }

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/models-tab.tsx
@@ -107,7 +107,7 @@ export function ModelsTab({
       <div className="flex min-h-[200px] flex-col items-center justify-center gap-1 px-6 text-center">
         <p className="text-foreground text-sm">No models yet</p>
         <p className="text-muted-foreground max-w-xs text-xs text-pretty">
-          Add a key on the API keys tab. The models it unlocks show up here.
+          Add a key on the Providers tab. The models it unlocks show up here.
         </p>
       </div>
     );

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/types.ts
@@ -1,5 +1,7 @@
 /**
- * Three tabs, each answering one question and owning one list:
+ * The dialog's three tabs — `QUICK_LLM_TABS` in `gateway-view.tsx`, aliased
+ * here so the modal's prop types and the strip it renders can never name a
+ * different set. Adding a tab to the dialog is one edit, in that file.
  *
  *  - `providers` — "where do my models come from" (`ProviderConnect`): ONE
  *     flat list of providers, one key field each.
@@ -12,7 +14,9 @@
  * who was not that person had to scroll past it — so it became a tab, which is
  * exactly what a tab is for.
  */
-export type ActiveTab = 'providers' | 'models' | 'custom';
+import type { QuickLlmTab } from '@/features/workspace/customize/sections/gateway-view';
+
+export type ActiveTab = QuickLlmTab;
 
 export interface ProjectProviderModalProps {
   projectId: string;

--- a/apps/web/src/features/workspace/settings/tabs/models-tab.test.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/models-tab.test.tsx
@@ -8,6 +8,7 @@ import {
   LlmTabStrip,
   MODELS_PAGE_DESCRIPTION,
   MODELS_PAGE_TITLE,
+  QUICK_LLM_TABS,
 } from '../../customize/sections/gateway-view';
 
 /**
@@ -30,6 +31,28 @@ describe('LlmTabStrip', () => {
       return out.indexOf(`>${t.label}<`);
     });
     expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  /**
+   * The quick dialog renders THIS component with a `tabs` subset — three of the
+   * same pills, in the same order, not three different ones. Anything the
+   * dialog needs that this component cannot express is a divergence.
+   */
+  test('renders a subset when given one, in LLM_TABS order and style', () => {
+    const out = renderToStaticMarkup(
+      <LlmTabStrip value="models" tabs={QUICK_LLM_TABS} onValueChange={() => {}} />,
+    );
+    for (const t of QUICK_LLM_TABS) expect(out).toContain(`>${t.label}<`);
+    // The four page-only tabs are absent, and nothing else changed: same
+    // default pill list, no underline rule.
+    for (const t of LLM_TABS.slice(3)) expect(out).not.toContain(`>${t.label}<`);
+    expect(out.indexOf('>Models<')).toBeGreaterThan(out.indexOf('>Providers<'));
+    expect(out.indexOf('>Custom<')).toBeGreaterThan(out.indexOf('>Models<'));
+    const full = renderToStaticMarkup(<LlmTabStrip value="models" onValueChange={() => {}} />);
+    // Identical trigger chrome — the class string a pill renders with.
+    const triggerClass = (html: string) =>
+      html.match(/data-slot="tabs-trigger"[^>]*class="([^"]+)"/)?.[1];
+    expect(triggerClass(out)).toBe(triggerClass(full));
   });
 
   test('the selected tab is the one it is given', () => {
@@ -111,10 +134,65 @@ describe('Models page chrome', () => {
     const actionStart = gatewaySource.indexOf('action={');
     const filtersStart = gatewaySource.indexOf('filters={');
     expect(actionStart).toBeGreaterThan(-1);
-    expect(gatewaySource.indexOf('<ModelSelector')).toBeGreaterThan(actionStart);
-    // The picker sits before `filters`, i.e. inside `action` — not inside the
-    // tab row, where a bordered dropdown reads as a second tab strip.
-    expect(gatewaySource.indexOf('<ModelSelector')).toBeLessThan(filtersStart);
+    expect(filtersStart).toBeGreaterThan(actionStart);
+    // The picker sits in `action` — not in the tab row, where a bordered
+    // dropdown reads as a second tab strip. It is a component now
+    // (`ProjectDefaultPicker`) because the quick dialog renders the same one;
+    // `<ModelSelector` itself lives inside it, higher up the file, so this
+    // asserts the SLOT's contents, not a raw file offset.
+    expect(gatewaySource.slice(actionStart, filtersStart)).toContain('<ProjectDefaultPicker');
+    const filtersSlot = gatewaySource.slice(filtersStart, gatewaySource.indexOf('<LlmSections'));
+    expect(filtersSlot).toContain('<LlmTabStrip');
+    expect(filtersSlot).not.toContain('ProjectDefaultPicker');
+    expect(filtersSlot).not.toContain('ModelSelector');
+  });
+
+  /**
+   * The one page-level control is one component, mounted twice: here in the
+   * shell's `action` slot and in `ProjectProviderModal`'s header. A second
+   * `<ModelSelector` in this file would mean the dialog and the page had
+   * drifted apart again.
+   */
+  test('ProjectDefaultPicker is the only place this module builds the picker', () => {
+    expect(gatewaySource.match(/<ModelSelector/g)).toHaveLength(1);
+    const picker = gatewaySource.slice(
+      gatewaySource.indexOf('export function ProjectDefaultPicker'),
+      gatewaySource.indexOf('export function LlmSections'),
+    );
+    expect(picker).toContain('<ModelSelector');
+    expect(picker).toContain('Project default');
+  });
+
+  /**
+   * `LlmSections` is the page body AND the dialog body. It must stay padding-
+   * free horizontally: the host column supplies it (`CapabilityPageShell`
+   * here, `px-5` in the dialog), and a `px-*` added here double-indents the
+   * page — which is the bug that made the model rows sit 20px right of the
+   * heading in the first place.
+   */
+  test('LlmSections carries no column padding of its own', () => {
+    const sections = gatewaySource.slice(
+      gatewaySource.indexOf('export function LlmSections'),
+      gatewaySource.indexOf('export function LlmManagementView'),
+    );
+    expect(sections).toContain("tab === 'models'");
+    expect(sections).not.toMatch(/className="[^"]*\bpx-\d/);
+    expect(sections).not.toMatch(/className="[^"]*\bp-[1-9]/);
+    // `ProviderConnect` is the one section with padding of its own to cancel.
+    expect(sections).toContain("className=\"gap-4 p-0\"");
+  });
+
+  /**
+   * The dialog's three tabs are a SLICE of the page's seven — same ids, same
+   * labels, same order. A second hand-written list is how "API keys" vs
+   * "Providers" happened.
+   */
+  test('QUICK_LLM_TABS is the first three of LLM_TABS, unchanged', () => {
+    expect(QUICK_LLM_TABS).toEqual(LLM_TABS.slice(0, 3));
+    expect(QUICK_LLM_TABS.map((t) => t.label)).toEqual(['Providers', 'Models', 'Custom']);
+    for (const t of QUICK_LLM_TABS) {
+      expect(LLM_TABS).toContainEqual(t);
+    }
   });
 
   test('no sub-tab declares a column of its own — the shell’s max-w-5xl is the page', () => {


### PR DESCRIPTION
## The problem

The small "AI models" dialog and the Customize > Models page were two
implementations of the same screen. Every difference between them was a bug
somebody had to notice:

| | dialog (before) | page |
|---|---|---|
| scroll body padding | **none** — search field and every model row ran edge to edge, and the row card's rounded border was clipped by `ModalContent`'s `overflow-hidden` | `CapabilityPageShell`'s column |
| tab strip | underline rule at `text-xs` | filled pills, default size |
| first tab | "API keys" | "Providers" |
| project default | absent | header control |
| heading | "AI models" / "Connect your own AI accounts, and choose which models this project can use." | "Models" / "Which providers and models this project can use." |

## The fix — one component, two shells

`gateway-view.tsx` (the page's own module) now exports the four pieces the
page is built from, and the dialog renders **those**:

- **`LlmTabStrip`** takes an optional `tabs` subset. The dialog passes
  `QUICK_LLM_TABS` — a slice of `LLM_TABS` — so it draws three of the *same*
  pills, in the same order, with the same labels. It cannot introduce a tab
  the page does not have, and it cannot relabel one.
- **`ProjectDefaultPicker`** — the one page-level control, in both places.
- **`LlmSections`** — the section bodies, chosen by the host's `tab`.
- **`MODELS_PAGE_TITLE` / `MODELS_PAGE_DESCRIPTION`** — the same two lines.

`llm-provider-modal.tsx` contributes the dialog chrome and a `px-5` column,
full stop. It declares no `TabsTrigger`, no section and no label of its own —
the test suite pins that.

### Why three tabs and not seven

The dialog opens from the session model picker's connect gate and the Secrets
tab. Both are "let me use a model right now" moments. It carries the three
tabs that answer that and drops the four that are project administration
(Gateway, Routing, Costs, Logs) — a log table wants the page's width and
height, not 680px of dialog. `QUICK_LLM_TABS` is that decision, expressed once.

### Also in this commit

- `ActiveTab` is an alias of the shared `QuickLlmTab`, so the dialog's prop
  types and the strip it renders cannot name different sets.
- The page's Custom form gets the same "Done returns to Providers" the dialog
  already had.
- Two stale "API keys tab" strings become "Providers tab".

## Verification

Local, on the worktree stack at `localhost:18000` (real project, real
`/model-picker` data), light and dark, 1360px and 420px:

- All three dialog tabs render the page's components. Screenshots in the
  thread.
- Padding proof: dialog left edge `232`, first input left `251` — 19px, the
  `px-5` column. Before, the input started at the dialog edge.
- The picker sits in the header and clears the close button (`sm:pr-11` vs
  the button's `absolute top-3 right-3 size-8`).
- `bun test` in `apps/web`: **8280 pass, 0 fail** across 639 files.
- `tsc --noEmit`: clean apart from the 4 known pre-existing errors
  (`test.each` noise + `@/.source` not generated in a fresh worktree).
- `eslint` on every changed file: 0 errors (1 pre-existing
  `react-hooks/set-state-in-effect` warning on the deep-link effect, unchanged).
