### PR TITLE
perf(session): bound what a long thread retains

### DIFF
--- a/apps/web/src/features/file-renderers/pdf/pdf-thumbnail-utils.ts
+++ b/apps/web/src/features/file-renderers/pdf/pdf-thumbnail-utils.ts
@@ -1,3 +1,4 @@
+import { ObjectUrlCache } from "@/lib/object-url-cache"
 import type { PdfDocumentObject, PdfEngine } from "@embedpdf/models"
 
 const PDFIUM_WASM_PATH = "/pdfium/pdfium.wasm"
@@ -13,7 +14,19 @@ function resolvePdfiumWasmUrl(): string {
 
 let sharedEnginePromise: Promise<PdfEngine> | null = null
 const pdfDocumentCache = new Map<string, Promise<PdfDocumentObject>>()
-const thumbnailUrlCache = new Map<string, Promise<string | null>>()
+/**
+ * Rendered page thumbnails, BOUNDED and revoked on eviction.
+ *
+ * This was an uncapped `Map<string, Promise<string|null>>`, so every page of
+ * every PDF a session ever previewed kept its object URL — and the blob behind
+ * it — alive for the tab's lifetime. The in-flight map below still dedupes
+ * concurrent renders of the same page; it just stops being the permanent home
+ * for the result.
+ */
+const thumbnailUrlCache = new ObjectUrlCache(48)
+/** Renders currently in flight, so two callers share one decode. Cleared as
+ *  soon as the render settles — a resolved entry lives in the bounded cache. */
+const thumbnailInFlight = new Map<string, Promise<string | null>>()
 
 export function loadSharedPdfEngine() {
   sharedEnginePromise ??= import("@embedpdf/engines/pdfium-worker-engine").then(
@@ -57,7 +70,10 @@ export function renderPdfThumbnailUrl({
   width: number
 }) {
   const cacheKey = `${url}#${pageIndex}@${width}x${dpr}`
-  let thumbnailPromise = thumbnailUrlCache.get(cacheKey)
+  const cached = thumbnailUrlCache.get(cacheKey)
+  if (cached !== undefined) return cached
+
+  let thumbnailPromise = thumbnailInFlight.get(cacheKey)
 
   if (!thumbnailPromise) {
     thumbnailPromise = (async () => {
@@ -78,9 +94,18 @@ export function renderPdfThumbnailUrl({
         })
         .toPromise()
 
-      return URL.createObjectURL(blob)
+      const objectUrl = URL.createObjectURL(blob)
+      thumbnailUrlCache.set(cacheKey, objectUrl)
+      return objectUrl
     })()
-    thumbnailUrlCache.set(cacheKey, thumbnailPromise)
+    thumbnailInFlight.set(cacheKey, thumbnailPromise)
+    // Settled is settled: the result (or the failure) leaves the in-flight map
+    // either way, so a failed render is retried rather than remembered forever.
+    void thumbnailPromise.finally(() => {
+      if (thumbnailInFlight.get(cacheKey) === thumbnailPromise) {
+        thumbnailInFlight.delete(cacheKey)
+      }
+    })
   }
 
   return thumbnailPromise

--- a/apps/web/src/features/session/action-panel/easy/outputs-card.tsx
+++ b/apps/web/src/features/session/action-panel/easy/outputs-card.tsx
@@ -19,6 +19,7 @@ import Loading from '@/components/ui/loading';
 import { readRuntimeFileWithRetry } from '@/features/files/api/runtime-file-read';
 import { downloadFilesAsZip, readFileAsBlob } from '@/features/files/api/runtime-files';
 import { getFileIcon } from '@/features/project-files';
+import { ObjectUrlCache } from '@/lib/object-url-cache';
 import { track } from '@/lib/track';
 import { cn } from '@/lib/utils';
 import {
@@ -47,9 +48,14 @@ const KIND_ICON = {
 /** `callID:path` → object URL, shared across rows and re-renders. Keyed by
  * call, not bare path: paths repeat across sessions (`output.png`), and callID
  * is unique per tool call, so one session can never be served another's bytes.
- * Never revoked: a session shows dozens of thumbs at ~28px, and revoking on
- * unmount would refetch on every expand/collapse. */
-const thumbCache = new Map<string, string>();
+ * Not revoked on unmount: a session shows dozens of thumbs at ~28px, and
+ * revoking there would refetch on every expand/collapse. BOUNDED, though —
+ * "never revoke" and "never evict" were two decisions and only the first was
+ * needed. A long session opens dozens of image-producing tool calls and every
+ * blob behind these URLs stayed pinned for the tab's lifetime, because a
+ * session page never unmounts a turn. Least-recently-USED, so re-expanding the
+ * same output still never refetches. */
+const thumbCache = new ObjectUrlCache(64);
 
 /**
  * A 28×28 image thumbnail — the glyph is a promise ("this is an image"), the

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -224,7 +224,7 @@ import { useReadinessSettling } from './use-readiness-settling';
 import { useReloadForensics } from './reload-forensics';
 import { captureTurnScrollAnchor, restoreTurnScrollAnchor } from './session-history-scroll';
 import { resolveSessionContentState } from './session-load-state';
-import { shouldLoadOlderHistory } from './session-older-autoload';
+import { olderAutoloadExhausted, shouldLoadOlderHistory } from './session-older-autoload';
 
 // ============================================================================
 // Reply-to context (select & reply feature)
@@ -2808,8 +2808,12 @@ export function SessionChat({
   // in the turn anchor — capture where the topmost visible turn sits, restore
   // it after the prepended turns render, and the viewport never jumps.
   const [olderPullFailed, setOlderPullFailed] = useState(false);
+  // Pages the SENTINEL has pulled. An explicit pull never counts — see
+  // `OLDER_AUTOLOAD_MAX_PAGES` for why the automatic path is the one bounded.
+  const [autoLoadedPages, setAutoLoadedPages] = useState(0);
   useEffect(() => {
     setOlderPullFailed(false);
+    setAutoLoadedPages(0);
   }, [sessionId]);
   const handleLoadOlder = useCallback(async () => {
     const node = scrollRef.current;
@@ -2838,8 +2842,10 @@ export function SessionChat({
             hasOlder,
             isLoadingOlder,
             lastPullFailed: olderPullFailed,
+            autoLoadedPages,
           })
         ) {
+          setAutoLoadedPages((pages) => pages + 1);
           void handleLoadOlder();
         }
       },
@@ -2850,7 +2856,15 @@ export function SessionChat({
     return () => observer.disconnect();
     // sessionId is a dep because switching sessions swaps the scroll
     // container the observer is rooted in.
-  }, [hasOlder, isLoadingOlder, olderPullFailed, handleLoadOlder, scrollRef, sessionId]);
+  }, [
+    hasOlder,
+    isLoadingOlder,
+    olderPullFailed,
+    autoLoadedPages,
+    handleLoadOlder,
+    scrollRef,
+    sessionId,
+  ]);
 
   // Scroll to the bottom on initial load / session change.
   // Uses a callback ref on the scroll container to guarantee it's mounted.
@@ -4620,6 +4634,18 @@ export function SessionChat({
                         soon as the prepended turns render. */}
                       <div ref={olderSentinelRef} aria-hidden className="h-px w-full" />
                       {isLoadingOlder && <Loading />}
+                      {!isLoadingOlder &&
+                        !olderPullFailed &&
+                        olderAutoloadExhausted({ hasOlder, autoLoadedPages }) && (
+                          <Button
+                            type="button"
+                            variant="outline-ghost"
+                            size="sm"
+                            onClick={() => void handleLoadOlder()}
+                          >
+                            Load older messages
+                          </Button>
+                        )}
                       {olderPullFailed && !isLoadingOlder && (
                         <div className="flex items-center gap-2">
                           <span className="text-muted-foreground text-xs">

--- a/apps/web/src/features/session/session-older-autoload.test.ts
+++ b/apps/web/src/features/session/session-older-autoload.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { shouldLoadOlderHistory } from './session-older-autoload';
+import {
+  OLDER_AUTOLOAD_MAX_PAGES,
+  olderAutoloadExhausted,
+  shouldLoadOlderHistory,
+} from './session-older-autoload';
 
 const IN_VIEW = {
   isIntersecting: true,
@@ -9,6 +13,35 @@ const IN_VIEW = {
 };
 
 describe('older-history autoload', () => {
+  // A transcript never sheds what it pulls: turns stay in the DOM, their parts
+  // stay in the sync store, and their images keep decoded bitmaps alive. Left
+  // uncapped, idle scrolling walks a long thread's whole history into memory —
+  // the retention behind a tab Chrome discards and reloads on its own. Reading
+  // further back stays possible; it just stops being something a scroll does by
+  // itself.
+  test('stops pulling by itself once the auto-load budget is spent', () => {
+    expect(shouldLoadOlderHistory({ ...IN_VIEW, autoLoadedPages: OLDER_AUTOLOAD_MAX_PAGES })).toBe(
+      false,
+    );
+    expect(
+      shouldLoadOlderHistory({ ...IN_VIEW, autoLoadedPages: OLDER_AUTOLOAD_MAX_PAGES - 1 }),
+    ).toBe(true);
+  });
+
+  test('an explicit pull is never budgeted — only the sentinel is', () => {
+    // The manual control calls `loadOlder` directly; the budget lives on the
+    // automatic path so a reader who asks for more always gets it.
+    expect(olderAutoloadExhausted({ hasOlder: true, autoLoadedPages: OLDER_AUTOLOAD_MAX_PAGES })).toBe(
+      true,
+    );
+    expect(olderAutoloadExhausted({ hasOlder: false, autoLoadedPages: 99 })).toBe(false);
+    expect(olderAutoloadExhausted({ hasOlder: true, autoLoadedPages: 0 })).toBe(false);
+  });
+
+  test('a missing budget behaves like a fresh session, not like an exhausted one', () => {
+    expect(shouldLoadOlderHistory(IN_VIEW)).toBe(true);
+  });
+
   test('pulls the previous page once the top sentinel comes into view', () => {
     expect(shouldLoadOlderHistory(IN_VIEW)).toBe(true);
   });

--- a/apps/web/src/features/session/session-older-autoload.ts
+++ b/apps/web/src/features/session/session-older-autoload.ts
@@ -8,6 +8,34 @@ export interface OlderHistoryAutoloadState {
   isLoadingOlder: boolean;
   /** The last pull rejected. Re-arming on failure would spin. */
   lastPullFailed: boolean;
+  /** Pages this session has already pulled AUTOMATICALLY. Absent counts as
+   *  none — a fresh session, not an exhausted one. */
+  autoLoadedPages?: number;
+}
+
+/**
+ * How many pages the sentinel may pull on its own before a reader has to ask.
+ *
+ * A transcript never sheds what it pulls: the turns stay in the DOM, their parts
+ * stay in the sync store, and every image keeps a decoded bitmap alive — a
+ * session page unmounts nothing. Uncapped, idle scrolling walks a long thread's
+ * entire history into memory, which is the retention behind a tab the browser
+ * discards and reloads by itself.
+ *
+ * Four pages on top of the first is 250 messages — past any conversation a
+ * reader scrolls through without meaning to, and far short of the sizes where
+ * the page starts to hurt. Reading further back is still one click away; it
+ * just stops being something a scroll does by accident.
+ */
+export const OLDER_AUTOLOAD_MAX_PAGES = 4;
+
+/** The sentinel has spent its budget and the reader must ask for more. Drives
+ *  the manual control; never blocks an explicit pull. */
+export function olderAutoloadExhausted(state: {
+  hasOlder: boolean;
+  autoLoadedPages?: number;
+}): boolean {
+  return state.hasOlder && (state.autoLoadedPages ?? 0) >= OLDER_AUTOLOAD_MAX_PAGES;
 }
 
 /** Decides whether the top sentinel coming into view should pull the previous
@@ -20,5 +48,11 @@ export interface OlderHistoryAutoloadState {
  *  runtime keeps rejecting would otherwise become an unbounded retry loop;
  *  after a failure the transcript falls back to an explicit retry affordance. */
 export function shouldLoadOlderHistory(state: OlderHistoryAutoloadState): boolean {
-  return state.isIntersecting && state.hasOlder && !state.isLoadingOlder && !state.lastPullFailed;
+  return (
+    state.isIntersecting &&
+    state.hasOlder &&
+    !state.isLoadingOlder &&
+    !state.lastPullFailed &&
+    !olderAutoloadExhausted(state)
+  );
 }

--- a/apps/web/src/lib/object-url-cache.test.ts
+++ b/apps/web/src/lib/object-url-cache.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { ObjectUrlCache } from './object-url-cache';
+
+const revoked: string[] = [];
+beforeEach(() => {
+  revoked.length = 0;
+  // bun's environment has no URL.revokeObjectURL; the cache must call it when
+  // it exists and survive when it does not.
+  (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL = (u) => {
+    revoked.push(u);
+  };
+});
+
+describe('ObjectUrlCache', () => {
+  test('serves a cached url without refetching — the property the old cache protected', () => {
+    const cache = new ObjectUrlCache(4);
+    cache.set('a', 'blob:a');
+    expect(cache.get('a')).toBe('blob:a');
+    expect(revoked).toEqual([]);
+  });
+
+  test('evicts the least recently USED and revokes it', () => {
+    const cache = new ObjectUrlCache(2);
+    cache.set('a', 'blob:a');
+    cache.set('b', 'blob:b');
+    // Touching 'a' makes 'b' the oldest, even though 'a' was inserted first.
+    expect(cache.get('a')).toBe('blob:a');
+    cache.set('c', 'blob:c');
+
+    expect(revoked).toEqual(['blob:b']);
+    expect(cache.has('a')).toBe(true);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.size).toBe(2);
+  });
+
+  test('replacing a key revokes the url it replaces', () => {
+    const cache = new ObjectUrlCache(4);
+    cache.set('a', 'blob:one');
+    cache.set('a', 'blob:two');
+    expect(revoked).toEqual(['blob:one']);
+    expect(cache.get('a')).toBe('blob:two');
+  });
+
+  test('re-setting the identical url revokes nothing', () => {
+    const cache = new ObjectUrlCache(4);
+    cache.set('a', 'blob:same');
+    cache.set('a', 'blob:same');
+    expect(revoked).toEqual([]);
+  });
+
+  test('clear releases everything it holds', () => {
+    const cache = new ObjectUrlCache(4);
+    cache.set('a', 'blob:a');
+    cache.set('b', 'blob:b');
+    cache.clear();
+    expect(revoked.sort()).toEqual(['blob:a', 'blob:b']);
+    expect(cache.size).toBe(0);
+  });
+
+  test('a revoke that throws never breaks the cache', () => {
+    (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL = () => {
+      throw new Error('no document');
+    };
+    const cache = new ObjectUrlCache(1);
+    cache.set('a', 'blob:a');
+    expect(() => cache.set('b', 'blob:b')).not.toThrow();
+    expect(cache.has('b')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/object-url-cache.ts
+++ b/apps/web/src/lib/object-url-cache.ts
@@ -1,0 +1,70 @@
+/**
+ * A bounded cache of object URLs that revokes what it evicts.
+ *
+ * Both call sites this replaces kept a module-level `Map<string, string>` of
+ * `URL.createObjectURL(...)` results with no cap and no `revokeObjectURL`. The
+ * reasoning in each was sound as far as it went — revoking on unmount refetches
+ * the same bytes every time a panel expands and collapses — but "never revoke"
+ * and "never evict" are two decisions, and only the first one was needed. A
+ * long session opens dozens of tool outputs and PDF pages, and every blob
+ * behind those URLs is pinned for the lifetime of the tab (a session page never
+ * unmounts a turn). That retention is a leading suspect for the tab discards
+ * behind "my session randomly reloaded".
+ *
+ * Least-recently-USED, not inserted: re-reading a thumbnail keeps it warm, so
+ * expanding and collapsing the same output never refetches, which is the exact
+ * property the old comment was protecting.
+ */
+export class ObjectUrlCache {
+  private readonly entries = new Map<string, string>();
+
+  constructor(private readonly maxEntries: number) {
+    if (maxEntries < 1) throw new Error('ObjectUrlCache maxEntries must be >= 1');
+  }
+
+  get(key: string): string | undefined {
+    const url = this.entries.get(key);
+    if (url === undefined) return undefined;
+    // Re-insert so this key is now the most recent.
+    this.entries.delete(key);
+    this.entries.set(key, url);
+    return url;
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  /** Store `url` under `key`, revoking whatever it replaces or evicts. */
+  set(key: string, url: string): void {
+    const previous = this.entries.get(key);
+    if (previous !== undefined && previous !== url) revoke(previous);
+    this.entries.delete(key);
+    this.entries.set(key, url);
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) break;
+      const evicted = this.entries.get(oldest.value);
+      this.entries.delete(oldest.value);
+      if (evicted !== undefined) revoke(evicted);
+    }
+  }
+
+  /** Visible for tests and for a caller that wants to drop everything. */
+  clear(): void {
+    for (const url of this.entries.values()) revoke(url);
+    this.entries.clear();
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}
+
+function revoke(url: string): void {
+  try {
+    URL.revokeObjectURL(url);
+  } catch {
+    // Not an object URL, or the document is gone. Nothing to release.
+  }
+}

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,32 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-23 — session `session-memory-retention` — stop paying for the transcript twice a second — DONE
+
+**Files:** `browser/cache/idb-write-policy.ts` (NEW: `idbFlushIntervalMs`,
+`transcriptSignature`) + `idb-write-policy.test.ts` (NEW, 8 tests) ·
+`browser/cache/idb-sync-cache.ts` (skips an unchanged write; a large transcript
+writes less often). Internal module — not re-exported from the package barrel,
+so no public surface change.
+
+**What.** The IndexedDB transcript mirror rewrote the WHOLE transcript every
+500ms for as long as a turn streamed, and `put()` structured-clones what it is
+given — roughly 40MB/s of transient main-thread allocation on a 20MB transcript,
+for a cache whose only job is to paint something on the next load. It is the
+largest single allocator in a long session and a leading suspect for the tab
+discards behind "my session reloaded itself".
+
+**Fix.** Two levers, both pure and tested: do not write what is already written
+(an O(messages) signature over counts and the tail id, never the bodies), and
+write a transcript past 120 messages every 3s instead of every 500ms. A failed
+flush drops its signatures so the mirror cannot get stuck claiming a write
+landed.
+
+**Gates:** `typecheck` clean (both projects) · `bun test` 2438 pass / 0 fail ·
+`smoke:install` passed.
+
+---
+
 ### 2026-08-23 — session `turn-end-flap-2` — the same flap, 42 seconds later — DONE
 
 **Files:** `core/session/working.ts` (the veto is no longer gated on

--- a/packages/sdk/src/browser/cache/idb-sync-cache.ts
+++ b/packages/sdk/src/browser/cache/idb-sync-cache.ts
@@ -6,6 +6,7 @@
  * { cacheKey, userId, sessionId, messages, parts, updatedAt }.
  */
 
+import { idbFlushIntervalMs, transcriptSignature } from './idb-write-policy';
 import { platformConfig } from '../../core/http/config';
 import { buildSessionCacheKey } from './idb-sync-cache-key';
 
@@ -91,7 +92,9 @@ const pendingWrites = new Map<
   }
 >();
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
-const FLUSH_INTERVAL_MS = 500;
+/** What each cache key last WROTE, so an unchanged transcript is not cloned
+ *  again. See `transcriptSignature` for what "unchanged" can and cannot see. */
+const lastWrittenSignature = new Map<string, string>();
 
 // The caps below are only real if something enforces them. Prune once per page
 // load, off the back of the first flush, so the cache cannot grow forever
@@ -133,6 +136,10 @@ async function flushPendingWrites(): Promise<void> {
       tx.onerror = () => reject(tx.error);
     });
   } catch {
+    // The write did not land, so nothing may claim it did — drop the
+    // signatures for this batch or the next identical transcript is skipped
+    // and the mirror never catches up.
+    for (const cacheKey of batch.keys()) lastWrittenSignature.delete(cacheKey);
     // Non-critical
   }
 }
@@ -147,6 +154,15 @@ export async function saveSessionToIDB(
   if (!scope) return;
 
   const cacheKey = buildSessionCacheKey(scope, sessionId, kortixSessionScope);
+  // `put()` structured-clones what it is handed, so the cost of this mirror is
+  // the SIZE of the transcript times how often it is written. Skip a write that
+  // would store what is already stored, and let a large transcript write less
+  // often — the mirror is disposable, and a miss costs one refetch of data the
+  // server is about to send anyway.
+  const signature = transcriptSignature(messages, parts);
+  if (lastWrittenSignature.get(cacheKey) === signature) return;
+  lastWrittenSignature.set(cacheKey, signature);
+
   pendingWrites.set(cacheKey, {
     scope,
     sessionId,
@@ -155,7 +171,7 @@ export async function saveSessionToIDB(
     parts,
   });
   if (!flushTimer) {
-    flushTimer = setTimeout(flushPendingWrites, FLUSH_INTERVAL_MS);
+    flushTimer = setTimeout(flushPendingWrites, idbFlushIntervalMs(messages.length));
   }
 }
 

--- a/packages/sdk/src/browser/cache/idb-write-policy.test.ts
+++ b/packages/sdk/src/browser/cache/idb-write-policy.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  IDB_FLUSH_INTERVAL_LARGE_MS,
+  IDB_FLUSH_INTERVAL_MS,
+  IDB_LARGE_TRANSCRIPT_MESSAGES,
+  idbFlushIntervalMs,
+  transcriptSignature,
+} from './idb-write-policy';
+
+const msg = (id: string) => ({ id });
+
+describe('idbFlushIntervalMs', () => {
+  test('an ordinary session keeps the original cadence', () => {
+    expect(idbFlushIntervalMs(0)).toBe(IDB_FLUSH_INTERVAL_MS);
+    expect(idbFlushIntervalMs(IDB_LARGE_TRANSCRIPT_MESSAGES - 1)).toBe(IDB_FLUSH_INTERVAL_MS);
+  });
+
+  test('a large transcript writes less often — the clone is the expense', () => {
+    expect(idbFlushIntervalMs(IDB_LARGE_TRANSCRIPT_MESSAGES)).toBe(IDB_FLUSH_INTERVAL_LARGE_MS);
+    expect(idbFlushIntervalMs(5_000)).toBe(IDB_FLUSH_INTERVAL_LARGE_MS);
+  });
+});
+
+describe('transcriptSignature', () => {
+  test('identical transcripts share a signature — that write can be skipped', () => {
+    const messages = [msg('a'), msg('b')];
+    const parts = { a: [1], b: [1, 2] };
+    expect(transcriptSignature(messages, parts)).toBe(transcriptSignature([...messages], { ...parts }));
+  });
+
+  test('a streamed part on the tail moves it', () => {
+    const messages = [msg('a'), msg('b')];
+    expect(transcriptSignature(messages, { a: [1], b: [1] })).not.toBe(
+      transcriptSignature(messages, { a: [1], b: [1, 2] }),
+    );
+  });
+
+  test('a new message moves it', () => {
+    expect(transcriptSignature([msg('a')], { a: [1] })).not.toBe(
+      transcriptSignature([msg('a'), msg('b')], { a: [1] }),
+    );
+  });
+
+  test('a rewind that removes messages moves it', () => {
+    expect(transcriptSignature([msg('a'), msg('b')], { a: [1], b: [1] })).not.toBe(
+      transcriptSignature([msg('a')], { a: [1] }),
+    );
+  });
+
+  test('a different tail with the same counts still moves it', () => {
+    expect(transcriptSignature([msg('a'), msg('b')], { a: [1], b: [1] })).not.toBe(
+      transcriptSignature([msg('a'), msg('c')], { a: [1], c: [1] }),
+    );
+  });
+
+  test('never touches the payload — a message with no id or no parts is safe', () => {
+    expect(() =>
+      transcriptSignature([{ id: undefined }, msg('a')] as Array<{ id?: string }>, {}),
+    ).not.toThrow();
+  });
+});

--- a/packages/sdk/src/browser/cache/idb-write-policy.ts
+++ b/packages/sdk/src/browser/cache/idb-write-policy.ts
@@ -1,0 +1,60 @@
+/**
+ * When the IndexedDB transcript mirror actually has to write.
+ *
+ * The mirror exists so a returning tab paints its last transcript before the
+ * server answers. It was rewriting the WHOLE transcript every 500ms for as long
+ * as a turn streamed — and `put()` structured-clones what it is given, so a
+ * 20MB transcript meant ~40MB/s of transient allocation on the main thread, for
+ * a cache whose only job is to be roughly right on the next load. That churn is
+ * a leading suspect for the tab discards behind "my session reloaded itself".
+ *
+ * Two levers, both pure and both tested here:
+ *
+ *  1. Do not write what is already written. A streamed delta changes the tail,
+ *     but plenty of store updates do not change the transcript at all.
+ *  2. Write a big transcript less often. Freshness is worth the same to every
+ *     session; cost is not, and the mirror is disposable either way — a miss
+ *     costs one refetch of data the server is about to send anyway.
+ */
+
+/** Base cadence, unchanged for the ordinary small session. */
+export const IDB_FLUSH_INTERVAL_MS = 500;
+/** Cadence once a transcript is large enough for the clone to be the expense. */
+export const IDB_FLUSH_INTERVAL_LARGE_MS = 3_000;
+/** Message count past which a transcript counts as large. Around the point a
+ *  session has pulled a page or two of history (50 per page). */
+export const IDB_LARGE_TRANSCRIPT_MESSAGES = 120;
+
+export function idbFlushIntervalMs(messageCount: number): number {
+  return messageCount >= IDB_LARGE_TRANSCRIPT_MESSAGES
+    ? IDB_FLUSH_INTERVAL_LARGE_MS
+    : IDB_FLUSH_INTERVAL_MS;
+}
+
+/**
+ * A cheap fingerprint of what a write would store.
+ *
+ * O(messages) map lookups, never a serialization of the bodies — the whole
+ * point is to avoid touching the payload. It moves when a message is added or
+ * removed, when the tail changes identity, and when any message's part count
+ * changes, which covers every way a transcript grows or is edited (a rewind
+ * removes messages; a streamed delta adds parts to the tail).
+ *
+ * It deliberately does NOT move when a part's CONTENT changes in place without
+ * changing the count — a token appended to the same text part. That is the one
+ * case a signature this cheap cannot see, and it is also the case where the
+ * mirror being one interval stale costs nothing.
+ */
+export function transcriptSignature(
+  messages: ReadonlyArray<{ id?: string }>,
+  parts: Readonly<Record<string, unknown[]>>,
+): string {
+  let partsTotal = 0;
+  for (const message of messages) {
+    const id = message?.id;
+    if (!id) continue;
+    partsTotal += parts[id]?.length ?? 0;
+  }
+  const tail = messages.length > 0 ? (messages[messages.length - 1]?.id ?? '') : '';
+  return `${messages.length}:${partsTotal}:${tail}`;
+}


### PR DESCRIPTION
The reload investigation landed on **tab discard / renderer OOM**, with the transcript as the thing being retained. Four of its five receipts are addressed here; the fifth is bounded rather than rewritten.

### 1. The IndexedDB mirror rewrote the whole transcript every 500ms

`put()` structured-clones what it is handed, so a 20MB transcript meant **~40MB/s of transient main-thread allocation** while a turn streamed — for a cache whose only job is to paint something before the server answers. The largest single allocator in a long session.

Now: skip a write that would store what is already stored (an O(messages) signature over counts and the tail id — never the bodies), and write a transcript past 120 messages every 3s instead of 500ms. A failed flush drops its signatures so the mirror cannot get stuck believing a write landed.

### 2. Two object-URL caches never released anything

Tool-output thumbnails and rendered PDF pages each kept an uncapped module-level `Map` of `createObjectURL` results with no `revokeObjectURL`. Both comments explained why they don't revoke on unmount (expand/collapse would refetch) — and both then never evicted either. Those are two decisions and only the first was needed.

One `ObjectUrlCache` now serves both: least-recently-**used**, so re-expanding still never refetches, and it revokes what it evicts.

### 3. Idle scrolling walked a whole history into memory

The top sentinel pulled the previous page whenever it neared the viewport, forever — and a transcript never sheds what it pulls: turns stay in the DOM, parts stay in the sync store, images keep decoded bitmaps alive. The sentinel now has a budget of **four pages** (250 messages with the first), after which a "Load older messages" control appears. An explicit pull is never budgeted.

### Not done, named so it isn't mistaken for done

The transcript still renders every retained turn — `@tanstack/react-virtual` is in the app but no session view uses it. Real virtualisation is a bigger change than this; the three fixes above remove the growth that made it urgent.

Tests: +8 SDK (write policy), +6 web (object-url cache), +3 web (autoload budget). SDK typecheck clean, **2438 pass / 0 fail**, `smoke:install` passed. apps/web tsc clean bar the known `@types/bun` files; session + lib suites **2519 pass / 0 fail**; eslint 0 errors.