### PR TITLE
fix(relay): cross Cloudflare for PTY sockets

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2039,3 +2039,23 @@ pass through the same network boundary used by dev.
 
 *Incident:* PR #6686, merge `b03f92bdcd`, and PR #6773, merge `32abd10082`.
 The local rollback restored file reads and PTY command output before deployment.
+
+## Every WebSocket hop through Cloudflare needs an explicit User-Agent
+
+2026-08-23. The browser-to-API PTY upgrade returned HTTP `101`, but the API's
+second WebSocket hop to `/v1/internal/node-relay/socket/*` failed before the
+relay handler. Bun's WebSocket client omitted `User-Agent`. Cloudflare rejected
+that internal handshake, so clients received `relay socket failed` after a
+successful outer upgrade.
+
+**The rule.** Treat each WebSocket hop as a separate edge contract. Every Bun
+WebSocket client that crosses Cloudflare must send an explicit `User-Agent`.
+A successful outer upgrade does not prove that a chained internal upgrade works.
+
+**The enforcement.** The relay socket unit test asserts
+`User-Agent: kortix-api/node-relay`. Dev acceptance must send a command through
+the PTY WebSocket and observe its output. HTTP `101` alone is insufficient.
+
+*Incident:* PR #6776 dev verification, session
+`92f4c37c-ad04-496e-8c52-3068a629214b`, PTY
+`kpty_f59eca26882440fdaeb6fccc24e5990d`.

--- a/apps/api/src/compute-nodes/relay-socket.test.ts
+++ b/apps/api/src/compute-nodes/relay-socket.test.ts
@@ -22,6 +22,7 @@ describe('compute-node relay WebSocket transport', () => {
       relayUrl: 'https://api.test/v1', key, nodeId: 'node/a', port: 8000, path: '/pty/1?q=2', headers: { authorization: 'Bearer scoped' }, handlers: { open() {}, message() {}, close() {} },
       socketFactory: (url, headers) => {
         expect(url).toBe(target.toString())
+        expect(headers.get('user-agent')).toBe('kortix-api/node-relay')
         expect(verifyRelayAuthorization({ key, method: 'GET', target: target.pathname + target.search, headers, guard: new RelayReplayGuard() })).toEqual({ ok: true })
         const request = new Request(url, { headers })
         const prepared = prepareRelaySocketUpgrade({ request, key, guard: new RelayReplayGuard() })

--- a/apps/api/src/compute-nodes/relay-socket.ts
+++ b/apps/api/src/compute-nodes/relay-socket.ts
@@ -72,6 +72,10 @@ interface ClientWebSocket {
 export function connectComputeNodeSocketThroughRelay(input: { relayUrl: string; key: string; nodeId: string; port: number; path: string; headers: Record<string, string>; handlers: ComputeNodeSocketHandlers; socketFactory?: (url: string, headers: Headers) => ClientWebSocket }): ComputeNodeSocket {
   const target = computeNodeRelaySocketTarget(input.relayUrl, input.nodeId, input.port, input.path)
   const headers = createRelayAuthorization({ key: input.key, method: 'GET', target: target.pathname + target.search })
+  // Bun's WebSocket client sends no User-Agent by default. Cloudflare rejects
+  // that handshake before it reaches the relay server, while localhost accepts
+  // it. Keep this edge-compatible just like the node channel client.
+  headers.set('user-agent', 'kortix-api/node-relay')
   headers.set(UPSTREAM_HEADERS, encodeHeaders(input.headers))
   const socket = (input.socketFactory ?? ((url, requestHeaders) => new WebSocket(url, { headers: Object.fromEntries(requestHeaders) } as any) as unknown as ClientWebSocket))(target.toString(), headers)
   socket.binaryType = 'arraybuffer'


### PR DESCRIPTION
## Problem

The outer PTY WebSocket upgrades on dev, but the API relay's internal WebSocket omits `User-Agent`. Cloudflare rejects that second hop before the relay handler.

## Change

- send `User-Agent: kortix-api/node-relay` on the API relay WebSocket
- assert the edge header in the relay socket test
- record the production-shaped incident rule

## Verification

- `bun test apps/api/src/compute-nodes/relay-socket.test.ts apps/api/src/compute-nodes/relay-e2e.test.ts` — 5 pass, 0 fail
- `pnpm --filter kortix-api typecheck` — exit 0
- dev failure evidence before fix: outer upgrade HTTP 101 followed by close reason `relay socket failed`

No staging or production deployment.