### PR TITLE
fix(kortixd): connect through deployed WebSocket edge

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1957,3 +1957,24 @@ past its `Move :dev` step.
 *Incident:* PR #6764, merge `e6c4ba0b62`, 2026-08-22 23:43 UTC. No outage —
 a frontend-only fix sat undeployed on dev for ~25 minutes while both the run
 list and the deployed-SHA probe read as healthy.
+
+## Test the compiled daemon through the deployed WebSocket edge
+
+2026-08-23. The `kortixd` node channel passed local Bun tests. The compiled
+daemon still failed against `wss://dev-api.kortix.com/v1/nodes/ws` with
+`Expected 101 status code`. Bun's native WebSocket client did not complete the
+Cloudflare upgrade. Node's standards-based WebSocket client completed the same
+upgrade and received `node.auth.ok`.
+
+**The rule.** A local WebSocket server does not prove the released daemon can
+cross the deployed edge. Every node-channel release must run the compiled
+daemon against the deployed API. The API must persist the node as `online`.
+
+**The enforcement.** `kortixd` uses the `ws` HTTP/1.1 client for its outbound
+channel. The channel test covers the Buffer text-frame representation used by
+that client. Dev verification compiles the executable, enrolls it, runs it
+against the Cloudflare origin, and reads the persisted compute-node status.
+
+*Incident:* PR #6686 dev verification, compute node
+`65ad5a11-472b-4670-932a-fae12e772fd6`. The API kept the node `offline` until
+the client transport changed from Bun's native WebSocket to `ws`.

--- a/apps/kortix-sandbox-agent-server/bun.lock
+++ b/apps/kortix-sandbox-agent-server/bun.lock
@@ -7,11 +7,13 @@
       "dependencies": {
         "hono": "^4.12.25",
         "node-forge": "^1.4.0",
+        "ws": "^8.18.0",
         "zod": "^3.23.8",
       },
       "devDependencies": {
         "@types/bun": "^1.1.0",
         "@types/node-forge": "^1.3.11",
+        "@types/ws": "^8.18.1",
         "typescript": "^5.6.0",
       },
     },
@@ -23,6 +25,8 @@
 
     "@types/node-forge": ["@types/node-forge@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
@@ -32,6 +36,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
   }

