### PR TITLE
fix(api,web,sdk): terminal attach wakes a parked sandbox instead of looping on 1006

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1764,6 +1764,7 @@ export default {
       }
       const prep = await preparePreviewWsUpgrade(url);
       if (!prep.ok) {
+        console.warn(`[preview-ws] REFUSED ${prep.status} ${prep.message} path=${url.pathname} hasToken=${url.searchParams.has('token')}`);
         return new Response(JSON.stringify({ error: prep.message }), {
           status: prep.status,
           headers: { 'Content-Type': 'application/json' },

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -1728,8 +1728,9 @@ export async function resolvePreviewWsUpstream(opts: {
         accessKind: 'principal',
       })
     ) {
-      await resumeStoppedSandboxByExternalId(record.externalId).catch((err) => {
-        console.warn(`[preview-ws] auto-resume failed for ${record.externalId}:`, err);
+      const resumeExternalId = record.externalId;
+      await resumeStoppedSandboxByExternalId(resumeExternalId).catch((err) => {
+        console.warn(`[preview-ws] auto-resume failed for ${resumeExternalId}:`, err);
         return false;
       });
       // The resume flips the row to 'active' immediately; the box finishes

--- a/apps/api/src/sandbox-proxy/routes/preview.ts
+++ b/apps/api/src/sandbox-proxy/routes/preview.ts
@@ -14,6 +14,7 @@ import { syncSandboxEnvForPrompt } from '../../projects/lib/sandbox-env-sync';
 import { remintGrantForAgentSwitch } from '../../projects/lib/session-token-grant';
 import { scheduleOpencodeSnapshotSync } from '../../projects/opencode-session-snapshot';
 import { resumeStoppedSandboxByExternalId } from '../../projects/routes/shared';
+import { classifyPtyWebSocketPath } from '../../platform/providers/pty-ingress';
 import { recordSessionActivity } from '../../projects/session-activity';
 import {
   createExtendThrottle,
@@ -724,6 +725,38 @@ export function shouldAutoResumeStoppedSandbox(
     return Boolean(method && !['GET', 'HEAD', 'OPTIONS'].includes(method));
   }
   return opts.browserNavigation === true && !carriesSessionData(upstreamPort);
+}
+
+/**
+ * Should a WebSocket UPGRADE wake a stopped box?
+ *
+ * The HTTP data path wakes a parked box on explicit user intent
+ * (`shouldAutoResumeStoppedSandbox`). The WebSocket path had no such branch at
+ * all: it answered `503 sandbox not ready` and stopped there. A browser never
+ * sees that status — a refused upgrade surfaces only as close code `1006` — so
+ * the terminal reconnected against a parked box forever, and nothing in the
+ * loop could ever wake it. Reloading the page did not help either: the panel's
+ * `GET /kortix/pty` is a GET on a session-data port, which by policy also never
+ * resumes. The terminal was therefore unrecoverable until the user prompted the
+ * agent (a POST) or restarted the session.
+ *
+ * A terminal ATTACH is the same class of intent as a session mutation: a human
+ * opened the panel or pressed "Reconnect now". The client marks exactly those
+ * two connects with `wake=1` and NEVER marks its automatic backoff retries, so
+ * the "passive resurrection" the resume policy exists to prevent (polling,
+ * hydration, background reconnects) still cannot wake a box.
+ *
+ * Pure + exported so the gate is unit-tested without provisioning a box.
+ */
+export function shouldWakeStoppedSandboxForWsAttach(
+  status: string,
+  remainingPath: string,
+  opts: { wakeRequested: boolean; accessKind?: string },
+): boolean {
+  if (status !== 'stopped') return false;
+  if (!opts.wakeRequested) return false;
+  if (opts.accessKind && opts.accessKind !== 'principal') return false;
+  return classifyPtyWebSocketPath(remainingPath) !== null;
 }
 /**
  * Is this a proxied attempt at the daemon's DESTRUCTIVE branch reset?
@@ -1638,6 +1671,10 @@ export async function resolvePreviewWsUpstream(opts: {
   /** The caller's AGENT/SANDBOX token binding. Only the trigger-session manager
    *  override reads it (connectors/share.ts). REQUIRED, same reasoning. */
   boundCredentialSessionId: string | null;
+  /** The client marked this attach as user-initiated (`wake=1`): the panel's
+   *  first connect, or "Reconnect now". Automatic backoff retries never set it.
+   *  See `shouldWakeStoppedSandboxForWsAttach`. */
+  wakeRequested?: boolean;
 }): Promise<
   | { ok: true; url: string; headers: Record<string, string> }
   | { ok: false; status: number; message: string }
@@ -1646,7 +1683,7 @@ export async function resolvePreviewWsUpstream(opts: {
   const callerSessionId = opts.callerSessionId;
   const boundCredentialSessionId = opts.boundCredentialSessionId;
 
-  const record = await loadSandbox(sandboxId);
+  let record = await loadSandbox(sandboxId);
   if (!record) return { ok: false, status: 404, message: 'sandbox not found' };
 
   const ingressRequest = {
@@ -1682,7 +1719,27 @@ export async function resolvePreviewWsUpstream(opts: {
     };
   }
   if (record.status !== 'active') {
-    return { ok: false, status: 503, message: 'sandbox not ready' };
+    // A user-initiated terminal attach resumes a parked box, exactly like a
+    // session mutation does on the HTTP path. Without this the socket can only
+    // loop: the browser sees 1006, retries, and nothing ever wakes the sandbox.
+    if (
+      shouldWakeStoppedSandboxForWsAttach(record.status, remainingPath, {
+        wakeRequested: opts.wakeRequested === true,
+        accessKind: 'principal',
+      })
+    ) {
+      await resumeStoppedSandboxByExternalId(record.externalId).catch((err) => {
+        console.warn(`[preview-ws] auto-resume failed for ${record.externalId}:`, err);
+        return false;
+      });
+      // The resume flips the row to 'active' immediately; the box finishes
+      // booting in the background and the client's next retry connects.
+      const resumed = await loadSandbox(sandboxId);
+      if (resumed) record = resumed;
+    }
+    if (record.status !== 'active') {
+      return { ok: false, status: 503, message: `sandbox not ready (status: ${record.status})` };
+    }
   }
 
   const ingress = await resolveSandboxIngress(record, ingressRequest);

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -221,8 +221,12 @@ async function resolveUpgradeForPrincipal(input: {
   // Strip our own auth credentials before forwarding — opencode authenticates
   // via the Daytona preview token header, not our query params.
   const upstreamQuery = new URLSearchParams(input.search);
+  // `wake=1` is OUR resume signal (see shouldWakeStoppedSandboxForWsAttach) and
+  // means nothing to the daemon — strip it with the credentials.
+  const wakeRequested = upstreamQuery.get('wake') === '1';
   upstreamQuery.delete('token');
   upstreamQuery.delete('public_share');
+  upstreamQuery.delete('wake');
   const queryString = upstreamQuery.toString() ? `?${upstreamQuery.toString()}` : '';
 
   try {
@@ -236,6 +240,7 @@ async function resolveUpgradeForPrincipal(input: {
       // A PreviewPrincipal's sessionId is the SANDBOX's own token binding, never
       // a Supabase login id — so it is also the correct agent binding.
       boundCredentialSessionId: callerSessionId,
+      wakeRequested,
     });
     if (!upstream.ok) {
       return { ok: false, status: upstream.status, message: upstream.message };

--- a/apps/api/src/sandbox-proxy/ws-wake-policy.test.ts
+++ b/apps/api/src/sandbox-proxy/ws-wake-policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { shouldWakeStoppedSandboxForWsAttach } from './routes/preview';
+
+const PTY = '/kortix/pty/kpty_1/connect';
+
+describe('shouldWakeStoppedSandboxForWsAttach', () => {
+  // The whole incident: a terminal attach to a parked box was refused 503,
+  // the browser saw only close 1006, and nothing in the retry loop could ever
+  // wake the sandbox. A user-initiated attach must resume it.
+  test('a user-initiated pty attach wakes a stopped box', () => {
+    expect(shouldWakeStoppedSandboxForWsAttach('stopped', PTY, { wakeRequested: true })).toBe(true);
+  });
+
+  test('an automatic retry (no wake marker) never wakes a box', () => {
+    expect(shouldWakeStoppedSandboxForWsAttach('stopped', PTY, { wakeRequested: false })).toBe(false);
+  });
+
+  test('an active box needs no wake', () => {
+    expect(shouldWakeStoppedSandboxForWsAttach('active', PTY, { wakeRequested: true })).toBe(false);
+  });
+
+  test('a non-resumable status is never woken here', () => {
+    for (const status of ['archived', 'deleted', 'provisioning', 'error']) {
+      expect(shouldWakeStoppedSandboxForWsAttach(status, PTY, { wakeRequested: true })).toBe(false);
+    }
+  });
+
+  test('opencode-hosted pty attaches count too', () => {
+    expect(shouldWakeStoppedSandboxForWsAttach('stopped', '/pty/abc/connect', { wakeRequested: true })).toBe(true);
+  });
+
+  test('a non-pty websocket (app preview, hmr) never wakes a box', () => {
+    expect(shouldWakeStoppedSandboxForWsAttach('stopped', '/_next/webpack-hmr', { wakeRequested: true })).toBe(false);
+    expect(shouldWakeStoppedSandboxForWsAttach('stopped', '/socket.io/', { wakeRequested: true })).toBe(false);
+  });
+
+  test('only a real principal may wake a box', () => {
+    expect(
+      shouldWakeStoppedSandboxForWsAttach('stopped', PTY, { wakeRequested: true, accessKind: 'public_share' }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -145,6 +145,10 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
   const reconnectAttemptsRef = useRef(0);
   const disposedRef = useRef(false);
   const hadErrorRef = useRef(false);
+  /** True while the NEXT connect is user intent (mount, or "Reconnect now") and
+   *  may therefore wake a parked sandbox. Cleared by each connect so automatic
+   *  backoff retries never resurrect a box. */
+  const wakeOnNextConnectRef = useRef(true);
   // Until this timestamp, drop capability-query responses (see isTerminalReport)
   // so the scrollback replayed on connect doesn't echo garbage at the prompt.
   const suppressReportsUntilRef = useRef(0);
@@ -293,6 +297,11 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
     const connectWebSocket = async () => {
       if (disposedRef.current) return;
+      // A user-initiated attach (panel open, "Reconnect now") may WAKE a parked
+      // sandbox; an automatic backoff retry may not. Consume the flag here so a
+      // single intent wakes the box exactly once — see getPtyWebSocketUrl.
+      const wake = wakeOnNextConnectRef.current;
+      wakeOnNextConnectRef.current = false;
 
       // --- WebSocket connect ---
       globalPtyConnectionId++;
@@ -306,7 +315,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
       let wsUrl = '';
       try {
-        wsUrl = await getPtyWebSocketUrl(pty.id, serverUrl);
+        wsUrl = await getPtyWebSocketUrl(pty.id, serverUrl, { wake });
       } catch (err) {
         console.error('[PtyTerminal] Failed to resolve WebSocket URL:', err);
         hadErrorRef.current = true;
@@ -387,6 +396,13 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
       ws.onerror = () => {
         if (connectionIdRef.current !== myConnectionId || disposedRef.current) return;
+        // A refused upgrade reaches the browser as a bare error + 1006 with no
+        // status, so the one thing we DO know is worth saying: this attach asked
+        // the API to wake a parked sandbox, and a parked box takes a few seconds
+        // to come back. Without this the panel just counts down at the user.
+        if (wake) {
+          term.writeln('\r\n\x1b[33mWaking the sandbox — this can take a few seconds...\x1b[0m');
+        }
         // Browser WS error events carry no detail (always an empty Event) and the
         // status (e.g. a 401) is never exposed. The onclose that follows drives
         // backoff/reconnect, so just flag it — don't spam the terminal with red
@@ -432,6 +448,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     // next automatic retry (if this one also fails) starts at 1s again.
     reconnectNowRef.current = () => {
       if (disposedRef.current) return;
+      wakeOnNextConnectRef.current = true;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = null;
@@ -440,6 +457,10 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
       setReconnectPending(false);
       connectWebSocket();
     };
+
+    // A fresh (pty, serverUrl) pair is a new attach — the panel opened, or the
+    // runtime moved. Both are user intent, so the first dial may wake a parked box.
+    wakeOnNextConnectRef.current = true;
 
     // Delay fit + initial WS connect to ensure the container has real dimensions
     const initTimer = setTimeout(() => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,33 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-23 — session `terminal-ws-wake` — a terminal attach may wake a parked box — DONE
+
+**Files:** `core/runtime/pty.ts` (`getKortixPtyWebSocketUrl` takes `{ wake }`) +
+`core/runtime/pty.test.ts` (NEW, 3 tests) · `react/use-opencode-pty.ts`
+(`getPtyWebSocketUrl` passes it through). Additive optional argument — no
+export added, no signature broken.
+
+**What.** The session Terminal panel looped `Reconnecting in Ns (code 1006)`
+forever. A sandbox that idle-parks answers a WebSocket UPGRADE with
+`503 sandbox not ready` (`resolvePreviewWsUpstream` in `apps/api`), and a
+browser can only report a refused upgrade as close code `1006`. The HTTP data
+path wakes a parked box on explicit user intent; the WebSocket path had no wake
+branch at all, so nothing in the retry loop could ever resume the box — and the
+panel's own `GET /kortix/pty` is a GET on a session-data port, which by policy
+also never resumes. Reloading the page did not help.
+
+**Fix.** A USER-INITIATED attach (panel mount, "Reconnect now") carries
+`wake=1`; the API resumes a stopped box for a marked PTY attach only
+(`shouldWakeStoppedSandboxForWsAttach`). Automatic backoff retries stay
+unmarked, so polling and background reconnects still cannot resurrect a box.
+
+**Gates:** `typecheck` clean (both projects) · `bun test` 2424 pass / 0 fail ·
+verified live in a browser: parked box → `1006` loop → Reconnect now → row
+`stopped`→`active` → `WebSocket connected` → `echo` executed in the shell.
+
+---
+
 ### 2026-08-23 — session `commands-not-iterable` — a list endpoint must never hand back a non-list — DONE
 
 **Files:** `react/use-opencode-sessions/shared.ts` (NEW internal `asRuntimeList`,

--- a/packages/sdk/src/core/runtime/pty.test.ts
+++ b/packages/sdk/src/core/runtime/pty.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+mock.module('../http/auth', () => ({
+  authenticatedFetch: async () => new Response('[]'),
+  getAuthToken: async () => 'test-token',
+}));
+
+import { getKortixPtyWebSocketUrl } from './pty';
+
+const BASE = 'https://api.example.com/v1/p/sbx_1/8000';
+
+describe('getKortixPtyWebSocketUrl', () => {
+  test('builds the wss attach url with the auth token', async () => {
+    const url = new URL(await getKortixPtyWebSocketUrl('kpty_1', BASE));
+    expect(url.protocol).toBe('wss:');
+    expect(url.pathname).toBe('/v1/p/sbx_1/8000/kortix/pty/kpty_1/connect');
+    expect(url.searchParams.get('token')).toBe('test-token');
+    expect(url.searchParams.get('wake')).toBeNull();
+  });
+
+  // A parked sandbox refuses the upgrade with 503, which a browser can only
+  // report as close code 1006 — so an attach that never says "this is a human
+  // opening a terminal" loops forever against a box nothing will wake. Only a
+  // user-initiated connect (first mount, "Reconnect now") carries `wake=1`;
+  // automatic backoff retries must not, or polling would resurrect boxes.
+  test('marks a user-initiated attach with wake=1', async () => {
+    const url = new URL(await getKortixPtyWebSocketUrl('kpty_1', BASE, { wake: true }));
+    expect(url.searchParams.get('wake')).toBe('1');
+    expect(url.searchParams.get('token')).toBe('test-token');
+  });
+
+  test('an explicit non-wake attach stays unmarked', async () => {
+    const url = new URL(await getKortixPtyWebSocketUrl('kpty_1', BASE, { wake: false }));
+    expect(url.searchParams.get('wake')).toBeNull();
+  });
+});

--- a/packages/sdk/src/core/runtime/pty.ts
+++ b/packages/sdk/src/core/runtime/pty.ts
@@ -89,8 +89,20 @@ export async function removeKortixPty(baseUrl: string, ptyId: string): Promise<v
  * mixed-content upgrade, and `?token=` query auth (WebSocket can't set
  * custom headers) the OpenCode-backed terminal used, just pointed at
  * `/kortix/pty` instead of OpenCode's `/pty`.
+ *
+ * `opts.wake` marks the attach as USER-INITIATED (the panel's first connect, or
+ * "Reconnect now"). A parked sandbox refuses the upgrade with 503, which the
+ * browser can only surface as close code 1006 — so without this marker the
+ * terminal reconnects forever against a box that nothing in the loop will ever
+ * wake. The API resumes a stopped box only for a marked attach
+ * (`shouldWakeStoppedSandboxForWsAttach`), so automatic backoff retries — which
+ * must never resurrect a box — leave it off.
  */
-export async function getKortixPtyWebSocketUrl(ptyId: string, baseUrl: string): Promise<string> {
+export async function getKortixPtyWebSocketUrl(
+  ptyId: string,
+  baseUrl: string,
+  opts?: { wake?: boolean },
+): Promise<string> {
   const base = requireBaseUrl(baseUrl);
   const wsBase = (() => {
     try {
@@ -107,13 +119,16 @@ export async function getKortixPtyWebSocketUrl(ptyId: string, baseUrl: string): 
       return base.replace('https://', 'wss://').replace('http://', 'ws://');
     }
   })();
-  const url = `${wsBase}/kortix/pty/${encodeURIComponent(ptyId)}/connect`;
+  const connectUrl = `${wsBase}/kortix/pty/${encodeURIComponent(ptyId)}/connect`;
+  const params = new URLSearchParams();
   // Browser WebSocket API doesn't support custom headers, so inject the auth
   // token as a query param for the daemon (via the backend proxy) to check.
   const token = await getAuthToken();
-  if (!token) return url;
-  const sep = url.includes('?') ? '&' : '?';
-  return `${url}${sep}token=${encodeURIComponent(token)}`;
+  if (token) params.set('token', token);
+  if (opts?.wake) params.set('wake', '1');
+  const query = params.toString();
+  if (!query) return connectUrl;
+  return `${connectUrl}${connectUrl.includes('?') ? '&' : '?'}${query}`;
 }
 
 /** Grouped namespace for ergonomic use (also available as named exports). */

--- a/packages/sdk/src/react/use-opencode-pty.ts
+++ b/packages/sdk/src/react/use-opencode-pty.ts
@@ -135,6 +135,14 @@ export function useUpdatePty(options?: PtyMutationOptions) {
 // WebSocket URL helper
 // ============================================================================
 
-export async function getPtyWebSocketUrl(ptyId: string, serverUrl?: string): Promise<string> {
-  return getKortixPtyWebSocketUrl(ptyId, serverUrl || getActiveOpenCodeUrl());
+/**
+ * `opts.wake` marks a USER-INITIATED attach so the API resumes a parked box.
+ * Automatic reconnect attempts must leave it off — see `getKortixPtyWebSocketUrl`.
+ */
+export async function getPtyWebSocketUrl(
+  ptyId: string,
+  serverUrl?: string,
+  opts?: { wake?: boolean },
+): Promise<string> {
+  return getKortixPtyWebSocketUrl(ptyId, serverUrl || getActiveOpenCodeUrl(), opts);
 }


### PR DESCRIPTION
## The symptom

The session **Terminal** panel prints `Reconnecting in Ns (code 1006)...` forever
and never recovers without a full page reload.

## Root cause (verified live, not inferred)

A sandbox that idle-parks (`session_sandboxes.status = 'stopped'`) answers a
WebSocket **upgrade** with `503 sandbox not ready` in `resolvePreviewWsUpstream`.
A browser can only surface a refused upgrade as close code **1006** — no status,
no reason — so the client just backs off and dials the same dead endpoint again.

The asymmetry that made it permanent:

| path | parked box |
|---|---|
| HTTP data path | wakes it on explicit user intent (`shouldAutoResumeStoppedSandbox`) |
| WebSocket upgrade | `503`, **no wake branch at all** |

So nothing in the reconnect loop could ever resume the box. Reloading the page
did not help either: the panel's own `GET /kortix/pty` is a GET on a
session-data port, which by the same policy never resumes. The terminal stayed
dead until the user prompted the agent (a POST) or restarted the session.

Captured from the running API while reproducing:

```
[preview-ws] REFUSED 503 sandbox not ready (status: stopped)
  path=/v1/p/sbx_01M0QNX7…/8000/kortix/pty/kpty_4d45ea…/connect hasToken=true
```

## Fix

A **user-initiated** attach — the panel's first connect, or "Reconnect now" —
carries `wake=1`. The API resumes a stopped box only for a marked PTY attach
from a real principal (`shouldWakeStoppedSandboxForWsAttach`), re-reads the row,
and proceeds. Automatic backoff retries never carry the marker, so the passive
resurrection the resume policy exists to prevent (polling, hydration, background
stream reconnects) still cannot wake a box.

- `packages/sdk` — `getKortixPtyWebSocketUrl(ptyId, baseUrl, { wake })`, additive
  optional argument; `getPtyWebSocketUrl` passes it through. No new export.
- `apps/web` — wake on mount and on "Reconnect now"; never on a retry. Says
  "Waking the sandbox — this can take a few seconds..." instead of counting down.
- `apps/api` — the wake branch + a one-line log for every refused preview WS
  upgrade (its absence is why this needed a live capture to find).

## Verification

Live, against a real parked sandbox on a local stack:

1. `POST /sessions/:id/stop` → row `stopped`.
2. Terminal in the browser: `[PtyTerminal] WebSocket closed: 1006` → the exact
   reported loop, and `[preview-ws] REFUSED 503 sandbox not ready (status: stopped)`
   in the API log.
3. Click **Reconnect now** → row flips `stopped` → `active` → console logs
   `[PtyTerminal] WebSocket connected`.
4. Typed `echo KORTIX_TERMINAL_VERIFIED_OK` in the terminal; the sandbox printed
   `KORTIX_TERMINAL_VERIFIED_OK` and returned a fresh prompt.

Gates:

- `packages/sdk`: `pnpm typecheck` clean · `pnpm test` **2424 pass / 0 fail**
- `apps/api`: `pnpm typecheck` clean · new policy suite **7 pass / 0 fail**
- `apps/web`: `bun test src/features/session/pty-connection.test.ts` 11 pass · eslint clean
- `apps/api` `src/sandbox-proxy/` suite: 39 failures, **all pre-existing** —
  the same 40 fail on this branch's base with these files stashed.
