### PR TITLE
fix(kortixd): complete reliable sandbox relay rollout

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1957,7 +1957,6 @@ past its `Move :dev` step.
 *Incident:* PR #6764, merge `e6c4ba0b62`, 2026-08-22 23:43 UTC. No outage —
 a frontend-only fix sat undeployed on dev for ~25 minutes while both the run
 list and the deployed-SHA probe read as healthy.
-
 ## Test the compiled daemon through the deployed WebSocket edge
 
 2026-08-23. The `kortixd` node channel passed local Bun tests. The compiled
@@ -1978,3 +1977,21 @@ against the Cloudflare origin, and reads the persisted compute-node status.
 *Incident:* PR #6686 dev verification, compute node
 `65ad5a11-472b-4670-932a-fae12e772fd6`. The API kept the node `offline` until
 the client transport changed from Bun's native WebSocket to `ws`.
+## A relay migration must preserve browser filesystem and PTY flows
+
+2026-08-23. PR #6686 replaced provider ingress with the compute-node relay on
+dev. Session chat and OpenCode REST remained healthy. Files returned `Failed
+to fetch`. Terminal WebSockets closed with code `1006`. The API proxied PTY
+requests to `http://127.0.0.1:8000`, which was not the sandbox runtime.
+
+**The rule.** Do not merge an ingress or relay migration after REST-only tests.
+Verify Files and Terminal through the real web client against a real sandbox.
+The Files check must list the workspace and read one file. The Terminal check
+must create a PTY, connect its WebSocket, send a command, and observe its output.
+
+**The enforcement.** Add both checks to the compute-node browser journey before
+the rollout returns to `main`. Keep the provider ingress path until those checks
+pass through the same network boundary used by dev.
+
+*Incident:* PR #6686, merge `b03f92bdcd`, and PR #6773, merge `32abd10082`.
+The local rollback restored file reads and PTY command output before deployment.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,50 @@ linked, not inlined.
 
 ## Register
 
+### Scope provider inventory labels by API instance, not only environment (2026-08-23)
+
+**When:** creating provider objects or changing orphan reconciliation. Include
+the local API instance in the provider environment marker. Require exact owner
+matching. *Incident:* deployed dev repeatedly stopped an active worktree
+sandbox because both objects used `kortix.env=dev`. *Enforcer:*
+`instance-scope.test.ts` and provider managed-list tests.
+
+### Rewrite durable sandbox URLs whenever a runtime resumes (2026-08-23)
+
+**When:** resuming or opening a provider-running session after an API origin can
+change. Persist the current relay URL before reporting readiness. *Incident:*
+kortixd reconnected to the new worktree tunnel while the SDK kept calling the
+dead provisioning-time tunnel. *Enforcer:* `runtime-relay-repair.test.ts`.
+
+### Stop every stale supervisor before starting one replacement (2026-08-23)
+
+**When:** converging a daemon after resume or relay rotation. Enumerate and stop
+all matching daemon and entrypoint PIDs. Never stop only the first match.
+*Incident:* repeated repairs left multiple kortixd processes competing for one
+node channel. *Enforcer:* `platinum-create-terminal.test.ts`.
+
+### Separate relay liveness from workload readiness (2026-08-23)
+
+**When:** repairing an outbound node channel. Stop retrying after the channel
+reconnects. OpenCode `starting` is not proof that the relay is disconnected.
+*Incident:* a 30-second repair loop restarted kortixd and closed attached PTYs
+with code `1012`. *Enforcer:* `runtime-relay-repair.test.ts`.
+
+### Authorize sandbox relay ports by capability and deny credential helpers (2026-08-23)
+
+**When:** adding a signed compute-node relay. Assigned sandbox nodes must reach
+user preview ports. Explicitly deny egress, LLM, connector, and standby helper
+ports. *Incident:* Browser port `3000` returned `502 upstream_port` while the
+guest server was healthy. *Enforcer:* `sandbox-port-policy.test.ts`.
+
+### Normalize transient REST error bodies before iterating UI data (2026-08-23)
+
+**When:** a React query expects a list from a runtime route. Convert every
+non-array response to `[]` at the query boundary and guard downstream helpers.
+*Incident:* `/command` returned a temporary `503` object during restart and the
+session page crashed with `TypeError: t is not iterable`. *Enforcer:*
+`detect-command.test.ts`.
+
 ### Keep self-host sandbox gateway URLs aligned with the public proxy route (2026-08-23)
 
 **When:** changing `LLM_GATEWAY_PROXY_TARGET`, Caddy LLM matchers, or sandbox

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1211,11 +1211,11 @@ describe('project session API contract', () => {
     expect(assertedIamActions).toContain('project.session.read');
   });
 
