### PR TITLE
fix(kortixd): disable node-channel compression

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2059,3 +2059,21 @@ the PTY WebSocket and observe its output. HTTP `101` alone is insufficient.
 *Incident:* PR #6776 dev verification, session
 `92f4c37c-ad04-496e-8c52-3068a629214b`, PTY
 `kpty_f59eca26882440fdaeb6fccc24e5990d`.
+
+## Disable compression on Bun WebSocket clients
+
+2026-08-23. The `kortixd` node channel authenticated through Cloudflare, then
+Bun 1.3.14 emitted repeated `Decompression error: ZlibError` messages. The API
+lost the node channel. Session REST routes returned `503` although the daemon
+and OpenCode remained healthy inside the sandbox.
+
+**The rule.** Disable `permessage-deflate` on every `ws` client that runs under
+Bun. Small control frames do not justify a runtime-specific compression failure
+that disconnects the only control-plane channel.
+
+**The enforcement.** The node-channel unit test asserts
+`perMessageDeflate: false`. Dev acceptance must restart a sandbox, wait for the
+updated daemon, then verify chat, Files, and Terminal through the relay.
+
+*Incident:* PR #6776 dev verification, session
+`2e1fcec9-2485-481f-afca-8d1ab035761a`.

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto'
 import { describe, expect, test } from 'bun:test'
-import { KortixNodeChannel } from './client'
+import { KortixNodeChannel, NODE_CHANNEL_WEBSOCKET_OPTIONS } from './client'
 
 class FakeSocket extends EventTarget {
   static readonly OPEN = 1
@@ -17,6 +17,13 @@ function signed(value: Record<string, unknown>, key: string, nonce: number) {
 }
 
 describe('kortixd outbound node channel', () => {
+  test('disables per-message compression for Bun compatibility', () => {
+    expect(NODE_CHANNEL_WEBSOCKET_OPTIONS).toEqual({
+      headers: { 'User-Agent': 'kortixd' },
+      perMessageDeflate: false,
+    })
+  })
+
   test('sends a User-Agent required by deployed WebSocket edges', async () => {
     let server: ReturnType<typeof Bun.serve>
     server = Bun.serve<{ authenticated?: boolean }>({

--- a/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
+++ b/apps/kortix-sandbox-agent-server/src/node/channel/client.ts
@@ -26,11 +26,20 @@ interface WebSocketLike {
   close(code?: number, reason?: string): void
 }
 
+export const NODE_CHANNEL_WEBSOCKET_OPTIONS = {
+  headers: { 'User-Agent': 'kortixd' },
+  // Cloudflare negotiates permessage-deflate by default. Bun 1.3.14 can fail
+  // to inflate those frames with `ZlibError`, which silently drops the only
+  // control-plane channel. Node-channel frames are small, so compression adds
+  // risk without meaningful bandwidth savings.
+  perMessageDeflate: false,
+} as const
+
 function defaultSocketFactory(url: string): WebSocketLike {
   // Bun omits User-Agent from its native WebSocket handshake. Cloudflare
   // rejects that upgrade with `Expected 101 status code`. The `ws` constructor
   // accepts an explicit header even when Bun provides its compatible runtime.
-  return new StandardWebSocket(url, { headers: { 'User-Agent': 'kortixd' } }) as unknown as WebSocketLike
+  return new StandardWebSocket(url, NODE_CHANNEL_WEBSOCKET_OPTIONS) as unknown as WebSocketLike
 }
 
 function textFrame(raw: unknown): string | null {


### PR DESCRIPTION
## Incident

A restarted dev sandbox kept `kortixd` and OpenCode healthy, but relay requests returned 503. The daemon log repeated `Decompression error: ZlibError` after Cloudflare negotiated `permessage-deflate`.

## Change

- disable `permessage-deflate` on the outbound `kortixd` node channel
- preserve the explicit `User-Agent` edge contract
- add the incident rule to the append-only learnings register

## Verification

- `bun test apps/kortix-sandbox-agent-server/src/node/channel/client.test.ts` — 6 pass, 0 fail
- `pnpm typecheck` in `apps/kortix-sandbox-agent-server` — pass
- `pnpm test` in `apps/kortix-sandbox-agent-server` — 913 pass, 0 fail
- `pnpm test -- --packages-only` — pass in 134.5s
- `pnpm build` in `apps/kortix-sandbox-agent-server` — produced one 95,778,944-byte Linux x86-64 `dist/kortixd`; no `dist/kortix-agent`

Dev relay verification follows merge and deployment.