### PR TITLE
fix(session): a queued prompt asks the inbox whether it survived, not the runtime

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -7,7 +7,11 @@ import { isPendingAction, useSessionAudit } from '@/features/session/session-aud
 import { SessionPermissionPrompt } from '@/features/session/session-permission-prompt';
 import { useSessionWallpaperLayer } from '@/features/session/session-wallpaper-layer';
 import { errorMessageOf, isDeliveredButDisconnected } from '@/lib/delivered-but-disconnected';
-import { type SessionPrompt, hasRetryingAssistantTurn } from '@kortix/sdk';
+import {
+  type SessionPrompt,
+  hasRetryingAssistantTurn,
+  listSessionPrompts,
+} from '@kortix/sdk';
 import { isOptimisticSessionPrompt } from '@kortix/sdk/react';
 import {
   WarningIcon as AlertTriangle,
@@ -3739,10 +3743,23 @@ export function SessionChat({
           acceptSendReceipt(clientMessageId);
           return { ok: true } as const;
         } catch (cause) {
-          // Unchanged recovery: clear busy, then either rehydrate the real
-          // messages or drop the optimistic one if the server has no record.
+          // Ask the INBOX, not the runtime. This prompt's home is a durable
+          // control-plane row; OpenCode's transcript cannot see it until the
+          // admission gate delivers it, so a rehydrate always reports it
+          // missing and the recovery used to delete the bubble on that answer —
+          // while the row was already running. Reported from a live self-host:
+          // "it queues the message and starts running it, but doesn't show in
+          // the frontend."
+          //
+          // `clientMessageId` is the POST's idempotency key, so the row is
+          // addressable by exactly the thing this send already holds.
           const error = recoverFromSendFailure(sessionId, messageID, cause, {
             classify: classifySessionError,
+            inboxRowExists: async () => {
+              if (!projectId || !projectSessionId) return false;
+              const { prompts } = await listSessionPrompts(projectId, projectSessionId);
+              return prompts.some((prompt) => prompt.client_message_id === clientMessageId);
+            },
           });
           return { ok: false, error, cause } as const;
         }
@@ -3752,6 +3769,13 @@ export function SessionChat({
         // rather than let a refused send claim `working` for a minute. Named,
         // so a slow refusal cannot drop the receipt of a send the user made
         // after it.
+        //
+        // ONE exception, and it resolves AFTER this line: if the inbox turns
+        // out to hold the row, `recoverFromSendFailure` re-takes the receipt
+        // when its lookup lands, so the composer goes back to working on its
+        // own. This clear is still right in the moment — as far as this tab
+        // knows right now, nothing is coming — and it is NAMED, so it can only
+        // ever drop this send's own receipt.
         clearSendReceipt(clientMessageId);
         setCommandError(result.error);
         throw result.cause instanceof Error ? result.cause : new Error(result.error.message);

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,33 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-23 — session `queued-prompt-invisible` — ask the inbox, not the runtime — DONE
+
+**Files:** `react/use-session-send.ts` (`recoverFromSendFailure` takes
+`inboxRowExists`) + `use-session-send.test.ts` (+3 tests). Additive optional
+option — no export added, no signature broken.
+
+**What.** Reported from a live self-host: stop a turn, send the next prompt, and
+the SERVER queues and runs it while the tab shows nothing — no bubble, no queued
+row, composer back on its send arrow. Everything appeared ~30s later under the
+runtime's echo.
+
+`recoverFromSendFailure` asked `client.session.messages()` — the RUNTIME — whether
+the send survived. A prompt that goes to `POST .../prompts` is a control-plane
+row waiting for admission and is not in OpenCode's transcript until the gate
+delivers it, so that question always answers "no such message", and the recovery
+deleted the user's bubble on the strength of it.
+
+**Fix.** For an inbox-backed send the recovery asks the INBOX, addressed by the
+`clientMessageId` the POST already carries. A row that exists means the send
+succeeded however the response ended — the bubble stays and the receipt is
+re-taken. No row means it really was lost. A lookup that itself fails keeps the
+bubble: not knowing is not evidence of loss.
+
+**Gates:** `typecheck` clean (both projects) · `bun test` 2441 pass / 0 fail.
+
+---
+
 ### 2026-08-23 — session `session-memory-retention` — stop paying for the transcript twice a second — DONE
 
 **Files:** `browser/cache/idb-write-policy.ts` (NEW: `idbFlushIntervalMs`,

--- a/packages/sdk/src/react/use-session-send.test.ts
+++ b/packages/sdk/src/react/use-session-send.test.ts
@@ -213,6 +213,67 @@ describe('abandonOptimisticSend', () => {
 });
 
 describe('recoverFromSendFailure', () => {
+  // Reported from a live self-host: the user stopped a turn, sent the next
+  // prompt, the SERVER queued it and ran it — and the tab showed nothing. No
+  // bubble, no queued row, the composer back on its send arrow. Everything
+  // appeared ~30s later when the runtime's echo arrived.
+  //
+  // The cause is which authority this function asks. A prompt that goes to the
+  // durable inbox is a CONTROL-PLANE row waiting for admission; it is not in
+  // OpenCode's transcript and will not be until the gate delivers it. Asking
+  // `session.messages()` about it therefore always answers "no such message",
+  // and the recovery deleted the user's bubble on the strength of that answer —
+  // while the row it could not see was already running.
+  //
+  // The row is addressable: the POST carries a `clientMessageId`, so the
+  // ambiguity a lost response creates is RESOLVABLE rather than guessable.
+  test('an inbox-backed send whose row exists is a SUCCESS, not a loss', async () => {
+    beginOptimisticSend('sess-1', 'msg-1', 'go');
+    useSessionWorkingStore.getState().noteSendReceipt('sess-1', { messageId: 'msg-1', atMs: 1 });
+    messagesImpl = async () => ({ data: undefined });
+
+    const classified = recoverFromSendFailure('sess-1', 'msg-1', new Error('network down'), {
+      inboxRowExists: async () => true,
+    });
+    await tick();
+    await tick();
+
+    // The bubble stays: the server has the prompt and is going to run it.
+    expect(useSyncStore.getState().messages['sess-1']?.some((m) => m.id === 'msg-1')).toBe(true);
+    // And the composer keeps saying so — the receipt is re-accepted, because a
+    // row the control plane holds is exactly what a receipt is waiting for.
+    expect(useSessionWorkingStore.getState().receipts['sess-1']?.messageId).toBe('msg-1');
+    expect(classified.kind).toBeDefined();
+  });
+
+  test('an inbox-backed send with NO row still drops the bubble', async () => {
+    beginOptimisticSend('sess-1', 'msg-2', 'never landed');
+    messagesImpl = async () => ({ data: undefined });
+
+    recoverFromSendFailure('sess-1', 'msg-2', new Error('network down'), {
+      inboxRowExists: async () => false,
+    });
+    await tick();
+    await tick();
+
+    expect(useSyncStore.getState().messages['sess-1']?.some((m) => m.id === 'msg-2')).toBe(false);
+  });
+
+  test('an inbox lookup that itself fails keeps the bubble — ambiguity is not proof of loss', async () => {
+    beginOptimisticSend('sess-1', 'msg-3', 'unknown fate');
+    messagesImpl = async () => ({ data: undefined });
+
+    recoverFromSendFailure('sess-1', 'msg-3', new Error('network down'), {
+      inboxRowExists: async () => {
+        throw new Error('inbox unreachable');
+      },
+    });
+    await tick();
+    await tick();
+
+    expect(useSyncStore.getState().messages['sess-1']?.some((m) => m.id === 'msg-3')).toBe(true);
+  });
+
   test('a billing error keeps the optimistic message, clears busy, and rehydrates from the server', async () => {
     beginOptimisticSend('sess-1', 'msg-1', 'buy me a model');
     messagesImpl = async () => ({

--- a/packages/sdk/src/react/use-session-send.ts
+++ b/packages/sdk/src/react/use-session-send.ts
@@ -188,6 +188,23 @@ export interface SendRecoveryOptions {
    * apps/web's `ProviderModelNotFoundError` special-casing) injects its own
    * classifier that wraps it. */
   classify?: (error: unknown) => KortixSendError;
+  /**
+   * Does the durable prompt inbox already hold this send?
+   *
+   * A prompt that goes to `POST .../prompts` becomes a CONTROL-PLANE row
+   * waiting for admission. It is not in OpenCode's transcript and will not be
+   * until the gate delivers it — so the message rehydrate below, which asks the
+   * RUNTIME, always answers "no such message" for one. Acting on that answer
+   * deleted the user's bubble while the row it could not see was already
+   * running: reported from a live self-host as "it queues the message and
+   * starts running it, but doesn't show in the frontend".
+   *
+   * The POST carries a `clientMessageId`, so this ambiguity is resolvable
+   * rather than guessable. Provide this for an inbox-backed send and the
+   * recovery asks the right authority. A lookup that throws keeps the bubble:
+   * not knowing is not evidence of loss.
+   */
+  inboxRowExists?: () => Promise<boolean>;
 }
 
 /**
@@ -219,6 +236,31 @@ export function recoverFromSendFailure(
   // NAMED: a slow failure must not drop the receipt of a send submitted after
   // it whose POST is still on the wire. See `clearSendReceipt`.
   useSessionWorkingStore.getState().clearSendReceipt(sessionId, messageId);
+
+  // The inbox is the authority for an inbox-backed send, and it outranks
+  // everything below: a row the control plane holds means the prompt was NOT
+  // lost, however the response to this tab ended.
+  if (options.inboxRowExists) {
+    void options
+      .inboxRowExists()
+      .then((exists) => {
+        if (!exists) {
+          useSyncStore.getState().optimisticRemove(sessionId, messageId);
+          return;
+        }
+        // The send succeeded after all. Put the receipt back so the composer
+        // keeps saying so until `GET .../turn` reports the turn the inbox
+        // admits, exactly as a clean send would have.
+        useSessionWorkingStore
+          .getState()
+          .noteSendReceipt(sessionId, { messageId, atMs: Date.now() });
+      })
+      .catch(() => {
+        // Unreachable inbox: the prompt's fate is unknown, and an unknown fate
+        // is not a deletion. The bubble stays; the inbox poll reconciles it.
+      });
+    return classified;
+  }
 
   let client: OpenCodeMessagesClient;
   try {


### PR DESCRIPTION
**Reported live:** stop a turn, send the next prompt — the server queues it and starts running it, and the tab shows **nothing**. No bubble, no queued row, composer back on its send arrow. Everything appears ~30s later when the runtime's echo arrives.

### Cause: the recovery asks the wrong authority

A prompt sent through the composer goes to `POST .../prompts` and becomes a durable **control-plane** row waiting for admission. It is not in OpenCode's transcript, and will not be until the admission gate delivers it.

`recoverFromSendFailure` asked `client.session.messages()` — the **runtime** — whether the send survived. For an inbox-backed prompt that question can only ever answer "no such message", and the recovery deleted the user's bubble on the strength of it. The row it could not see was already running.

### Fix: resolve the ambiguity instead of guessing

A lost response is ambiguous, but the POST carries a `clientMessageId` — which is exactly how the row is addressed:

| inbox lookup | outcome |
|---|---|
| row exists | the send **succeeded**, however the response ended → bubble stays, receipt re-taken, composer returns to working on its own |
| no row | genuinely lost → bubble drops, as before |
| lookup throws | bubble stays — not knowing is not evidence of loss |

`inboxRowExists` is an additive optional option; the runtime rehydrate remains the path for a direct-to-OpenCode send that has no inbox row to ask about.

Tests: +3 covering all three branches. SDK typecheck clean, **2441 pass / 0 fail**. apps/web tsc clean bar the known `@types/bun` files, session suite **2513 pass / 0 fail**, eslint 0 errors.

**Note on where this bites:** essentia is a self-host on a released image, so it does not yet have today's other session fixes. This one is independent of them.