### PR TITLE
fix(api): protect sandbox PID 1

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2159,13 +2159,15 @@ entrypoint owned the Daytona container lifecycle. Files and PTY worked briefly,
 then Daytona stopped the VM and chat returned `503`.
 
 **The rule.** Runtime convergence may terminate replaceable daemon processes.
-It must not terminate a provider or image entrypoint. Treat the entrypoint as
-container lifecycle infrastructure even when its name contains `kortix`.
+It must never signal PID `1`. It must not terminate a provider or image
+entrypoint. Treat PID `1` as container lifecycle infrastructure even when its
+command line is the legacy daemon binary.
 
 **The enforcement.** Daytona and Platinum bootstrap tests reject both legacy
-entrypoint command lines in the convergence kill list. Dev acceptance must keep
-a PTY connected while Files and chat run, then reuse the PTY after the prior
-failure interval.
+entrypoint command lines in the convergence kill list. They also require an
+explicit PID `1` exclusion before command-line matching. Dev acceptance must
+keep a PTY connected while Files and chat run, then reuse the PTY after the
+prior failure interval.
 
 *Incident:* PR #6783 dev verification, session
 `e5d79018-2787-42e5-b2df-b605b82f928d`.

--- a/apps/api/src/platform/providers/daytona-eager-preview.test.ts
+++ b/apps/api/src/platform/providers/daytona-eager-preview.test.ts
@@ -143,6 +143,7 @@ test('session runtime convergence starts the kortixd supervisor with the current
   expect(processCommands[0]?.command).toContain('/opt/kortix/agent.bootstrap run');
   expect(processCommands[0]?.command).not.toContain('"/usr/local/bin/kortix-entrypoint"|');
   expect(processCommands[0]?.command).not.toContain('"/bin/sh /usr/local/bin/kortix-entrypoint"');
+  expect(processCommands[0]?.command).toContain('[ "$pid" = 1 ] && continue');
   expect(processCommands[0]?.command).not.toContain('ps -u');
   expect(processCommands[0]?.timeout).toBe(15);
 });

--- a/apps/api/src/platform/providers/platinum-create-terminal.test.ts
+++ b/apps/api/src/platform/providers/platinum-create-terminal.test.ts
@@ -71,10 +71,11 @@ function expectSessionBootstrap(body: string, legacyEnrollment = false): void {
     expect(parsed.cmd[2]).toContain('/opt/kortix/agent.bootstrap run');
     expect(parsed.cmd[2]).not.toContain('"/usr/local/bin/kortix-entrypoint"|');
     expect(parsed.cmd[2]).not.toContain('"/bin/sh /usr/local/bin/kortix-entrypoint"');
+    expect(parsed.cmd[2]).toContain('[ "$pid" = 1 ] && continue');
   }
   expect(parsed.cmd[2]).toContain('/usr/local/bin/kortix-agent');
   expect(parsed.cmd[2]).toContain('/opt/kortix/agent.current run');
-  expect(parsed.cmd[2]).toContain('kill -TERM "${proc#/proc/}"');
+  expect(parsed.cmd[2]).toContain('kill -TERM "$pid"');
   expect(parsed.cmd[2]).not.toContain('ps -u');
   expect(parsed.cmd[2]).toContain("KORTIX_API_URL='https://api.example.com/v1'");
   expect(parsed.cmd[2]).toContain('/opt/kortix/agent.bootstrap supervise');

--- a/apps/api/src/platform/providers/session-supervisor-command.ts
+++ b/apps/api/src/platform/providers/session-supervisor-command.ts
@@ -17,7 +17,7 @@ export function buildSessionSupervisorCommand(
   // Never terminate the image entrypoint. On legacy Daytona snapshots it owns
   // the container lifecycle, so killing it stops the VM after a short delay.
   // Converge only the replaceable daemon processes that the entrypoint starts.
-  const stopOldProcesses = String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/opt/kortix/agent.bootstrap run"|"/opt/kortix/agent.bootstrap supervise"|"/opt/kortix/node/runtime/agent.current run") kill -TERM "${'${proc#/proc/}'}" 2>/dev/null || true;; esac; done; sleep 1`;
+  const stopOldProcesses = String.raw`for proc in /proc/[0-9]*; do [ -r "$proc/cmdline" ] || continue; pid=${'${proc#/proc/}'}; [ "$pid" = 1 ] && continue; cmd=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null); cmd=${'${cmd% }'}; case "$cmd" in "/usr/local/bin/kortix-agent"|"/opt/kortix/agent.current run"|"/opt/kortix/agent.bootstrap run"|"/opt/kortix/agent.bootstrap supervise"|"/opt/kortix/node/runtime/agent.current run") kill -TERM "$pid" 2>/dev/null || true;; esac; done; sleep 1`;
   if (!identity) {
     return `${stopOldProcesses}; KORTIX_API_URL=${quoteShell(normalizedRelayUrl)} setsid -f /usr/local/bin/kortix-entrypoint >>/tmp/kortix-entrypoint.log 2>&1 </dev/null`;
   }


### PR DESCRIPTION
## Problem

A legacy snapshot uses `/usr/local/bin/kortix-agent` as PID 1 after its entrypoint calls `exec`. Runtime convergence matched the daemon path and terminated PID 1. Daytona stopped the VM ten seconds after wake.

## Change

- exclude PID 1 before daemon command-line matching
- retain the provider-entrypoint exclusions
- enforce the invariant for Daytona and Platinum
- update the incident rule

## Verification

- RED: both provider tests rejected the missing PID 1 guard
- GREEN: 12 pass, 0 fail, 70 assertions
- `pnpm --filter kortix-api typecheck` exits 0

Dev acceptance will wake the same pre-rollout Daytona session and keep PTY, Files, and chat active beyond the prior failure interval.