### PR TITLE
fix(router): accept the session PAT that every built-in tool actually presents

### DIFF
--- a/apps/api/src/router/routes/proxy/credential-resolution.test.ts
+++ b/apps/api/src/router/routes/proxy/credential-resolution.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+// The two token tables the platform mints into. `resolveKortixAccount` must ask
+// the right one per prefix — asking only `kortix_api_keys` is what 401'd every
+// built-in tool, because the in-sandbox KORTIX_TOKEN is a `kortix_pat_` row in
+// `account_tokens`.
+let patCalls: string[] = [];
+let keyCalls: string[] = [];
+
+mock.module('../../../repositories/account-tokens', () => ({
+  validateAccountToken: async (token: string) => {
+    patCalls.push(token);
+    return token === 'kortix_pat_good'
+      ? { isValid: true, accountId: 'acct-pat' }
+      : { isValid: false, error: 'API key not found or invalid' };
+  },
+}));
+
+mock.module('../../../repositories/api-keys', () => ({
+  validateSecretKey: async (token: string) => {
+    keyCalls.push(token);
+    return token === 'kortix_goodkey'
+      ? { isValid: true, accountId: 'acct-key' }
+      : { isValid: false, error: 'API key not found or invalid' };
+  },
+}));
+
+const { resolveKortixAccount } = await import('./helpers');
+
+describe('resolveKortixAccount', () => {
+  test('a session PAT resolves through account_tokens (the in-sandbox KORTIX_TOKEN)', async () => {
+    patCalls = [];
+    keyCalls = [];
+    expect(await resolveKortixAccount('kortix_pat_good')).toBe('acct-pat');
+    expect(patCalls).toEqual(['kortix_pat_good']);
+    // Never wasted on the wrong table.
+    expect(keyCalls).toEqual([]);
+  });
+
+  test('an API key / sandbox key resolves through kortix_api_keys', async () => {
+    patCalls = [];
+    keyCalls = [];
+    expect(await resolveKortixAccount('kortix_goodkey')).toBe('acct-key');
+    expect(keyCalls).toEqual(['kortix_goodkey']);
+    expect(patCalls).toEqual([]);
+  });
+
+  test('an invalid credential of either shape resolves to null, never to an account', async () => {
+    expect(await resolveKortixAccount('kortix_pat_revoked')).toBeNull();
+    expect(await resolveKortixAccount('kortix_deadkey')).toBeNull();
+  });
+});

--- a/apps/api/src/router/routes/proxy/helpers.ts
+++ b/apps/api/src/router/routes/proxy/helpers.ts
@@ -1,7 +1,8 @@
 import { HTTPException } from 'hono/http-exception';
 import { matchAllowedRoute, type ProxyServiceConfig } from '../../config/proxy-services';
 import { validateSecretKey } from '../../../repositories/api-keys';
-import { isKortixToken } from '../../../shared/crypto';
+import { validateAccountToken } from '../../../repositories/account-tokens';
+import { isAccountToken, isKortixToken } from '../../../shared/crypto';
 import { config, getToolCost } from '../../../config';
 import { deductToolCredits } from '../../services/billing';
 import { grantCredits } from '../../../billing/services/credits';
@@ -13,6 +14,31 @@ import type { ToolCreditReservation, AuthResult } from './app';
 // Re-export matchAllowedRoute for handlers (kept here so handlers import from one place)
 export { matchAllowedRoute };
 
