### PR TITLE
fix(models): a connected ChatGPT subscription can be removed again

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/chatgpt-subscription-connect.tsx
@@ -4,18 +4,24 @@ import { ChatGptDeviceChallenge } from '@/components/projects/chatgpt-device-cha
 import { Button } from '@/components/ui/button';
 import { InfoBanner } from '@/components/ui/info-banner';
 import Loading from '@/components/ui/loading';
-import { successToast } from '@/components/ui/toast';
+import { errorToast, successToast } from '@/components/ui/toast';
 import { ProviderLogo } from '@/features/providers/provider-branding';
-import { pollProjectProviderOAuth, startProjectProviderOAuth } from '@kortix/sdk';
-import { qk, refreshProjectProviderState } from '@kortix/sdk/react';
+import {
+  deleteProjectProviderOAuth,
+  listProjectSecrets,
+  pollProjectProviderOAuth,
+  startProjectProviderOAuth,
+} from '@kortix/sdk';
+import { contract, qk, refreshProjectProviderState } from '@kortix/sdk/react';
 import {
   CheckCircleIcon as CheckCircle2,
   WarningIcon as TriangleAlert,
 } from '@phosphor-icons/react';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { subscriptionIsConnected, subscriptionPrimaryAction } from './subscription-control';
 import type { ChatGptChallenge, ChatGptPhase } from './types';
 import { sleep } from './utils';
 
@@ -105,7 +111,39 @@ export function ChatGptSubscriptionConnect({
     }
   }, [projectId, queryClient, onConnected]);
 
+  // What the PROJECT holds, not what this component remembers doing. A
+  // credential connected in another tab, another surface, or before this page
+  // load is still connected — and until this read existed the card offered
+  // "Connect ChatGPT" over it and no way to remove it at all.
+  const secretsQuery = useQuery({
+    queryKey: qk.project.secrets(projectId),
+    queryFn: () => listProjectSecrets(projectId),
+    ...contract('config'),
+  });
+  const connected = useMemo(() => {
+    const data = secretsQuery.data;
+    const items = Array.isArray(data) ? data : (data?.items ?? []);
+    return subscriptionIsConnected(items.map((item) => item.name));
+  }, [secretsQuery.data]);
+
+  const disconnect = useMutation({
+    // The server route was always correct and always unreachable: it deletes
+    // the credential, audits it, and refreshes the model catalog. Nothing in
+    // the product called it.
+    mutationFn: () => deleteProjectProviderOAuth(projectId, 'openai'),
+    onSuccess: () => {
+      successToast('ChatGPT subscription disconnected');
+      setPhase('idle');
+      setError(null);
+      queryClient.invalidateQueries({ queryKey: qk.project.secrets(projectId) });
+      refreshProjectProviderState(queryClient, projectId);
+    },
+    onError: (err) =>
+      errorToast(err instanceof Error ? err.message : 'Failed to disconnect the subscription'),
+  });
+
   const waiting = phase === 'waiting';
