### PR TITLE
Fix OpenCode resolution in generated sandbox templates

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2021,3 +2021,21 @@ past its `Move :dev` step.
 *Incident:* PR #6764, merge `e6c4ba0b62`, 2026-08-22 23:43 UTC. No outage —
 a frontend-only fix sat undeployed on dev for ~25 minutes while both the run
 list and the deployed-SHA probe read as healthy.
+
+## Update every generated Dockerfile when the sandbox runtime changes
+
+2026-08-23. A fix changed the canonical sandbox Dockerfile, but self-hosted
+template builds continued to fail. The live builder rendered its Dockerfile
+from `packages/shared/src/sandbox/dockerfile-layer.ts`. The fast and meta
+renderers also retained the failed command.
+
+**The rule.** A sandbox runtime command change must update the canonical
+Dockerfile and every generated Dockerfile. A passing canonical Dockerfile test
+does not prove the remote template build path.
+
+**The enforcement.** The layer, fast, and meta renderer tests assert
+`pnpm root -g`. Each test rejects `pnpm list -g`. Golden snapshots make the
+live layered Dockerfile change visible in review.
+
+*Incident:* a self-hosted project template rebuild repeated the retired
+OpenCode package lookup after the canonical image fix deployed.

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -108,7 +108,7 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
     && opencode --version \\
-    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_package="$(pnpm root -g)/opencode-ai" \\
     && opencode_native="$opencode_package/bin/opencode.exe" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
@@ -293,7 +293,7 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
     && opencode --version \\
-    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_package="$(pnpm root -g)/opencode-ai" \\
     && opencode_native="$opencode_package/bin/opencode.exe" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
@@ -479,7 +479,7 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
 RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
     && command -v opencode \\
     && opencode --version \\
-    && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+    && opencode_package="$(pnpm root -g)/opencode-ai" \\
     && opencode_native="$opencode_package/bin/opencode.exe" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -25,8 +25,9 @@ describe('buildFastSandboxDockerfile', () => {
 expect(dockerfile).toContain('FROM ubuntu:24.04');
     expect(dockerfile).toContain('opencode-ai@1.18.19');
     expect(dockerfile).toContain(
-      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+      'opencode_package="$(pnpm root -g)/opencode-ai"',
     );
+    expect(dockerfile).not.toContain('pnpm list -g');
     expect(dockerfile).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
     expect(dockerfile).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
     expect(dockerfile).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');

--- a/packages/shared/src/sandbox/__tests__/layer-render.test.ts
+++ b/packages/shared/src/sandbox/__tests__/layer-render.test.ts
@@ -141,8 +141,9 @@ describe('runtime artifact integrity', () => {
 
   test('exposes the native OpenCode executable at the supervisor path', () => {
     expect(rendered).toContain(
-      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+      'opencode_package="$(pnpm root -g)/opencode-ai"',
     );
+    expect(rendered).not.toContain('pnpm list -g');
     expect(rendered).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
     expect(rendered).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
     expect(rendered).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');

--- a/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
@@ -18,8 +18,9 @@ describe('buildMetaSandboxDockerfile', () => {
     expect(dockerfile).toContain('pnpm runtime set node 22.23.1 --global');
     expect(dockerfile).toContain('opencode-ai@1.18.19');
     expect(dockerfile).toContain(
-      "opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\"",
+      'opencode_package="$(pnpm root -g)/opencode-ai"',
     );
+    expect(dockerfile).not.toContain('pnpm list -g');
     expect(dockerfile).toContain('opencode_native="$opencode_package/bin/opencode.exe"');
     expect(dockerfile).toContain('test "$(wc -c < "$opencode_native")" -gt 50000000');
     expect(dockerfile).toContain('ln -sfn "$opencode_native" /opt/kortix/opencode.current');

--- a/packages/shared/src/sandbox/dockerfile-layer.ts
+++ b/packages/shared/src/sandbox/dockerfile-layer.ts
@@ -597,7 +597,7 @@ export function kortixToolchainLayer(opts: KortixToolchainLayerOpts): string {
     `RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@${opencodeVersion}" \\`,
     '    && command -v opencode \\',
     '    && opencode --version \\',
-    "    && opencode_package=\"$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)\" \\",
+    '    && opencode_package="$(pnpm root -g)/opencode-ai" \\',
     '    && opencode_native="$opencode_package/bin/opencode.exe" \\',
     '    && test -x "$opencode_native" \\',
     '    && test "$(wc -c < "$opencode_native")" -gt 50000000 \\',

--- a/packages/shared/src/sandbox/fast-dockerfile.ts
+++ b/packages/shared/src/sandbox/fast-dockerfile.ts
@@ -74,7 +74,7 @@ RUN case "$(uname -m)" in \
  && test "$(npm --version)" = "${NPM_VERSION}" \
  && HOME=/home/kortix pnpm add --global --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \
  && test "$(opencode --version)" = "${OPENCODE_VERSION}" \
- && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \
+ && opencode_package="$(pnpm root -g)/opencode-ai" \
  && opencode_native="$opencode_package/bin/opencode.exe" \
  && test -x "$opencode_native" \
  && test "$(wc -c < "$opencode_native")" -gt 50000000 \

--- a/packages/shared/src/sandbox/meta-dockerfile.ts
+++ b/packages/shared/src/sandbox/meta-dockerfile.ts
@@ -77,7 +77,7 @@ RUN curl -fsSL https://get.pnpm.io/install.sh \\
       | env HOME=/home/kortix SHELL=/bin/bash PNPM_VERSION=${PNPM_VERSION} sh - \\
  && HOME=/home/kortix pnpm runtime set node ${NODE_VERSION} --global \\
  && HOME=/home/kortix pnpm add --global --allow-build=opencode-ai "opencode-ai@${OPENCODE_VERSION}" \\
- && opencode_package="$(pnpm list -g --parseable --depth 0 opencode-ai | sed -n '\\#/node_modules/opencode-ai$#p' | tail -n 1)" \\
+ && opencode_package="$(pnpm root -g)/opencode-ai" \\
  && opencode_native="$opencode_package/bin/opencode.exe" \\
  && test -x "$opencode_native" \\
  && test "$(wc -c < "$opencode_native")" -gt 50000000 \\


### PR DESCRIPTION
## Problem
Self-hosted template builders still rendered a pnpm global-package lookup that returns no package path with current pnpm. The canonical Dockerfile fix did not change generated template Dockerfiles.

## Change
- resolve OpenCode through `pnpm root -g` in layered, fast, and meta renderers
- reject the retired lookup in each renderer test
- update layered Dockerfile golden snapshots
- record the generator coverage incident rule

## Verification
- `bun test packages/shared/src/sandbox/__tests__ apps/sandbox/opencode-warmup.test.ts` — 79 pass, 0 fail
- repository search returns no retired OpenCode lookup