+/**
+ * Resolve ANY Kortix credential to the account it bills.
+ *
+ * The platform mints two shapes and they live in different tables:
+ *   - `kortix_pat_…`  → `account_tokens`   (`validateAccountToken`)
+ *   - `kortix_…` / `kortix_sb_…` → `kortix_api_keys` (`validateSecretKey`)
+ *
+ * The in-sandbox `KORTIX_TOKEN` — the credential every built-in tool presents
+ * to this proxy — is the FIRST shape: a session-scoped PAT auto-minted at
+ * session create (projects/routes/r3.ts). This resolver only ever consulted
+ * the second table, so every built-in tool call answered
+ * `401 Invalid Kortix token in x-api-key` while the same token authenticated
+ * fine on every other route. Try the right validator for the prefix; never
+ * widen what counts as valid (both validators still enforce active + not
+ * expired + not revoked).
+ */
+export async function resolveKortixAccount(token: string): Promise<string | null> {
+  if (isAccountToken(token)) {
+    const pat = await validateAccountToken(token);
+    return pat.isValid && pat.accountId ? pat.accountId : null;
+  }
+  const key = await validateSecretKey(token);
+  return key.isValid && key.accountId ? key.accountId : null;
+}
+
 export async function tryAuthenticate(c: any): Promise<AuthResult> {
   const authHeader = c.req.header('Authorization');
   const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
@@ -23,10 +49,8 @@ export async function tryAuthenticate(c: any): Promise<AuthResult> {
 
   if (bearerToken && isKortixToken(bearerToken) && config.DATABASE_URL) {
     try {
-      const result = await validateSecretKey(bearerToken);
-      if (result.isValid && result.accountId) {
-        return { isKortixUser: true, accountId: result.accountId };
-      }
+      const accountId = await resolveKortixAccount(bearerToken);
+      if (accountId) return { isKortixUser: true, accountId };
     } catch {
       // Fall through to reject below
     }
@@ -40,10 +64,8 @@ export async function tryAuthenticate(c: any): Promise<AuthResult> {
   const tokenPrefixed = authHeader?.startsWith('Token ') ? authHeader.slice(6) : undefined;
   if (tokenPrefixed && isKortixToken(tokenPrefixed) && config.DATABASE_URL) {
     try {
-      const result = await validateSecretKey(tokenPrefixed);
-      if (result.isValid && result.accountId) {
-        return { isKortixUser: true, accountId: result.accountId };
-      }
+      const accountId = await resolveKortixAccount(tokenPrefixed);
+      if (accountId) return { isKortixUser: true, accountId };
     } catch {
       // Fall through to reject below
     }
@@ -56,10 +78,8 @@ export async function tryAuthenticate(c: any): Promise<AuthResult> {
   const xApiKey = c.req.header('x-api-key');
   if (xApiKey && isKortixToken(xApiKey) && config.DATABASE_URL) {
     try {
-      const result = await validateSecretKey(xApiKey);
-      if (result.isValid && result.accountId) {
-        return { isKortixUser: true, accountId: result.accountId };
-      }
+      const accountId = await resolveKortixAccount(xApiKey);
+      if (accountId) return { isKortixUser: true, accountId };
     } catch {
       // Fall through to reject below
     }
@@ -77,10 +97,8 @@ export async function tryAuthenticate(c: any): Promise<AuthResult> {
         const json = JSON.parse(bodyText);
         const bodyApiKey = json?.api_key;
         if (bodyApiKey && isKortixToken(bodyApiKey)) {
-          const result = await validateSecretKey(bodyApiKey);
-          if (result.isValid && result.accountId) {
-            return { isKortixUser: true, accountId: result.accountId };
-          }
+          const accountId = await resolveKortixAccount(bodyApiKey);
+          if (accountId) return { isKortixUser: true, accountId };
           throw new HTTPException(401, { message: 'Invalid Kortix token in request body' });
         }
       }
@@ -100,10 +118,8 @@ export async function tryAuthenticate(c: any): Promise<AuthResult> {
     const kortixTokenHeader = c.req.header('X-Kortix-Token');
     if (kortixTokenHeader && isKortixToken(kortixTokenHeader)) {
       try {
-        const result = await validateSecretKey(kortixTokenHeader);
-        if (result.isValid && result.accountId) {
-          return { isKortixUser: true, accountId: result.accountId, isPassthrough: true };
-        }
+        const accountId = await resolveKortixAccount(kortixTokenHeader);
+        if (accountId) return { isKortixUser: true, accountId, isPassthrough: true };
       } catch {
         // Fall through to reject below
       }


### PR DESCRIPTION
Every built-in tool (Serper, Tavily, Firecrawl, Replicate, Context7, LLM passthrough) answered `401 Invalid Kortix token in x-api-key` from inside a sandbox.

**Root cause.** Two credential shapes, two tables:

| shape | table | validator |
|---|---|---|
| `kortix_pat_…` | `account_tokens` | `validateAccountToken` |
| `kortix_…`, `kortix_sb_…` | `kortix_api_keys` | `validateSecretKey` |

The in-sandbox `KORTIX_TOKEN` is the first shape — a session-scoped PAT auto-minted at session create. `tryAuthenticate` consulted only the second table in all five of its modes, so a valid token was rejected *here* while it authenticated fine everywhere else.

**Fix.** One `resolveKortixAccount(token)` picks the validator by prefix; all five modes use it. Nothing widened — both validators still require active / unexpired / unrevoked, and an unknown credential still hard-rejects.

**Verified against the running API with a real session PAT**

| call | before | after |
|---|---|---|
| `POST /v1/router/serper/search` (x-api-key) | 401 | **200**, real results |
| `POST /v1/router/tavily/search` (body api_key) | 401 | **200** |
| `POST /v1/router/firecrawl/v1/scrape` (Bearer) | 401 | **200** |
| `GET /v1/projects/:id` with the same PAT | 200 | 200 (it was never an invalid token) |

Tests: +3. Router suite fails 34 with and without this change (pre-existing). Typecheck clean.