### PR TITLE
fix(session): stop claiming a live session is "waking" before we have looked

### DIFF
--- a/apps/web/src/features/session/reload-forensics.test.ts
+++ b/apps/web/src/features/session/reload-forensics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { isInvoluntaryLoad } from './reload-forensics';
+
+describe('isInvoluntaryLoad', () => {
+  test('a discarded tab is involuntary — Chrome dropped it, the user did not', () => {
+    expect(
+      isInvoluntaryLoad({ discarded: true, navigationType: 'reload', recentChunkError: null }),
+    ).toBe(true);
+  });
+
+  test('a chunk that failed just before the reload is involuntary', () => {
+    expect(
+      isInvoluntaryLoad({
+        discarded: false,
+        navigationType: 'reload',
+        recentChunkError: 'Loading chunk 4821 failed',
+      }),
+    ).toBe(true);
+  });
+
+  // A person pressing cmd+R looks identical to an automatic reload in the
+  // navigation entry, so reporting every 'reload' would bury the real signal.
+  test('a bare reload is NOT reported — it is indistinguishable from cmd+R', () => {
+    expect(
+      isInvoluntaryLoad({ discarded: false, navigationType: 'reload', recentChunkError: null }),
+    ).toBe(false);
+  });
+
+  test('an ordinary navigation is not reported', () => {
+    expect(
+      isInvoluntaryLoad({ discarded: false, navigationType: 'navigate', recentChunkError: null }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/reload-forensics.ts
+++ b/apps/web/src/features/session/reload-forensics.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Why did this session page load again?
+ *
+ * A user reported sessions "randomly disconnecting" on long threads, and a
+ * screen recording (2026-08-23) showed the page reload ITSELF mid-turn — no
+ * click, cursor motionless — then re-render into the composer's waking state.
+ * Nothing in the app calls `location.reload()` on its own, so the reload came
+ * from outside our code, and after the fact there is no way to tell which
+ * outside: Chrome discarding a heavy tab under memory pressure, a chunk that
+ * 404'd after a deploy (App Router recovers with a hard navigation), or a
+ * renderer crash. Those need different fixes, and guessing between them is how
+ * this stays open.
+ *
+ * So record the one moment that can distinguish them — the load right after —
+ * and label it. Read-only, best-effort, and silent unless something actually
+ * looks involuntary.
+ */
+
+const CHUNK_ERROR_KEY = 'kortix.lastChunkError';
+
+/** A failed lazy chunk is the one involuntary reload cause we can see COMING. */
+export function noteChunkLoadFailure(message: string): void {
+  try {
+    sessionStorage.setItem(CHUNK_ERROR_KEY, JSON.stringify({ message, at: Date.now() }));
+  } catch {
+    /* storage unavailable — the label is a nice-to-have, never a requirement */
+  }
+}
+
+export interface ReloadForensics {
+  /** Chrome dropped the tab (memory pressure) and restored it on return. */
+  discarded: boolean;
+  /** 'reload' | 'navigate' | 'back_forward' | 'prerender' | null */
+  navigationType: string | null;
+  /** A chunk load failed in the previous life of this tab, within 30s. */
+  recentChunkError: string | null;
+}
+
+export function readReloadForensics(now = Date.now()): ReloadForensics {
+  let discarded = false;
+  let navigationType: string | null = null;
+  let recentChunkError: string | null = null;
+
+  try {
+    discarded = (document as Document & { wasDiscarded?: boolean }).wasDiscarded === true;
+  } catch {
+    /* older engines */
+  }
+  try {
+    const [nav] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+    navigationType = nav?.type ?? null;
+  } catch {
+    /* no navigation timing */
+  }
+  try {
+    const raw = sessionStorage.getItem(CHUNK_ERROR_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { message?: string; at?: number };
+      // Only the previous life counts. An hour-old entry says nothing about
+      // THIS load, and a stale label is worse than none.
+      if (parsed?.at && now - parsed.at < 30_000 && parsed.message) {
+        recentChunkError = parsed.message;
+      }
+      sessionStorage.removeItem(CHUNK_ERROR_KEY);
+    }
+  } catch {
+    /* storage unavailable */
+  }
+
+  return { discarded, navigationType, recentChunkError };
+}
+
+/** True when the load looks involuntary — worth reporting, unlike an ordinary
+ *  navigation or a reload the user pressed themselves (which we cannot tell
+ *  apart from an automatic one, so a bare 'reload' alone is NOT enough). */
+export function isInvoluntaryLoad(f: ReloadForensics): boolean {
+  return f.discarded || f.recentChunkError !== null;
+}
+
+/**
+ * Label this page load, and watch for the chunk failure that would explain the
+ * NEXT one. Mount once per session page.
+ *
+ * Reports only an involuntary load (`isInvoluntaryLoad`), so an ordinary
+ * navigation — or a reload someone pressed — stays silent. What lands in Sentry
+ * is the distinction the screen recording could not make: discarded tab vs
+ * chunk-404-after-deploy.
+ */
+export function useReloadForensics(sessionId: string | null | undefined): void {
+  useEffect(() => {
+    const onError = (event: ErrorEvent) => {
+      const message = event?.message ?? '';
+      if (/loading chunk|chunkloaderror|failed to fetch dynamically imported module/i.test(message)) {
+        noteChunkLoadFailure(message);
+      }
+    };
+    window.addEventListener('error', onError);
+
+    const forensics = readReloadForensics();
+    if (isInvoluntaryLoad(forensics)) {
+      console.warn('[session] involuntary page load', { sessionId, ...forensics });
+      Sentry.captureMessage('session page reloaded involuntarily', {
+        level: 'warning',
+        extra: { sessionId, ...forensics },
+      });
+    }
+
+    return () => window.removeEventListener('error', onError);
+  }, [sessionId]);
+}

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -220,6 +220,8 @@ import {
   serverHoldsOpenTurn,
   sessionComposerReadiness,
 } from './session-composer-readiness';
+import { useReadinessSettling } from './use-readiness-settling';
+import { useReloadForensics } from './reload-forensics';
 import { captureTurnScrollAnchor, restoreTurnScrollAnchor } from './session-history-scroll';
 import { resolveSessionContentState } from './session-load-state';
 import { shouldLoadOlderHistory } from './session-older-autoload';
@@ -4386,8 +4388,18 @@ export function SessionChat({
   // failure counter every tick, so `unreachable` never fires no matter how
   // long it stays wedged. See `useRuntimeBootStalled`.
   const runtimeStalled = useRuntimeBootStalled();
+  // Label an involuntary page load (discarded tab, or a chunk 404 after a
+  // deploy) so the next "my session randomly disconnected" report arrives with
+  // its cause attached instead of a shrug.
+  useReloadForensics(projectSessionId);
+  // Nothing has answered yet and the mount is young: the difference between
+  // "this session is asleep" and "we have not looked yet". Without it, every
+  // page load painted the waking notice for a beat over a session that was
+  // never asleep — which reads as a disconnect. See `settling`.
+  const composerSettling = useReadinessSettling(runtimePhase === 'connecting');
   const composerReadiness = sessionComposerReadiness({
     runtimeReady,
+    settling: composerSettling,
     // Only an OPEN TURN the control plane is holding counts here. This tab's
     // optimistic receipt and a stream frame both survive a box that died
     // mid-turn, and a durable inbox row (which the projection also sources to

--- a/apps/web/src/features/session/session-composer-readiness.test.ts
+++ b/apps/web/src/features/session/session-composer-readiness.test.ts
@@ -8,6 +8,47 @@ import {
 } from './session-composer-readiness';
 
 describe('sessionComposerReadiness', () => {
+  // Screen recording (dev, 2026-08-23): a session page reloaded itself while the
+  // agent was mid-turn, and for ~2s the composer claimed "Waking this session
+  // up…" before the transcript resumed streaming. Nothing was asleep — the box
+  // was up and working the whole time. On a cold mount the health probe has not
+  // answered and `GET .../turn` has not landed, so every input is false and the
+  // final fallback asserted the one thing we had not checked. Read to the user
+  // that is a disconnect: the session "dropped and came back".
+  test('says NOTHING while it has not contacted the runtime yet', () => {
+    const readiness = sessionComposerReadiness({ runtimeReady: false, settling: true });
+
+    expect(readiness.notice).toBeNull();
+    expect(readiness.ready).toBe(false);
+    expect(readiness.retryable).toBe(false);
+  });
+
+  test('claims waking once the settle window closes and it is still not ready', () => {
+    expect(sessionComposerReadiness({ runtimeReady: false, settling: false }).notice).toMatch(
+      /waking/i,
+    );
+  });
+
+  test('a KNOWN failure still speaks during the settle window', () => {
+    // `settling` withholds a guess, never a fact. An unreachable box and a
+    // stalled boot are both observations, and both carry a retry.
+    const unreachable = sessionComposerReadiness({
+      runtimeReady: false,
+      settling: true,
+      unreachable: true,
+    });
+    expect(unreachable.notice).toMatch(/lost contact/i);
+    expect(unreachable.retryable).toBe(true);
+
+    const stalled = sessionComposerReadiness({ runtimeReady: false, settling: true, stalled: true });
+    expect(stalled.notice).toMatch(/taking longer/i);
+    expect(stalled.retryable).toBe(true);
+  });
+
+  test('a ready runtime is unaffected by the settle window', () => {
+    expect(sessionComposerReadiness({ runtimeReady: true, settling: true }).notice).toBeNull();
+  });
+
   test('a ready runtime leaves the composer alone — no notice', () => {
     expect(sessionComposerReadiness({ runtimeReady: true })).toEqual({
       ready: true,

--- a/apps/web/src/features/session/session-composer-readiness.ts
+++ b/apps/web/src/features/session/session-composer-readiness.ts
@@ -131,6 +131,24 @@ export function sessionComposerReadiness(input: {
    * "indistinguishable from stuck" failure this module exists to prevent.
    */
   stalled?: boolean;
+  /**
+   * Nothing has been CONTACTED yet — the runtime probe has not answered and
+   * `GET .../turn` has not landed, and the mount is young enough that this is
+   * ordinary startup rather than a wait.
+   *
+   * On a cold mount every other input here is false: not ready, no open turn,
+   * not unreachable, not stalled. The fallback below then asserted the one
+   * thing nobody had checked — that the session is asleep — and a page that had
+   * just reloaded under a working agent showed "Waking this session up…" for a
+   * couple of seconds before the transcript resumed streaming (screen
+   * recording, dev, 2026-08-23). To the person watching, the session dropped
+   * and came back. It never went anywhere; we simply had not looked yet.
+   *
+   * Withholding a GUESS, never a fact: an unreachable box and a stalled boot
+   * are observations and still speak immediately, and so does a live server
+   * turn. Only the "must be waking, then" fallback waits to be sure.
+   */
+  settling?: boolean;
 }): SessionComposerReadiness {
   if (input.runtimeReady) return { ready: true, notice: null, retryable: false };
   if (input.serverTurnLive) {
@@ -160,6 +178,10 @@ export function sessionComposerReadiness(input: {
         'Still waking this session up — taking longer than usual. Messages you send will be queued.',
       retryable: true,
     };
+  }
+  if (input.settling) {
+    // We know nothing yet. Say nothing — see `settling`.
+    return { ready: false, notice: null, retryable: false };
   }
   return {
     ready: false,

--- a/apps/web/src/features/session/use-readiness-settling.test.ts
+++ b/apps/web/src/features/session/use-readiness-settling.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { READINESS_SETTLE_MS } from './use-readiness-settling';
+
+describe('READINESS_SETTLE_MS', () => {
+  // The window only buys silence for the first probe round trip. Anything
+  // longer delays a REAL wake notice on a parked box, which is the state the
+  // notice exists for.
+  test('is short enough that a real wake still announces itself promptly', () => {
+    expect(READINESS_SETTLE_MS).toBeLessThanOrEqual(2_000);
+  });
+
+  test('is long enough to cover a first health probe', () => {
+    expect(READINESS_SETTLE_MS).toBeGreaterThanOrEqual(1_000);
+  });
+});

--- a/apps/web/src/features/session/use-readiness-settling.ts
+++ b/apps/web/src/features/session/use-readiness-settling.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * How long a freshly mounted session may say NOTHING about its runtime.
+ *
+ * Long enough to cover the first health probe + `GET .../turn` round trip on a
+ * healthy session (both answer well inside a second locally and on dev), short
+ * enough that a genuinely parked box still announces its wake promptly. The
+ * cost of being wrong in one direction is a false "your session dropped" flash
+ * on every page load; in the other, a real wake notice arrives ~1.5s later.
+ */
+export const READINESS_SETTLE_MS = 1_500;
+
+/**
+ * True while the runtime has not been contacted yet AND the mount is young.
+ *
+ * Feeds `sessionComposerReadiness({ settling })`, whose fallback would
+ * otherwise assert "Waking this session up…" the instant a page loads — the
+ * one claim nothing had checked. See that input's docstring.
+ */
+export function useReadinessSettling(uncontacted: boolean, windowMs = READINESS_SETTLE_MS): boolean {
+  // Each uninterrupted stretch of "uncontacted" is one ARM. The timer reports
+  // which arm it belongs to, so a session switch (uncontacted false -> true)
+  // starts a fresh window without a state reset inside the effect.
+  const armRef = useRef(0);
+  const [expiredArm, setExpiredArm] = useState(-1);
+
+  useEffect(() => {
+    if (!uncontacted) return;
+    const arm = (armRef.current += 1);
+    const timer = window.setTimeout(() => setExpiredArm(arm), windowMs);
+    return () => window.clearTimeout(timer);
+  }, [uncontacted, windowMs]);
+
+  return uncontacted && expiredArm !== armRef.current;
+}


### PR DESCRIPTION
**From the screen recording** (Gemini 3.7 Flash read it frame by frame): at 00:11 the session page reloads **by itself** while the agent is mid-turn — no click, cursor motionless — then shows `Waking this session up… messages you send will be queued and go out automatically` from 00:13 to 00:15, after which streaming resumes and the transcript is intact. The box was never asleep.

**Cause of the false notice.** On a cold mount every input to `sessionComposerReadiness` is false: probe unanswered, no turn read yet, not unreachable, not stalled. The fallback then asserted the one thing nobody had checked — that the session is waking.

**Fix.** A `settling` input withholds that guess while the runtime is uncontacted and the mount is young (1.5s). It withholds a guess, never a fact — an unreachable box, a stalled boot, and a live server turn all still speak immediately.

**The reload itself is not explained yet, and I did not guess.** Nothing in the app calls `location.reload()` unprompted. The two candidates behave differently and need different fixes: Chrome discarding a heavy tab (long thread + leaving the tab, which is what the user reports) versus a chunk 404 after a deploy. `reload-forensics` labels the following load — `document.wasDiscarded`, navigation type, and any chunk-load error from the tab's previous life — and reports only an involuntary one, so the next occurrence arrives with its cause. A bare `reload` stays silent because it is indistinguishable from cmd+R.

Tests: +10. `apps/web` tsc clean (bar the 3 known `@types/bun` test files), eslint 0 errors.

**Not verified in a browser A/B:** my headless test browser kept losing its auth session, so the before/after is pinned by unit tests and the recording, not by a live capture.