### PR TITLE
refactor: make LLM gateway the default runtime

### DIFF
--- a/apps/api/src/__tests__/unit-feature-flags.test.ts
+++ b/apps/api/src/__tests__/unit-feature-flags.test.ts
@@ -158,47 +158,24 @@ describe('resolveFeatureFlag — explicit override wins', () => {
     ).toBe(false);
   });
 
-  test('llm_gateway is platform-gated and follows the fleet default', () => {
-    const available = findCatalogFlag('llm_gateway').available;
-    expect(resolveFeatureFlag({}, 'llm_gateway')).toBe(
-      available && config.LLM_GATEWAY_DEFAULT_ENABLED,
-    );
-    expect(resolveFeatureFlag({ experimental: { llm_gateway: true } }, 'llm_gateway')).toBe(
-      available,
-    );
-    expect(resolveFeatureFlag({ experimental: { llm_gateway: false } }, 'llm_gateway')).toBe(false);
-    expect(projectLlmGatewayEnabled({ experimental: { llm_gateway: true } })).toBe(available);
-  });
-
-  test('llm_gateway fleet default rolls all projects on while the kill switch and project-off override still win', () => {
+  test('llm_gateway is an operator capability, not a project feature flag', () => {
     const previousEnabled = config.LLM_GATEWAY_ENABLED;
-    const previousDefault = config.LLM_GATEWAY_DEFAULT_ENABLED;
     try {
       config.LLM_GATEWAY_ENABLED = false;
-      config.LLM_GATEWAY_DEFAULT_ENABLED = true;
       expect(resolveFeatureFlag({}, 'llm_gateway')).toBe(false);
       expect(projectLlmGatewayEnabled({})).toBe(false);
 
       config.LLM_GATEWAY_ENABLED = true;
-      config.LLM_GATEWAY_DEFAULT_ENABLED = false;
-      expect(resolveFeatureFlag({}, 'llm_gateway')).toBe(false);
-
-      config.LLM_GATEWAY_DEFAULT_ENABLED = true;
       expect(resolveFeatureFlag({}, 'llm_gateway')).toBe(true);
       expect(projectLlmGatewayEnabled({})).toBe(true);
-      expect(resolveFeatureFlag({ experimental: { llm_gateway: false } }, 'llm_gateway')).toBe(
-        false,
-      );
-      expect(projectLlmGatewayEnabled({ experimental: { llm_gateway: false } })).toBe(false);
-
-      // The kill switch also beats an explicit project ON.
-      config.LLM_GATEWAY_ENABLED = false;
-      expect(resolveFeatureFlag({ experimental: { llm_gateway: true } }, 'llm_gateway')).toBe(
-        false,
+      expect(resolveFeatureFlag({ experimental: { llm_gateway: false } }, 'llm_gateway')).toBe(true);
+      expect(projectLlmGatewayEnabled({ experimental: { llm_gateway: false } })).toBe(true);
+      expect(projectLlmGatewayEnabled({ experimental: { llm_gateway: true } })).toBe(true);
+      expect(buildFeatureFlagCatalog({ experimental: { llm_gateway: false } })).not.toContainEqual(
+        expect.objectContaining({ key: 'llm_gateway' }),
       );
     } finally {
       config.LLM_GATEWAY_ENABLED = previousEnabled;
-      config.LLM_GATEWAY_DEFAULT_ENABLED = previousDefault;
     }
   });
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,18 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-23 — session `gateway-default` — retire project gateway mode — IN PROGRESS
+
+**Scope:** Keep the published `llm_gateway` feature-key literal as a deprecated
+compatibility input. Stop advertising or honoring the project override. Make
+`LLM_GATEWAY_ENABLED` the only runtime availability gate. Remove native-mode UI
+branches and the account-entitlement gate from sandbox provider injection.
+
+**TDD:** The API registry tests will first pin that the project catalog omits
+`llm_gateway` and stored `true`/`false` overrides cannot change runtime mode.
+
+---
+
 ### 2026-08-21 — session `session-busy-flicker` — display order was not an order — DONE
 
 **Files:** `core/turns/grouping.ts` (`compareMessagesForDisplay` rewritten as two


### PR DESCRIPTION
## Problem

The product exposes LLM Gateway as an experimental per-project flag. The native OpenCode provider path does not provide a functional Kortix experience. A project-level off switch therefore exposes a broken state.

## Intended change

- Make `LLM_GATEWAY_ENABLED` the sole operator availability gate.
- Ignore existing `experimental.llm_gateway` project overrides.
- Remove LLM Gateway from the project Feature Flags catalog and UI.
- Route every eligible sandbox through the gateway.
- Remove the sandbox account-entitlement gate. The gateway enforces model affordability per request.
- Keep the published SDK feature-key literal as deprecated compatibility until the next major release.

## Current state

Draft. This commit contains the SDK progress claim and the failing contract test only. Runtime implementation, UI cleanup, tests, local verification, dev deployment, and deployed verification remain incomplete.

## Verification

- `git diff --check`: passed.
- Focused Bun test: blocked before test execution because the standalone process lacked the repository test environment variables. The root test runner remains required.

## Tracking

Linear was unavailable in the Codex session, so no Team Jay issue was updated.