### PR TITLE
fix(sdk,web): a runtime list endpoint never hands back a non-list ('t is not iterable')

### DIFF
--- a/apps/web/src/features/session/detect-command.test.ts
+++ b/apps/web/src/features/session/detect-command.test.ts
@@ -26,6 +26,23 @@ describe('detectCommandFromText', () => {
     expect(detectCommandFromText('something completely unrelated', commands)).toBeUndefined();
   });
 
+  // Regression for Better Stack error "TypeError: t is not iterable" (dev,
+  // 2026-08-23), thrown from this module's `for (const cmd of commands)`. The
+  // runtime's `GET /command` is typed `Command[]`, but a proxy or daemon that
+  // answers with an object body hands the render a truthy non-array, which
+  // crashed the whole session view. Detection must degrade instead, exactly
+  // like it does for a non-string template.
+  test('does NOT throw when commands is a truthy non-array', () => {
+    expect(
+      detectCommandFromText('build the project now please', {} as unknown as Command[]),
+    ).toBeUndefined();
+    expect(
+      detectCommandFromText('build the project now please', {
+        commands: [cmd('build', 'build the project now please $ARGUMENTS')],
+      } as unknown as Command[]),
+    ).toBeUndefined();
+  });
+
   test('returns undefined for empty input', () => {
     expect(
       detectCommandFromText('', [cmd('build', 'build the project now please $ARGUMENTS')]),

--- a/apps/web/src/features/session/detect-command.ts
+++ b/apps/web/src/features/session/detect-command.ts
@@ -12,7 +12,13 @@ export function detectCommandFromText(
   rawText: string,
   commands?: Command[],
 ): { name: string; args?: string } | undefined {
-  if (!commands || !rawText) return undefined;
+  // `commands` is typed `Command[]`, but the runtime's `GET /command` has been
+  // observed answering with a truthy NON-array (Better Stack, dev 2026-08-23:
+  // "TypeError: t is not iterable" thrown from the `for…of` below, which took
+  // the whole session view down through the error boundary). `@kortix/sdk` now
+  // normalizes that response, and this guard keeps the crash site itself safe
+  // for any other caller — same spirit as the non-string `template` guard below.
+  if (!Array.isArray(commands) || !rawText) return undefined;
 
   const trimmedRawText = rawText.trim();
   const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,37 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-23 — session `commands-not-iterable` — a list endpoint must never hand back a non-list — DONE
+
+**Files:** `react/use-opencode-sessions/shared.ts` (NEW internal `asRuntimeList`,
+`cachedRuntimeList`) + `shared.test.ts` (+9 tests) ·
+`react/use-opencode-sessions/commands.ts` (`useOpenCodeCommands` normalizes the
+response and the localStorage placeholder). No public surface change — both
+helpers stay inside `./shared`, which the barrel deliberately does not re-export.
+
+**What.** `dev.kortix.com` threw `TypeError: t is not iterable` from a `useMemo`
+and the session view fell into its error boundary ("Something went wrong").
+Deminified, the frame is `detectCommandFromText`'s `for (const cmd of commands)`
+in `apps/web` — so `commands` was TRUTHY but not iterable. It comes from
+`useRuntimeCommands()` → `useOpenCodeCommands()`, which returned
+`unwrap(client.command.list())` verbatim. `GET /command` is typed `Command[]`;
+a runtime or proxy that answers a list route with an object body breaks that
+type at runtime, and the bad value was also written to the localStorage
+placeholder cache, so the crash survived a reload.
+
+**Fix.** Normalize at the seam. `asRuntimeList` coerces a non-array list
+response to `[]`; `cachedRuntimeList` treats a cached non-array as a MISS so a
+poisoned placeholder refetches instead of painting. Every consumer
+(`detectCommandFromText`, the slash menu's `slash-items`, `composer-logic`,
+`command-attachments`) iterates the list unconditionally, so the guard belongs
+here — one place — not at four call sites. `apps/web`'s `detectCommandFromText`
+also grew an `Array.isArray` guard for defense in depth, matching its existing
+per-item non-string `template` guard.
+
+**Gates:** `typecheck` clean (both projects) · `bun test` — see PR.
+
+---
+
 ### 2026-08-21 — session `session-busy-flicker` — display order was not an order — DONE
 
 **Files:** `core/turns/grouping.ts` (`compareMessagesForDisplay` rewritten as two

--- a/packages/sdk/src/react/use-opencode-sessions/commands.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/commands.ts
@@ -4,12 +4,24 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { getClient } from '../../core/runtime/client';
 import type { Command } from '@opencode-ai/sdk/v2/client';
 import { opencodeKeys, useOpenCodeRuntimeReady } from './keys';
-import { unwrap, getLSCache, setLSCache, LS_COMMANDS } from './shared';
+import { unwrap, asRuntimeList, cachedRuntimeList, setLSCache, LS_COMMANDS } from './shared';
 
 // ============================================================================
 // Command Hooks
 // ============================================================================
 
+/**
+ * The session's slash commands.
+ *
+ * Always resolves an ARRAY. `GET /command` is typed `Command[]`, but a runtime
+ * or proxy that answers with an object body used to hand that value straight
+ * to the render, where `for (const cmd of commands)` threw
+ * `TypeError: t is not iterable` and killed the whole session view (dev,
+ * 2026-08-23). `asRuntimeList` normalizes the response and `cachedRuntimeList`
+ * treats a corrupt localStorage placeholder as a miss, so every consumer
+ * (`detectCommandFromText`, the slash menu, command attachments) can iterate
+ * the result unconditionally.
+ */
 export function useOpenCodeCommands() {
   const runtimeReady = useOpenCodeRuntimeReady();
   return useQuery<Command[]>({
@@ -17,11 +29,11 @@ export function useOpenCodeCommands() {
     queryFn: async () => {
       const client = getClient();
       const result = await client.command.list();
-      const commands = unwrap(result);
+      const commands = asRuntimeList<Command>(unwrap(result));
       setLSCache(LS_COMMANDS, commands);
       return commands;
     },
-    placeholderData: () => getLSCache<Command[]>(LS_COMMANDS),
+    placeholderData: () => cachedRuntimeList<Command>(LS_COMMANDS),
     enabled: runtimeReady,
     staleTime: Infinity,
     gcTime: 10 * 60 * 1000,

--- a/packages/sdk/src/react/use-opencode-sessions/shared.test.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/shared.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   activeServerKey,
+  asRuntimeList,
+  cachedRuntimeList,
   canQueryOpenCodeSession,
   CACHE_SCOPE_GLOBAL,
   clearProjectProviderCache,
   getLSCache,
   LS_AGENTS,
+  LS_COMMANDS,
   LS_PROVIDERS,
   LS_SESSIONS,
   setLSCache,
@@ -175,5 +178,65 @@ describe('getLSCache / setLSCache (localStorage stubbed)', () => {
     delete (globalThis as GlobalWithDom).localStorage;
     expect(() => setLSCache(LS_SESSIONS, ['x'])).not.toThrow();
     expect(getLSCache(LS_SESSIONS)).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// asRuntimeList / cachedRuntimeList — the shape guard for runtime LIST
+// endpoints.
+//
+// Incident (dev, 2026-08-23): `TypeError: t is not iterable` crashed the whole
+// session view. `GET /command` is typed `Command[]`, but the value that reached
+// the render was a truthy non-array, and every consumer iterates the list
+// (`for…of` in detect-command, `.find`/`.some`/`.filter` in the composer). A
+// list endpoint that answers with an unexpected shape must degrade to "no
+// items", never crash the page.
+// ============================================================================
+
+describe('asRuntimeList', () => {
+  test('passes an array through unchanged (same reference)', () => {
+    const list = [{ name: 'build' }];
+    expect(asRuntimeList(list)).toBe(list);
+  });
+
+  test('coerces every truthy non-array shape to an empty list', () => {
+    expect(asRuntimeList({})).toEqual([]);
+    expect(asRuntimeList({ commands: [{ name: 'build' }] })).toEqual([]);
+    expect(asRuntimeList('not-a-list')).toEqual([]);
+    expect(asRuntimeList(42)).toEqual([]);
+    expect(asRuntimeList(true)).toEqual([]);
+  });
+
+  test('coerces undefined/null to an empty list', () => {
+    expect(asRuntimeList(undefined)).toEqual([]);
+    expect(asRuntimeList(null)).toEqual([]);
+  });
+});
+
+describe('cachedRuntimeList (localStorage stubbed)', () => {
+  beforeEach(() => {
+    (globalThis as GlobalWithDom).window = {};
+    (globalThis as GlobalWithDom).localStorage = new MemoryStorage();
+    setCurrentRuntime(null);
+  });
+
+  afterEach(() => {
+    delete (globalThis as GlobalWithDom).window;
+    delete (globalThis as GlobalWithDom).localStorage;
+    setCurrentRuntime(null);
+  });
+
+  test('returns the cached array', () => {
+    setLSCache(LS_COMMANDS, [{ name: 'build' }]);
+    expect(cachedRuntimeList<{ name: string }>(LS_COMMANDS)).toEqual([{ name: 'build' }]);
+  });
+
+  test('a cached non-array reads as a MISS, not as placeholder data', () => {
+    setLSCache(LS_COMMANDS, { commands: [{ name: 'build' }] });
+    expect(cachedRuntimeList(LS_COMMANDS)).toBeUndefined();
+  });
+
+  test('an empty cache is a miss', () => {
+    expect(cachedRuntimeList(LS_COMMANDS)).toBeUndefined();
   });
 });

--- a/packages/sdk/src/react/use-opencode-sessions/shared.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/shared.ts
@@ -112,6 +112,40 @@ export function setLSCache(family: string, value: unknown, scope?: string): void
   cacheByFamily[family]?.set(scope ?? activeServerKey(), value);
 }
 
+// ============================================================================
+// Helper: shape guard for runtime LIST endpoints
+// ============================================================================
+
+/**
+ * Coerce a runtime list response to an array.
+ *
+ * The OpenCode REST types say `GET /command`, `GET /agent`, … return an array,
+ * but the value that actually arrives does not always agree: a daemon or proxy
+ * that answers a list route with an object body hands the caller a TRUTHY
+ * non-array. Consumers iterate the list (`for…of`, `.find`, `.some`,
+ * `.filter`), so that value does not degrade — it throws
+ * `TypeError: <x> is not iterable` inside a render and takes the whole session
+ * view down with it (dev, 2026-08-23). Normalize at the seam so an unexpected
+ * body reads as "no items" instead.
+ *
+ * This is the list-level twin of `detectCommandFromText`'s per-item
+ * `typeof cmd.template !== 'string'` guard in `apps/web`.
+ */
+export function asRuntimeList<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+/**
+ * Read a localStorage-cached list for `placeholderData`. A cached value that is
+ * not an array reads as a MISS (`undefined`), exactly like a legacy-shaped
+ * entry — the query then simply refetches instead of painting a corrupt
+ * placeholder into the render.
+ */
+export function cachedRuntimeList<T>(family: string, scope?: string): T[] | undefined {
+  const cached = getLSCache<unknown>(family, scope);
+  return Array.isArray(cached) ? (cached as T[]) : undefined;
+}
+
 const PROJECT_SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 


### PR DESCRIPTION
## The crash

`dev.kortix.com` error boundary: **"Something went wrong"**, with

```
TypeError: t is not iterable
  at 2oxrja3vek1uj.js:1:114715   <- detectCommandFromText, `for (const cmd of commands)`
  at 2oxrja3vek1uj.js:52:58986   <- user-message.tsx useMemo
```

Deminified against the deployed chunk: byte 114721 of line 1 is
`for(let e of t)` inside `detectCommandFromText`. The guard above it is
`if(!t||!e)return` — so `commands` was **truthy but not iterable**.

## Root cause

`commands` comes from `useRuntimeCommands()` -> `useOpenCodeCommands()`, which
returned `unwrap(client.command.list())` verbatim. `GET /command` is typed
`Command[]`, but a runtime or proxy that answers a list route with an object
body breaks that type at runtime. The same value was written to the
localStorage placeholder cache (`kortix_cache_commands:<scope>`), so the crash
survived a reload.

Four consumers iterate that list — `detectCommandFromText` (`for…of`),
`slash-items` (`.length`, `for…of`), `composer-logic` (`.find`),
`command-attachments` (`.some`) — so the guard belongs at the seam, once.

## Fix

`packages/sdk/src/react/use-opencode-sessions/shared.ts` (internal; the barrel
deliberately does not re-export `./shared`, so the public surface is unchanged):

- `asRuntimeList<T>(value)` — coerces a non-array list response to `[]`.
- `cachedRuntimeList<T>(family)` — a cached non-array reads as a MISS, so a
  poisoned placeholder refetches instead of painting.

`useOpenCodeCommands` uses both; its result is now always an array.
`apps/web`'s `detectCommandFromText` also guards with `Array.isArray` for
defense in depth, matching its existing non-string `template` guard
(db049d5dac).

## Verification

RED first — the new web test reproduces the exact production error:

```
20 |   for (const cmd of commands) {
TypeError: {} is not iterable
  at detectCommandFromText (detect-command.ts:20:14)
(fail) detectCommandFromText > does NOT throw when commands is a truthy non-array
6 pass / 1 fail
```

GREEN after the fix:

- `apps/web`: `bun test src/features/session/detect-command.test.ts` -> 7 pass / 0 fail
- `packages/sdk`: `pnpm typecheck` clean (both projects)
- `packages/sdk`: `pnpm test` -> **2430 pass / 2 skip / 0 fail** (162 files)
- `packages/sdk`: `pnpm smoke:install` -> `install smoke test passed`
- `npx eslint` on both changed web files -> clean

Public surface snapshots unchanged (covered by the SDK suite).

Dev verification after merge: poison the placeholder cache
(`kortix_cache_commands:<scope>` = `{"v":{},"t":<now>}`) and reload a session —
the old build crashes into the error boundary, this build renders.
