### PR TITLE
fix(api): retire code.storage as a provisioning target everywhere

### DIFF
--- a/apps/api/src/__tests__/unit-git-backends.test.ts
+++ b/apps/api/src/__tests__/unit-git-backends.test.ts
@@ -56,6 +56,29 @@ describe('registry', () => {
     process.env.MANAGED_GIT_PROVIDER = 'github';
     expect(getDefaultManagedBackend()).toBe(githubBackend);
   });
+
+  // code.storage is RETIRED as a provisioning target. The value still exists in
+  // deployed env bundles (dev's `kortix-dev-env` among them), and every one of
+  // them would otherwise keep minting new repos on a host we no longer want.
+  // The code refuses it outright so no environment can select it by config —
+  // reading and writing EXISTING code.storage repos is unaffected, since those
+  // resolve per project through `getBackend(connection.provider)`.
+  test('MANAGED_GIT_PROVIDER=code-storage no longer selects code.storage', () => {
+    process.env.MANAGED_GIT_PROVIDER = 'code-storage';
+    expect(getDefaultManagedBackend()).toBe(githubBackend);
+    process.env.MANAGED_GIT_PROVIDER = ' Code-Storage ';
+    expect(getDefaultManagedBackend()).toBe(githubBackend);
+    process.env.MANAGED_GIT_PROVIDER = 'code_storage';
+    expect(getDefaultManagedBackend()).toBe(githubBackend);
+  });
+
+  // Existing repos must keep resolving through their own backend, or every
+  // manifest read on a code.storage project fails the way the retirement was
+  // supposed to prevent.
+  test('an existing code-storage connection still resolves its own backend', () => {
+    expect(getBackend('code-storage').id).toBe('code-storage');
+    expect(hasBackend('code-storage')).toBe(true);
+  });
 });
 
 describe('basicAuthHeader', () => {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -272,7 +272,10 @@ const envSchema = z.object({
 
   // ── Managed git (provider-agnostic via the git proxy) ────────────────────
   // MANAGED_GIT_PROVIDER selects the backend NEW managed repos provision on
-  // ('github' default). The GitHub backend creates repos under
+  // ('github' default). `code-storage` is RETIRED here and is refused by
+  // `defaultManagedProviderId()` — a deployed bundle that still names it
+  // provisions on github and logs a warning. Existing code.storage repos keep
+  // resolving through their own connection row. The GitHub backend creates repos under
   // MANAGED_GIT_GITHUB_OWNER (a Kortix-owned org) via the Kortix App
   // installed there (MANAGED_GIT_GITHUB_INSTALL_ID). Reuses KORTIX_GITHUB_APP_*
   // for the App JWT. Each backend's isConfigured() checks its own vars, so
@@ -286,8 +289,10 @@ const envSchema = z.object({
   // collaborator). Leave blank to use the App installation instead.
   MANAGED_GIT_GITHUB_TOKEN: optStr,
   // Second managed backend: code.storage (Pierre), a headless git-hosting API
-  // (https://code.storage/docs). Select it with MANAGED_GIT_PROVIDER=code-storage
-  // — inert (isConfigured() false) until org + private key are both set.
+  // (https://code.storage/docs). RETIRED as a provisioning target — it can no
+  // longer be selected with MANAGED_GIT_PROVIDER. These credentials stay
+  // because EXISTING projects still clone, fetch and push their repos through
+  // it; clearing them breaks those projects, not new ones.
   // CODE_STORAGE_ORG: your code.storage organization identifier — doubles as
   // the JWT `iss` claim and (unless overridden) the git-remote/API host prefix.
   CODE_STORAGE_ORG: optStr,

--- a/apps/api/src/projects/git-backends/index.ts
+++ b/apps/api/src/projects/git-backends/index.ts
@@ -1,5 +1,11 @@
 export * from './types';
-export { getBackend, getDefaultManagedBackend, hasBackend } from './registry';
+export {
+  defaultManagedProviderId,
+  getBackend,
+  getDefaultManagedBackend,
+  hasBackend,
+  isRetiredManagedProvider,
+} from './registry';
 export {
   githubBackend,
   managedGithubInstallId,

--- a/apps/api/src/projects/git-backends/registry.ts
+++ b/apps/api/src/projects/git-backends/registry.ts
@@ -5,12 +5,20 @@
  * Forgejo/Artifacts project resolves through its own — all behind the same
  * Kortix git proxy.
  *
- * GitHub is the default managed backend. code.storage (Pierre) is a second,
- * flag-gated drop-in — select it per-deployment with
- * `MANAGED_GIT_PROVIDER=code-storage`; it stays fully inert (isConfigured()
- * false) until CODE_STORAGE_ORG/CODE_STORAGE_PRIVATE_KEY are set. Forgejo /
- * Cloudflare Artifacts slot in here the same way (same `GitHostBackend`
- * interface) with zero changes to the proxy, sandbox, or CLI.
+ * GitHub is the managed backend for every NEW project, in every environment.
+ *
+ * code.storage (Pierre) is RETIRED as a provisioning target: it stays
+ * registered so existing projects keep reading and writing their repos
+ * (`getBackend(connection.provider)` resolves per project), but it can no
+ * longer be SELECTED as the default — `MANAGED_GIT_PROVIDER=code-storage` is
+ * refused below. The value still sits in deployed env bundles that this repo
+ * does not own (dev's `kortix-dev-env`, ADR-004), and each of them would
+ * otherwise keep minting new repos on a host we are leaving. Retiring it in
+ * code, not in config, is what makes "no new code.storage repos" true
+ * everywhere at once.
+ *
+ * Forgejo / Cloudflare Artifacts slot in here the same way (same
+ * `GitHostBackend` interface) with zero changes to the proxy, sandbox, or CLI.
  */
 import { codeStorageBackend } from './code-storage';
 import { githubBackend } from './github';
@@ -37,8 +45,34 @@ export function getBackend(provider: string): GitHostBackend {
   return backends.get(provider) ?? githubBackend;
 }
 
+/** Providers that may no longer be chosen for a NEW managed repo. Existing
+ *  connections on them keep resolving through `getBackend`. */
+const RETIRED_MANAGED_PROVIDERS = new Set(['code-storage', 'code_storage', 'codestorage']);
+
+/** True when `provider` may no longer host a NEW managed repo. */
+export function isRetiredManagedProvider(provider: string | null | undefined): boolean {
+  return RETIRED_MANAGED_PROVIDERS.has((provider ?? '').trim().toLowerCase());
+}
+
+/**
+ * Provider id NEW managed repos are provisioned on: `MANAGED_GIT_PROVIDER`
+ * unless it names a retired backend, in which case github. Read this rather
+ * than `process.env.MANAGED_GIT_PROVIDER` so a deployed env bundle this repo
+ * does not own cannot re-select a retired host.
+ */
+export function defaultManagedProviderId(): string {
+  const configured = process.env.MANAGED_GIT_PROVIDER?.trim().toLowerCase() || '';
+  if (isRetiredManagedProvider(configured)) {
+    console.warn(
+      `[git-backends] MANAGED_GIT_PROVIDER=${configured} is retired for new repos — provisioning on github instead. ` +
+        'Existing repos on that provider are unaffected; clear the variable to silence this.',
+    );
+    return githubBackend.id;
+  }
+  return configured || 'github';
+}
+
 /** The backend NEW managed projects are provisioned on. */
 export function getDefaultManagedBackend(): GitHostBackend {
-  const provider = process.env.MANAGED_GIT_PROVIDER?.trim() || 'github';
-  return getBackend(provider);
+  return getBackend(defaultManagedProviderId());
 }

--- a/apps/api/src/projects/provision-core.test.ts
+++ b/apps/api/src/projects/provision-core.test.ts
@@ -40,7 +40,7 @@ describe('provision phases', () => {
     expect(fnStart).toBeGreaterThan(-1);
 
     const emitValidating = source.indexOf("emit('validating')", fnStart);
-    const providerCheck = source.indexOf('MANAGED_GIT_PROVIDER', fnStart);
+    const providerCheck = source.indexOf('defaultManagedProviderId()', fnStart);
     const nameCheck = source.indexOf("name is required", fnStart);
     expect(emitValidating).toBeGreaterThan(-1);
     expect(providerCheck).toBeGreaterThan(-1);

--- a/apps/api/src/projects/provision-core.ts
+++ b/apps/api/src/projects/provision-core.ts
@@ -14,7 +14,14 @@
  * response shape is a contract (the CLI and `@kortix/sdk` depend on it) and
  * must not change. The streaming route (next) is the only real consumer.
  */
-import { getBackend, hasBackend, parseBasicAuthHeader, type GitConnectionRef } from './git-backends';
+import {
+  defaultManagedProviderId,
+  getBackend,
+  hasBackend,
+  isRetiredManagedProvider,
+  parseBasicAuthHeader,
+  type GitConnectionRef,
+} from './git-backends';
 import {
   ManagedRepoSeedError,
   buildManagedRepoSeedState,
@@ -157,11 +164,22 @@ export async function runProvision(ctx: ProvisionContext, emit: ProvisionEmit): 
   // Managed-git provider, provider-agnostic via the backend registry. GitHub is
   // the default + only active managed backend. Forgejo / Artifacts slot in here
   // as drop-ins.
-  const provider =
-    normalizeString(body.provider) ??
-    (process.env.MANAGED_GIT_PROVIDER?.trim() || 'github');
+  //
+  // `defaultManagedProviderId()` — never `process.env.MANAGED_GIT_PROVIDER`
+  // directly: a retired backend must not be selectable by a deployed env bundle
+  // (see registry.ts). A caller naming one explicitly is refused for the same
+  // reason; EXISTING repos on it keep working through their connection row.
+  const provider = normalizeString(body.provider) ?? defaultManagedProviderId();
   if (!hasBackend(provider)) {
     return { status: 400, body: { error: `Unsupported managed git provider "${provider}"` } };
+  }
+  if (isRetiredManagedProvider(provider)) {
+    return {
+      status: 400,
+      body: {
+        error: `Managed git provider "${provider}" is retired — new repositories are provisioned on github`,
+      },
+    };
   }
   const backend = getBackend(provider);
   if (!(await backend.isConfigured())) {


### PR DESCRIPTION
`MANAGED_GIT_PROVIDER=code-storage` still sits in deployed env bundles this repo does not own (dev's `kortix-dev-env`, ADR-004), so flipping the committed `.env` files only fixed local runs. This retires it in code, so no environment can select it regardless of its bundle.

- `defaultManagedProviderId()` refuses the retired ids and returns `github`, with a warning naming the stale variable.
- `runProvision` uses it instead of reading the env directly, and refuses an explicit `provider: "code-storage"` with 400.
- The backend stays registered so EXISTING projects keep cloning/pushing — they resolve per project from `project_git_connections.provider`.

**Verified against an API process started with `MANAGED_GIT_PROVIDER=code-storage`** (what dev holds today):

| check | result |
|---|---|
| `POST /v1/projects/provision` | 201 → `https://github.com/managed-kortix/retired-provider-check-<id>.git` |
| connection row | `provider = github` |
| body `{"provider":"code-storage"}` | 400 "…is retired…" |
| existing code-storage project `GET …/scope` | 200 (manifest still readable) |

Tests: +2 registry tests, typecheck clean. `src/projects/` slice fails 292 with and without this change (pre-existing).