--- a/apps/kortix-sandbox-agent-server/package.json
+++ b/apps/kortix-sandbox-agent-server/package.json
@@ -20,11 +20,13 @@
   "dependencies": {
     "hono": "^4.12.25",
     "node-forge": "^1.4.0",
+    "ws": "^8.18.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/bun": "^1.1.0",
-    "typescript": "^5.6.0",
-    "@types/node-forge": "^1.3.11"
+    "@types/node-forge": "^1.3.11",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.6.0"
   }
 }

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
@@ -16,6 +16,32 @@ function signed(value: Record<string, unknown>, key: string, nonce: number) {
 }
 
 describe('kortixd outbound node channel', () => {
+  test('sends a User-Agent required by deployed WebSocket edges', async () => {
+    let server: ReturnType<typeof Bun.serve>
+    server = Bun.serve<{ authenticated?: boolean }>({
+      port: 0,
+      fetch(request, bunServer) {
+        if (request.headers.get('user-agent') !== 'kortixd') return new Response('missing user-agent', { status: 403 })
+        return bunServer.upgrade(request, { data: {} }) ? undefined : new Response('upgrade failed', { status: 500 })
+      },
+      websocket: {
+        message(socket, raw) {
+          const frame = JSON.parse(String(raw))
+          if (frame.type === 'node.auth') socket.send(JSON.stringify({ type: 'node.auth.ok', signing_key: 'edge-key' }))
+        },
+      },
+    })
+    try {
+      const channel = new KortixNodeChannel({ apiUrl: `http://127.0.0.1:${server.port}/v1`, nodeId: 'node-1', token: 'secret', ports: new Set() })
+      channel.connect()
+      for (let attempt = 0; attempt < 40 && !channel.status().connected; attempt++) await Bun.sleep(25)
+      expect(channel.status()).toEqual({ connected: true, lastError: null })
+      channel.disconnect()
+    } finally {
+      server.stop(true)
+    }
+  })
+
   test('authenticates without putting the credential in the URL', () => {
     const socket = new FakeSocket()
     const channel = new KortixNodeChannel({ apiUrl: 'https://api.test/v1', nodeId: 'node-1', token: 'secret', ports: new Set([8000]), socketFactory: (url) => {
@@ -42,5 +68,24 @@ describe('kortixd outbound node channel', () => {
     socket.receive(signed(open, 'session-key', 1))
     await Bun.sleep(0)
     expect(channel.status().lastError).toContain('nonce')
+  })
+
+  test('accepts text frames delivered as Node WebSocket buffers', async () => {
+    const socket = new FakeSocket()
+    const channel = new KortixNodeChannel({
+      apiUrl: 'https://api.test/v1',
+      nodeId: 'node-1',
+      token: 'secret',
+      ports: new Set([8000]),
+      socketFactory: () => socket as unknown as WebSocket,
+    })
+    channel.connect()
+    socket.dispatchEvent(new Event('open'))
+    socket.dispatchEvent(new MessageEvent('message', {
+      data: Buffer.from(JSON.stringify({ type: 'node.auth.ok', signing_key: 'session-key' })),
+    }))
+    await Bun.sleep(0)
+    expect(channel.status()).toEqual({ connected: true, lastError: null })
+    expect(JSON.parse(socket.sent[1]!).type).toBe('node.heartbeat')
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
@@ -1,5 +1,6 @@
 import { createHmac, timingSafeEqual } from 'node:crypto'
 import { parseNodeChannelFrame, type NodeChannelFrame } from '@kortix/api-contract/node-channel'
+import { WebSocket as StandardWebSocket } from 'ws'
 import { NodeStreamAgent, type PortPolicy } from './stream-agent'
 import { NodeSocketAgent } from './socket-agent'
 import { NodeRpcAgent } from './rpc-agent'
@@ -14,7 +15,28 @@ interface ChannelOptions {
   capabilities?: NodeCapabilityRegistry
   assignments?: NodeAssignmentManager
   onAuthenticated?: () => void | Promise<void>
-  socketFactory?: (url: string) => WebSocket
+  socketFactory?: (url: string) => WebSocketLike
+}
+
+interface WebSocketLike {
+  readonly readyState: number
+  addEventListener(type: string, listener: (event: any) => void): void
+  send(data: string): void
+  close(code?: number, reason?: string): void
+}
+
+function defaultSocketFactory(url: string): WebSocketLike {
+  // Bun omits User-Agent from its native WebSocket handshake. Cloudflare
+  // rejects that upgrade with `Expected 101 status code`. The `ws` constructor
+  // accepts an explicit header even when Bun provides its compatible runtime.
+  return new StandardWebSocket(url, { headers: { 'User-Agent': 'kortixd' } }) as unknown as WebSocketLike
+}
+
+function textFrame(raw: unknown): string | null {
+  if (typeof raw === 'string') return raw
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString('utf8')
+  if (ArrayBuffer.isView(raw)) return Buffer.from(raw.buffer, raw.byteOffset, raw.byteLength).toString('utf8')
+  return null
 }
 
 function wsUrl(apiUrl: string): string {
@@ -28,7 +50,7 @@ function signature(key: string, nonce: number, payload: string): string {
 }
 
 export class KortixNodeChannel {
-  private socket: WebSocket | null = null
+  private socket: WebSocketLike | null = null
   private key: string | null = null
   private sendNonce = 0
   private receiveNonce = 0
@@ -50,7 +72,7 @@ export class KortixNodeChannel {
   }
 
   connect(): void {
-    this.socket = (this.options.socketFactory ?? ((url) => new WebSocket(url)))(wsUrl(this.options.apiUrl))
+    this.socket = (this.options.socketFactory ?? defaultSocketFactory)(wsUrl(this.options.apiUrl))
     this.socket.addEventListener('open', () => {
       this.key = null
       this.sendNonce = 0
@@ -90,8 +112,9 @@ export class KortixNodeChannel {
 
   private async receive(raw: unknown): Promise<void> {
     try {
-      if (typeof raw !== 'string') throw new Error('non-text node channel frame')
-      const value = JSON.parse(raw) as Record<string, unknown>
+      const text = textFrame(raw)
+      if (text === null) throw new Error('non-text node channel frame')
+      const value = JSON.parse(text) as Record<string, unknown>
       if (value.type === 'node.auth.ok' && typeof value.signing_key === 'string') {
         this.key = value.signing_key
         this.lastError = null
@@ -123,7 +146,7 @@ export class KortixNodeChannel {
   send(frame: NodeChannelFrame): void { this.sendSigned(frame) }
 
   private sendSigned(frame: NodeChannelFrame): void {
-    if (!this.key || !this.socket || this.socket.readyState !== WebSocket.OPEN) return
+    if (!this.key || !this.socket || this.socket.readyState !== StandardWebSocket.OPEN) return
     const nonce = ++this.sendNonce
     const payload = JSON.stringify(frame)
     this.socket.send(JSON.stringify({ ...frame, _nonce: nonce, _sig: signature(this.key, nonce, payload) }))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,9 @@ importers:
       node-forge:
         specifier: ^1.4.0
         version: 1.4.0
+      ws:
+        specifier: ^8.18.0
+        version: 8.21.0
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -336,6 +339,9 @@ importers:
       '@types/node-forge':
         specifier: ^1.3.11
         version: 1.3.14
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       typescript:
         specifier: ^5.6.0
         version: 5.9.3


### PR DESCRIPTION
## Problem

The compiled Bun daemon fails the Cloudflare WebSocket upgrade because its native handshake omits `User-Agent`. The API keeps the enrolled compute node offline.

## Change

- send an explicit `User-Agent: kortixd` on the sole outbound node channel
- accept Buffer-backed text frames from the `ws` runtime
- add an edge-policy regression test
- declare and lock the standalone `ws` dependency
- record the incident rule in the learnings register

## Verification

- `bun test src/node/channel/client.test.ts`: 4 pass, 0 fail
- `bun test src/egress-shim/blocked-headers.test.ts src/node/channel/client.test.ts`: 15 pass, 0 fail
- `bun run typecheck`: exit 0
- compiled `kortixd` against `wss://dev-api.kortix.com/v1/nodes/ws`: API persisted `status=online` with `filesystem`, `shell`, and `desktop`
- `pnpm test -- --full`: PASS in 256.9s