### PR TITLE
fix(api): bootstrap kortixd on legacy sandboxes

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2110,3 +2110,23 @@ updated daemon, then verify chat, Files, and Terminal through the relay.
 
 *Incident:* PR #6776 dev verification, session
 `2e1fcec9-2485-481f-afca-8d1ab035761a`.
+
+## Bootstrap the current daemon before starting a legacy sandbox
+
+2026-08-23. The API enrolled an old Daytona sandbox as a compute node and
+rotated its node credential. The wake command then started the image's old
+`/usr/local/bin/kortix-entrypoint`. That entrypoint predated daemon self-update,
+so the node channel never connected and the API stopped the sandbox after 184
+seconds.
+
+**The rule.** A legacy-sandbox repair cannot depend on code baked into the
+legacy image. The provider bootstrap must download the authenticated daemon
+artifact first. It must then launch that artifact through its native supervisor.
+
+**The enforcement.** Provider bootstrap tests assert the authenticated
+`/v1/runtime-assets/agent` download and `kortixd supervise` launch. Dev
+acceptance must wake a sandbox created before the rollout and prove terminal,
+filesystem, and chat traffic through its new node channel.
+
+*Incident:* PR #6780 dev verification, session
+`e5d79018-2787-42e5-b2df-b605b82f928d`.

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -134,6 +134,8 @@ test('session runtime convergence starts the kortixd supervisor with the current
   expect(processCommands[0]?.command).toContain("KORTIX_NODE_TOKEN='knd_test_legacy_credential'");
   expect(processCommands[0]?.command).toContain('kill -TERM');
   expect(processCommands[0]?.command).toContain('/proc/[0-9]*');
+  expect(processCommands[0]?.command).toContain('/runtime-assets/agent');
+  expect(processCommands[0]?.command).toContain('agent.bootstrap supervise');
   expect(processCommands[0]?.command).not.toContain('ps -u');
   expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -331,6 +331,7 @@ export class DaytonaProvider implements SandboxProvider {
     const command = buildSessionSupervisorCommand(
       config.KORTIX_NODE_RELAY_URL || config.KORTIX_URL,
       identity,
+      config.KORTIX_URL,
     );
     const result = await withTimeout(
       sandbox.process.executeCommand(command, undefined, undefined, 15),

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -57,10 +57,14 @@ const baseOpts = {
   snapshot: 'tpl_test',
 };
 
-function expectSessionBootstrap(body: string): void {
+function expectSessionBootstrap(body: string, legacyEnrollment = false): void {
   const parsed = JSON.parse(body) as { cmd: string[]; timeout_ms: number };
   expect(parsed.cmd.slice(0, 2)).toEqual(['/bin/sh', '-lc']);
   expect(parsed.cmd[2]).toContain('/proc/[0-9]*');
+  if (legacyEnrollment) {
+    expect(parsed.cmd[2]).toContain('/runtime-assets/agent');
+    expect(parsed.cmd[2]).toContain('agent.bootstrap supervise');
+  }
   expect(parsed.cmd[2]).toContain('/usr/local/bin/kortix-agent');
   expect(parsed.cmd[2]).toContain('/opt/kortix/agent.current run');
   expect(parsed.cmd[2]).toContain('kill -TERM "${proc#/proc/}"');
@@ -111,7 +115,7 @@ test('session runtime convergence starts the kortixd supervisor after a wake', a
   const bootstrap = calls.find(
     (c) => c.method === 'POST' && c.path === '/v1/sandboxes/sbx_session/exec',
   );
-  expectSessionBootstrap(bootstrap!.body!);
+  expectSessionBootstrap(bootstrap!.body!, true);
   expect(bootstrap!.body!).toContain("KORTIX_COMPUTE_NODE_ID='node-legacy-1'");
   expect(bootstrap!.body!).toContain("KORTIX_NODE_TOKEN='knd_test_legacy_credential'");
 });

--- a/apps/api/src/platform/providers/platinum.ts
+++ b/apps/api/src/platform/providers/platinum.ts
@@ -487,7 +487,11 @@ export class PlatinumProvider implements SandboxProvider {
     // tree and relaunch the existing verified supervisor with this API's relay
     // URL. No human can be attached while the provider VM is stopped. The new
     // process starts with an empty PTY registry and converges its own binary.
-    const allProcessCommand = buildSessionSupervisorCommand(config.KORTIX_NODE_RELAY_URL, identity);
+    const allProcessCommand = buildSessionSupervisorCommand(
+      config.KORTIX_NODE_RELAY_URL || config.KORTIX_URL,
+      identity,
+      config.KORTIX_URL,
+    );
     const response = await platinumJson<PlatinumExecResponse>(`/v1/sandboxes/${externalId}/exec`, {
       method: 'POST',
       body: JSON.stringify({ cmd: ['/bin/sh', '-lc', allProcessCommand], timeout_ms: 15_000 }),

--- a/apps/api/src/platform/providers/session-supervisor-command.ts
+++ b/apps/api/src/platform/providers/session-supervisor-command.ts
@@ -5,6 +5,7 @@ function quoteShell(value: string): string {
 export function buildSessionSupervisorCommand(
   relayUrl: string,
   identity?: { nodeId: string; nodeToken: string },
+  assetApiUrl: string = relayUrl,
 ): string {
   const normalizedRelayUrl = `${relayUrl
     .replace(/\/+$/, '')
@@ -13,5 +14,11 @@ export function buildSessionSupervisorCommand(
   const identityEnv = identity
     ? ` KORTIX_COMPUTE_NODE_ID=${quoteShell(identity.nodeId)} KORTIX_NODE_TOKEN=${quoteShell(identity.nodeToken)}`
     : '';
-  return String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/usr/local/bin/kortix-entrypoint"|"/bin/sh /usr/local/bin/kortix-entrypoint") kill -TERM "${'${proc#/proc/}'}" 2>/dev/null || true;; esac; done; sleep 1; KORTIX_API_URL=` + quoteShell(normalizedRelayUrl) + identityEnv + String.raw` setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
+  const stopOldProcesses = String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/opt/kortix/agent.bootstrap supervise"|"/usr/local/bin/kortix-entrypoint"|"/bin/sh /usr/local/bin/kortix-entrypoint") kill -TERM "${'${proc#/proc/}'}" 2>/dev/null || true;; esac; done; sleep 1`;
+  if (!identity) {
+    return `${stopOldProcesses}; KORTIX_API_URL=${quoteShell(normalizedRelayUrl)} setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
+  }
+  const normalizedAssetApiUrl = `${assetApiUrl.replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
+  const assetUrl = `${normalizedAssetApiUrl}/runtime-assets/agent`;
+  return `${stopOldProcesses}; install -d -o kortix -g kortix -m 0755 /opt/kortix /opt/kortix/node; tmp=/opt/kortix/agent.bootstrap.tmp; curl -fsSL --retry 3 --retry-delay 1 -H ${quoteShell(`Authorization: Bearer ${identity.nodeToken}`)} ${quoteShell(assetUrl)} -o "$tmp"; chmod 0755 "$tmp"; "$tmp" version >/dev/null; mv -f "$tmp" /opt/kortix/agent.bootstrap; chown kortix:kortix /opt/kortix/agent.bootstrap; ${identityEnv.trim()} KORTIX_API_URL=${quoteShell(normalizedRelayUrl)} KORTIXD_HOME=/opt/kortix/node setsid -f setpriv --reuid kortix --regid kortix --init-groups /opt/kortix/agent.bootstrap supervise >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
 }


### PR DESCRIPTION
Problem: A sandbox created before the kortixd rollout cannot repair itself. Its baked entrypoint predates daemon self-update, so wake times out after node enrollment. Change: Download and validate the authenticated current daemon during provider wake. Launch the native supervisor as the sandbox runtime user. Preserve the new-image entrypoint path when legacy enrollment is not required. Verification: focused provider tests 12 pass and 0 fail; API typecheck exit 0; complete API suite 8184 pass, 78 skip, and 0 fail. Dev acceptance after merge will wake the known legacy Daytona session and prove terminal, files, and chat through its node channel.