### PR TITLE
docs(learnings): normalize remote list responses at the SDK seam

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,18 @@ linked, not inlined.
 
 ## Register
 
+### A typed list from a remote endpoint is not a list — normalize it at the SDK seam (2026-08-23)
+
+**When:** adding or touching any `@kortix/sdk` hook that returns a LIST from the
+runtime or platform API. Coerce the response with `asRuntimeList` and read the
+localStorage placeholder with `cachedRuntimeList`, so a body with an unexpected
+shape degrades to "no items" instead of reaching a render that iterates it.
+*Incident:* `GET /command` returned a truthy non-array on dev; the session view
+crashed into its error boundary with `TypeError: t is not iterable` from
+`detectCommandFromText`, and the bad value was cached, so a reload did not clear
+it. Fixed by PR #6790. *Enforcer:* `shared.test.ts` covers both helpers; the
+guard is only real for hooks that call them — check the call site in review.
+
 ### Give reviewed infrastructure rollbacks an explicit delete path (2026-08-23)
 
 **When:** a rollback removes Terraform-managed resources. Keep automatic pushes


### PR DESCRIPTION
Deposits the rule from the `TypeError: t is not iterable` crash fixed in #6790 (merged 02ae6022d3). Append-only register entry, no code change.