### PR TITLE
fix(api): preserve legacy sandbox entrypoint

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2150,3 +2150,22 @@ idle interval.
 
 *Incident:* PR #6782 dev verification, session
 `e5d79018-2787-42e5-b2df-b605b82f928d`.
+
+## Never terminate a provider container entrypoint during runtime convergence
+
+2026-08-23. Legacy-node convergence terminated
+`/usr/local/bin/kortix-entrypoint` while replacing its daemon child. That
+entrypoint owned the Daytona container lifecycle. Files and PTY worked briefly,
+then Daytona stopped the VM and chat returned `503`.
+
+**The rule.** Runtime convergence may terminate replaceable daemon processes.
+It must not terminate a provider or image entrypoint. Treat the entrypoint as
+container lifecycle infrastructure even when its name contains `kortix`.
+
+**The enforcement.** Daytona and Platinum bootstrap tests reject both legacy
+entrypoint command lines in the convergence kill list. Dev acceptance must keep
+a PTY connected while Files and chat run, then reuse the PTY after the prior
+failure interval.
+
+*Incident:* PR #6783 dev verification, session
+`e5d79018-2787-42e5-b2df-b605b82f928d`.

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -128,7 +128,7 @@ test('session runtime convergence starts the kortixd supervisor with the current
   });
 
   expect(processCommands).toHaveLength(1);
-  expect(processCommands[0]?.command).toContain('/usr/local/bin/kortix-entrypoint');
+  expect(processCommands[0]?.command).toContain('/opt/kortix/agent.bootstrap supervise');
   expect(processCommands[0]?.command).toContain('KORTIX_API_URL=\'https://api.example.com/v1\'');
   expect(processCommands[0]?.command).toContain("KORTIX_COMPUTE_NODE_ID='node-legacy-1'");
   expect(processCommands[0]?.command).toContain("KORTIX_NODE_TOKEN='knd_test_legacy_credential'");
@@ -141,6 +141,8 @@ test('session runtime convergence starts the kortixd supervisor with the current
   expect(processCommands[0]?.command).toContain('mkdir /opt/kortix/bootstrap.lock');
   expect(processCommands[0]?.command).toContain('agent.bootstrap.tmp.$$');
   expect(processCommands[0]?.command).toContain('/opt/kortix/agent.bootstrap run');
+  expect(processCommands[0]?.command).not.toContain('"/usr/local/bin/kortix-entrypoint"|');
+  expect(processCommands[0]?.command).not.toContain('"/bin/sh /usr/local/bin/kortix-entrypoint"');
   expect(processCommands[0]?.command).not.toContain('ps -u');
   expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -69,13 +69,15 @@ function expectSessionBootstrap(body: string, legacyEnrollment = false): void {
     expect(parsed.cmd[2]).toContain('mkdir /opt/kortix/bootstrap.lock');
     expect(parsed.cmd[2]).toContain('agent.bootstrap.tmp.$$');
     expect(parsed.cmd[2]).toContain('/opt/kortix/agent.bootstrap run');
+    expect(parsed.cmd[2]).not.toContain('"/usr/local/bin/kortix-entrypoint"|');
+    expect(parsed.cmd[2]).not.toContain('"/bin/sh /usr/local/bin/kortix-entrypoint"');
   }
   expect(parsed.cmd[2]).toContain('/usr/local/bin/kortix-agent');
   expect(parsed.cmd[2]).toContain('/opt/kortix/agent.current run');
   expect(parsed.cmd[2]).toContain('kill -TERM "${proc#/proc/}"');
   expect(parsed.cmd[2]).not.toContain('ps -u');
   expect(parsed.cmd[2]).toContain("KORTIX_API_URL='https://api.example.com/v1'");
-  expect(parsed.cmd[2]).toContain('/usr/local/bin/kortix-entrypoint');
+  expect(parsed.cmd[2]).toContain('/opt/kortix/agent.bootstrap supervise');
   expect(parsed.timeout_ms).toBe(15_000);
 }
 

--- a/apps/api/src/platform/providers/session-supervisor-command.ts
+++ b/apps/api/src/platform/providers/session-supervisor-command.ts
@@ -14,7 +14,10 @@ export function buildSessionSupervisorCommand(
   const identityEnv = identity
     ? ` KORTIX_COMPUTE_NODE_ID=${quoteShell(identity.nodeId)} KORTIX_NODE_TOKEN=${quoteShell(identity.nodeToken)}`
     : '';
-  const stopOldProcesses = String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/opt/kortix/agent.bootstrap run"|"/opt/kortix/agent.bootstrap supervise"|"/opt/kortix/node/runtime/agent.current run"|"/usr/local/bin/kortix-entrypoint"|"/bin/sh /usr/local/bin/kortix-entrypoint") kill -TERM "${'${proc#/proc/}'}" 2>/dev/null || true;; esac; done; sleep 1`;
+  // Never terminate the image entrypoint. On legacy Daytona snapshots it owns
+  // the container lifecycle, so killing it stops the VM after a short delay.
+  // Converge only the replaceable daemon processes that the entrypoint starts.
+  const stopOldProcesses = String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/opt/kortix/agent.bootstrap run"|"/opt/kortix/agent.bootstrap supervise"|"/opt/kortix/node/runtime/agent.current run") kill -TERM "${'${proc#/proc/}'}" 2>/dev/null || true;; esac; done; sleep 1`;
   if (!identity) {
     return `${stopOldProcesses}; KORTIX_API_URL=${quoteShell(normalizedRelayUrl)} setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
   }


### PR DESCRIPTION
## Problem

Legacy kortixd convergence terminated `/usr/local/bin/kortix-entrypoint`. Daytona treats that process as container lifecycle infrastructure. The VM stopped after Files and PTY initially succeeded, and chat returned 503.

## Change

- terminate only replaceable kortixd processes during convergence
- preserve provider and image entrypoints
- enforce the contract for Daytona and Platinum
- record the incident rule

## Verification

- RED: focused provider tests failed on both entrypoint assertions
- GREEN: `bun test apps/api/src/platform/providers/daytona-eager-preview.test.ts apps/api/src/platform/providers/platinum-create-terminal.test.ts` -> 12 pass, 0 fail, 68 assertions
- `pnpm --filter kortix-api typecheck` -> exit 0

Dev acceptance after merge keeps PTY connected while Files and chat execute, then reuses PTY after the prior failure interval.