### PR TITLE
fix(sdk): a status snapshot may fill a gap, never overwrite the live stream

### DIFF
--- a/packages/sdk/src/react/use-opencode-events/hydrate-status-guard.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/hydrate-status-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * `hydrateCore`'s `client.session.status()` snapshot describes the moment its
+ * request was ISSUED and carries no timestamp of its own. Written back
+ * unconditionally, a `busy` that was true on the way out overwrote an `idle`
+ * frame that arrived while it was in flight — and because the object identity
+ * changed, the store restamped that stale reading as the freshest observation
+ * there is. Stop and the turn shimmer came back on a finished turn.
+ *
+ * The guard is one line, so this pins it in the source rather than standing up
+ * the whole event-stream harness: hydration may FILL a gap, never overwrite a
+ * value the live stream already put there.
+ */
+const SOURCE = await Bun.file(new URL('./index.ts', import.meta.url).pathname).text();
+
+function hydrateStatusBlock(): string {
+  const start = SOURCE.indexOf('client.session\n        .status()');
+  expect(start).toBeGreaterThan(-1);
+  const end = SOURCE.indexOf('reconcileMissingBusySessions.current(statuses)', start);
+  expect(end).toBeGreaterThan(start);
+  return SOURCE.slice(start, end);
+}
+
+describe('hydrateCore session-status snapshot', () => {
+  test('skips any session the live stream has already answered for', () => {
+    const block = hydrateStatusBlock();
+    expect(block).toContain('if (useSyncStore.getState().sessionStatus[sessionID]) continue;');
+  });
+
+  test('the skip precedes the write, so a stale reading cannot land first', () => {
+    const block = hydrateStatusBlock();
+    const guard = block.indexOf('sessionStatus[sessionID]) continue');
+    const write = block.indexOf('applySyncEvent(');
+    expect(guard).toBeGreaterThan(-1);
+    expect(write).toBeGreaterThan(guard);
+  });
+
+  test('the enumeration repair still runs — absence is not a per-session reading', () => {
+    expect(SOURCE).toContain('reconcileMissingBusySessions.current(statuses)');
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -212,6 +212,30 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
           // for the rest.
           const statuses = res.data ?? {};
           for (const [sessionID, status] of Object.entries(statuses)) {
+            // ONLY where this read is newer than what the live stream has
+            // already said. The read is a snapshot of the moment it was ISSUED,
+            // it carries no timestamp of its own, and it used to be written in
+            // unconditionally — so a `busy` that was true when the request left
+            // overwrote an `idle` frame that arrived while it was in flight, and
+            // because the object identity changed the store restamped the stale
+            // reading as the freshest observation there is. That put the Stop
+            // button and the turn shimmer back on a finished turn, and
+            // `hydrateCore` runs on every heartbeat-gap rehydrate, so it could
+            // land on any turn boundary.
+            // FILL A GAP, NEVER OVERWRITE. This snapshot describes the moment
+            // the request was ISSUED and carries no timestamp of its own, so an
+            // unconditional write let a `busy` that was true on the way out
+            // clobber an `idle` frame that arrived while it was in flight — and
+            // because the object identity changed, the store restamped that
+            // stale reading as the freshest observation there is. Stop and the
+            // turn shimmer came back on a finished turn, and `hydrateCore` runs
+            // on every heartbeat-gap rehydrate, so it could land on any turn
+            // boundary. While the live stream is delivering (~140ms per frame
+            // for a busy session, and this runs on connect) the stream owns this
+            // value; the correction for a session that went idle unseen is
+            // `reconcileMissingBusySessions` below, which reads ABSENCE from the
+            // complete list rather than a per-session reading.
+            if (useSyncStore.getState().sessionStatus[sessionID]) continue;
             // Locally-synthesized event (this is a REST poll, not an SSE
             // frame) — omits the `id` field every real `Event` union member
             // carries, hence the assertion.
@@ -220,6 +244,10 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
               properties: { sessionID, status },
             } as unknown as OpenCodeSdkEvent);
           }
+          // The ENUMERATION half is not a per-session reading and does not go
+          // stale the same way: a session absent from a complete list was not
+          // running when the list was taken, and the repair it drives
+          // (`markSessionIdleLocally`) is guarded on its own.
           reconcileMissingBusySessions.current(statuses);
         })
         .catch((err) => {


### PR DESCRIPTION
The audit's **#1 remaining suspect** for the reported "it finishes then comes back" flash, and the third instance today of the same shape: a reading believed for a reason other than being the newest evidence.

`hydrateCore` reads `client.session.status()` — the runtime's complete set of non-idle sessions — and wrote every entry back into the sync store unconditionally. That read describes the moment its request was **issued** and carries no timestamp of its own, so a `busy` that was true on the way out overwrote an `idle` frame that arrived while it was in flight. Worse, the write changes the object's identity, so `useSessionWorking` stamped the stale reading as the freshest observation there is — putting Stop and the turn shimmer back on a finished turn.

`hydrateCore` runs on connect **and on every heartbeat-gap rehydrate**, so it could land on any turn boundary.

**Fix:** skip the write for any session the live stream has already answered for. While the stream is delivering (~140ms per frame for a busy session, and this runs on connect) the stream owns that value. `reconcileMissingBusySessions` is untouched — it reads *absence* from a complete list, which is not a per-session reading and does not go stale the same way.

Tests: +3 pinning the guard, its position before the write, and that the enumeration repair still runs. SDK typecheck clean, **2430 pass / 0 fail**.