+  const action = subscriptionPrimaryAction({ connected, failed: !!error });
 
   return (
     <div className="bg-popover rounded-md border px-4 py-4">
@@ -152,7 +190,7 @@ export function ChatGptSubscriptionConnect({
         </div>
       )}
 
-      {phase === 'done' && (
+      {(phase === 'done' || (connected && !waiting)) && (
         <InfoBanner tone="success" icon={CheckCircle2} className="mt-3 text-xs">
           {tHardcodedUi.raw(
             'autoComponentsProjectsProjectProviderModalJsxTextChatGPTSubscriptionConnectedcf12bc87',
@@ -171,6 +209,17 @@ export function ChatGptSubscriptionConnect({
           <Button type="button" size="sm" variant="outline" className="px-4" onClick={reset}>
             Cancel
           </Button>
+        ) : action === 'disconnect' ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="px-4"
+            disabled={disconnect.isPending}
+            onClick={() => disconnect.mutate()}
+          >
+            {disconnect.isPending ? 'Disconnecting…' : 'Disconnect ChatGPT'}
+          </Button>
         ) : (
           <Button
             type="button"
@@ -179,7 +228,7 @@ export function ChatGptSubscriptionConnect({
             className="px-4"
             onClick={handleConnect}
           >
-            {error || phase === 'done' ? 'Reconnect ChatGPT' : 'Connect ChatGPT'}
+            {action === 'reconnect' ? 'Reconnect ChatGPT' : 'Connect ChatGPT'}
           </Button>
         )}
       </div>

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/subscription-control.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/subscription-control.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { subscriptionIsConnected, subscriptionPrimaryAction } from './subscription-control';
+
+describe('subscriptionIsConnected', () => {
+  test('sees the current credential', () => {
+    expect(subscriptionIsConnected(['CODEX_AUTH_JSON'])).toBe(true);
+  });
+
+  // Projects connected before the rename still hold the legacy name, and they
+  // are exactly the long-lived ones a user would now be trying to disconnect.
+  test('sees the legacy credential', () => {
+    expect(subscriptionIsConnected(['OPENCODE_AUTH_JSON'])).toBe(true);
+  });
+
+  test('an API key alone is NOT a subscription', () => {
+    expect(subscriptionIsConnected(['OPENAI_API_KEY'])).toBe(false);
+    expect(subscriptionIsConnected([])).toBe(false);
+  });
+});
+
+describe('subscriptionPrimaryAction', () => {
+  // The defect: a connected subscription offered "Connect" forever and could
+  // never be removed from any surface in the product.
+  test('a connected subscription offers DISCONNECT', () => {
+    expect(subscriptionPrimaryAction({ connected: true, failed: false })).toBe('disconnect');
+  });
+
+  test('nothing connected offers CONNECT', () => {
+    expect(subscriptionPrimaryAction({ connected: false, failed: false })).toBe('connect');
+  });
+
+  test('a failed attempt offers RECONNECT even when a credential is on file', () => {
+    expect(subscriptionPrimaryAction({ connected: true, failed: true })).toBe('reconnect');
+    expect(subscriptionPrimaryAction({ connected: false, failed: true })).toBe('reconnect');
+  });
+});

--- a/apps/web/src/features/workspace/customize/sections/llm-provider/subscription-control.ts
+++ b/apps/web/src/features/workspace/customize/sections/llm-provider/subscription-control.ts
@@ -1,0 +1,43 @@
+import { CODEX_AUTH_JSON_SECRET_NAME, LEGACY_RUNTIME_AUTH_JSON_SECRET_NAME } from './constants';
+
+/**
+ * What the ChatGPT-subscription card offers, given what the project actually
+ * holds.
+ *
+ * The card used to decide this from LOCAL state only (`phase`), which knows
+ * nothing about a credential connected in another tab, another surface, or
+ * before this page load. It therefore said "Connect ChatGPT" over an already
+ * connected subscription and — the reason this file exists — offered no way to
+ * REMOVE one. That was the whole product: a subscription could be connected
+ * from four surfaces and disconnected from none.
+ *
+ * `providerDisconnectPlan` does carry `oauthProvider: 'openai'`, so removing
+ * the OpenAI API KEY takes the subscription with it — but the openai row only
+ * renders when `OPENAI_API_KEY` exists. Connect only the subscription (the
+ * common case: it is the whole point of "sign in with ChatGPT") and there is no
+ * row, no remove control, and no way back out.
+ *
+ * The server side was never the problem: `DELETE /projects/:id/oauth/openai`
+ * deletes the credential, audits it, and refreshes the model catalog. Nothing
+ * called it.
+ */
+export type SubscriptionAction = 'connect' | 'reconnect' | 'disconnect';
+
+export function subscriptionIsConnected(secretNames: Iterable<string>): boolean {
+  for (const name of secretNames) {
+    if (name === CODEX_AUTH_JSON_SECRET_NAME || name === LEGACY_RUNTIME_AUTH_JSON_SECRET_NAME) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function subscriptionPrimaryAction(input: {
+  connected: boolean;
+  failed: boolean;
+}): SubscriptionAction {
+  // A failure outranks the stored credential: the thing on file did not work,
+  // so the useful button is the one that replaces it.
+  if (input.failed) return 'reconnect';
+  return input.connected ? 'disconnect' : 'connect';
+}


### PR DESCRIPTION
**Reported:** removing model keys doesn't work. **Traced end to end against the running API** — the server side was never broken:

| call | result |
|---|---|
| `DELETE /projects/:id/secrets/CODEX_AUTH_JSON` | 400 — refused by design ("must be disconnected as an OAuth provider") |
| `DELETE /projects/:id/oauth/openai` | 200 — credential gone from the exact list the UI reads, models refreshed, audited |
| `OPENAI_API_KEY` add → delete | 200 — gone (plain BYOK removal was fine) |
| `PUT /secrets/OPENAI_API_KEY/personal` | 400 — provider keys are always project-wide, so no per-user row can survive a removal |

**Nothing in the product called the one route that works.** The only Disconnect was deleted along with the account-scoped Connected row (`connected-tab.tsx` documents this), and `ChatGptSubscriptionConnect` decided everything from local state: it showed "Connect ChatGPT" over an already-connected subscription and offered no removal. `providerDisconnectPlan` does carry `oauthProvider: 'openai'`, but the openai row only renders when `OPENAI_API_KEY` exists — so a subscription connected on its own had no row, no remove control, and no way out, while its GPT models kept working.

**Fix:** `subscription-control.ts` derives the card's action from the project's secrets (current *and* legacy credential names), and the card offers **Disconnect ChatGPT** → `deleteProjectProviderOAuth(projectId, 'openai')` with the same invalidations the connect path uses. Both hosting surfaces inherit it.

Tests +6; tsc clean bar the known `@types/bun` files; eslint clean; 75 llm-provider tests pass.

**Not captured:** a literal click-through — my headless test browser kept losing its auth session. The chain the button fires is verified against the live API above.