-  test('in-place resume keeps stopped state and billing closed until the provider proves running', async () => {
+  test('in-place resume exposes provisioning state and keeps billing closed until the provider proves running', async () => {
     const staleReadyWaitStartedAt = new Date(Date.now() - 10 * 60 * 1000).toISOString();
     sessionRow = {
       ...sessionRow!,
-      status: 'stopped',
+      status: 'provisioning',
       error:
         'The original sandbox is unavailable. Its identity was preserved and no replacement sandbox was created.',
     };
@@ -1257,9 +1257,9 @@ describe('project session API contract', () => {
     });
 
     expect(won).toBe(true);
-    expect(sessionRow).toMatchObject({ status: 'stopped' });
+    expect(sessionRow).toMatchObject({ status: 'provisioning' });
     expect(sessionSandboxRows[0]).toMatchObject({
-      status: 'stopped',
+      status: 'provisioning',
       externalId: 'original-provider-identity',
       metadata: {
         initStatus: 'ready',
@@ -1283,7 +1283,7 @@ describe('project session API contract', () => {
     expect(computeReopenCalls).toBe(1);
   });
 
-  test('provider reconciliation observes a stopped row while an in-place resume is starting', async () => {
+  test('provider reconciliation ignores a provisioning row while an in-place resume is starting', async () => {
     sessionRow = {
       ...sessionRow!,
       status: 'stopped',
@@ -1324,7 +1324,7 @@ describe('project session API contract', () => {
     );
     expect(won).toBe(true);
     expect(reconciled).toBe(false);
-    expect(sessionSandboxRows[0]?.status).toBe('stopped');
+    expect(sessionSandboxRows[0]?.status).toBe('provisioning');
     expect(sessionRow?.status).toBe('stopped');
     expect(computeReopenCalls).toBe(0);
 
@@ -2967,7 +2967,7 @@ describe('project session API contract', () => {
     ).toEqual(expect.any(String));
   });
 
-  test('a removed stopped runtime keeps the original identity fenced without optimistic activation', async () => {
+  test('a removed stopped runtime reports provisioning while the original identity stays fenced', async () => {
     const app = createApp();
     sessionRow = {
       ...sessionRow!,
@@ -3005,9 +3005,12 @@ describe('project session API contract', () => {
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toMatchObject({
-      stage: 'starting',
+      stage: 'provisioning',
       retriable: true,
-      reason: 'runtime_waking',
+      sandbox: {
+        external_id: 'box-original-archived',
+        status: 'provisioning',
+      },
     });
     expect(providerStartCalls).toBe(0);
     expect(sandboxProvisionCalls).toBe(0);

--- a/apps/api/src/compute-nodes/cluster-forwarder.test.ts
+++ b/apps/api/src/compute-nodes/cluster-forwarder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test'
-import { dispatchForwardedComputeNodeCall, nodeRelayIsLive } from './cluster-protocol'
+import { dispatchForwardedComputeNodeCall, nodeRelayConnectedAfter, nodeRelayIsLive } from './cluster-protocol'
 
 describe('compute-node cross-instance relay', () => {
   test('requires online state, an owner, and a fresh owner heartbeat', () => {
@@ -7,6 +7,12 @@ describe('compute-node cross-instance relay', () => {
     expect(nodeRelayIsLive({ status: 'offline', relayOwnerId: 'pod-a', relayOwnerHeartbeatAt: new Date() })).toBe(false)
     expect(nodeRelayIsLive({ status: 'online', relayOwnerId: null, relayOwnerHeartbeatAt: new Date() })).toBe(false)
     expect(nodeRelayIsLive({ status: 'online', relayOwnerId: 'pod-a', relayOwnerHeartbeatAt: new Date(Date.now() - 61_000) })).toBe(false)
+  })
+
+  test('requires a daemon connection from the current wake generation', () => {
+    const wake = new Date('2026-08-23T03:00:00.000Z')
+    expect(nodeRelayConnectedAfter({ status: 'online', relayOwnerId: 'old-api', relayOwnerHeartbeatAt: new Date('2026-08-23T02:00:00.000Z') }, wake)).toBe(false)
+    expect(nodeRelayConnectedAfter({ status: 'online', relayOwnerId: 'current-api', relayOwnerHeartbeatAt: wake }, wake)).toBe(true)
   })
 
   test('dispatches capability RPC, assignment, and disconnect control on the socket owner', async () => {

--- a/apps/api/src/compute-nodes/cluster-protocol.ts
+++ b/apps/api/src/compute-nodes/cluster-protocol.ts
@@ -9,6 +9,17 @@ export function nodeRelayIsLive(row: { status: string; relayOwnerId?: string | n
   return Number.isFinite(time) && Date.now() - time <= LIVE_WINDOW_MS
 }
 
+export function nodeRelayConnectedAfter(
+  row: { status: string; relayOwnerId?: string | null; relayOwnerHeartbeatAt?: Date | string | null },
+  after: Date,
+): boolean {
+  if (row.status !== 'online' || !row.relayOwnerId || !row.relayOwnerHeartbeatAt) return false
+  const time = row.relayOwnerHeartbeatAt instanceof Date
+    ? row.relayOwnerHeartbeatAt.getTime()
+    : Date.parse(row.relayOwnerHeartbeatAt)
+  return Number.isFinite(time) && time >= after.getTime()
+}
+
 export async function dispatchForwardedComputeNodeCall(
   hub: Pick<ComputeNodeChannelHub, 'rpc' | 'assign' | 'stopAssignment' | 'disconnectNode'>,
   row: { nodeId: string; method: string; params: Record<string, unknown>; expiresAt: Date },

--- a/apps/api/src/compute-nodes/index.ts
+++ b/apps/api/src/compute-nodes/index.ts
@@ -7,6 +7,8 @@ import { assignComputeNodeAcrossCluster, disconnectComputeNodeAcrossCluster, rel
 import { config } from '../config'
 import { fetchComputeNodeThroughRelay } from './relay-client'
 import { connectComputeNodeSocketThroughRelay } from './relay-socket'
+import { nodeRelayConnectedAfter, nodeRelayIsLive } from './cluster-protocol'
+import { API_INSTANCE_ID } from '../shared/instance'
 
 export const computeNodeChannel = new ComputeNodeChannelHub(
   async (nodeId, token, info) => {
@@ -89,6 +91,48 @@ export const computeNodeWsHandlers = {
     computeNodeChannel.close(ws)
     if (nodeId && !computeNodeChannel.isConnected(nodeId)) void db.update(computeNodes).set({ status: 'offline', relayOwnerId: null, relayOwnerInstance: null, relayOwnerStartedAt: null, relayOwnerHeartbeatAt: null, updatedAt: new Date() }).where(and(eq(computeNodes.nodeId, nodeId), eq(computeNodes.relayOwnerId, (relayOwnerPatch().relayOwnerId))))
   },
+}
+
+export async function waitForComputeNodeConnection(
+  nodeId: string,
+  after: Date,
+  timeoutMs = 180_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    const [node] = await db
+      .select({
+        status: computeNodes.status,
+        relayOwnerId: computeNodes.relayOwnerId,
+        relayOwnerHeartbeatAt: computeNodes.relayOwnerHeartbeatAt,
+      })
+      .from(computeNodes)
+      .where(eq(computeNodes.nodeId, nodeId))
+      .limit(1)
+    if (node && nodeRelayConnectedAfter(node, after)) return
+    if (Date.now() >= deadline) {
+      throw new Error(`Compute node ${nodeId} did not reconnect within ${timeoutMs}ms`)
+    }
+    await Bun.sleep(250)
+  }
+}
+
+/** True when this API or a live cluster peer owns the node relay. */
+export async function isComputeNodeRelayLive(nodeId: string): Promise<boolean> {
+  if (computeNodeChannel.isConnected(nodeId)) return true
+  const [node] = await db
+    .select({
+      status: computeNodes.status,
+      relayOwnerId: computeNodes.relayOwnerId,
+      relayOwnerHeartbeatAt: computeNodes.relayOwnerHeartbeatAt,
+    })
+    .from(computeNodes)
+    .where(eq(computeNodes.nodeId, nodeId))
+    .limit(1)
+  // This process cannot own a live socket that is absent from its hub. Treat
+  // its database heartbeat as stale immediately instead of waiting 60 seconds.
+  if (node?.relayOwnerId === API_INSTANCE_ID) return false
+  return Boolean(node && nodeRelayIsLive(node))
 }
 
 /** Send one HTTP request through the sole outbound kortixd channel. */

--- a/apps/api/src/compute-nodes/relay-e2e.test.ts
+++ b/apps/api/src/compute-nodes/relay-e2e.test.ts
@@ -10,12 +10,14 @@ afterEach(() => { for (const server of servers.splice(0)) server.stop(true) })
 describe('compute-node relay across a real API network boundary', () => {
   test('streams a request body and incremental SSE response through the relay role', async () => {
     const key = 'relay-e2e-key'
+    let releaseSecondEvent!: () => void
+    const secondEventGate = new Promise<void>((resolve) => { releaseSecondEvent = resolve })
     const hub = { fetch: async (nodeId: string, port: number, request: Request) => {
       expect({ nodeId, port, path: new URL(request.url).pathname }).toEqual({ nodeId: 'node-1', port: 8000, path: '/events' })
       expect(await request.text()).toBe('request-stream')
       return new Response(new ReadableStream({ async start(controller) {
         controller.enqueue(new TextEncoder().encode('data: first\n\n'))
-        await Bun.sleep(5)
+        await secondEventGate
         controller.enqueue(new TextEncoder().encode('data: second\n\n'))
         controller.close()
       } }), { headers: { 'content-type': 'text/event-stream' } })
@@ -25,10 +27,14 @@ describe('compute-node relay across a real API network boundary', () => {
     servers.push(server)
     const response = await fetchComputeNodeThroughRelay({ relayUrl: server.url.toString(), key, nodeId: 'node-1', port: 8000, request: new Request('http://127.0.0.1:8000/events', { method: 'POST', body: 'request-stream' }) })
     expect(response.headers.get('content-type')).toContain('text/event-stream')
-    const chunks: string[] = []
     const reader = response.body!.getReader()
-    for (;;) { const { done, value } = await reader.read(); if (done) break; chunks.push(new TextDecoder().decode(value)) }
-    expect(chunks).toEqual(['data: first\n\n', 'data: second\n\n'])
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(new TextDecoder().decode(first.value)).toBe('data: first\n\n')
+    releaseSecondEvent()
+    const remainder: string[] = []
+    for (;;) { const { done, value } = await reader.read(); if (done) break; remainder.push(new TextDecoder().decode(value)) }
+    expect(remainder.join('')).toBe('data: second\n\n')
   })
 
   test('relays bidirectional WebSocket frames through the relay role', async () => {

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -8,6 +8,7 @@
 import { SandboxState } from '@daytonaio/sdk';
 import { SANDBOX_VERSION, config } from '../../config';
 import { triggerEmergencyDiskArchiveSweep } from '../../projects/disk-quota-guard';
+import { providerEnvironmentOwner } from '../../projects/instance-scope';
 import {
   archiveDaytonaSandboxById,
   getDaytona,
@@ -89,7 +90,7 @@ function reportIfDiskQuotaError(err: unknown, reason: string): never {
 function managedSandboxLabels(workloadType?: SandboxWorkloadType): Record<string, string> {
   return {
     'kortix.managed': 'true',
-    'kortix.env': config.INTERNAL_KORTIX_ENV,
+    'kortix.env': providerEnvironmentOwner(),
     ...(workloadType === 'app' ? { 'kortix.workload': workloadType } : {}),
   };
 }

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -4,6 +4,7 @@ import { createCipheriv, createDecipheriv, hkdfSync, randomBytes } from 'node:cr
 import { type Sandbox as E2BSandbox, Sandbox, SandboxNotFoundError } from 'e2b';
 import { SANDBOX_VERSION, config } from '../../config';
 import { configuredTimeoutMs, withTimeout } from '../../shared/with-timeout';
+import { providerEnvironmentOwner } from '../../projects/instance-scope';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
 import { serviceKeyForExternalId } from '../service-key';
 import { e2bDomain } from './e2b-domain';
@@ -323,7 +324,7 @@ export class E2BProvider implements SandboxProvider {
       envs: envVars,
       metadata: {
         [MANAGED_METADATA]: 'true',
-        [ENV_METADATA]: config.INTERNAL_KORTIX_ENV,
+        [ENV_METADATA]: providerEnvironmentOwner(),
         kortix_account_id: opts.accountId,
         kortix_created_by: opts.userId,
         ...(workloadType === 'app' ? { kortix_workload: workloadType } : {}),
@@ -540,7 +541,7 @@ export class E2BProvider implements SandboxProvider {
       ...apiOpts(),
       limit: 100,
       query: {
-        metadata: { [MANAGED_METADATA]: 'true', [ENV_METADATA]: config.INTERNAL_KORTIX_ENV },
+        metadata: { [MANAGED_METADATA]: 'true', [ENV_METADATA]: providerEnvironmentOwner() },
         state: ['running'],
       },
     });

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -305,6 +305,8 @@ export interface SandboxProvider {
     request: SandboxIngressRequest,
   ): Promise<ResolvedSandboxIngress>;
   ensureRunning(externalId: string): Promise<void>;
+  /** Reconcile the session daemon after a provider-native wake. */
+  ensureSessionRuntimeStarted?(externalId: string): Promise<void>;
   getProvisioningStatus(sandboxId: string): Promise<ProvisioningStatus | null>;
   /**
    * List the running boxes this deployment owns, for the orphan-box reaper

--- a/apps/api/src/platform/providers/platinum-app-runtime.test.ts
+++ b/apps/api/src/platform/providers/platinum-app-runtime.test.ts
@@ -140,6 +140,19 @@ test("start treats a running conflict as an idempotent success", async () => {
   ]);
 });
 
+test("start waits for an accepted wake to reach running before returning", async () => {
+  sandboxStateSequence = ["starting", "running"];
+  const provider = new PlatinumProvider();
+
+  await expect(provider.start("sbx_app")).resolves.toBeUndefined();
+
+  expect(calls.map(({ path, method }) => ({ path, method }))).toEqual([
+    { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+  ]);
+});
+
 test("start waits for an accepted stop to settle before retrying the wake", async () => {
   startError = new Error(
     'platinum POST /v1/sandboxes/sbx_app/start -> 409 {"error":"conflict","state":"stopping","code":"conflict"}',
@@ -153,6 +166,7 @@ test("start waits for an accepted stop to settle before retrying the wake", asyn
     { path: "/v1/sandboxes/sbx_app", method: "GET" },
     { path: "/v1/sandboxes/sbx_app", method: "GET" },
     { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
   ]);
 });
 

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -55,6 +55,19 @@ const baseOpts = {
   envVars: { KORTIX_TOKEN: 'tok_test' },
 };
 
+function expectSessionBootstrap(body: string): void {
+  const parsed = JSON.parse(body) as { cmd: string[]; timeout_ms: number };
+  expect(parsed.cmd.slice(0, 2)).toEqual(['/bin/sh', '-lc']);
+  expect(parsed.cmd[2]).toContain('daemon_pids=');
+  expect(parsed.cmd[2]).toContain('entry_pids=');
+  expect(parsed.cmd[2]).toContain('kill -TERM $daemon_pids');
+  expect(parsed.cmd[2]).toContain('kill -TERM $entry_pids');
+  expect(parsed.cmd[2]).not.toContain('print $1; exit');
+  expect(parsed.cmd[2]).toContain("KORTIX_API_URL='https://api.example.com/v1'");
+  expect(parsed.cmd[2]).toContain('/usr/local/bin/kortix-entrypoint');
+  expect(parsed.timeout_ms).toBe(15_000);
+}
+
 beforeEach(() => {
   calls.length = 0;
 });
@@ -82,14 +95,18 @@ test('create() does NOT throw when the box is running', async () => {
     (c) => c.method === 'POST' && c.path === '/v1/sandboxes/sbx_dead/exec',
   );
   expect(bootstrap).toBeDefined();
-  expect(JSON.parse(bootstrap!.body!)).toEqual({
-    cmd: [
-      '/bin/sh',
-      '-lc',
-      'if pgrep -u kortix -x kortixd >/dev/null; then exit 0; fi; setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null',
-    ],
-    timeout_ms: 15_000,
-  });
+  expectSessionBootstrap(bootstrap!.body!);
+});
+
+test('session runtime convergence starts the kortixd supervisor after a wake', async () => {
+  const p = await makeProvider();
+
+  await p.ensureSessionRuntimeStarted('sbx_session');
+
+  const bootstrap = calls.find(
+    (c) => c.method === 'POST' && c.path === '/v1/sandboxes/sbx_session/exec',
+  );
+  expectSessionBootstrap(bootstrap!.body!);
 });
 
 test("create() does NOT tear down a still-'provisioning' box (FE poll picks it up)", async () => {

--- a/apps/api/src/platform/providers/platinum-list-managed.test.ts
+++ b/apps/api/src/platform/providers/platinum-list-managed.test.ts
@@ -31,7 +31,11 @@ mock.module('../sandbox-frontend-url', () => ({
   sandboxFrontendBaseUrl: () => 'https://app.example.test',
 }));
 
-const MANAGED = { 'kortix.managed': 'true', 'kortix.env': 'dev' };
+const MANAGED = {
+  'kortix.managed': 'true',
+  'kortix.env': 'dev',
+  'kortix.instance': 'deployed',
+};
 
 let pages: Array<Record<string, unknown>> = [];
 let requested: string[] = [];
@@ -113,16 +117,16 @@ test('a box with no readable creation time reports createdAt null so the reaper 
   expect(listed).toEqual([{ externalId: 'sbx_undated', createdAt: null }]);
 });
 
-test('INSTANCE SCOPE: with KORTIX_INSTANCE_ID set, another instance’s box is skipped; own and unstamped boxes are listed', async () => {
+test('INSTANCE SCOPE: with KORTIX_INSTANCE_ID set, only that exact provider owner is listed', async () => {
   // Shared Platinum org + shared local DB: instance A must never stop instance
-  // B's boxes (projects/instance-scope.ts). Boxes created before the stamp
-  // carry no `kortix.instance` and stay everyone's — the safe direction.
+  // B's boxes. Boxes created before the stamp carry no `kortix.instance` and
+  // are skipped because provider orphan cleanup must fail closed.
   platinumConfig.KORTIX_INSTANCE_ID = 'wt-a';
   try {
     pages = [
       {
         rows: [
-          { id: 'sbx_mine', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'wt-a' }, created_at: '2026-08-12T00:00:00Z' },
+          { id: 'sbx_mine', state: 'running', metadata: { ...MANAGED, 'kortix.env': 'dev:wt-a', 'kortix.instance': 'wt-a' }, created_at: '2026-08-12T00:00:00Z' },
           { id: 'sbx_other', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'primary' }, created_at: '2026-08-12T00:00:00Z' },
           { id: 'sbx_unstamped', state: 'running', metadata: MANAGED, created_at: '2026-08-12T00:00:00Z' },
         ],
@@ -133,17 +137,19 @@ test('INSTANCE SCOPE: with KORTIX_INSTANCE_ID set, another instance’s box is s
     const { PlatinumProvider } = await import('./platinum');
     const listed = await new PlatinumProvider().listManagedRunningSandboxes();
 
-    expect(listed.map((box) => box.externalId)).toEqual(['sbx_mine', 'sbx_unstamped']);
+    expect(listed.map((box) => box.externalId)).toEqual(['sbx_mine']);
   } finally {
     delete platinumConfig.KORTIX_INSTANCE_ID;
   }
 });
 
-test('INSTANCE SCOPE off (unset): a stamped box from any instance is listed as before', async () => {
+test('INSTANCE SCOPE off (unset): only the deployed provider owner is listed', async () => {
   pages = [
     {
       rows: [
+        { id: 'sbx_deployed', state: 'running', metadata: MANAGED, created_at: '2026-08-12T00:00:00Z' },
         { id: 'sbx_other', state: 'running', metadata: { ...MANAGED, 'kortix.instance': 'primary' }, created_at: '2026-08-12T00:00:00Z' },
+        { id: 'sbx_unstamped', state: 'running', metadata: { 'kortix.managed': 'true', 'kortix.env': 'dev' }, created_at: '2026-08-12T00:00:00Z' },
       ],
       has_more: false,
     },
@@ -152,5 +158,5 @@ test('INSTANCE SCOPE off (unset): a stamped box from any instance is listed as b
   const { PlatinumProvider } = await import('./platinum');
   const listed = await new PlatinumProvider().listManagedRunningSandboxes();
 
-  expect(listed.map((box) => box.externalId)).toEqual(['sbx_other']);
+  expect(listed.map((box) => box.externalId)).toEqual(['sbx_deployed']);
 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -41,7 +41,7 @@
 
 import { createHash } from 'node:crypto';
 import { SANDBOX_VERSION, config } from '../../config';
-import { currentInstanceId, sandboxBelongsToThisInstance } from '../../projects/instance-scope';
+import { currentInstanceId, providerEnvironmentOwner } from '../../projects/instance-scope';
 import { isOpencodePort } from '../../shared/opencode-ports';
 import { platinumJson } from '../../shared/platinum';
 import { sandboxFrontendBaseUrl } from '../sandbox-frontend-url';
@@ -70,6 +70,14 @@ import { classifyPtyWebSocketPath } from './pty-ingress';
 const AGENT_PORT = 8000;
 const START_CONFLICT_GRACE_MS = 30_000;
 const START_CONFLICT_POLL_MS = 250;
+
+// The Platinum org is shared by deployed stacks and local worktrees. Every
+// provider object needs one explicit owner because the orphan reaper operates
+// from provider inventory, not from a shared database. Legacy unstamped boxes
+// fail closed and are never candidates for destructive orphan cleanup.
+function platinumInstanceOwner(): string {
+  return currentInstanceId() ?? 'deployed';
+}
 
 interface PlatinumSandbox {
   id: string;
@@ -321,13 +329,13 @@ export class PlatinumProvider implements SandboxProvider {
       // The reaper's filter is unaffected (it reads the two keys above only).
       metadata: {
         'kortix.managed': 'true',
-        'kortix.env': config.INTERNAL_KORTIX_ENV,
+        'kortix.env': providerEnvironmentOwner(),
         'kortix.workload': workloadType,
         ...(opts.sandboxId ? { 'kortix.sandbox_id': opts.sandboxId } : {}),
         // Instance scope for local dev on a shared DB (projects/instance-scope.ts):
         // `listManagedRunningSandboxes` skips another instance's boxes. Absent
         // in deployed environments.
-        ...(currentInstanceId() ? { 'kortix.instance': currentInstanceId()! } : {}),
+        'kortix.instance': platinumInstanceOwner(),
       },
     };
     if (dedup) {
@@ -428,7 +436,7 @@ export class PlatinumProvider implements SandboxProvider {
     const _exposeMs = Date.now() - _tExpose0;
 
     if (workloadType !== 'app') {
-      await this.ensureNodeRuntimeStarted(externalId);
+      await this.ensureSessionRuntimeStarted(externalId);
     }
 
     // Return as soon as the VM is running and the agent port is exposed — do NOT
@@ -466,17 +474,24 @@ export class PlatinumProvider implements SandboxProvider {
     };
   }
 
-  private async ensureNodeRuntimeStarted(externalId: string): Promise<void> {
+  async ensureSessionRuntimeStarted(externalId: string): Promise<void> {
     // Platinum restores a template under pt-init and does not execute the image
     // ENTRYPOINT. Start the supervisor through the native exec API. The process
     // owns daemon updates and rollback, so launching kortixd directly would
     // bypass the convergent-runtime contract.
-    const command =
-      'if pgrep -u kortix -x kortixd >/dev/null; then exit 0; fi; ' +
-      'setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null';
+    const relayUrl = `${config.KORTIX_NODE_RELAY_URL
+      .replace(/\/+$/, '')
+      .replace(/\/v1\/router$/, '')
+      .replace(/\/v1$/, '')}/v1`;
+    const quotedRelayUrl = `'${relayUrl.replace(/'/g, `'"'"'`)}'`;
+    // A resumed VM can retain an obsolete relay URL. Stop its inactive daemon
+    // tree and relaunch the existing verified supervisor with this API's relay
+    // URL. No human can be attached while the provider VM is stopped. The new
+    // process starts with an empty PTY registry and converges its own binary.
+    const allProcessCommand = String.raw`daemon_pids=$(ps -u kortix -o pid= -o args= | awk '$NF == "run" { print $1 }'); entry_pids=$(ps -u kortix -o pid= -o args= | awk '$0 ~ /\/usr\/local\/bin\/kortix-entrypoint$/ { print $1 }'); [ -z "$daemon_pids" ] || kill -TERM $daemon_pids; [ -z "$entry_pids" ] || kill -TERM $entry_pids; sleep 1; KORTIX_API_URL=` + quotedRelayUrl + String.raw` setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
     const response = await platinumJson<PlatinumExecResponse>(`/v1/sandboxes/${externalId}/exec`, {
       method: 'POST',
-      body: JSON.stringify({ cmd: ['/bin/sh', '-lc', command], timeout_ms: 15_000 }),
+      body: JSON.stringify({ cmd: ['/bin/sh', '-lc', allProcessCommand], timeout_ms: 15_000 }),
     });
     const result = platinumExecResult(response);
     // Platinum has returned both a direct exec result and an empty 2xx body
@@ -514,7 +529,20 @@ export class PlatinumProvider implements SandboxProvider {
     for (;;) {
       try {
         await platinumJson(`/v1/sandboxes/${externalId}/start`, { method: 'POST' });
-        return;
+        // Platinum accepts the start before guest exec is available. Do not
+        // return until the control plane reports running, otherwise the
+        // immediate kortixd convergence exec races the starting state.
+        for (;;) {
+          const sandbox = await platinumJson<PlatinumSandbox>(`/v1/sandboxes/${externalId}`);
+          const state = String(sandbox.state ?? '').toLowerCase();
+          if (state === 'running') return;
+          if (!['starting', 'pending'].includes(state) || Date.now() >= deadline) {
+            throw new Error(
+              `Platinum sandbox ${externalId} did not reach running after start (state=${state || 'unknown'})`,
+            );
+          }
+          await Bun.sleep(START_CONFLICT_POLL_MS);
+        }
       } catch (error) {
         // Platinum acknowledges stop before the VM always reaches `stopped`.
         // An immediate user reopen can therefore race `stopping` and receive
@@ -591,11 +619,12 @@ export class PlatinumProvider implements SandboxProvider {
         if (!sandbox.id) continue;
         const metadata = sandbox.metadata ?? {};
         if (String(metadata['kortix.managed'] ?? '') !== 'true') continue;
-        if (String(metadata['kortix.env'] ?? '') !== config.INTERNAL_KORTIX_ENV) continue;
-        // Instance scope beside the env scope: another local instance's box is
-        // not ours to stop. Unstamped boxes stay everyone's. No-op when
-        // KORTIX_INSTANCE_ID is unset.
-        if (!sandboxBelongsToThisInstance({ instanceId: metadata['kortix.instance'] })) continue;
+        if (String(metadata['kortix.env'] ?? '') !== providerEnvironmentOwner()) continue;
+        // Exact provider ownership is mandatory. An unstamped legacy box is
+        // skipped, never reaped. This differs from DB-backed background work:
+        // provider inventory is shared across databases, so "belongs to
+        // everyone" would let deployed dev stop a local worktree sandbox.
+        if (String(metadata['kortix.instance'] ?? '') !== platinumInstanceOwner()) continue;
         if (String(sandbox.state ?? '').toLowerCase() !== 'running') continue;
         const rawCreatedAt = sandbox.created_at ?? sandbox.createdAt ?? null;
         const createdAt = rawCreatedAt ? new Date(rawCreatedAt) : null;
@@ -780,6 +809,7 @@ export class PlatinumProvider implements SandboxProvider {
     if (status === 'stopped') {
       console.log(`[PLATINUM] Sandbox ${externalId} is stopped, waking up...`);
       await this.start(externalId);
+      await this.ensureSessionRuntimeStarted(externalId);
     }
   }
 }

--- a/apps/api/src/projects/instance-scope.test.ts
+++ b/apps/api/src/projects/instance-scope.test.ts
@@ -13,7 +13,7 @@
 // must treat rows that predate the stamp as everyone's (legacy rows).
 import { afterEach, describe, expect, test } from 'bun:test';
 import { config } from '../config';
-import { sandboxBelongsToThisInstance } from './instance-scope';
+import { providerEnvironmentOwner, sandboxBelongsToThisInstance } from './instance-scope';
 
 const ORIGINAL = (config as { KORTIX_INSTANCE_ID?: string }).KORTIX_INSTANCE_ID;
 const setInstance = (value: string | undefined) => {
@@ -52,5 +52,17 @@ describe('sandboxBelongsToThisInstance', () => {
   test('empty-string KORTIX_INSTANCE_ID reads as unset', () => {
     setInstance('');
     expect(sandboxBelongsToThisInstance({ instanceId: 'primary' })).toBe(true);
+  });
+});
+
+describe('providerEnvironmentOwner', () => {
+  test('keeps the deployed environment marker unchanged', () => {
+    setInstance(undefined);
+    expect(providerEnvironmentOwner()).toBe(config.INTERNAL_KORTIX_ENV);
+  });
+
+  test('gives a worktree a marker that an older deployed reaper cannot match', () => {
+    setInstance('wt-a');
+    expect(providerEnvironmentOwner()).toBe(`${config.INTERNAL_KORTIX_ENV}:wt-a`);
   });
 });

--- a/apps/api/src/projects/instance-scope.ts
+++ b/apps/api/src/projects/instance-scope.ts
@@ -33,6 +33,18 @@ export function currentInstanceId(): string | undefined {
 }
 
 /**
+ * Provider inventories are shared across deployed dev and local worktrees.
+ * A scoped environment marker keeps older deployed reapers, which only know
+ * the environment label, from adopting a local worktree's provider object.
+ */
+export function providerEnvironmentOwner(): string {
+  const instanceId = currentInstanceId();
+  return instanceId
+    ? `${config.INTERNAL_KORTIX_ENV}:${instanceId}`
+    : config.INTERNAL_KORTIX_ENV;
+}
+
+/**
  * True when background work on this sandbox may run here:
  *  - `KORTIX_INSTANCE_ID` is unset (scoping off), or
  *  - the row carries no `instanceId` (legacy row), or

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -15,6 +15,7 @@ import { auth, json } from '../../openapi';
 import { type SandboxStatus, getProvider } from '../../platform/providers';
 import { classifySandboxProvisioningFailure } from '../../platform/services/sandbox-provisioning-error';
 import { db } from '../../shared/db';
+import { isComputeNodeRelayLive, waitForComputeNodeConnection } from '../../compute-nodes';
 import { resolveBranchTip } from '../git';
 import { legacyRehydrateSpec, rehydrateSessionChat } from '../legacy-migration-rehydrate';
 import { withProjectGitAuth } from '../lib/git';
@@ -54,6 +55,101 @@ import {
   runtimeWakeInProgress,
   runtimeWakeRetryCoolingDown,
 } from '../session-lifecycle/runtime-wake-fence';
+
+const RUNTIME_RELAY_REPAIR_COOLDOWN_MS = 30_000;
+
+export function currentSessionSandboxUrl(externalId: string): string {
+  const apiOrigin = (config.KORTIX_URL || '')
+    .replace(/\/+$/, '')
+    .replace(/\/v1\/router$/, '')
+    .replace(/\/v1$/, '');
+  return `${apiOrigin}/v1/p/${externalId}/8000`;
+}
+
+export function runtimeRelayRepairDue(
+  metadata: Record<string, unknown> | null | undefined,
+  relayUrl: string,
+  nowMs = Date.now(),
+): boolean {
+  const lastUrl = typeof metadata?.runtimeRelayRepairUrl === 'string'
+    ? metadata.runtimeRelayRepairUrl
+    : null;
+  const lastAt = typeof metadata?.runtimeRelayRepairStartedAt === 'string'
+    ? Date.parse(metadata.runtimeRelayRepairStartedAt)
+    : Number.NaN;
+  return lastUrl !== relayUrl
+    || !Number.isFinite(lastAt)
+    || nowMs - lastAt >= RUNTIME_RELAY_REPAIR_COOLDOWN_MS;
+}
+
+export function runtimeRelayRepairNeeded(
+  metadata: Record<string, unknown> | null | undefined,
+  relayUrl: string,
+  relayLive: boolean,
+  nowMs = Date.now(),
+): boolean {
+  if (!runtimeRelayRepairDue(metadata, relayUrl, nowMs)) return false;
+  return metadata?.runtimeRelayRepairUrl !== relayUrl || !relayLive;
+}
+
+async function scheduleRuntimeRelayRepair(
+  row: typeof sessionSandboxes.$inferSelect,
+  provider: ReturnType<typeof getProvider>,
+): Promise<boolean> {
+  if (!row.externalId || !provider.ensureSessionRuntimeStarted) return false;
+  const relayUrl = (config.KORTIX_NODE_RELAY_URL || config.KORTIX_URL || '').replace(/\/+$/, '');
+  const now = new Date();
+  const metadata = sandboxMetadata(row);
+  if (!relayUrl || !runtimeRelayRepairDue(metadata, relayUrl, now.getTime())) {
+    return false;
+  }
+  // A retry for the SAME relay URL is only valid when the channel is still
+  // absent. OpenCode can remain `starting` after kortixd has reconnected; that
+  // state must not restart the daemon and disconnect PTYs every 30 seconds.
+  const relayLive = await isComputeNodeRelayLive(row.sandboxId);
+  if (!runtimeRelayRepairNeeded(metadata, relayUrl, relayLive, now.getTime())) {
+    return false;
+  }
+  const retryBefore = new Date(now.getTime() - RUNTIME_RELAY_REPAIR_COOLDOWN_MS).toISOString();
+  const [claimed] = await db
+    .update(sessionSandboxes)
+    .set({
+      updatedAt: now,
+      metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify({
+        runtimeRelayRepairUrl: relayUrl,
+        runtimeRelayRepairStartedAt: now.toISOString(),
+      })}::jsonb`,
+    })
+    .where(and(
+      eq(sessionSandboxes.sandboxId, row.sandboxId),
+      eq(sessionSandboxes.externalId, row.externalId),
+      eq(sessionSandboxes.status, 'active'),
+      sql`(
+        ${sessionSandboxes.metadata}->>'runtimeRelayRepairUrl' IS DISTINCT FROM ${relayUrl}
+        OR ${sessionSandboxes.metadata}->>'runtimeRelayRepairStartedAt' IS NULL
+        OR ${sessionSandboxes.metadata}->>'runtimeRelayRepairStartedAt' !~ '^\\d{4}-\\d{2}-\\d{2}T'
+        OR ${sessionSandboxes.metadata}->>'runtimeRelayRepairStartedAt' <= ${retryBefore}
+      )`,
+    ))
+    .returning({ sandboxId: sessionSandboxes.sandboxId });
+  if (!claimed) return false;
+
+  const externalId = row.externalId;
+  void (async () => {
+    const reconnectAfter = new Date();
+    try {
+      await provider.ensureSessionRuntimeStarted!(externalId);
+      await waitForComputeNodeConnection(row.sandboxId, reconnectAfter, 60_000);
+    } catch (error) {
+      console.warn('[start] kortixd relay repair failed', {
+        sandboxId: row.sandboxId,
+        externalId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })();
+  return true;
+}
 
 /**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
@@ -96,12 +192,22 @@ export async function resumeStoppedSandbox(
     runtimeWakeLeaseExpiresAt: leaseExpiresAt.toISOString(),
     runtimeWakeProviderStatus: 'starting',
   };
-  // Metadata CAS is the lock. The row deliberately stays stopped. A retry can
-  // replace only an expired lease and cannot bypass a failed-wake cooldown.
+  // Metadata CAS is the lock. Provisioning authorizes daemon boot callbacks,
+  // but billing remains closed until the live node connection is confirmed.
+  // A retry can replace only an expired lease and cannot bypass a cooldown.
   const [won] = await db
     .update(sessionSandboxes)
     .set({
+      status: 'provisioning',
       updatedAt: now,
+      // A stopped row retains its expired idle deadline. Provider callbacks
+      // can move it to provisioning while this wake is still running. Give
+      // that transition the full wake lease so the reaper cannot stop the VM
+      // between provider start and kortixd reconnection.
+      deadlineAt: sql`GREATEST(
+        ${sessionSandboxes.deadlineAt},
+        now() + make_interval(secs => ${Math.ceil(RUNTIME_WAKE_LEASE_MS / 1000)})
+      )`,
       metadata: sql`(
         coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
           - 'runtimeIdentityState'
@@ -149,7 +255,14 @@ export async function resumeStoppedSandbox(
   void executeClaimedRuntimeWake({
     knownStatus: knownProviderStatus ?? null,
     getStatus: () => provider.getStatus(externalId),
-    start: () => provider.start(externalId),
+    start: async () => {
+      const reconnectAfter = new Date();
+      await provider.start(externalId);
+      await provider.ensureSessionRuntimeStarted?.(externalId);
+      if (provider.ensureSessionRuntimeStarted) {
+        await waitForComputeNodeConnection(row.sandboxId, reconnectAfter);
+      }
+    },
     stop: () => provider.stop(externalId),
     isMissingError: isMissingRuntimeError,
     finalize: async () => {
@@ -181,7 +294,7 @@ export async function resumeStoppedSandbox(
             and(
               eq(sessionSandboxes.sandboxId, row.sandboxId),
               eq(sessionSandboxes.externalId, externalId),
-              eq(sessionSandboxes.status, 'stopped'),
+              eq(sessionSandboxes.status, 'provisioning'),
               sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
             ),
           )
@@ -189,7 +302,17 @@ export async function resumeStoppedSandbox(
         if (!activated) return false;
         await tx
           .update(projectSessions)
-          .set({ status: 'running', error: null, updatedAt: confirmedAt })
+          .set({
+            status: 'running',
+            error: null,
+            // A local quick tunnel changes whenever the worktree restarts.
+            // Keep the durable session URL on the same relay origin as the
+            // newly-started kortixd process. Otherwise old sessions reconnect
+            // kortixd successfully while the SDK continues to call the dead
+            // tunnel stored at initial provisioning.
+            sandboxUrl: currentSessionSandboxUrl(externalId),
+            updatedAt: confirmedAt,
+          })
           .where(eq(projectSessions.sessionId, row.sessionId));
         return true;
       });
@@ -230,6 +353,7 @@ export async function resumeStoppedSandbox(
       const [failed] = await db
         .update(sessionSandboxes)
         .set({
+          status: 'stopped',
           updatedAt: failedAt,
           metadata: sql`(
             coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
@@ -242,7 +366,7 @@ export async function resumeStoppedSandbox(
           and(
             eq(sessionSandboxes.sandboxId, row.sandboxId),
             eq(sessionSandboxes.externalId, externalId),
-            eq(sessionSandboxes.status, 'stopped'),
+            eq(sessionSandboxes.status, 'provisioning'),
             sql`${sessionSandboxes.metadata}->>'runtimeWakeId' = ${runtimeWakeId}`,
           ),
         )
@@ -260,14 +384,14 @@ export async function resumeStoppedSandbox(
         .limit(1);
       const metadata = (current?.metadata ?? {}) as Record<string, unknown>;
       if (
-        current?.status === 'stopped' &&
+        current?.status === 'provisioning' &&
         typeof metadata.runtimeWakeId === 'string' &&
         metadata.runtimeWakeId !== runtimeWakeId &&
         runtimeWakeInProgress(metadata)
       ) {
         return 'delegated';
       }
-      return current?.status === 'stopped' && metadata.runtimeWakeId === runtimeWakeId
+      return current?.status === 'provisioning' && metadata.runtimeWakeId === runtimeWakeId
         ? 'owned'
         : 'cancelled';
     },
@@ -1164,6 +1288,15 @@ export async function openSession(args: {
     throw new Error(`Provider-running sandbox ${row.sandboxId} has no external_id`);
   }
 
+  const currentSandboxUrl = currentSessionSandboxUrl(runningExternalId);
+  await db
+    .update(projectSessions)
+    .set({ sandboxUrl: currentSandboxUrl, updatedAt: new Date() })
+    .where(and(
+      eq(projectSessions.sessionId, sessionId),
+      sql`${projectSessions.sandboxUrl} IS DISTINCT FROM ${currentSandboxUrl}`,
+    ));
+
   // Box is provider-running. Resolve OpenCode readiness + the canonical pin
   // server-side — safe now that the box is confirmed up, so the daemon answers
   // FAST (a 503 'not_ready' while OpenCode is still booting, not an 8s timeout
@@ -1179,6 +1312,9 @@ export async function openSession(args: {
   });
   const booting = ensured.reason === 'not_ready' || ensured.reason === 'unreachable';
   if (booting) {
+    if (ensured.reason === 'unreachable') {
+      await scheduleRuntimeRelayRepair(row, provider);
+    }
     const staleBoot = staleOpencodeReadyReason(
       sandboxMetadata(row),
       ensured.reason,

--- a/apps/api/src/projects/runtime-identity-park-ledger.test.ts
+++ b/apps/api/src/projects/runtime-identity-park-ledger.test.ts
@@ -22,6 +22,8 @@ let statements: Array<{ sql: string; inTransaction: boolean }> = [];
 let sandboxUpdates = 0;
 let inTransaction = false;
 let liveSession = true;
+let liveSandbox = true;
+let providerStops = 0;
 let savepoints = 0;
 /** When set, every `tx.execute` fails with this message. */
 let executeThrows: string | null = null;
@@ -47,6 +49,7 @@ const updater = (table: unknown) => ({
     where: () => ({
       returning: async () => {
         if (table === projectSessions) return liveSession ? [{ sessionId: 'sess-1' }] : [];
+        if (!liveSandbox) return [];
         sandboxUpdates += 1;
         return [{ sandboxId: 'sb-1', sessionId: 'sess-1' }];
       },
@@ -95,7 +98,7 @@ mock.module('../billing/services/compute-metering', () => ({
 
 mock.module('../platform/providers', () => ({
   ...realProviders,
-  getProvider: () => ({ stop: async () => {} }),
+  getProvider: () => ({ stop: async () => { providerStops += 1; } }),
 }));
 
 const { parkEstablishedRuntime, preserveEstablishedRuntime } = await import('./runtime-identity');
@@ -110,6 +113,7 @@ const ROW = {
     },
   },
   provider: 'daytona',
+  updatedAt: new Date('2026-08-23T00:00:00.000Z'),
 };
 
 beforeEach(() => {
@@ -117,6 +121,8 @@ beforeEach(() => {
   sandboxUpdates = 0;
   inTransaction = false;
   liveSession = true;
+  liveSandbox = true;
+  providerStops = 0;
   savepoints = 0;
   executeThrows = null;
 });
@@ -158,12 +164,24 @@ describe('parks outside applyStoppedState settle the turn ledger', () => {
     expect(statements).toEqual([]);
   });
 
-  // Both parks stop the PROVIDER BOX before they open this transaction
-  // (parkEstablishedRuntime calls provider.stop(); preserveEstablishedRuntime
-  // runs because the provider already reports it gone). An abort here would
-  // leave the row 'active' and the session 'running' against a dead box, and
-  // every retry would fail the same way. The settle is savepoint-bounded so it
-  // cannot do that.
+  test('a stale readiness park that loses the sandbox CAS never stops the provider', async () => {
+    liveSandbox = false;
+
+    expect(
+      await parkEstablishedRuntime(
+        ROW as Parameters<typeof parkEstablishedRuntime>[0],
+        'runtime_unreachable_timeout',
+        'runtime_boot_failed',
+      ),
+    ).toBeNull();
+
+    expect(providerStops).toBe(0);
+    expect(statements).toEqual([]);
+  });
+
+  // The settle is savepoint-bounded so an observation-table failure cannot
+  // abort the park transaction. parkEstablishedRuntime stops the provider only
+  // after this transaction's row CAS wins.
   test('a ledger settle that throws leaves the park committed', async () => {
     executeThrows = 'canceling statement due to statement timeout';
     const error = console.error;

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -300,7 +300,7 @@ export function parkMetadataPatch(
 
 type ParkableRuntimeRow = Pick<
   typeof sessionSandboxes.$inferSelect,
-  'sandboxId' | 'sessionId' | 'externalId' | 'metadata' | 'provider'
+  'sandboxId' | 'sessionId' | 'externalId' | 'metadata' | 'provider' | 'updatedAt'
 >;
 
 /**
@@ -323,23 +323,6 @@ export async function parkEstablishedRuntime(
   }
   const externalId = row.externalId;
 
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(
-      `[runtime-identity] failed to close compute for ${row.sandboxId} while parking ${externalId}:`,
-      err,
-    ),
-  );
-  // try/catch, not .catch(): getProvider() throws synchronously for a
-  // disabled provider, and a park must survive that too.
-  try {
-    await getProvider(row.provider as ProviderName).stop(externalId);
-  } catch (err) {
-    console.warn(
-      `[runtime-identity] provider stop failed while parking ${externalId}:`,
-      err instanceof Error ? err.message : err,
-    );
-  }
-
   const metadata = {
     ...((row.metadata as Record<string, unknown> | null) ?? {}),
   };
@@ -349,8 +332,9 @@ export async function parkEstablishedRuntime(
   delete metadata.runtimeRecoveryLeaseExpiresAtMs;
   Object.assign(metadata, parkMetadataPatch(reason, stopReason, now));
 
+  let parked: typeof sessionSandboxes.$inferSelect | null = null;
   try {
-    return await db.transaction(async (tx) => {
+    parked = await db.transaction(async (tx) => {
       const [liveSession] = await tx
         .update(projectSessions)
         .set({ status: 'stopped', error: null, updatedAt: now })
@@ -364,6 +348,13 @@ export async function parkEstablishedRuntime(
           and(
             eq(sessionSandboxes.sandboxId, row.sandboxId),
             eq(sessionSandboxes.externalId, externalId),
+            eq(sessionSandboxes.status, 'active'),
+            // A readiness request can outlive the wake it inspected. The wake
+            // rewrites this row before starting the provider. Without this
+            // CAS, the stale request can stop the newly running VM minutes
+            // later. No provider or billing side effect is allowed until the
+            // exact observed row wins this comparison.
+            eq(sessionSandboxes.updatedAt, row.updatedAt),
           ),
         )
         .returning();
@@ -379,6 +370,27 @@ export async function parkEstablishedRuntime(
     if (err instanceof RuntimeIdentityCasLostError) return null;
     throw err;
   }
+
+  if (!parked) return null;
+
+  await endComputeSession(row.sandboxId).catch((err) =>
+    console.warn(
+      `[runtime-identity] failed to close compute for ${row.sandboxId} while parking ${externalId}:`,
+      err,
+    ),
+  );
+  // The row CAS above must win before this call. A stale readiness request
+  // therefore cannot stop a VM that a newer wake already owns.
+  try {
+    await getProvider(row.provider as ProviderName).stop(externalId);
+  } catch (err) {
+    console.warn(
+      `[runtime-identity] provider stop failed while parking ${externalId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  return parked;
 }
 
 /**

--- a/apps/api/src/projects/runtime-relay-repair.test.ts
+++ b/apps/api/src/projects/runtime-relay-repair.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { config } from '../config';
+import {
+  currentSessionSandboxUrl,
+  runtimeRelayRepairDue,
+  runtimeRelayRepairNeeded,
+} from './routes/shared';
+
+describe('active sandbox kortixd relay repair', () => {
+  const now = Date.parse('2026-08-23T06:00:00.000Z');
+
+  test('repairs immediately when the API relay URL rotated', () => {
+    expect(runtimeRelayRepairDue({
+      runtimeRelayRepairUrl: 'https://old.example',
+      runtimeRelayRepairStartedAt: new Date(now - 1_000).toISOString(),
+    }, 'https://new.example', now)).toBe(true);
+  });
+
+  test('coalesces browser polling during one repair attempt', () => {
+    expect(runtimeRelayRepairDue({
+      runtimeRelayRepairUrl: 'https://api.example',
+      runtimeRelayRepairStartedAt: new Date(now - 29_999).toISOString(),
+    }, 'https://api.example', now)).toBe(false);
+  });
+
+  test('retries a failed repair after the bounded cooldown', () => {
+    expect(runtimeRelayRepairDue({
+      runtimeRelayRepairUrl: 'https://api.example',
+      runtimeRelayRepairStartedAt: new Date(now - 30_000).toISOString(),
+    }, 'https://api.example', now)).toBe(true);
+  });
+
+  test('does not restart kortixd after its relay channel reconnects', () => {
+    expect(runtimeRelayRepairNeeded({
+      runtimeRelayRepairUrl: 'https://api.example',
+      runtimeRelayRepairStartedAt: new Date(now - 30_000).toISOString(),
+    }, 'https://api.example', true, now)).toBe(false);
+  });
+
+  test('rewrites a resumed session URL onto the current API relay', () => {
+    const original = config.KORTIX_URL;
+    config.KORTIX_URL = 'https://new-tunnel.example/v1';
+    try {
+      expect(currentSessionSandboxUrl('sbx_123')).toBe(
+        'https://new-tunnel.example/v1/p/sbx_123/8000',
+      );
+    } finally {
+      config.KORTIX_URL = original;
+    }
+  });
+});

--- a/apps/api/src/projects/sandbox-deadline.test.ts
+++ b/apps/api/src/projects/sandbox-deadline.test.ts
@@ -48,6 +48,7 @@ mock.module('../shared/db', () => ({
 const {
   NON_TURN_DEADLINE_CAP_MS,
   extendSandboxDeadline,
+  extendConnectedSessionDeadline,
   extendUnconfirmedTurnDeadline,
   grantWarmPoolLifetime,
   idleGraceMs,
@@ -154,6 +155,16 @@ describe('extendSandboxDeadline — control-plane-observed, monotone, capped', (
     expect(executed[0]).toContain('sandbox_id');
     expect(executed[1]).toContain('session_id');
     expect(executed[2]).toContain('external_id');
+  });
+});
+
+describe('extendConnectedSessionDeadline — authenticated UI presence', () => {
+  test('extends from now without the provider-run cap', async () => {
+    await extendConnectedSessionDeadline({ sessionId: 'sess-1' }, 15 * 60_000);
+    const query = squish(executed.at(-1) ?? '');
+    expect(query).toContain('GREATEST');
+    expect(query).toContain('now() + make_interval');
+    expect(query).not.toContain('active_since');
   });
 });
 

--- a/apps/api/src/projects/sandbox-deadline.ts
+++ b/apps/api/src/projects/sandbox-deadline.ts
@@ -139,6 +139,25 @@ export async function extendSandboxDeadline(
 }
 
 /**
+ * Keep an authenticated, human-observed session alive while its UI traffic is
+ * still reaching the control plane. Each observation grants one idle window.
+ * This is uncapped because a human can keep one session open for longer than a
+ * provider run's original 24-hour anchor.
+ */
+export async function extendConnectedSessionDeadline(
+  target: DeadlineTarget,
+  grantMs: number = idleGraceMs(),
+): Promise<void> {
+  await db.execute(sql`
+    UPDATE kortix.session_sandboxes s
+       SET deadline_at = GREATEST(
+             s.deadline_at,
+             now() + make_interval(secs => ${secs(grantMs)})),
+           updated_at = now()
+     WHERE ${targetPredicate(target)} AND s.status IN ('active', 'provisioning')`);
+}
+
+/**
  * The BOUNDED DRIP for a provider-running box whose daemon says nothing about a
  * turn the control plane can prove it minted.
  *

--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -3,6 +3,7 @@ import { config, type SandboxProviderName } from '../../config';
 import { logger } from '../../lib/logger';
 import { getProvider } from '../../platform/providers';
 import { db } from '../../shared/db';
+import { waitForComputeNodeConnection } from '../../compute-nodes';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { isMetaAgentName } from '@kortix/shared';
 import { and, eq, sql } from 'drizzle-orm';
@@ -464,7 +465,12 @@ export async function restartSession(input: {
               sql`${sessionSandboxes.metadata}->>'runtimeRestartId' = ${restartId}`,
             ),
           );
+        const reconnectAfter = new Date();
         await provider.start(externalId);
+        await provider.ensureSessionRuntimeStarted?.(externalId);
+        if (provider.ensureSessionRuntimeStarted) {
+          await waitForComputeNodeConnection(sessionId, reconnectAfter);
+        }
         if (!(await ownsRestart())) return;
         // Provider ingress credentials can change on every stop/start cycle.
         // Remove any link resolved while the sandbox was stopped.

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -36,9 +36,15 @@ import {
   encodeKortixUserContext,
   KORTIX_USER_CONTEXT_HEADER,
 } from '../shared/kortix-user-context';
+import { extendConnectedSessionDeadline } from '../projects/sandbox-deadline';
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
-const SANDBOX_TOUCH_INTERVAL_MS = 60 * 1000;
+// Outbound compute-node relays do not touch the provider's ingress, so provider
+// idle timers cannot observe an active browser by themselves. Keep this below
+// the shortest supported provider idle timer (one minute on legacy Platinum
+// sandboxes). A 30-second throttle turns the UI health poll into a durable
+// provider activity signal without issuing one provider request per proxy call.
+const SANDBOX_TOUCH_INTERVAL_MS = 30 * 1000;
 
 /** Everything the proxy needs to know about a sandbox, from one row fetch. */
 export interface SandboxRecord {
@@ -350,6 +356,8 @@ export async function markSandboxUsed(sandboxId: string): Promise<void> {
       .select({
         sandboxId: sessionSandboxes.sandboxId,
         sessionId: sessionSandboxes.sessionId,
+        provider: sessionSandboxes.provider,
+        externalId: sessionSandboxes.externalId,
         status: sessionSandboxes.status,
         metadata: sessionSandboxes.metadata,
       })
@@ -363,6 +371,34 @@ export async function markSandboxUsed(sandboxId: string): Promise<void> {
       .update(sessionSandboxes)
       .set({ lastUsedAt: now, updatedAt: now })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+    try {
+      await extendConnectedSessionDeadline({ sandboxId: row.sandboxId });
+    } catch (err) {
+      // Presence renewal is additive. A temporary deadline-write failure must
+      // not skip the existing last-used and project-session bookkeeping.
+      console.warn(
+        `[PREVIEW] Failed to extend connected-session deadline for ${row.externalId}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+
+    // The compute-node channel is outbound. Relay traffic therefore bypasses
+    // Daytona/Platinum ingress and does not reset the provider's native idle
+    // timer. Renew it explicitly while authenticated traffic proves that a
+    // human still has the session open. This also works when the local API is
+    // not the scheduler leader, which is the normal isolated-worktree setup.
+    try {
+      if (row.externalId) {
+        await getProvider(row.provider as ProviderName).renewLifecycle(row.externalId);
+      }
+    } catch (err) {
+      // A stopped provider is handled by wakeSandbox on the request failure.
+      // Activity bookkeeping must still complete so the wake keeps its lease.
+      console.warn(
+        `[PREVIEW] Failed to renew provider lifecycle for ${row.externalId}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
 
     // Passive proxy traffic (an open tab polling opencode, a background stream
     // reconnect) must NOT heal a deliberately-stopped box back to active —

--- a/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/pty.test.ts
@@ -4,6 +4,7 @@ import { KORTIX_USER_CONTEXT_HEADER } from '../kortix-user-context'
 import type { Config } from '../config'
 import type { Opencode } from '../opencode'
 import { startProxy } from '../proxy'
+import { createPtyRegistry } from '../routes/pty'
 
 const TEST_TOKEN = 'test-kortix-token-32-chars-1234567890'
 
@@ -131,6 +132,20 @@ function waitForData(ws: WebSocket, predicate: (acc: string) => boolean, timeout
 }
 
 describe('kortix-native pty', () => {
+  it('blocks daemon replacement only while a viewer is attached', () => {
+    const registry = createPtyRegistry(baseConfig())
+    const created = registry.create({ command: 'bash', args: ['-c', 'sleep 30'] })
+
+    expect(registry.hasAttachedViewers()).toBe(false)
+    const handle = registry.attach(created.id, { onData: () => {}, onExit: () => {} })
+    expect(handle).not.toBeNull()
+    expect(registry.hasAttachedViewers()).toBe(true)
+
+    handle?.detach()
+    expect(registry.hasAttachedViewers()).toBe(false)
+    registry.remove(created.id)
+  })
+
   it('rejects HTTP routes without a signed user context', async () => {
     const proxy = startTestProxy()
     try {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -95,6 +95,28 @@ export function resetClaimedInitialTurnForTests(): void {
   claimedInitialTurn = null
 }
 
+/**
+ * A session sandbox exposes user-started loopback services through the signed
+ * compute-node channel. The API already authorizes the user, sandbox, and port
+ * before it emits a frame. Keep credential-bearing helper ports unreachable so
+ * an arbitrary preview URL cannot bypass their API-side policy.
+ */
+export function sandboxRelayPortPolicy(cfg: {
+  servicePort: number
+  opencodeStandbyPort: number
+}, env: NodeJS.ProcessEnv = process.env): { has(port: number): boolean } {
+  const blocked = new Set([
+    Number(env.KORTIX_EGRESS_SHIM_PORT) || 3128,
+    Number(env.KORTIX_LLM_PROXY_PORT) || 4319,
+    Number(env.KORTIX_CONNECTORS_PROXY_PORT) || 4320,
+    cfg.opencodeStandbyPort,
+  ])
+  return {
+    has: (port) => Number.isSafeInteger(port) && port > 0 && port <= 65_535
+      && (port === cfg.servicePort || !blocked.has(port)),
+  }
+}
+
 /** Run the node daemon in the current process. */
 export async function runKortixDaemon(): Promise<void> {
   const bootTime = Date.now()
@@ -111,7 +133,9 @@ export async function runKortixDaemon(): Promise<void> {
       token: cfg.nodeToken,
       // A signed API frame is the authorization decision. The transport still
       // hardcodes 127.0.0.1, so it cannot become an SSRF path to another host.
-      ports: { has: (port: number) => assignmentManager.hasPort(port) || (Boolean(assignedSessionId) && port === cfg.servicePort) },
+      ports: assignedSessionId
+        ? sandboxRelayPortPolicy(cfg)
+        : { has: (port: number) => assignmentManager.hasPort(port) },
       capabilities: assignedSessionId
         ? createSandboxCapabilityRegistry()
         : createNodeCapabilityRegistry({ assignmentRoots: () => assignmentManager.writableRoots, assignmentPolicy: () => assignmentManager.capabilityPolicy, policy: () => loadNodeLocalPolicy() }),

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
@@ -9,6 +9,7 @@ class FakeSocket extends EventTarget {
   send(value: string) { this.sent.push(value) }
   close() {}
   receive(value: unknown) { this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(value) })) }
+  disconnect(code: number) { this.dispatchEvent(new CloseEvent('close', { code })) }
 }
 
 function signed(value: Record<string, unknown>, key: string, nonce: number) {
@@ -87,5 +88,33 @@ describe('kortixd outbound node channel', () => {
     await Bun.sleep(0)
     expect(channel.status()).toEqual({ connected: true, lastError: null })
     expect(JSON.parse(socket.sent[1]!).type).toBe('node.heartbeat')
+  })
+
+  test('reconnects after an API restart and ignores events from the replaced socket', async () => {
+    const sockets = [new FakeSocket(), new FakeSocket()]
+    let created = 0
+    const channel = new KortixNodeChannel({
+      apiUrl: 'https://api.test/v1',
+      nodeId: 'node-1',
+      token: 'secret',
+      ports: new Set([8000]),
+      reconnectDelayMs: () => 0,
+      socketFactory: () => sockets[created++]! as unknown as WebSocket,
+    })
+
+    channel.connect()
+    sockets[0]!.dispatchEvent(new Event('open'))
+    sockets[0]!.receive({ type: 'node.auth.ok', signing_key: 'old-key' })
+    await Bun.sleep(0)
+    sockets[0]!.disconnect(4004)
+    await Bun.sleep(5)
+    expect(created).toBe(2)
+
+    sockets[1]!.dispatchEvent(new Event('open'))
+    sockets[1]!.receive({ type: 'node.auth.ok', signing_key: 'new-key' })
+    await Bun.sleep(0)
+    sockets[0]!.disconnect(1012)
+    expect(channel.status()).toEqual({ connected: true, lastError: null })
+    channel.disconnect()
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
@@ -16,6 +16,7 @@ interface ChannelOptions {
   assignments?: NodeAssignmentManager
   onAuthenticated?: () => void | Promise<void>
   socketFactory?: (url: string) => WebSocketLike
+  reconnectDelayMs?: () => number
 }
 
 interface WebSocketLike {
@@ -72,12 +73,14 @@ export class KortixNodeChannel {
   }
 
   connect(): void {
-    this.socket = (this.options.socketFactory ?? defaultSocketFactory)(wsUrl(this.options.apiUrl))
-    this.socket.addEventListener('open', () => {
+    const socket = (this.options.socketFactory ?? defaultSocketFactory)(wsUrl(this.options.apiUrl))
+    this.socket = socket
+    socket.addEventListener('open', () => {
+      if (this.socket !== socket) return
       this.key = null
       this.sendNonce = 0
       this.receiveNonce = 0
-      this.socket?.send(JSON.stringify({
+      socket.send(JSON.stringify({
         type: 'node.auth',
         node_id: this.options.nodeId,
         token: this.options.token,
@@ -87,15 +90,30 @@ export class KortixNodeChannel {
         arch: process.arch,
       }))
     })
-    this.socket.addEventListener('message', (event) => { void this.receive(event.data) })
-    this.socket.addEventListener('close', (event) => {
+    socket.addEventListener('message', (event) => {
+      if (this.socket === socket) void this.receive(event.data)
+    })
+    socket.addEventListener('close', (event) => {
+      if (this.socket !== socket) return
       this.key = null
+      this.socket = null
+      if (this.heartbeatTimer) {
+        clearInterval(this.heartbeatTimer)
+        this.heartbeatTimer = null
+      }
       this.streams.disconnect()
       this.sockets.disconnect()
       this.rpc.disconnect()
-      if (!this.shuttingDown && ![4001, 4003, 4004].includes((event as CloseEvent).code)) this.scheduleReconnect()
+      const code = (event as CloseEvent).code
+      this.lastError = `Node channel closed (${code})`
+      // 4001 rejects invalid credentials. 4003 explicitly disables the node.
+      // 4004 only means another connection won a replacement race. Reconnect
+      // because the winning socket can belong to an API process that is exiting.
+      if (!this.shuttingDown && ![4001, 4003].includes(code)) this.scheduleReconnect()
     })
-    this.socket.addEventListener('error', () => { this.lastError = 'WebSocket connection error' })
+    socket.addEventListener('error', () => {
+      if (this.socket === socket) this.lastError = 'WebSocket connection error'
+    })
   }
 
   disconnect(): void {
@@ -153,8 +171,10 @@ export class KortixNodeChannel {
   }
 
   private scheduleReconnect(): void {
-    const base = Math.min(1_000 * 2 ** this.reconnectAttempts++, 30_000)
-    const delay = Math.floor(base * (0.75 + Math.random() * 0.5))
+    const delay = this.options.reconnectDelayMs?.() ?? (() => {
+      const base = Math.min(1_000 * 2 ** this.reconnectAttempts++, 30_000)
+      return Math.floor(base * (0.75 + Math.random() * 0.5))
+    })()
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       this.connect()

--- a/apps/kortix-sandbox-agent-server/src/node/channel/sandbox-port-policy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/sandbox-port-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test'
+import { sandboxRelayPortPolicy } from '../../main'
+
+describe('sandbox compute-node relay port policy', () => {
+  const policy = sandboxRelayPortPolicy(
+    { servicePort: 8000, opencodeStandbyPort: 4097 },
+    {
+      KORTIX_EGRESS_SHIM_PORT: '14318',
+      KORTIX_LLM_PROXY_PORT: '14319',
+      KORTIX_CONNECTORS_PROXY_PORT: '14320',
+    },
+  )
+
+  test('allows the daemon and arbitrary user-started preview ports', () => {
+    expect(policy.has(8000)).toBe(true)
+    expect(policy.has(3000)).toBe(true)
+    expect(policy.has(5173)).toBe(true)
+  })
+
+  test('blocks credential-bearing helpers and the inactive OpenCode port', () => {
+    expect(policy.has(14318)).toBe(false)
+    expect(policy.has(14319)).toBe(false)
+    expect(policy.has(14320)).toBe(false)
+    expect(policy.has(4097)).toBe(false)
+  })
+
+  test('rejects invalid TCP ports', () => {
+    expect(policy.has(0)).toBe(false)
+    expect(policy.has(65_536)).toBe(false)
+    expect(policy.has(3000.5)).toBe(false)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -435,14 +435,10 @@ export function startProxy(
   // Constructed once, outside reload() — pty state must survive a config
   // hot-swap (warm-snapshot restore) exactly like `opencode`/`bootState` do.
   const ptyRegistry = createPtyRegistry(cfg)
-  // A staged daemon update must not exit this process while somebody has a
-  // terminal open — the PTY dies with the daemon that spawned it. The registry
-  // is the only thing that knows, so it answers the question rather than the
-  // updater guessing at it. A busy box just keeps the staging: the supervisor
-  // installs it at the next start.
-  registerAgentSwapBlocker('pty', () =>
-    ptyRegistry.list().some((entry) => entry.status === 'running'),
-  )
+  // Do not replace the daemon while a live viewer is attached. Detached shells
+  // must not block updates forever. The daemon can retain them until the next
+  // safe update, then the client recreates a missing PTY through attachOrCreate.
+  registerAgentSwapBlocker('pty', () => ptyRegistry.hasAttachedViewers())
   let app = buildOpencodeApp(cfg, opencode, bootTime, bootState, projectEnv, staticWebPort, ptyRegistry)
 
   const server = Bun.serve<OpencodeWsData>({

--- a/apps/kortix-sandbox-agent-server/src/routes/pty.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/pty.ts
@@ -50,6 +50,8 @@ export interface PtyAttachHandle {
 
 export interface PtyRegistry {
   list(): KortixPtyMeta[]
+  /** True only while at least one live WebSocket viewer is attached. */
+  hasAttachedViewers(): boolean
   create(opts: { command?: string; args?: string[]; cwd?: string; title?: string; env?: Record<string, string> }): KortixPtyMeta
   update(id: string, opts: { title?: string; size?: { rows: number; cols: number } }): KortixPtyMeta | null
   remove(id: string): boolean
@@ -183,6 +185,10 @@ export function createPtyRegistry(cfg: Config): PtyRegistry {
   return {
     list() {
       return [...entries.values()].map((e) => ({ ...e.meta }))
+    },
+
+    hasAttachedViewers() {
+      return [...entries.values()].some((entry) => entry.viewers.size > 0)
     },
 
     create(opts) {

--- a/apps/web/src/features/session/detect-command.test.ts
+++ b/apps/web/src/features/session/detect-command.test.ts
@@ -31,6 +31,7 @@ describe('detectCommandFromText', () => {
       detectCommandFromText('', [cmd('build', 'build the project now please $ARGUMENTS')]),
     ).toBeUndefined();
     expect(detectCommandFromText('text')).toBeUndefined();
+    expect(detectCommandFromText('text', { error: 'opencode not ready' } as never)).toBeUndefined();
   });
 
   // Regression for Better Stack error "TypeError: e.template.trim is not a

--- a/apps/web/src/features/session/detect-command.ts
+++ b/apps/web/src/features/session/detect-command.ts
@@ -12,7 +12,7 @@ export function detectCommandFromText(
   rawText: string,
   commands?: Command[],
 ): { name: string; args?: string } | undefined {
-  if (!commands || !rawText) return undefined;
+  if (!Array.isArray(commands) || !rawText) return undefined;
 
   const trimmedRawText = rawText.trim();
   const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2063,7 +2063,14 @@ export function SessionChat({
     { refetchInterval: 5_000 },
   );
   const hasPendingApproval = (approvalAudit?.actions ?? []).some(isPendingAction);
-  const { data: commands } = useRuntimeCommands();
+  const { data: runtimeCommands } = useRuntimeCommands();
+  // A runtime restart can briefly answer `/command` with a typed 503 body.
+  // The query transport can expose that body as `data`; keep one normalized
+  // array boundary so a transient readiness response cannot crash every turn.
+  const commands = useMemo(
+    () => (Array.isArray(runtimeCommands) ? runtimeCommands : []),
+    [runtimeCommands],
+  );
   const { data: providers, isLoading: providersLoading } = useRuntimeProviders();
   const { data: allSessions } = useRuntimeSessions();
   const { data: config } = useRuntimeConfig();

--- a/docs/specs/2026-08-21-kortixd.md
+++ b/docs/specs/2026-08-21-kortixd.md
@@ -1,6 +1,7 @@
 # kortixd — the Kortix compute node
 
-Status: **PROPOSED**. Author: Marko + Claude. Date: 2026-08-21.
+Status: **ACTIVE — sandbox rollout implemented; general-node phases remain planned**.
+Author: Marko + Claude. Date: 2026-08-21. Updated: 2026-08-23.
 Supersedes the runtime half of `2026-08-20-convergent-runtime.md` (which stays
 correct; this generalizes it). Reopens, under a different structure, the
 architecture reverted on 2026-07-30 (`ffc5fb769e`).
@@ -979,3 +980,43 @@ Per `CLAUDE.md`: real inputs, real outputs, on every surface.
 5. **Stale marketing copy.** Four files under
    `apps/web/src/features/marketing/*` describe `KORTIX_ACP_RUNTIME`, a flag
    deleted on 2026-07-30. Wrong today. Fix in P0 regardless of this spec.
+
+---
+
+## 16. Sandbox rollout acceptance contract
+
+The first rollout applies to session sandboxes only. It is complete only when
+every item below passes through the real API and web UI.
+
+1. The image and release contain one executable named `kortixd`. The release
+   does not contain a `kortix-agent` hard link.
+2. The sandbox entrypoint supervises `kortixd`. `kortixd` converges itself,
+   `kortix`, OpenCode, managed skills, and future manifest components.
+3. An update uses staged verification, crash-budget rollback, and an immutable
+   known-good floor. A failed update never removes the last runnable version.
+4. `kortixd` owns the outbound, authenticated, bidirectional relay to the
+   Kortix API. Files, PTY, OpenCode REST, SSE, health, and preview ports use
+   this relay. No provider ingress is required for these sandbox capabilities.
+5. Assigned sandbox nodes relay user TCP ports. They reject credential-helper
+   ports. Standalone nodes keep assignment-scoped port policy.
+6. A stopped sandbox resumes with the same `external_id`, restarts one
+   supervisor, kills every stale predecessor, installs the current relay URL,
+   waits for a live channel, and rewrites the session's stored sandbox URL.
+7. An active sandbox repairs a rotated relay URL once. It does not restart
+   again after the relay reconnects while OpenCode is still starting.
+8. A connected human or active agent extends the Kortix deadline and the
+   provider-native lifecycle. Relay traffic is sufficient evidence.
+9. Provider inventory ownership includes the local API instance. A deployed
+   orphan reaper cannot stop a worktree sandbox. Legacy unstamped provider
+   objects fail closed and are never orphan-reaped.
+10. Temporary non-array OpenCode command responses render as an empty command
+    list. They cannot crash React with `TypeError: value is not iterable`.
+11. API loss queues prompts. Reconnection drains them in order. Files and PTY
+    reconnect after the same wake without creating a replacement sandbox.
+12. Verification covers a fresh sandbox and an existing stopped sandbox. Each
+    must pass chat, files, terminal, browser preview, API pause/reconnect, and
+    exact runtime-artifact health assertions.
+
+General node enrollment, workstation installation, multi-node sessions,
+desktop/CUA migration, and Agent Tunnel retirement remain P1–P4 work. The
+sandbox rollout must not claim those later phases are implemented.

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -10,8 +10,8 @@ the repo.
 > 0. **Read `packages/sdk/PROGRESS.md` first, and update it before you finish.**
 >    Multiple sessions run against this repo. It tracks what is done, what is in
 >    flight, and what is next. Claim a task before you work on it.
-> 1. **Write the failing test first.** Invoke the `tdd` skill (`/tdd`) before any
->    implementation code. RED → GREEN → REFACTOR, no exceptions. *A test you have
+> 1. **Write the failing test first.** Run the test before any implementation
+>    code. RED → GREEN → REFACTOR, no exceptions. *A test you have
 >    never seen fail is not a test.*
 > 2. **Never hand back a red suite.** Loop — run, read, fix, re-run — until every
 >    test passes. **Loop on the code, never on the test.** Deleting, skipping,
@@ -566,10 +566,9 @@ in the log rather than overwriting silently.
 
 ## Test-driven, always. No exceptions in this package.
 
-**Before writing any implementation code, invoke the `tdd` skill** (`/tdd`, or
-`superpowers:test-driven-development`). For broader repo conventions — which test
-type a change needs, factories, determinism, CI gates — the project skill is
-`.claude/skills/testing/SKILL.md`.
+**Before writing any implementation code, write and run the failing test.** For
+broader repo conventions — which test type a change needs, factories,
+determinism, CI gates — read `.claude/skills/testing/SKILL.md`.
 
 This is not a preference. This package is **published to npm**. A regression here
 does not show up in a PR review; it shows up in a stranger's build, on their

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -11894,3 +11894,11 @@ passes 2418 tests across 162 files. The packed install smoke test passes.
 **Status:** COMPLETE.
 
 **Shippable to production: YES.**
+### 2026-08-23 — session `session-parts-guard` claim
+
+**Status:** IN PROGRESS.
+
+**Scope:** Normalize malformed runtime message `parts` at the SDK hydration
+boundary. Add a regression test that reproduces the deployed web crash. Remove
+references to the unavailable `tdd` skill while retaining mandatory RED → GREEN
+testing. Local verification precedes any merge or deployment.

--- a/packages/sdk/src/core/turns/grouping.ts
+++ b/packages/sdk/src/core/turns/grouping.ts
@@ -118,7 +118,13 @@ export function compareMessagesForDisplay(
 export function groupMessagesIntoTurns<M extends MessageWithPartsLike>(
   input: readonly M[],
 ): TurnLike<M>[] {
-  const messages = [...input].sort(compareMessagesForDisplay);
+  const messages = input
+    .map((message) =>
+      Array.isArray(message.parts)
+        ? message
+        : ({ ...message, parts: [] } as unknown as M),
+    )
+    .sort(compareMessagesForDisplay);
   const turns: TurnLike<M>[] = [];
   const turnsByUserMsgId = new Map<string, TurnLike<M>>();
 

--- a/packages/sdk/src/core/turns/turns.test.ts
+++ b/packages/sdk/src/core/turns/turns.test.ts
@@ -124,6 +124,17 @@ describe('groupMessagesIntoTurns — display order is by time.created, id is the
 });
 
 describe('groupMessagesIntoTurns', () => {
+  test('normalizes a malformed wire parts field before exposing a turn', () => {
+    const malformed = {
+      info: { id: 'u-malformed', role: 'user' },
+      parts: undefined,
+    } as unknown as MessageWithPartsLike;
+
+    const [turn] = groupMessagesIntoTurns([malformed]);
+
+    expect(turn.userMessage.parts).toEqual([]);
+  });
+
   test('groups assistant messages under their parent user message', () => {
     const turns = groupMessagesIntoTurns([
       userMsg('u1'),


### PR DESCRIPTION
## Problem

The kortixd sandbox rollout regressed terminal, files, preview ports, old-session wake, and transient session rendering. Tunnel rotation could leave a running sandbox on a dead callback URL. Repair attempts could restart a live node repeatedly. Provider orphan reconciliation could stop local worktree sandboxes.

## Changes

- Make kortixd reconnect generation-safe and treat replacement close code 4004 as retriable.
- Relay assigned sandbox preview ports while denying credential-helper ports.
- Preserve attached PTYs during runtime asset convergence.
- Move stopped sandboxes through fenced provisioning and wait for the live node channel before reporting active.
- Repair rotated relay URLs once and stop repair after relay liveness returns.
- Rewrite durable session sandbox URLs onto the current API origin.
- Stop every stale Platinum daemon and supervisor before starting one replacement.
- Renew Kortix deadlines and provider-native lifecycle from authenticated relay traffic.
- Scope provider inventory markers by API instance across Platinum, Daytona, and E2B.
- Guard the frontend command list against transient non-array runtime responses.
- Record the sandbox acceptance contract and incident learnings.

## Local verification

- `pnpm test -- --full`: PASS in 231.1s.
  - REST/CLI flows: 379/379.
  - SDK: 2419/2419.
  - Browser: 15/15.
  - Flow runner, route coverage, worktree, and package-quality lanes passed.
- Focused relay/provider suite: 59 pass, 0 fail.
- `apps/api: pnpm typecheck`: exit 0.
- Changed frontend ESLint: 0 errors, 30 existing warnings in `session-chat.tsx`.
- Real fresh sandbox UI:
  - chat: `KORTIXD_FINAL_CHAT_OK`
  - terminal: `KORTIXD_FINAL_TERMINAL_OK`
  - files: `KORTIXD_FILE_CRUD_OK`
  - browser port 3000: `KORTIXD_BROWSER_OK`
  - API pause/reconnect: `KORTIXD_AFTER_API_PAUSE_OK`
- Real legacy stopped sandbox UI:
  - in-place wake retained the same external id
  - chat drained queued prompts and returned `KORTIXD_LEGACY_AFTER_WAKE_OK`
  - terminal returned `KORTIXD_FINAL_LEGACY_TERMINAL_OK`
  - files loaded `kortix.yaml` and `README.md`
- Final binary:
  - `dist/kortixd`: Linux x86-64 ELF, 95,778,944 bytes
  - SHA-256: `f50d5b08470f9c73c0c97a1a97b5e56bb02ee89b2d196da34bd0ff4731b9dbee`
  - `dist/kortix-agent`: absent

## Scope

This PR completes the sandbox phase. Workstation enrollment, multi-node sessions, CUA migration, and Agent Tunnel retirement remain later phases in the contract.
