### PR TITLE
fix(api): wait through Platinum archive restore

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,14 @@ linked, not inlined.
 
 ## Register
 
+### Send protocol pings on every user-facing WebSocket hop (2026-08-23)
+
+**When:** proxying PTY or preview WebSockets through an edge. Send a protocol
+ping every 30 seconds on both the browser-facing socket and any internal relay
+socket. A daemon heartbeat does not keep sibling WebSockets alive. *Incident:*
+an attached terminal disconnected after about two idle minutes while the node
+channel and session remained online. *Enforcer:* `ws-heartbeat.test.ts`.
+
 ### Treat provider archive states as distinct lifecycle phases (2026-08-23)
 
 **When:** starting or restoring a Platinum compute node. Wait through

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,15 @@ linked, not inlined.
 
 ## Register
 
+### Treat provider archive states as distinct lifecycle phases (2026-08-23)
+
+**When:** starting or restoring a Platinum compute node. Wait through
+`archiving`. Retry `/start` only after `archived`. Accept `archived` and
+`archiving` after an accepted wake until the node reaches `running`.
+*Incident:* a July sandbox failed every legacy wake because the API treated
+`archiving` as a terminal start failure. *Enforcer:*
+`platinum-app-runtime.test.ts` covers accepted and conflicted restore flows.
+
 ### Scope provider inventory labels by API instance, not only environment (2026-08-23)
 
 **When:** creating provider objects or changing orphan reconciliation. Include

--- a/apps/api/src/compute-nodes/relay-socket.ts
+++ b/apps/api/src/compute-nodes/relay-socket.ts
@@ -1,5 +1,6 @@
 import type { ComputeNodeChannelHub, ComputeNodeSocket, ComputeNodeSocketHandlers } from './channel'
 import { createRelayAuthorization, RelayReplayGuard, verifyRelayAuthorization } from './relay-auth'
+import { startWebSocketHeartbeat } from './ws-heartbeat'
 
 const PREFIX = '/v1/internal/node-relay/socket/'
 const UPSTREAM_HEADERS = 'x-kortix-relay-upstream-headers'
@@ -99,13 +100,15 @@ export interface RelaySocketServerState {
   ready: boolean
   queue: Array<string | Buffer>
   upstream?: ComputeNodeSocket
+  stopHeartbeat?: () => void
 }
 
