### PR TITLE
docs(learnings): a websocket upgrade must obey the HTTP wake policy

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,21 @@ linked, not inlined.
 
 ## Register
 
+### A WebSocket upgrade must obey the SAME wake policy as the HTTP path (2026-08-23)
+
+**When:** adding or changing a gate in `resolvePreviewWsUpstream` / `ws-proxy`,
+or any policy that answers a sandbox request with 503. A browser cannot see a
+refused upgrade — it reports close code `1006` with no status and no reason — so
+a gate the WebSocket path applies but the HTTP path does not becomes an
+unrecoverable client loop, never an error the user can act on. Mirror the HTTP
+resume policy, and log every refused upgrade with its status and path.
+*Incident:* the session Terminal reconnected forever against an idle-parked box:
+HTTP wakes it on user intent, the WS path had no wake branch at all, and the
+panel's own `GET /kortix/pty` never resumes either — so a reload could not fix
+it. PR #6792 adds `wake=1` for user-initiated attaches only.
+*Enforcer:* `ws-wake-policy.test.ts` pins the marked/unmarked split; the
+`[preview-ws] REFUSED` log makes the next one findable in one grep.
+
 ### A typed list from a remote endpoint is not a list — normalize it at the SDK seam (2026-08-23)
 
 **When:** adding or touching any `@kortix/sdk` hook that returns a LIST from the


### PR DESCRIPTION
Deposits the rule from the terminal 1006 loop fixed in #6792 (merged 7fc6ca9a82). Append-only register entry, no code change.