-interface RelayServerSocket { data: RelaySocketServerState; send(data: string | Buffer | Uint8Array): void; close(code?: number, reason?: string): void }
+interface RelayServerSocket { data: RelaySocketServerState; send(data: string | Buffer | Uint8Array): void; close(code?: number, reason?: string): void; ping(): void }
 
 export function relaySocketHandlers(hub: ComputeNodeChannelHub) {
   return {
     open(ws: RelayServerSocket) {
+      ws.data.stopHeartbeat = startWebSocketHeartbeat(ws)
       void hub.connectWebSocket(ws.data.nodeId, ws.data.port, ws.data.path, ws.data.headers, {
         open: () => {
           ws.data.ready = true
@@ -119,6 +122,9 @@ export function relaySocketHandlers(hub: ComputeNodeChannelHub) {
       if (ws.data.ready && ws.data.upstream) ws.data.upstream.send(message)
       else ws.data.queue.push(message)
     },
-    close(ws: RelayServerSocket, code = 1000, reason: string | Buffer = '') { try { ws.data.upstream?.close(code, typeof reason === 'string' ? reason : reason.toString('utf8')) } catch {} },
+    close(ws: RelayServerSocket, code = 1000, reason: string | Buffer = '') {
+      ws.data.stopHeartbeat?.()
+      try { ws.data.upstream?.close(code, typeof reason === 'string' ? reason : reason.toString('utf8')) } catch {}
+    },
   }
 }

--- a/apps/api/src/compute-nodes/ws-heartbeat.test.ts
+++ b/apps/api/src/compute-nodes/ws-heartbeat.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from 'bun:test';
+
+import { startWebSocketHeartbeat } from './ws-heartbeat';
+
+test('WebSocket heartbeat sends protocol pings and stops cleanly', () => {
+  let tick = () => {};
+  let cleared: unknown = null;
+  let pings = 0;
+  const stop = startWebSocketHeartbeat(
+    { ping: () => { pings += 1; } },
+    (callback) => {
+      tick = callback;
+      return 42 as unknown as ReturnType<typeof setInterval>;
+    },
+    (timer) => { cleared = timer; },
+  );
+
+  expect(pings).toBe(0);
+  tick();
+  expect(pings).toBe(1);
+  stop();
+  expect(cleared).toBe(42);
+});
+
+test('WebSocket heartbeat tolerates a socket closing during a tick', () => {
+  let tick = () => {};
+  const stop = startWebSocketHeartbeat(
+    { ping: () => { throw new Error('closed'); } },
+    (callback) => {
+      tick = callback;
+      return 7 as unknown as ReturnType<typeof setInterval>;
+    },
+    () => {},
+  );
+
+  expect(() => tick()).not.toThrow();
+  stop();
+});

--- a/apps/api/src/compute-nodes/ws-heartbeat.ts
+++ b/apps/api/src/compute-nodes/ws-heartbeat.ts
@@ -1,0 +1,19 @@
+export const WEBSOCKET_HEARTBEAT_INTERVAL_MS = 30_000;
+
+type IntervalFactory = (
+  callback: () => void,
+  intervalMs: number,
+) => ReturnType<typeof setInterval>;
+
+/** Keep an otherwise-idle WebSocket alive across edge proxies. */
+export function startWebSocketHeartbeat(
+  socket: { ping(): unknown },
+  setIntervalFn: IntervalFactory = setInterval,
+  clearIntervalFn: (timer: ReturnType<typeof setInterval>) => void = clearInterval,
+): () => void {
+  const timer = setIntervalFn(() => {
+    try { socket.ping(); } catch {}
+  }, WEBSOCKET_HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  return () => clearIntervalFn(timer);
+}

--- a/apps/api/src/platform/providers/platinum-app-runtime.test.ts
+++ b/apps/api/src/platform/providers/platinum-app-runtime.test.ts
@@ -153,6 +153,21 @@ test("start waits for an accepted wake to reach running before returning", async
   ]);
 });
 
+test("start waits through archived restore states after an accepted wake", async () => {
+  sandboxStateSequence = ["archived", "archiving", "starting", "running"];
+  const provider = new PlatinumProvider();
+
+  await expect(provider.start("sbx_app")).resolves.toBeUndefined();
+
+  expect(calls.map(({ path, method }) => ({ path, method }))).toEqual([
+    { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+  ]);
+});
+
 test("start waits for an accepted stop to settle before retrying the wake", async () => {
   startError = new Error(
     'platinum POST /v1/sandboxes/sbx_app/start -> 409 {"error":"conflict","state":"stopping","code":"conflict"}',
@@ -166,6 +181,24 @@ test("start waits for an accepted stop to settle before retrying the wake", asyn
     { path: "/v1/sandboxes/sbx_app", method: "GET" },
     { path: "/v1/sandboxes/sbx_app", method: "GET" },
     { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+  ]);
+});
+
+test("start waits for archiving to reach archived before retrying a conflicted wake", async () => {
+  startError = new Error(
+    'platinum POST /v1/sandboxes/sbx_app/start -> 409 {"error":"conflict","state":"archiving","code":"conflict"}',
+  );
+  sandboxStateSequence = ["archiving", "archived", "starting", "running"];
+  const provider = new PlatinumProvider();
+
+  await expect(provider.start("sbx_app")).resolves.toBeUndefined();
+  expect(calls.map(({ path, method }) => ({ path, method }))).toEqual([
+    { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
+    { path: "/v1/sandboxes/sbx_app/start", method: "POST" },
+    { path: "/v1/sandboxes/sbx_app", method: "GET" },
     { path: "/v1/sandboxes/sbx_app", method: "GET" },
   ]);
 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -536,7 +536,11 @@ export class PlatinumProvider implements SandboxProvider {
           const sandbox = await platinumJson<PlatinumSandbox>(`/v1/sandboxes/${externalId}`);
           const state = String(sandbox.state ?? '').toLowerCase();
           if (state === 'running') return;
-          if (!['starting', 'pending'].includes(state) || Date.now() >= deadline) {
+          const isRestoreTransition = state === 'archived' || state === 'archiving';
+          if (
+            (!['starting', 'pending'].includes(state) && !isRestoreTransition) ||
+            Date.now() >= deadline
+          ) {
             throw new Error(
               `Platinum sandbox ${externalId} did not reach running after start (state=${state || 'unknown'})`,
             );
@@ -558,8 +562,11 @@ export class PlatinumProvider implements SandboxProvider {
         const sandbox = await platinumJson<PlatinumSandbox>(`/v1/sandboxes/${externalId}`);
         const state = String(sandbox.state ?? '').toLowerCase();
         if (state === 'running') return;
-        if (state === 'stopped' || state.includes('archiv')) break;
-        if (!['starting', 'stopping', 'pending'].includes(state) || Date.now() >= deadline) {
+        if (state === 'stopped' || state === 'archived') break;
+        if (
+          !['starting', 'stopping', 'pending', 'archiving'].includes(state) ||
+          Date.now() >= deadline
+        ) {
           throw firstConflict;
         }
         await Bun.sleep(START_CONFLICT_POLL_MS);

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -27,6 +27,7 @@ import { resolvePreviewWsUpstream } from './routes/preview';
 import { classifyPtyWebSocketPath } from '../platform/providers/pty-ingress';
 import { OPENCODE_PRIMARY_PORT, isOpencodePort } from '../shared/opencode-ports';
 import { fetchComputeNodeById, connectComputeNodeWebSocket } from '../compute-nodes';
+import { startWebSocketHeartbeat } from '../compute-nodes/ws-heartbeat';
 import { establishPreviewSession, resolvePreviewRequest, sessionFromCookies } from './preview-origin';
 
 // opencode's PTY WebSocket endpoint lives on opencode's own port, reachable via
@@ -83,6 +84,7 @@ export interface PreviewWsData {
   upstream?: Awaited<ReturnType<typeof connectComputeNodeWebSocket>>;
   ready?: boolean;
   queue?: Array<string | Buffer | ArrayBuffer | Uint8Array>;
+  stopHeartbeat?: () => void;
 }
 
 /** Minimal shape of the Bun server WebSocket we touch. */
@@ -90,6 +92,7 @@ interface ServerWs {
   data: PreviewWsData;
   send: (data: string | ArrayBufferView | ArrayBuffer) => void;
   close: (code?: number, reason?: string) => void;
+  ping: () => void;
 }
 
 /** True when the path is a path-based preview route eligible for WS proxying. */
@@ -277,6 +280,7 @@ export const previewWsHandlers = {
     const state = ws.data;
     state.queue = [];
     state.ready = false;
+    state.stopHeartbeat = startWebSocketHeartbeat(ws);
 
     void connectComputeNodeWebSocket(state.externalId, state.port, state.path, state.headers, {
       open: () => {
@@ -312,6 +316,7 @@ export const previewWsHandlers = {
   },
 
   close(ws: ServerWs) {
+    ws.data.stopHeartbeat?.();
     try { ws.data.upstream?.close(); } catch {}
   },
 };


### PR DESCRIPTION
## Problem

Legacy Platinum compute nodes report `archived` and `archiving` during restore. The API rejected these valid states and returned `Session runtime not ready (stage: stopped)`.

## Change

- wait through archive restore states after an accepted start
- retry a conflicted start only after `archiving` reaches `archived`
- add regression coverage and the incident learning

## Verification

- `bun test apps/api/src/platform/providers/platinum-app-runtime.test.ts` — 11 pass, 0 fail
- `bun run --cwd apps/api typecheck` — exit 0
- `pnpm test -- --packages-only` — PASS in 135.5s