### PR TITLE
Fix duplicate prompts from CLI new-session chat

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,14 @@ linked, not inlined.
 
 ## Register
 
+### Submit an initial session prompt exactly once (2026-08-23)
+
+**When:** creating a session with `initial_prompt`. Do not submit the same
+prompt again after session readiness. Assert one user turn and one assistant
+turn through the real CLI process. *Incident:* the CLI created the session with
+the prompt, then posted it again and returned HTTP 500 after the first reply.
+*Enforcer:* `sessions.test.ts` counts runtime prompt requests for `--new`.
+
 ### Resolve a pnpm global package through `pnpm root -g` (2026-08-23)
 
 **When:** validating or linking a binary installed by `pnpm add -g`. Build the
@@ -90,7 +98,7 @@ lock must record the boot ID and owner PID, and recover an empty or stale lock.
 **When:** changing `LLM_GATEWAY_PROXY_TARGET`, Caddy LLM matchers, or sandbox
 gateway URL resolution. Test the final public URL through the deployed proxy.
 Internal proxy mode does not prove that `/v1/llm-gateway/v1` is public.
-*Incident:* Essentia sessions received Caddy `404` because Compose selected that
+*Incident:* self-host sessions received Caddy `404` because Compose selected that
 internal prefix while Caddy exposed `/v1/llm` directly to the gateway.
 *Enforcer:* `compose-assets.test.ts` pins `LLM_GATEWAY_BASE_URL` to the public
 `${KORTIX_URL}/v1/llm` route.

--- a/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
@@ -31,6 +31,8 @@ let stdout = '';
 let stderr = '';
 let promptBody: Record<string, unknown> | null = null;
 let runtimeAuthorization: string | null = null;
+let runtimePromptPosts = 0;
+let createBody: Record<string, unknown> | null = null;
 
 function sessionRow() {
   return {
@@ -99,11 +101,17 @@ describe('sessions chat uses the session-scoped SDK runtime', () => {
     stderr = '';
     promptBody = null;
     runtimeAuthorization = null;
+    runtimePromptPosts = 0;
+    createBody = null;
 
     server = Bun.serve({
       port: 0,
       fetch: async (request) => {
         const url = new URL(request.url);
+        if (request.method === 'POST' && url.pathname === `/v1/projects/${PROJECT_ID}/sessions`) {
+          createBody = (await request.json()) as Record<string, unknown>;
+          return Response.json(sessionRow());
+        }
         if (
           request.method === 'GET' &&
           url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`
@@ -126,6 +134,7 @@ describe('sessions chat uses the session-scoped SDK runtime', () => {
           request.method === 'POST' &&
           url.pathname === `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
         ) {
+          runtimePromptPosts += 1;
           runtimeAuthorization = request.headers.get('authorization');
           promptBody = (await request.json()) as Record<string, unknown>;
           return Response.json(assistantReply());
@@ -220,6 +229,24 @@ describe('sessions chat uses the session-scoped SDK runtime', () => {
     expect(JSON.parse(stdout)).toEqual([
       expect.objectContaining({ role: 'assistant', text: 'OpenCode REST reply' }),
     ]);
+
+    stdout = '';
+    const code = await runSessions([
+      'chat',
+      '--new',
+      '--project',
+      PROJECT_ID,
+      '--prompt',
+      'one initial prompt',
+      '--agent',
+      'default',
+      '--json',
+    ]);
+
+    expect(code).toBe(0);
+    expect(createBody).toMatchObject({ initial_prompt: 'one initial prompt', agent_name: 'default' });
+    expect(runtimePromptPosts).toBe(1);
+    expect(JSON.parse(stdout).text).toBe('OpenCode REST reply');
     expect(stderr).toBe('');
   });
 });

--- a/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
@@ -1,36 +1,38 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { runSessions } from '../commands/sessions.ts';
+import { runSessions } from "../commands/sessions.ts";
 
-const PROJECT_ID = '00000000-0000-4000-a000-00000000c111';
-const ACCOUNT_ID = '00000000-0000-4000-a000-00000000c222';
-const SESSION_ID = '00000000-0000-4000-a000-00000000c333';
-const OPENCODE_SESSION_ID = 'ses_cli_sdk';
-const EXTERNAL_ID = 'external-cli-sdk';
-const TOKEN = 'kortix_pat_cli_sdk';
+const PROJECT_ID = "00000000-0000-4000-a000-00000000c111";
+const ACCOUNT_ID = "00000000-0000-4000-a000-00000000c222";
+const SESSION_ID = "00000000-0000-4000-a000-00000000c333";
+const OPENCODE_SESSION_ID = "ses_cli_sdk";
+const EXTERNAL_ID = "external-cli-sdk";
+const TOKEN = "kortix_pat_cli_sdk";
 
 const ENV_KEYS = [
-  'KORTIX_CONFIG_FILE',
-  'KORTIX_TOKEN',
-  'KORTIX_TOKEN',
-  'KORTIX_API_URL',
-  'KORTIX_PROJECT_ID',
-  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
+  "KORTIX_CONFIG_FILE",
+  "KORTIX_TOKEN",
+  "KORTIX_TOKEN",
+  "KORTIX_API_URL",
+  "KORTIX_PROJECT_ID",
+  "KORTIX_DISABLE_SANDBOX_ENV_FILE",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
 const realStdoutWrite = process.stdout.write;
 const realStderrWrite = process.stderr.write;
 
-let directory = '';
+let directory = "";
 let server: ReturnType<typeof Bun.serve> | null = null;
-let stdout = '';
-let stderr = '';
+let stdout = "";
+let stderr = "";
 let promptBody: Record<string, unknown> | null = null;
 let runtimeAuthorization: string | null = null;
+let runtimePromptPosts = 0;
+let createBody: Record<string, unknown> | null = null;
 
 function sessionRow() {
   return {
@@ -38,34 +40,34 @@ function sessionRow() {
     account_id: ACCOUNT_ID,
     project_id: PROJECT_ID,
     branch_name: SESSION_ID,
-    base_ref: 'main',
-    sandbox_provider: 'daytona',
+    base_ref: "main",
+    sandbox_provider: "daytona",
     sandbox_id: SESSION_ID,
     sandbox_url: null,
     opencode_session_id: OPENCODE_SESSION_ID,
-    name: 'SDK chat',
+    name: "SDK chat",
     custom_name: null,
-    agent_name: 'default',
-    status: 'running',
+    agent_name: "default",
+    status: "running",
     error: null,
     metadata: {},
-    created_at: '2026-07-30T00:00:00.000Z',
-    updated_at: '2026-07-30T00:00:00.000Z',
+    created_at: "2026-07-30T00:00:00.000Z",
+    updated_at: "2026-07-30T00:00:00.000Z",
   };
 }
 
 function assistantReply() {
   return {
     info: {
-      id: 'msg_assistant',
-      role: 'assistant',
+      id: "msg_assistant",
+      role: "assistant",
       sessionID: OPENCODE_SESSION_ID,
-      parentID: 'msg_user',
-      agent: 'default',
-      mode: 'build',
-      modelID: 'test-model',
-      providerID: 'test-provider',
-      path: { cwd: '/workspace', root: '/workspace' },
+      parentID: "msg_user",
+      agent: "default",
+      mode: "build",
+      modelID: "test-model",
+      providerID: "test-provider",
+      path: { cwd: "/workspace", root: "/workspace" },
       cost: 0,
       tokens: {
         input: 1,
@@ -74,67 +76,80 @@ function assistantReply() {
         cache: { read: 0, write: 0 },
       },
       time: { created: 2, completed: 3 },
-      finish: 'stop',
+      finish: "stop",
     },
     parts: [
       {
-        id: 'part_assistant',
+        id: "part_assistant",
         sessionID: OPENCODE_SESSION_ID,
-        messageID: 'msg_assistant',
-        type: 'text',
-        text: 'OpenCode REST reply',
+        messageID: "msg_assistant",
+        type: "text",
+        text: "OpenCode REST reply",
       },
     ],
   };
 }
 
-describe('sessions chat uses the session-scoped SDK runtime', () => {
+describe("sessions chat uses the session-scoped SDK runtime", () => {
   beforeEach(() => {
     for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
     for (const key of ENV_KEYS) delete process.env[key];
-    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
+    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = "1";
 
-    directory = mkdtempSync(join(tmpdir(), 'kortix-cli-sdk-chat-'));
-    stdout = '';
-    stderr = '';
+    directory = mkdtempSync(join(tmpdir(), "kortix-cli-sdk-chat-"));
+    stdout = "";
+    stderr = "";
     promptBody = null;
     runtimeAuthorization = null;
+    runtimePromptPosts = 0;
+    createBody = null;
 
     server = Bun.serve({
       port: 0,
       fetch: async (request) => {
         const url = new URL(request.url);
         if (
-          request.method === 'GET' &&
+          request.method === "POST" &&
+          url.pathname === `/v1/projects/${PROJECT_ID}/sessions`
+        ) {
+          createBody = (await request.json()) as Record<string, unknown>;
+          return Response.json(sessionRow());
+        }
+        if (
+          request.method === "GET" &&
           url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`
         ) {
           return Response.json(sessionRow());
         }
         if (
-          request.method === 'POST' &&
-          url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`
+          request.method === "POST" &&
+          url.pathname ===
+            `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`
         ) {
           return Response.json({
-            stage: 'ready',
-            agent_name: 'default',
+            stage: "ready",
+            agent_name: "default",
             retriable: false,
             sandbox: { external_id: EXTERNAL_ID },
             opencode_session_id: OPENCODE_SESSION_ID,
           });
         }
         if (
-          request.method === 'POST' &&
-          url.pathname === `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
+          request.method === "POST" &&
+          url.pathname ===
+            `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
         ) {
-          runtimeAuthorization = request.headers.get('authorization');
+          runtimePromptPosts += 1;
+          runtimeAuthorization = request.headers.get("authorization");
           promptBody = (await request.json()) as Record<string, unknown>;
           return Response.json(assistantReply());
         }
         if (
-          request.method === 'GET' &&
-          url.pathname === `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
+          request.method === "GET" &&
+          url.pathname ===
+            `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
         ) {
-          runtimeAuthorization = request.headers.get('authorization');
+          runtimeAuthorization = request.headers.get("authorization");
           return Response.json([assistantReply()]);
         }
         return Response.json(
@@ -144,20 +159,20 @@ describe('sessions chat uses the session-scoped SDK runtime', () => {
       },
     });
 
-    const configPath = join(directory, 'config.json');
+    const configPath = join(directory, "config.json");
     process.env.KORTIX_CONFIG_FILE = configPath;
     writeFileSync(
       configPath,
       JSON.stringify({
-        active: 'default',
+        active: "default",
         hosts: {
           default: {
             url: `http://127.0.0.1:${server.port}`,
             token: TOKEN,
-            user_id: 'user-cli-sdk',
-            user_email: 'cli-sdk@example.test',
+            user_id: "user-cli-sdk",
+            user_email: "cli-sdk@example.test",
             account_id: ACCOUNT_ID,
-            logged_in_at: '2026-07-30T00:00:00.000Z',
+            logged_in_at: "2026-07-30T00:00:00.000Z",
           },
         },
       }),
@@ -185,41 +200,65 @@ describe('sessions chat uses the session-scoped SDK runtime', () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  test('sends and reads chat through the SDK-resolved OpenCode REST URL', async () => {
+  test("sends and reads chat through the SDK-resolved OpenCode REST URL", async () => {
     const chatCode = await runSessions([
-      'chat',
+      "chat",
       SESSION_ID,
-      '--project',
+      "--project",
       PROJECT_ID,
-      '--prompt',
-      'hello from the CLI',
-      '--json',
+      "--prompt",
+      "hello from the CLI",
+      "--json",
     ]);
 
     expect(chatCode).toBe(0);
     expect(runtimeAuthorization).toBe(`Bearer ${TOKEN}`);
     expect(promptBody).toMatchObject({
-      agent: 'default',
-      parts: [{ type: 'text', text: 'hello from the CLI' }],
+      agent: "default",
+      parts: [{ type: "text", text: "hello from the CLI" }],
     });
-    expect(JSON.parse(stdout).text).toBe('OpenCode REST reply');
+    expect(JSON.parse(stdout).text).toBe("OpenCode REST reply");
 
-    stdout = '';
+    stdout = "";
     const logCode = await runSessions([
-      'log',
+      "log",
       SESSION_ID,
-      '--project',
+      "--project",
       PROJECT_ID,
-      '--limit',
-      '5',
-      '--json',
+      "--limit",
+      "5",
+      "--json",
     ]);
 
     expect(logCode).toBe(0);
     expect(runtimeAuthorization).toBe(`Bearer ${TOKEN}`);
     expect(JSON.parse(stdout)).toEqual([
-      expect.objectContaining({ role: 'assistant', text: 'OpenCode REST reply' }),
+      expect.objectContaining({
+        role: "assistant",
+        text: "OpenCode REST reply",
+      }),
     ]);
-    expect(stderr).toBe('');
+
+    stdout = "";
+    const code = await runSessions([
+      "chat",
+      "--new",
+      "--project",
+      PROJECT_ID,
+      "--prompt",
+      "one initial prompt",
+      "--agent",
+      "default",
+      "--json",
+    ]);
+
+    expect(code).toBe(0);
+    expect(createBody).toMatchObject({
+      initial_prompt: "one initial prompt",
+      agent_name: "default",
+    });
+    expect(runtimePromptPosts).toBe(1);
+    expect(JSON.parse(stdout).text).toBe("OpenCode REST reply");
+    expect(stderr).toBe("");
   });
 });

--- a/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
+++ b/apps/cli/src/__tests__/sessions-chat-sdk.e2e.test.ts
@@ -1,38 +1,36 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
-import { runSessions } from "../commands/sessions.ts";
+import { runSessions } from '../commands/sessions.ts';
 
-const PROJECT_ID = "00000000-0000-4000-a000-00000000c111";
-const ACCOUNT_ID = "00000000-0000-4000-a000-00000000c222";
-const SESSION_ID = "00000000-0000-4000-a000-00000000c333";
-const OPENCODE_SESSION_ID = "ses_cli_sdk";
-const EXTERNAL_ID = "external-cli-sdk";
-const TOKEN = "kortix_pat_cli_sdk";
+const PROJECT_ID = '00000000-0000-4000-a000-00000000c111';
+const ACCOUNT_ID = '00000000-0000-4000-a000-00000000c222';
+const SESSION_ID = '00000000-0000-4000-a000-00000000c333';
+const OPENCODE_SESSION_ID = 'ses_cli_sdk';
+const EXTERNAL_ID = 'external-cli-sdk';
+const TOKEN = 'kortix_pat_cli_sdk';
 
 const ENV_KEYS = [
-  "KORTIX_CONFIG_FILE",
-  "KORTIX_TOKEN",
-  "KORTIX_TOKEN",
-  "KORTIX_API_URL",
-  "KORTIX_PROJECT_ID",
-  "KORTIX_DISABLE_SANDBOX_ENV_FILE",
+  'KORTIX_CONFIG_FILE',
+  'KORTIX_TOKEN',
+  'KORTIX_TOKEN',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_DISABLE_SANDBOX_ENV_FILE',
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
 const realStdoutWrite = process.stdout.write;
 const realStderrWrite = process.stderr.write;
 
-let directory = "";
+let directory = '';
 let server: ReturnType<typeof Bun.serve> | null = null;
-let stdout = "";
-let stderr = "";
+let stdout = '';
+let stderr = '';
 let promptBody: Record<string, unknown> | null = null;
 let runtimeAuthorization: string | null = null;
-let runtimePromptPosts = 0;
-let createBody: Record<string, unknown> | null = null;
 
 function sessionRow() {
   return {
@@ -40,34 +38,34 @@ function sessionRow() {
     account_id: ACCOUNT_ID,
     project_id: PROJECT_ID,
     branch_name: SESSION_ID,
-    base_ref: "main",
-    sandbox_provider: "daytona",
+    base_ref: 'main',
+    sandbox_provider: 'daytona',
     sandbox_id: SESSION_ID,
     sandbox_url: null,
     opencode_session_id: OPENCODE_SESSION_ID,
-    name: "SDK chat",
+    name: 'SDK chat',
     custom_name: null,
-    agent_name: "default",
-    status: "running",
+    agent_name: 'default',
+    status: 'running',
     error: null,
     metadata: {},
-    created_at: "2026-07-30T00:00:00.000Z",
-    updated_at: "2026-07-30T00:00:00.000Z",
+    created_at: '2026-07-30T00:00:00.000Z',
+    updated_at: '2026-07-30T00:00:00.000Z',
   };
 }
 
 function assistantReply() {
   return {
     info: {
-      id: "msg_assistant",
-      role: "assistant",
+      id: 'msg_assistant',
+      role: 'assistant',
       sessionID: OPENCODE_SESSION_ID,
-      parentID: "msg_user",
-      agent: "default",
-      mode: "build",
-      modelID: "test-model",
-      providerID: "test-provider",
-      path: { cwd: "/workspace", root: "/workspace" },
+      parentID: 'msg_user',
+      agent: 'default',
+      mode: 'build',
+      modelID: 'test-model',
+      providerID: 'test-provider',
+      path: { cwd: '/workspace', root: '/workspace' },
       cost: 0,
       tokens: {
         input: 1,
@@ -76,80 +74,67 @@ function assistantReply() {
         cache: { read: 0, write: 0 },
       },
       time: { created: 2, completed: 3 },
-      finish: "stop",
+      finish: 'stop',
     },
     parts: [
       {
-        id: "part_assistant",
+        id: 'part_assistant',
         sessionID: OPENCODE_SESSION_ID,
-        messageID: "msg_assistant",
-        type: "text",
-        text: "OpenCode REST reply",
+        messageID: 'msg_assistant',
+        type: 'text',
+        text: 'OpenCode REST reply',
       },
     ],
   };
 }
 
-describe("sessions chat uses the session-scoped SDK runtime", () => {
+describe('sessions chat uses the session-scoped SDK runtime', () => {
   beforeEach(() => {
     for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
     for (const key of ENV_KEYS) delete process.env[key];
-    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = "1";
+    process.env.KORTIX_DISABLE_SANDBOX_ENV_FILE = '1';
 
-    directory = mkdtempSync(join(tmpdir(), "kortix-cli-sdk-chat-"));
-    stdout = "";
-    stderr = "";
+    directory = mkdtempSync(join(tmpdir(), 'kortix-cli-sdk-chat-'));
+    stdout = '';
+    stderr = '';
     promptBody = null;
     runtimeAuthorization = null;
-    runtimePromptPosts = 0;
-    createBody = null;
 
     server = Bun.serve({
       port: 0,
       fetch: async (request) => {
         const url = new URL(request.url);
         if (
-          request.method === "POST" &&
-          url.pathname === `/v1/projects/${PROJECT_ID}/sessions`
-        ) {
-          createBody = (await request.json()) as Record<string, unknown>;
-          return Response.json(sessionRow());
-        }
-        if (
-          request.method === "GET" &&
+          request.method === 'GET' &&
           url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}`
         ) {
           return Response.json(sessionRow());
         }
         if (
-          request.method === "POST" &&
-          url.pathname ===
-            `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`
+          request.method === 'POST' &&
+          url.pathname === `/v1/projects/${PROJECT_ID}/sessions/${SESSION_ID}/start`
         ) {
           return Response.json({
-            stage: "ready",
-            agent_name: "default",
+            stage: 'ready',
+            agent_name: 'default',
             retriable: false,
             sandbox: { external_id: EXTERNAL_ID },
             opencode_session_id: OPENCODE_SESSION_ID,
           });
         }
         if (
-          request.method === "POST" &&
-          url.pathname ===
-            `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
+          request.method === 'POST' &&
+          url.pathname === `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
         ) {
-          runtimePromptPosts += 1;
-          runtimeAuthorization = request.headers.get("authorization");
+          runtimeAuthorization = request.headers.get('authorization');
           promptBody = (await request.json()) as Record<string, unknown>;
           return Response.json(assistantReply());
         }
         if (
-          request.method === "GET" &&
-          url.pathname ===
-            `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
+          request.method === 'GET' &&
+          url.pathname === `/v1/p/${EXTERNAL_ID}/8000/session/${OPENCODE_SESSION_ID}/message`
         ) {
-          runtimeAuthorization = request.headers.get("authorization");
+          runtimeAuthorization = request.headers.get('authorization');
           return Response.json([assistantReply()]);
         }
         return Response.json(
@@ -159,20 +144,20 @@ describe("sessions chat uses the session-scoped SDK runtime", () => {
       },
     });
 
-    const configPath = join(directory, "config.json");
+    const configPath = join(directory, 'config.json');
     process.env.KORTIX_CONFIG_FILE = configPath;
     writeFileSync(
       configPath,
       JSON.stringify({
-        active: "default",
+        active: 'default',
         hosts: {
           default: {
             url: `http://127.0.0.1:${server.port}`,
             token: TOKEN,
-            user_id: "user-cli-sdk",
-            user_email: "cli-sdk@example.test",
+            user_id: 'user-cli-sdk',
+            user_email: 'cli-sdk@example.test',
             account_id: ACCOUNT_ID,
-            logged_in_at: "2026-07-30T00:00:00.000Z",
+            logged_in_at: '2026-07-30T00:00:00.000Z',
           },
         },
       }),
@@ -200,65 +185,41 @@ describe("sessions chat uses the session-scoped SDK runtime", () => {
     rmSync(directory, { recursive: true, force: true });
   });
 
-  test("sends and reads chat through the SDK-resolved OpenCode REST URL", async () => {
+  test('sends and reads chat through the SDK-resolved OpenCode REST URL', async () => {
     const chatCode = await runSessions([
-      "chat",
+      'chat',
       SESSION_ID,
-      "--project",
+      '--project',
       PROJECT_ID,
-      "--prompt",
-      "hello from the CLI",
-      "--json",
+      '--prompt',
+      'hello from the CLI',
+      '--json',
     ]);
 
     expect(chatCode).toBe(0);
     expect(runtimeAuthorization).toBe(`Bearer ${TOKEN}`);
     expect(promptBody).toMatchObject({
-      agent: "default",
-      parts: [{ type: "text", text: "hello from the CLI" }],
+      agent: 'default',
+      parts: [{ type: 'text', text: 'hello from the CLI' }],
     });
-    expect(JSON.parse(stdout).text).toBe("OpenCode REST reply");
+    expect(JSON.parse(stdout).text).toBe('OpenCode REST reply');
 
-    stdout = "";
+    stdout = '';
     const logCode = await runSessions([
-      "log",
+      'log',
       SESSION_ID,
-      "--project",
+      '--project',
       PROJECT_ID,
-      "--limit",
-      "5",
-      "--json",
+      '--limit',
+      '5',
+      '--json',
     ]);
 
     expect(logCode).toBe(0);
     expect(runtimeAuthorization).toBe(`Bearer ${TOKEN}`);
     expect(JSON.parse(stdout)).toEqual([
-      expect.objectContaining({
-        role: "assistant",
-        text: "OpenCode REST reply",
-      }),
+      expect.objectContaining({ role: 'assistant', text: 'OpenCode REST reply' }),
     ]);
-
-    stdout = "";
-    const code = await runSessions([
-      "chat",
-      "--new",
-      "--project",
-      PROJECT_ID,
-      "--prompt",
-      "one initial prompt",
-      "--agent",
-      "default",
-      "--json",
-    ]);
-
-    expect(code).toBe(0);
-    expect(createBody).toMatchObject({
-      initial_prompt: "one initial prompt",
-      agent_name: "default",
-    });
-    expect(runtimePromptPosts).toBe(1);
-    expect(JSON.parse(stdout).text).toBe("OpenCode REST reply");
-    expect(stderr).toBe("");
+    expect(stderr).toBe('');
   });
 });

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -1,14 +1,9 @@
-import { createInterface } from "node:readline";
-import type {
-  MessageWithParts,
-  OpencodeClient,
-  Part,
-  SessionHandle,
-} from "@kortix/sdk";
+import { createInterface } from 'node:readline';
+import type { MessageWithParts, OpencodeClient, Part, SessionHandle } from '@kortix/sdk';
 
-import type { Auth } from "../api/auth.ts";
-import { kortixFromAuth, unwrapRuntime, withKortixScope } from "../api/sdk.ts";
-import type { ProjectSession } from "../api/types.ts";
+import type { Auth } from '../api/auth.ts';
+import { kortixFromAuth, unwrapRuntime, withKortixScope } from '../api/sdk.ts';
+import type { ProjectSession } from '../api/types.ts';
 import {
   emitJson,
   locateSessionAnywhere,
@@ -16,13 +11,10 @@ import {
   surfaceApiError,
   takeFlagBool,
   takeFlagValue,
-} from "../command-helpers.ts";
-import { C, help, pad, status } from "../style.ts";
-import { selectFromList } from "../tui-select.ts";
-import {
-  queueSessionPrompt,
-  type CreateSessionPromptResult,
-} from "./sessions-queue.ts";
+} from '../command-helpers.ts';
+import { C, help, pad, status } from '../style.ts';
+import { selectFromList } from '../tui-select.ts';
+import { queueSessionPrompt, type CreateSessionPromptResult } from './sessions-queue.ts';
 
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
@@ -59,7 +51,7 @@ export interface ResolvedSession {
 export async function loadSessionForChat(
   sessionId: string,
   opts: CtxOpts,
-  cliCommand = "sessions chat",
+  cliCommand = 'sessions chat',
   options: { requireRunning?: boolean } = {},
 ): Promise<ResolvedSession | null> {
   const found = await locateSessionAnywhere(
@@ -68,8 +60,7 @@ export async function loadSessionForChat(
     (host) => `kortix ${cliCommand} ${sessionId} --host ${host}`,
   );
   if (!found) return null;
-  const { client, projectId, auth, session, projectName, hostName } =
-    found.located;
+  const { client, projectId, auth, session, projectName, hostName } = found.located;
   const ctx = { client, projectId, auth };
   if (found.switched) {
     process.stderr.write(
@@ -78,7 +69,7 @@ export async function loadSessionForChat(
     );
   }
 
-  if (options.requireRunning !== false && session.status !== "running") {
+  if (options.requireRunning !== false && session.status !== 'running') {
     process.stderr.write(
       `${status.err(`Session ${session.session_id} is ${session.status}, not running.`)}\n` +
         `  ${C.dim}Run \`kortix sessions restart ${session.session_id}\` first.${C.reset}\n`,
@@ -86,7 +77,7 @@ export async function loadSessionForChat(
     return null;
   }
   const handle = kortixFromAuth(auth).session(projectId, session.session_id);
-  let ready: Awaited<ReturnType<SessionHandle["ensureReady"]>>;
+  let ready: Awaited<ReturnType<SessionHandle['ensureReady']>>;
   try {
     ready = await withKortixScope(auth, () => handle.ensureReady());
   } catch (error) {
@@ -110,9 +101,7 @@ export async function loadSessionForChat(
  * create one — and persist the id back to Kortix so subsequent CLI calls
  * stay glued to the same conversation.
  */
-export async function ensureOpencodeSession(
-  r: ResolvedSession,
-): Promise<string> {
+export async function ensureOpencodeSession(r: ResolvedSession): Promise<string> {
   return r.opencodeSessionId;
 }
 
@@ -121,60 +110,47 @@ export function extractMessageText(msg: MessageWithParts): string {
   return msg.parts
     .map((p) => partToText(p))
     .filter((s) => s.length > 0)
-    .join("\n");
+    .join('\n');
 }
 
 function partToText(part: Part): string {
-  if (
-    part.type === "text" &&
-    typeof (part as { text?: string }).text === "string"
-  ) {
-    if ((part as { synthetic?: boolean }).synthetic) return "";
+  if (part.type === 'text' && typeof (part as { text?: string }).text === 'string') {
+    if ((part as { synthetic?: boolean }).synthetic) return '';
     return (part as { text: string }).text;
   }
-  if (
-    part.type === "reasoning" &&
-    typeof (part as { text?: string }).text === "string"
-  ) {
+  if (part.type === 'reasoning' && typeof (part as { text?: string }).text === 'string') {
     return `${C.dim}[reasoning] ${(part as { text: string }).text}${C.reset}`;
   }
-  if (part.type === "tool") {
-    const name = (part as { tool?: string }).tool ?? "tool";
-    const state = (part as { state?: { status?: string; output?: string } })
-      .state;
-    const out = state?.output ? `\n${C.dim}${state.output}${C.reset}` : "";
-    return `${C.faded}[${name}${state?.status ? ` · ${state.status}` : ""}]${C.reset}${out}`;
+  if (part.type === 'tool') {
+    const name = (part as { tool?: string }).tool ?? 'tool';
+    const state = (part as { state?: { status?: string; output?: string } }).state;
+    const out = state?.output ? `\n${C.dim}${state.output}${C.reset}` : '';
+    return `${C.faded}[${name}${state?.status ? ` · ${state.status}` : ''}]${C.reset}${out}`;
   }
-  if (part.type === "file") {
+  if (part.type === 'file') {
     const filename = (part as { filename?: string }).filename;
-    return `${C.faded}[file${filename ? ` · ${filename}` : ""}]${C.reset}`;
+    return `${C.faded}[file${filename ? ` · ${filename}` : ''}]${C.reset}`;
   }
-  return "";
+  return '';
 }
 
 export function printMessage(msg: MessageWithParts): void {
-  const role = msg.info.role === "assistant" ? "assistant" : msg.info.role;
-  const color = role === "assistant" ? C.cyan : C.green;
-  const ts = msg.info.time?.created
-    ? new Date(msg.info.time.created).toLocaleTimeString()
-    : "";
-  process.stdout.write(
-    `\n${color}${C.bold}${role}${C.reset} ${C.faded}${ts}${C.reset}\n`,
-  );
+  const role = msg.info.role === 'assistant' ? 'assistant' : msg.info.role;
+  const color = role === 'assistant' ? C.cyan : C.green;
+  const ts = msg.info.time?.created ? new Date(msg.info.time.created).toLocaleTimeString() : '';
+  process.stdout.write(`\n${color}${C.bold}${role}${C.reset} ${C.faded}${ts}${C.reset}\n`);
   const body = extractMessageText(msg);
   if (body) {
-    for (const line of body.split("\n")) {
+    for (const line of body.split('\n')) {
       process.stdout.write(`  ${line}\n`);
     }
   }
   if (
-    msg.info.role === "assistant" &&
+    msg.info.role === 'assistant' &&
     (msg.info as { error?: { message?: string } | null }).error
   ) {
     const e = (msg.info as { error?: { message?: string } | null }).error;
-    process.stdout.write(
-      `  ${C.red}error: ${e?.message ?? "unknown"}${C.reset}\n`,
-    );
+    process.stdout.write(`  ${C.red}error: ${e?.message ?? 'unknown'}${C.reset}\n`);
   }
 }
 
@@ -218,7 +194,7 @@ In the REPL: type a message + Enter to send. Ctrl-D or \`exit\` quits.`;
  */
 export async function runSessionsChat(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes("-h") || rest.includes("--help")) {
+  if (rest.includes('-h') || rest.includes('--help')) {
     process.stdout.write(`${CHAT_HELP}\n`);
     return 0;
   }
@@ -231,20 +207,20 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   let json = false;
   let queue = false;
   try {
-    projectArg = takeFlagValue(rest, ["--project"]);
-    hostArg = takeFlagValue(rest, ["--host"]);
-    promptText = takeFlagValue(rest, ["--prompt", "-p"]);
-    agent = takeFlagValue(rest, ["--agent"]);
-    wantNew = takeFlagBool(rest, ["--new"]);
-    json = takeFlagBool(rest, ["--json"]);
-    queue = takeFlagBool(rest, ["--queue"]);
+    projectArg = takeFlagValue(rest, ['--project']);
+    hostArg = takeFlagValue(rest, ['--host']);
+    promptText = takeFlagValue(rest, ['--prompt', '-p']);
+    agent = takeFlagValue(rest, ['--agent']);
+    wantNew = takeFlagBool(rest, ['--new']);
+    json = takeFlagBool(rest, ['--json']);
+    queue = takeFlagBool(rest, ['--queue']);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
-  const positional = rest.filter((a) => !a.startsWith("-"));
+  const positional = rest.filter((a) => !a.startsWith('-'));
   if (positional.length > 1) {
-    process.stderr.write(`${status.err("Pass at most one session id.")}\n`);
+    process.stderr.write(`${status.err('Pass at most one session id.')}\n`);
     return 2;
   }
   if (queue && promptText === undefined) {
@@ -256,19 +232,7 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   const opts: CtxOpts = { projectArg, hostArg };
 
   // ── Resolve which session to chat with ──────────────────────────────────
-  const initialPromptSubmitted =
-    positional[0] === undefined &&
-    wantNew &&
-    promptText !== undefined &&
-    !queue;
-  const sessionId = await resolveChatSessionId(
-    positional[0],
-    wantNew,
-    queue ? undefined : promptText,
-    opts,
-    json,
-    agent,
-  );
+  const sessionId = await resolveChatSessionId(positional[0], wantNew, promptText, opts);
   if (!sessionId) return 1;
 
   // --queue is deliberately routed BEFORE loadSessionForChat: the whole point
@@ -278,7 +242,7 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
     return queuePrompt(sessionId, opts, promptText!, json);
   }
 
-  const resolved = await loadSessionForChat(sessionId, opts, "sessions chat");
+  const resolved = await loadSessionForChat(sessionId, opts, 'sessions chat');
   if (!resolved) return 1;
 
   const ocSessionId = await ensureOpencodeSession(resolved);
@@ -288,13 +252,12 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
 
   // ── One-shot ─────────────────────────────────────────────────────────────
   if (promptText !== undefined) {
-    if (initialPromptSubmitted) return waitForInitialReply(resolved, json);
     return sendAndPrint(resolved, promptText, extra, json);
   }
 
   // ── Interactive REPL ───────────────────────────────────────────────────────
   process.stdout.write(
-    `\n${C.dim}Chatting with ${C.reset}${C.bold}${resolved.session.name ?? resolved.session.session_id.split("-")[0]}${C.reset}` +
+    `\n${C.dim}Chatting with ${C.reset}${C.bold}${resolved.session.name ?? resolved.session.session_id.split('-')[0]}${C.reset}` +
       ` ${C.faded}(${resolved.session.agent_name})${C.reset}\n` +
       `${C.dim}Type a message and press Enter. Ctrl-D or \`exit\` to quit.${C.reset}\n`,
   );
@@ -316,14 +279,12 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   for (;;) {
     const line = await prompt(`\n${C.green}${C.bold}you${C.reset} `);
     const text = line.trim();
-    if (text === "") continue;
-    if (text === "exit" || text === "quit") break;
+    if (text === '') continue;
+    if (text === 'exit' || text === 'quit') break;
     const code = await sendAndPrint(resolved, text, extra);
     if (code !== 0) {
       // Transient sandbox error — let the user retry rather than killing the REPL.
-      process.stderr.write(
-        `${C.dim}(message failed — try again, or \`exit\`)${C.reset}\n`,
-      );
+      process.stderr.write(`${C.dim}(message failed — try again, or \`exit\`)${C.reset}\n`);
     }
   }
   process.stdout.write(`${C.dim}bye.${C.reset}\n`);
@@ -344,8 +305,7 @@ async function queuePrompt(
   const located = await locateSessionAnywhere(
     sessionId,
     opts,
-    (host) =>
-      `kortix sessions chat ${sessionId} --prompt "…" --queue --host ${host}`,
+    (host) => `kortix sessions chat ${sessionId} --prompt "…" --queue --host ${host}`,
   );
   if (!located) return 1;
   const { client, projectId, session } = located.located;
@@ -363,48 +323,10 @@ async function queuePrompt(
     `${status.ok(
       result.deduped
         ? `Already queued as ${C.bold}${result.prompt_id}${C.reset}`
-        : `Queued ${C.bold}${result.prompt_id}${C.reset} ${C.dim}(${result.state}) — \`kortix sessions queue ${session.session_id.split("-")[0]}\` to track it${C.reset}`,
+        : `Queued ${C.bold}${result.prompt_id}${C.reset} ${C.dim}(${result.state}) — \`kortix sessions queue ${session.session_id.split('-')[0]}\` to track it${C.reset}`,
     )}\n`,
   );
   return 0;
-}
-
-/** Read the reply to the `initial_prompt` submitted by session creation. */
-async function waitForInitialReply(
-  resolved: ResolvedSession,
-  json: boolean,
-): Promise<number> {
-  for (let attempt = 0; attempt < 120; attempt += 1) {
-    try {
-      const messages = await withKortixScope(resolved.auth, async () =>
-        unwrapRuntime(
-          await resolved.runtime.session.messages({
-            sessionID: resolved.opencodeSessionId,
-            limit: 10,
-          }),
-        ),
-      );
-      for (let index = messages.length - 1; index >= 0; index -= 1) {
-        const message = messages[index];
-        if (!message || message.info.role !== "assistant") continue;
-        const info = message.info as MessageWithParts["info"] & {
-          time?: { completed?: number };
-          error?: unknown;
-        };
-        if (info.time?.completed == null && !info.error) break;
-        if (json) emitJson(messageToJson(message));
-        else printMessage(message);
-        return info.error ? 1 : 0;
-      }
-    } catch (err) {
-      if (attempt === 119) return surfaceApiError(err);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-  process.stderr.write(
-    `${status.err("Timed out waiting for the initial prompt reply.")}\n`,
-  );
-  return 1;
 }
 
 /**
@@ -417,8 +339,6 @@ async function resolveChatSessionId(
   wantNew: boolean,
   initialPrompt: string | undefined,
   opts: CtxOpts,
-  quiet = false,
-  agent?: string,
 ): Promise<string | null> {
   if (explicit) return explicit;
 
@@ -428,22 +348,16 @@ async function resolveChatSessionId(
   if (wantNew) {
     const body: Record<string, unknown> = {};
     if (initialPrompt) body.initial_prompt = initialPrompt;
-    if (agent) body.agent_name = agent;
     try {
       const created = await ctx.client.post<ProjectSession>(
         `/projects/${ctx.projectId}/sessions`,
         body,
       );
-      if (!quiet) {
-        process.stdout.write(
-          `${status.ok(`Started session ${C.bold}${created.session_id.split("-")[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
-        );
-      }
-      if (created.status !== "running") {
-        if (!quiet)
-          process.stdout.write(
-            `  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`,
-          );
+      process.stdout.write(
+        `${status.ok(`Started session ${C.bold}${created.session_id.split('-')[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
+      );
+      if (created.status !== 'running') {
+        process.stdout.write(`  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`);
         const ready = await waitForRunning(ctx, created.session_id);
         if (!ready) return null;
       }
@@ -454,11 +368,11 @@ async function resolveChatSessionId(
     }
   }
 
-  const chosen = await chooseRunningSession(ctx, "Pick a session to chat with");
-  if (chosen === "error") return null;
+  const chosen = await chooseRunningSession(ctx, 'Pick a session to chat with');
+  if (chosen === 'error') return null;
   if (!chosen) {
     process.stderr.write(
-      `${status.err("No running session to chat with.")}\n` +
+      `${status.err('No running session to chat with.')}\n` +
         `  ${C.dim}Start one: ${C.reset}${C.cyan}kortix sessions chat --new${C.reset}` +
         `${C.dim}, or pass a session id.${C.reset}\n`,
     );
@@ -480,18 +394,16 @@ async function resolveChatSessionId(
 export async function chooseRunningSession(
   ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>,
   pickTitle: string,
-): Promise<ProjectSession | null | "error"> {
+): Promise<ProjectSession | null | 'error'> {
   let sessions: ProjectSession[];
   try {
-    sessions = await ctx.client.get<ProjectSession[]>(
-      `/projects/${ctx.projectId}/sessions`,
-    );
+    sessions = await ctx.client.get<ProjectSession[]>(`/projects/${ctx.projectId}/sessions`);
   } catch (err) {
     surfaceApiError(err);
-    return "error";
+    return 'error';
   }
   const running = sessions
-    .filter((s) => s.status === "running")
+    .filter((s) => s.status === 'running')
     .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
   const first = running[0];
   if (!first) return null;
@@ -504,8 +416,8 @@ export async function chooseRunningSession(
     title: pickTitle,
     items: running.map((s) => ({
       value: s,
-      label: s.name ?? s.session_id.split("-")[0] ?? s.session_id,
-      sublabel: `${s.status} · ${s.session_id.split("-")[0]} · ${s.branch_name}`,
+      label: s.name ?? s.session_id.split('-')[0] ?? s.session_id,
+      sublabel: `${s.status} · ${s.session_id.split('-')[0]} · ${s.branch_name}`,
     })),
   });
   return picked ?? null;
@@ -523,16 +435,16 @@ export async function resolveRunningSessionId(
   explicit: string | undefined,
   opts: CtxOpts,
   pickTitle: string,
-  startHint = "kortix sessions new --wait",
+  startHint = 'kortix sessions new --wait',
 ): Promise<string | null> {
   if (explicit) return explicit;
   const ctx = await resolveProjectContext(opts);
   if (!ctx) return null;
   const chosen = await chooseRunningSession(ctx, pickTitle);
-  if (chosen === "error") return null;
+  if (chosen === 'error') return null;
   if (!chosen) {
     process.stderr.write(
-      `${status.err("No running session to connect to.")}\n` +
+      `${status.err('No running session to connect to.')}\n` +
         `  ${C.dim}Start one: ${C.reset}${C.cyan}${startHint}${C.reset}` +
         `${C.dim}, or pass a session id.${C.reset}\n`,
     );
@@ -549,25 +461,21 @@ async function waitForRunning(
   for (let i = 0; i < 75; i += 1) {
     let s: ProjectSession;
     try {
-      s = await ctx.client.get<ProjectSession>(
-        `/projects/${ctx.projectId}/sessions/${sessionId}`,
-      );
+      s = await ctx.client.get<ProjectSession>(`/projects/${ctx.projectId}/sessions/${sessionId}`);
     } catch (err) {
       surfaceApiError(err);
       return false;
     }
-    if (s.status === "running") return true;
-    if (s.status === "failed" || s.status === "stopped") {
+    if (s.status === 'running') return true;
+    if (s.status === 'failed' || s.status === 'stopped') {
       process.stderr.write(
-        `${status.err(`Session ${s.status}${s.error ? `: ${s.error}` : ""}.`)}\n`,
+        `${status.err(`Session ${s.status}${s.error ? `: ${s.error}` : ''}.`)}\n`,
       );
       return false;
     }
     await new Promise((r) => setTimeout(r, 4000));
   }
-  process.stderr.write(
-    `${status.err("Timed out waiting for the sandbox to start.")}\n`,
-  );
+  process.stderr.write(`${status.err('Timed out waiting for the sandbox to start.')}\n`);
   return false;
 }
 
@@ -595,7 +503,7 @@ them is currently doing. Aliases: \`messages\`, \`history\`.`;
  */
 export async function runSessionsLog(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes("-h") || rest.includes("--help")) {
+  if (rest.includes('-h') || rest.includes('--help')) {
     process.stdout.write(`${LOG_HELP}\n`);
     return 0;
   }
@@ -605,17 +513,17 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   let limitRaw: string | undefined;
   let json = false;
   try {
-    projectArg = takeFlagValue(rest, ["--project"]);
-    hostArg = takeFlagValue(rest, ["--host"]);
-    limitRaw = takeFlagValue(rest, ["--limit", "-n"]);
-    json = takeFlagBool(rest, ["--json"]);
+    projectArg = takeFlagValue(rest, ['--project']);
+    hostArg = takeFlagValue(rest, ['--host']);
+    limitRaw = takeFlagValue(rest, ['--limit', '-n']);
+    json = takeFlagBool(rest, ['--json']);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
-  const positional = rest.filter((a) => !a.startsWith("-"));
+  const positional = rest.filter((a) => !a.startsWith('-'));
   if (positional.length > 1) {
-    process.stderr.write(`${status.err("Pass at most one session id.")}\n`);
+    process.stderr.write(`${status.err('Pass at most one session id.')}\n`);
     return 2;
   }
   const limit = limitRaw === undefined ? 10 : Number(limitRaw);
@@ -630,11 +538,11 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   if (!sessionId) {
     const ctx = await resolveProjectContext(opts);
     if (!ctx) return 1;
-    const chosen = await chooseRunningSession(ctx, "Pick a session to read");
-    if (chosen === "error") return 1;
+    const chosen = await chooseRunningSession(ctx, 'Pick a session to read');
+    if (chosen === 'error') return 1;
     if (!chosen) {
       process.stderr.write(
-        `${status.err("No running session.")}\n` +
+        `${status.err('No running session.')}\n` +
           `  ${C.dim}List sessions with ${C.reset}${C.cyan}kortix sessions ls${C.reset}` +
           `${C.dim}, or pass a session id.${C.reset}\n`,
       );
@@ -643,7 +551,7 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
     sessionId = chosen.session_id;
   }
 
-  const resolved = await loadSessionForChat(sessionId, opts, "sessions log");
+  const resolved = await loadSessionForChat(sessionId, opts, 'sessions log');
   if (!resolved) return 1;
   const ocSessionId = await ensureOpencodeSession(resolved);
   if (!ocSessionId) return 1;
@@ -663,15 +571,13 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   }
 
   if (json) {
-    process.stdout.write(
-      `${JSON.stringify(messages.map(messageToJson), null, 2)}\n`,
-    );
+    process.stdout.write(`${JSON.stringify(messages.map(messageToJson), null, 2)}\n`);
     return 0;
   }
 
   const s = resolved.session;
   process.stdout.write(
-    `\n${C.bold}${s.name ?? s.session_id.split("-")[0]}${C.reset} ` +
+    `\n${C.bold}${s.name ?? s.session_id.split('-')[0]}${C.reset} ` +
       `${C.faded}(${s.agent_name} · ${s.status})${C.reset}\n`,
   );
   if (messages.length === 0) {
@@ -679,13 +585,13 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
     return 0;
   }
   for (const msg of messages) printMessage(msg);
-  process.stdout.write("\n");
+  process.stdout.write('\n');
   return 0;
 }
 
 /** Compact, ANSI-free shape of a message for `--json` consumption. */
 function messageToJson(msg: MessageWithParts): Record<string, unknown> {
-  const info = msg.info as MessageWithParts["info"] & {
+  const info = msg.info as MessageWithParts['info'] & {
     time?: { created?: number; completed?: number };
     error?: { name?: string; message?: string } | null;
     agent?: string;
@@ -693,34 +599,26 @@ function messageToJson(msg: MessageWithParts): Record<string, unknown> {
   const text = msg.parts
     .filter(
       (p) =>
-        p.type === "text" &&
+        p.type === 'text' &&
         !(p as { synthetic?: boolean }).synthetic &&
-        typeof (p as { text?: string }).text === "string",
+        typeof (p as { text?: string }).text === 'string',
     )
     .map((p) => (p as { text: string }).text)
-    .join("\n");
+    .join('\n');
   const parts = msg.parts.map((p) => {
-    if (p.type === "tool") {
+    if (p.type === 'tool') {
       const state = (p as { state?: { status?: string } }).state;
-      return {
-        type: "tool",
-        tool: (p as { tool?: string }).tool,
-        status: state?.status,
-      };
+      return { type: 'tool', tool: (p as { tool?: string }).tool, status: state?.status };
     }
-    if (p.type === "file") {
-      return { type: "file", filename: (p as { filename?: string }).filename };
+    if (p.type === 'file') {
+      return { type: 'file', filename: (p as { filename?: string }).filename };
     }
     return { type: p.type };
   });
   return {
     role: info.role,
-    created: info.time?.created
-      ? new Date(info.time.created).toISOString()
-      : null,
-    completed: info.time?.completed
-      ? new Date(info.time.completed).toISOString()
-      : null,
+    created: info.time?.created ? new Date(info.time.created).toISOString() : null,
+    completed: info.time?.completed ? new Date(info.time.completed).toISOString() : null,
     error: info.error ?? null,
     text,
     parts,
@@ -744,11 +642,11 @@ async function sendAndPrint(
       emitJson(messageToJson({ info: reply.info, parts: reply.parts }));
       return reply.info.error ? 1 : 0;
     }
-    process.stdout.write(`${" ".repeat(12)}\r`); // clear "…thinking"
+    process.stdout.write(`${' '.repeat(12)}\r`); // clear "…thinking"
     printMessage({ info: reply.info, parts: reply.parts });
     return reply.info.error ? 1 : 0;
   } catch (err) {
-    if (!json) process.stdout.write(`${" ".repeat(12)}\r`);
+    if (!json) process.stdout.write(`${' '.repeat(12)}\r`);
     return surfaceApiError(err);
   }
 }
@@ -780,7 +678,7 @@ interface SessionActivity {
   /** Short human label: "running bash…", "thinking…", "idle", a reply snippet. */
   summary: string;
   /** Role of the most recent message. */
-  last_role?: "user" | "assistant";
+  last_role?: 'user' | 'assistant';
   /** ISO timestamp of the most recent activity. */
   last_at?: string;
 }
@@ -792,7 +690,7 @@ interface SessionActivity {
  */
 export async function runSessionsStatus(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes("-h") || rest.includes("--help")) {
+  if (rest.includes('-h') || rest.includes('--help')) {
     process.stdout.write(`${STATUS_HELP}\n`);
     return 0;
   }
@@ -802,18 +700,16 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   let all = false;
   let json = false;
   try {
-    projectArg = takeFlagValue(rest, ["--project"]);
-    hostArg = takeFlagValue(rest, ["--host"]);
-    all = takeFlagBool(rest, ["--all", "-a"]);
-    json = takeFlagBool(rest, ["--json"]);
+    projectArg = takeFlagValue(rest, ['--project']);
+    hostArg = takeFlagValue(rest, ['--host']);
+    all = takeFlagBool(rest, ['--all', '-a']);
+    json = takeFlagBool(rest, ['--json']);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
   if (rest.length > 0) {
-    process.stderr.write(
-      `${status.err(`Unexpected argument: ${rest[0]}`)}\n${STATUS_HELP}\n`,
-    );
+    process.stderr.write(`${status.err(`Unexpected argument: ${rest[0]}`)}\n${STATUS_HELP}\n`);
     return 2;
   }
   const opts: CtxOpts = { projectArg, hostArg };
@@ -824,19 +720,13 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
 
   let sessions: ProjectSession[];
   try {
-    sessions = await ctx.client.get<ProjectSession[]>(
-      `/projects/${ctx.projectId}/sessions`,
-    );
+    sessions = await ctx.client.get<ProjectSession[]>(`/projects/${ctx.projectId}/sessions`);
   } catch (err) {
     return surfaceApiError(err);
   }
 
   const shown = (
-    all
-      ? sessions
-      : sessions.filter(
-          (s) => s.status !== "stopped" && s.status !== "completed",
-        )
+    all ? sessions : sessions.filter((s) => s.status !== 'stopped' && s.status !== 'completed')
   ).sort(
     (a, b) =>
       statusRank(a.status) - statusRank(b.status) ||
@@ -844,7 +734,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   );
 
   // Pull live activity for running sessions, concurrency-capped.
-  const running = shown.filter((s) => s.status === "running");
+  const running = shown.filter((s) => s.status === 'running');
   const activity = new Map<string, SessionActivity>();
   await mapLimit(running, 8, async (s) => {
     const a = await fetchSessionActivity(s, ctx.projectId, auth);
@@ -868,7 +758,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
 
   if (shown.length === 0) {
     process.stdout.write(
-      `  ${C.dim}No ${all ? "" : "active "}sessions.${all ? "" : " (pass --all to include stopped ones)"}${C.reset}\n`,
+      `  ${C.dim}No ${all ? '' : 'active '}sessions.${all ? '' : ' (pass --all to include stopped ones)'}${C.reset}\n`,
     );
     return 0;
   }
@@ -876,7 +766,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   const counts = countByStatus(shown);
   const headline = Object.entries(counts)
     .map(([k, v]) => `${v} ${k}`)
-    .join(" · ");
+    .join(' · ');
   const labels = shown.map((s) => s.name ?? s.agent_name);
   const labelW = Math.max(...labels.map((l) => l.length), 4);
 
@@ -887,7 +777,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
     const id = shortId(s.session_id);
     const act = activity.get(s.session_id);
     const doing =
-      s.status === "running"
+      s.status === 'running'
         ? act
           ? `${act.working ? C.yellow : C.faded}${act.summary}${C.reset}`
           : `${C.faded}—${C.reset}`
@@ -897,7 +787,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
       `  ${dot} ${C.dim}${id}${C.reset}  ${pad(label, labelW)}  ${doing}  ${C.faded}${age}${C.reset}\n`,
     );
   }
-  process.stdout.write("\n");
+  process.stdout.write('\n');
   return 0;
 }
 
@@ -924,14 +814,13 @@ async function fetchSessionActivity(
       // The generated OpenCode client accepts RequestInit fields. The narrowed
       // SDK facade type currently lists only endpoint fields.
       signal: AbortSignal.timeout(SESSION_ACTIVITY_PHASE_TIMEOUT_MS),
-    } as Parameters<typeof handle.runtime.session.messages>[0] & {
-      signal: AbortSignal;
-    };
+    } as Parameters<typeof handle.runtime.session.messages>[0] & { signal: AbortSignal };
     const msgs = await withKortixScope(auth, async () =>
-      unwrapRuntime(await handle.runtime.session.messages(messageRequest)),
+      unwrapRuntime(
+        await handle.runtime.session.messages(messageRequest),
+      ),
     );
-    if (msgs.length === 0)
-      return { working: false, summary: "no messages yet" };
+    if (msgs.length === 0) return { working: false, summary: 'no messages yet' };
     return deriveActivity(msgs, s.status);
   } catch {
     // Sandbox still warming / proxy hiccup — treat as unknown, not fatal.
@@ -947,24 +836,22 @@ async function fetchSessionActivity(
  */
 export function deriveActivity(
   messages: MessageWithParts[],
-  status: ProjectSession["status"],
+  status: ProjectSession['status'],
 ): SessionActivity {
   // Lifecycle states before the agent can run describe the BOX, not a turn.
-  if (status === "provisioning" || status === "branching") {
-    return { working: true, summary: "provisioning…" };
+  if (status === 'provisioning' || status === 'branching') {
+    return { working: true, summary: 'provisioning…' };
   }
-  if (status === "queued") {
-    return { working: true, summary: "booting…" };
+  if (status === 'queued') {
+    return { working: true, summary: 'booting…' };
   }
 
   const last = messages[messages.length - 1];
-  if (!last) return { working: false, summary: "no messages yet" };
-  const lastInfo = last.info as MessageWithParts["info"] & {
+  if (!last) return { working: false, summary: 'no messages yet' };
+  const lastInfo = last.info as MessageWithParts['info'] & {
     time?: { created?: number; completed?: number };
   };
-  const at = lastInfo.time?.created
-    ? new Date(lastInfo.time.created).toISOString()
-    : undefined;
+  const at = lastInfo.time?.created ? new Date(lastInfo.time.created).toISOString() : undefined;
 
   // A running/pending tool ANYWHERE in the window means the agent is actively
   // working — even when the newest message is a (subagent) user-role prompt.
@@ -972,11 +859,10 @@ export function deriveActivity(
   let lastTool: string | undefined;
   for (const msg of messages) {
     for (const p of msg.parts) {
-      if (p.type !== "tool") continue;
+      if (p.type !== 'tool') continue;
       lastTool = (p as { tool?: string }).tool;
       const st = (p as { state?: { status?: string } }).state?.status;
-      if (st === "running" || st === "pending")
-        runningTool = (p as { tool?: string }).tool;
+      if (st === 'running' || st === 'pending') runningTool = (p as { tool?: string }).tool;
     }
   }
   if (runningTool) {
@@ -984,7 +870,7 @@ export function deriveActivity(
       working: true,
       tool: runningTool,
       summary: `running ${runningTool}…`,
-      last_role: "assistant",
+      last_role: 'assistant',
       last_at: at,
     };
   }
@@ -993,45 +879,28 @@ export function deriveActivity(
   // agent is still generating — report "working", not "queued", even if a later
   // user-role message is technically newest.
   let latestAssistant:
-    | (MessageWithParts["info"] & {
-        time?: { completed?: number };
-        error?: unknown;
-      })
+    | (MessageWithParts['info'] & { time?: { completed?: number }; error?: unknown })
     | undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (!message) continue;
     const info = message.info;
-    if (info.role === "assistant") {
-      latestAssistant = info as MessageWithParts["info"] & {
+    if (info.role === 'assistant') {
+      latestAssistant = info as MessageWithParts['info'] & {
         time?: { completed?: number };
         error?: unknown;
       };
       break;
     }
   }
-  if (
-    latestAssistant &&
-    latestAssistant.time?.completed == null &&
-    !latestAssistant.error
-  ) {
-    return {
-      working: true,
-      summary: "working…",
-      last_role: "assistant",
-      last_at: at,
-    };
+  if (latestAssistant && latestAssistant.time?.completed == null && !latestAssistant.error) {
+    return { working: true, summary: 'working…', last_role: 'assistant', last_at: at };
   }
 
   // Newest message is the user's and no assistant turn has started — genuinely
   // queued, waiting for the agent to pick it up.
-  if (lastInfo.role === "user") {
-    return {
-      working: true,
-      summary: "queued — agent picking up…",
-      last_role: "user",
-      last_at: at,
-    };
+  if (lastInfo.role === 'user') {
+    return { working: true, summary: 'queued — agent picking up…', last_role: 'user', last_at: at };
   }
 
   // Otherwise the last assistant turn is done — summarize its reply.
@@ -1039,22 +908,18 @@ export function deriveActivity(
   const text = last.parts
     .filter(
       (p) =>
-        p.type === "text" &&
+        p.type === 'text' &&
         !(p as { synthetic?: boolean }).synthetic &&
-        typeof (p as { text?: string }).text === "string",
+        typeof (p as { text?: string }).text === 'string',
     )
     .map((p) => (p as { text: string }).text)
-    .join(" ")
-    .replace(/\s+/g, " ")
+    .join(' ')
+    .replace(/\s+/g, ' ')
     .trim();
   return {
     working: false,
-    summary: text
-      ? truncate(text, 64)
-      : lastTool
-        ? `idle (last: ${lastTool})`
-        : "idle",
-    last_role: "assistant",
+    summary: text ? truncate(text, 64) : lastTool ? `idle (last: ${lastTool})` : 'idle',
+    last_role: 'assistant',
     last_at: completed ? new Date(completed).toISOString() : at,
   };
 }
@@ -1075,20 +940,18 @@ async function mapLimit<T>(
       await fn(item);
     }
   };
-  await Promise.all(
-    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
-  );
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
 }
 
 function statusRank(s: string): number {
   switch (s) {
-    case "running":
+    case 'running':
       return 0;
-    case "provisioning":
-    case "starting":
-    case "restarting":
+    case 'provisioning':
+    case 'starting':
+    case 'restarting':
       return 1;
-    case "failed":
+    case 'failed':
       return 2;
     default:
       return 3;
@@ -1097,13 +960,13 @@ function statusRank(s: string): number {
 
 function statusDot(s: string): string {
   switch (s) {
-    case "running":
+    case 'running':
       return `${C.green}●${C.reset}`;
-    case "failed":
+    case 'failed':
       return `${C.red}✗${C.reset}`;
-    case "provisioning":
-    case "starting":
-    case "restarting":
+    case 'provisioning':
+    case 'starting':
+    case 'restarting':
       return `${C.yellow}◐${C.reset}`;
     default:
       return `${C.faded}○${C.reset}`;
@@ -1117,7 +980,7 @@ function countByStatus(sessions: ProjectSession[]): Record<string, number> {
 }
 
 function shortId(id: string): string {
-  return id.split("-")[0] ?? id;
+  return id.split('-')[0] ?? id;
 }
 
 function truncate(s: string, max: number): string {
@@ -1126,7 +989,7 @@ function truncate(s: string, max: number): string {
 
 function relAge(iso: string): string {
   const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000);
-  if (m < 1) return "just now";
+  if (m < 1) return 'just now';
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ago`;

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -1,9 +1,14 @@
-import { createInterface } from 'node:readline';
-import type { MessageWithParts, OpencodeClient, Part, SessionHandle } from '@kortix/sdk';
+import { createInterface } from "node:readline";
+import type {
+  MessageWithParts,
+  OpencodeClient,
+  Part,
+  SessionHandle,
+} from "@kortix/sdk";
 
-import type { Auth } from '../api/auth.ts';
-import { kortixFromAuth, unwrapRuntime, withKortixScope } from '../api/sdk.ts';
-import type { ProjectSession } from '../api/types.ts';
+import type { Auth } from "../api/auth.ts";
+import { kortixFromAuth, unwrapRuntime, withKortixScope } from "../api/sdk.ts";
+import type { ProjectSession } from "../api/types.ts";
 import {
   emitJson,
   locateSessionAnywhere,
@@ -11,10 +16,13 @@ import {
   surfaceApiError,
   takeFlagBool,
   takeFlagValue,
-} from '../command-helpers.ts';
-import { C, help, pad, status } from '../style.ts';
-import { selectFromList } from '../tui-select.ts';
-import { queueSessionPrompt, type CreateSessionPromptResult } from './sessions-queue.ts';
+} from "../command-helpers.ts";
+import { C, help, pad, status } from "../style.ts";
+import { selectFromList } from "../tui-select.ts";
+import {
+  queueSessionPrompt,
+  type CreateSessionPromptResult,
+} from "./sessions-queue.ts";
 
 type CtxOpts = { projectArg?: string; hostArg?: string };
 
@@ -51,7 +59,7 @@ export interface ResolvedSession {
 export async function loadSessionForChat(
   sessionId: string,
   opts: CtxOpts,
-  cliCommand = 'sessions chat',
+  cliCommand = "sessions chat",
   options: { requireRunning?: boolean } = {},
 ): Promise<ResolvedSession | null> {
   const found = await locateSessionAnywhere(
@@ -60,7 +68,8 @@ export async function loadSessionForChat(
     (host) => `kortix ${cliCommand} ${sessionId} --host ${host}`,
   );
   if (!found) return null;
-  const { client, projectId, auth, session, projectName, hostName } = found.located;
+  const { client, projectId, auth, session, projectName, hostName } =
+    found.located;
   const ctx = { client, projectId, auth };
   if (found.switched) {
     process.stderr.write(
@@ -69,7 +78,7 @@ export async function loadSessionForChat(
     );
   }
 
-  if (options.requireRunning !== false && session.status !== 'running') {
+  if (options.requireRunning !== false && session.status !== "running") {
     process.stderr.write(
       `${status.err(`Session ${session.session_id} is ${session.status}, not running.`)}\n` +
         `  ${C.dim}Run \`kortix sessions restart ${session.session_id}\` first.${C.reset}\n`,
@@ -77,7 +86,7 @@ export async function loadSessionForChat(
     return null;
   }
   const handle = kortixFromAuth(auth).session(projectId, session.session_id);
-  let ready: Awaited<ReturnType<SessionHandle['ensureReady']>>;
+  let ready: Awaited<ReturnType<SessionHandle["ensureReady"]>>;
   try {
     ready = await withKortixScope(auth, () => handle.ensureReady());
   } catch (error) {
@@ -101,7 +110,9 @@ export async function loadSessionForChat(
  * create one — and persist the id back to Kortix so subsequent CLI calls
  * stay glued to the same conversation.
  */
-export async function ensureOpencodeSession(r: ResolvedSession): Promise<string> {
+export async function ensureOpencodeSession(
+  r: ResolvedSession,
+): Promise<string> {
   return r.opencodeSessionId;
 }
 
@@ -110,47 +121,60 @@ export function extractMessageText(msg: MessageWithParts): string {
   return msg.parts
     .map((p) => partToText(p))
     .filter((s) => s.length > 0)
-    .join('\n');
+    .join("\n");
 }
 
 function partToText(part: Part): string {
-  if (part.type === 'text' && typeof (part as { text?: string }).text === 'string') {
-    if ((part as { synthetic?: boolean }).synthetic) return '';
+  if (
+    part.type === "text" &&
+    typeof (part as { text?: string }).text === "string"
+  ) {
+    if ((part as { synthetic?: boolean }).synthetic) return "";
     return (part as { text: string }).text;
   }
-  if (part.type === 'reasoning' && typeof (part as { text?: string }).text === 'string') {
+  if (
+    part.type === "reasoning" &&
+    typeof (part as { text?: string }).text === "string"
+  ) {
     return `${C.dim}[reasoning] ${(part as { text: string }).text}${C.reset}`;
   }
-  if (part.type === 'tool') {
-    const name = (part as { tool?: string }).tool ?? 'tool';
-    const state = (part as { state?: { status?: string; output?: string } }).state;
-    const out = state?.output ? `\n${C.dim}${state.output}${C.reset}` : '';
-    return `${C.faded}[${name}${state?.status ? ` · ${state.status}` : ''}]${C.reset}${out}`;
+  if (part.type === "tool") {
+    const name = (part as { tool?: string }).tool ?? "tool";
+    const state = (part as { state?: { status?: string; output?: string } })
+      .state;
+    const out = state?.output ? `\n${C.dim}${state.output}${C.reset}` : "";
+    return `${C.faded}[${name}${state?.status ? ` · ${state.status}` : ""}]${C.reset}${out}`;
   }
-  if (part.type === 'file') {
+  if (part.type === "file") {
     const filename = (part as { filename?: string }).filename;
-    return `${C.faded}[file${filename ? ` · ${filename}` : ''}]${C.reset}`;
+    return `${C.faded}[file${filename ? ` · ${filename}` : ""}]${C.reset}`;
   }
-  return '';
+  return "";
 }
 
 export function printMessage(msg: MessageWithParts): void {
-  const role = msg.info.role === 'assistant' ? 'assistant' : msg.info.role;
-  const color = role === 'assistant' ? C.cyan : C.green;
-  const ts = msg.info.time?.created ? new Date(msg.info.time.created).toLocaleTimeString() : '';
-  process.stdout.write(`\n${color}${C.bold}${role}${C.reset} ${C.faded}${ts}${C.reset}\n`);
+  const role = msg.info.role === "assistant" ? "assistant" : msg.info.role;
+  const color = role === "assistant" ? C.cyan : C.green;
+  const ts = msg.info.time?.created
+    ? new Date(msg.info.time.created).toLocaleTimeString()
+    : "";
+  process.stdout.write(
+    `\n${color}${C.bold}${role}${C.reset} ${C.faded}${ts}${C.reset}\n`,
+  );
   const body = extractMessageText(msg);
   if (body) {
-    for (const line of body.split('\n')) {
+    for (const line of body.split("\n")) {
       process.stdout.write(`  ${line}\n`);
     }
   }
   if (
-    msg.info.role === 'assistant' &&
+    msg.info.role === "assistant" &&
     (msg.info as { error?: { message?: string } | null }).error
   ) {
     const e = (msg.info as { error?: { message?: string } | null }).error;
-    process.stdout.write(`  ${C.red}error: ${e?.message ?? 'unknown'}${C.reset}\n`);
+    process.stdout.write(
+      `  ${C.red}error: ${e?.message ?? "unknown"}${C.reset}\n`,
+    );
   }
 }
 
@@ -194,7 +218,7 @@ In the REPL: type a message + Enter to send. Ctrl-D or \`exit\` quits.`;
  */
 export async function runSessionsChat(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(`${CHAT_HELP}\n`);
     return 0;
   }
@@ -207,20 +231,20 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   let json = false;
   let queue = false;
   try {
-    projectArg = takeFlagValue(rest, ['--project']);
-    hostArg = takeFlagValue(rest, ['--host']);
-    promptText = takeFlagValue(rest, ['--prompt', '-p']);
-    agent = takeFlagValue(rest, ['--agent']);
-    wantNew = takeFlagBool(rest, ['--new']);
-    json = takeFlagBool(rest, ['--json']);
-    queue = takeFlagBool(rest, ['--queue']);
+    projectArg = takeFlagValue(rest, ["--project"]);
+    hostArg = takeFlagValue(rest, ["--host"]);
+    promptText = takeFlagValue(rest, ["--prompt", "-p"]);
+    agent = takeFlagValue(rest, ["--agent"]);
+    wantNew = takeFlagBool(rest, ["--new"]);
+    json = takeFlagBool(rest, ["--json"]);
+    queue = takeFlagBool(rest, ["--queue"]);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
-  const positional = rest.filter((a) => !a.startsWith('-'));
+  const positional = rest.filter((a) => !a.startsWith("-"));
   if (positional.length > 1) {
-    process.stderr.write(`${status.err('Pass at most one session id.')}\n`);
+    process.stderr.write(`${status.err("Pass at most one session id.")}\n`);
     return 2;
   }
   if (queue && promptText === undefined) {
@@ -232,7 +256,19 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   const opts: CtxOpts = { projectArg, hostArg };
 
   // ── Resolve which session to chat with ──────────────────────────────────
-  const sessionId = await resolveChatSessionId(positional[0], wantNew, promptText, opts);
+  const initialPromptSubmitted =
+    positional[0] === undefined &&
+    wantNew &&
+    promptText !== undefined &&
+    !queue;
+  const sessionId = await resolveChatSessionId(
+    positional[0],
+    wantNew,
+    queue ? undefined : promptText,
+    opts,
+    json,
+    agent,
+  );
   if (!sessionId) return 1;
 
   // --queue is deliberately routed BEFORE loadSessionForChat: the whole point
@@ -242,7 +278,7 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
     return queuePrompt(sessionId, opts, promptText!, json);
   }
 
-  const resolved = await loadSessionForChat(sessionId, opts, 'sessions chat');
+  const resolved = await loadSessionForChat(sessionId, opts, "sessions chat");
   if (!resolved) return 1;
 
   const ocSessionId = await ensureOpencodeSession(resolved);
@@ -252,12 +288,13 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
 
   // ── One-shot ─────────────────────────────────────────────────────────────
   if (promptText !== undefined) {
+    if (initialPromptSubmitted) return waitForInitialReply(resolved, json);
     return sendAndPrint(resolved, promptText, extra, json);
   }
 
   // ── Interactive REPL ───────────────────────────────────────────────────────
   process.stdout.write(
-    `\n${C.dim}Chatting with ${C.reset}${C.bold}${resolved.session.name ?? resolved.session.session_id.split('-')[0]}${C.reset}` +
+    `\n${C.dim}Chatting with ${C.reset}${C.bold}${resolved.session.name ?? resolved.session.session_id.split("-")[0]}${C.reset}` +
       ` ${C.faded}(${resolved.session.agent_name})${C.reset}\n` +
       `${C.dim}Type a message and press Enter. Ctrl-D or \`exit\` to quit.${C.reset}\n`,
   );
@@ -279,12 +316,14 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   for (;;) {
     const line = await prompt(`\n${C.green}${C.bold}you${C.reset} `);
     const text = line.trim();
-    if (text === '') continue;
-    if (text === 'exit' || text === 'quit') break;
+    if (text === "") continue;
+    if (text === "exit" || text === "quit") break;
     const code = await sendAndPrint(resolved, text, extra);
     if (code !== 0) {
       // Transient sandbox error — let the user retry rather than killing the REPL.
-      process.stderr.write(`${C.dim}(message failed — try again, or \`exit\`)${C.reset}\n`);
+      process.stderr.write(
+        `${C.dim}(message failed — try again, or \`exit\`)${C.reset}\n`,
+      );
     }
   }
   process.stdout.write(`${C.dim}bye.${C.reset}\n`);
@@ -305,7 +344,8 @@ async function queuePrompt(
   const located = await locateSessionAnywhere(
     sessionId,
     opts,
-    (host) => `kortix sessions chat ${sessionId} --prompt "…" --queue --host ${host}`,
+    (host) =>
+      `kortix sessions chat ${sessionId} --prompt "…" --queue --host ${host}`,
   );
   if (!located) return 1;
   const { client, projectId, session } = located.located;
@@ -323,10 +363,48 @@ async function queuePrompt(
     `${status.ok(
       result.deduped
         ? `Already queued as ${C.bold}${result.prompt_id}${C.reset}`
-        : `Queued ${C.bold}${result.prompt_id}${C.reset} ${C.dim}(${result.state}) — \`kortix sessions queue ${session.session_id.split('-')[0]}\` to track it${C.reset}`,
+        : `Queued ${C.bold}${result.prompt_id}${C.reset} ${C.dim}(${result.state}) — \`kortix sessions queue ${session.session_id.split("-")[0]}\` to track it${C.reset}`,
     )}\n`,
   );
   return 0;
+}
+
+/** Read the reply to the `initial_prompt` submitted by session creation. */
+async function waitForInitialReply(
+  resolved: ResolvedSession,
+  json: boolean,
+): Promise<number> {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    try {
+      const messages = await withKortixScope(resolved.auth, async () =>
+        unwrapRuntime(
+          await resolved.runtime.session.messages({
+            sessionID: resolved.opencodeSessionId,
+            limit: 10,
+          }),
+        ),
+      );
+      for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
+        if (!message || message.info.role !== "assistant") continue;
+        const info = message.info as MessageWithParts["info"] & {
+          time?: { completed?: number };
+          error?: unknown;
+        };
+        if (info.time?.completed == null && !info.error) break;
+        if (json) emitJson(messageToJson(message));
+        else printMessage(message);
+        return info.error ? 1 : 0;
+      }
+    } catch (err) {
+      if (attempt === 119) return surfaceApiError(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  process.stderr.write(
+    `${status.err("Timed out waiting for the initial prompt reply.")}\n`,
+  );
+  return 1;
 }
 
 /**
@@ -339,6 +417,8 @@ async function resolveChatSessionId(
   wantNew: boolean,
   initialPrompt: string | undefined,
   opts: CtxOpts,
+  quiet = false,
+  agent?: string,
 ): Promise<string | null> {
   if (explicit) return explicit;
 
@@ -348,16 +428,22 @@ async function resolveChatSessionId(
   if (wantNew) {
     const body: Record<string, unknown> = {};
     if (initialPrompt) body.initial_prompt = initialPrompt;
+    if (agent) body.agent_name = agent;
     try {
       const created = await ctx.client.post<ProjectSession>(
         `/projects/${ctx.projectId}/sessions`,
         body,
       );
-      process.stdout.write(
-        `${status.ok(`Started session ${C.bold}${created.session_id.split('-')[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
-      );
-      if (created.status !== 'running') {
-        process.stdout.write(`  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`);
+      if (!quiet) {
+        process.stdout.write(
+          `${status.ok(`Started session ${C.bold}${created.session_id.split("-")[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
+        );
+      }
+      if (created.status !== "running") {
+        if (!quiet)
+          process.stdout.write(
+            `  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`,
+          );
         const ready = await waitForRunning(ctx, created.session_id);
         if (!ready) return null;
       }
@@ -368,11 +454,11 @@ async function resolveChatSessionId(
     }
   }
 
-  const chosen = await chooseRunningSession(ctx, 'Pick a session to chat with');
-  if (chosen === 'error') return null;
+  const chosen = await chooseRunningSession(ctx, "Pick a session to chat with");
+  if (chosen === "error") return null;
   if (!chosen) {
     process.stderr.write(
-      `${status.err('No running session to chat with.')}\n` +
+      `${status.err("No running session to chat with.")}\n` +
         `  ${C.dim}Start one: ${C.reset}${C.cyan}kortix sessions chat --new${C.reset}` +
         `${C.dim}, or pass a session id.${C.reset}\n`,
     );
@@ -394,16 +480,18 @@ async function resolveChatSessionId(
 export async function chooseRunningSession(
   ctx: NonNullable<Awaited<ReturnType<typeof resolveProjectContext>>>,
   pickTitle: string,
-): Promise<ProjectSession | null | 'error'> {
+): Promise<ProjectSession | null | "error"> {
   let sessions: ProjectSession[];
   try {
-    sessions = await ctx.client.get<ProjectSession[]>(`/projects/${ctx.projectId}/sessions`);
+    sessions = await ctx.client.get<ProjectSession[]>(
+      `/projects/${ctx.projectId}/sessions`,
+    );
   } catch (err) {
     surfaceApiError(err);
-    return 'error';
+    return "error";
   }
   const running = sessions
-    .filter((s) => s.status === 'running')
+    .filter((s) => s.status === "running")
     .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at));
   const first = running[0];
   if (!first) return null;
@@ -416,8 +504,8 @@ export async function chooseRunningSession(
     title: pickTitle,
     items: running.map((s) => ({
       value: s,
-      label: s.name ?? s.session_id.split('-')[0] ?? s.session_id,
-      sublabel: `${s.status} · ${s.session_id.split('-')[0]} · ${s.branch_name}`,
+      label: s.name ?? s.session_id.split("-")[0] ?? s.session_id,
+      sublabel: `${s.status} · ${s.session_id.split("-")[0]} · ${s.branch_name}`,
     })),
   });
   return picked ?? null;
@@ -435,16 +523,16 @@ export async function resolveRunningSessionId(
   explicit: string | undefined,
   opts: CtxOpts,
   pickTitle: string,
-  startHint = 'kortix sessions new --wait',
+  startHint = "kortix sessions new --wait",
 ): Promise<string | null> {
   if (explicit) return explicit;
   const ctx = await resolveProjectContext(opts);
   if (!ctx) return null;
   const chosen = await chooseRunningSession(ctx, pickTitle);
-  if (chosen === 'error') return null;
+  if (chosen === "error") return null;
   if (!chosen) {
     process.stderr.write(
-      `${status.err('No running session to connect to.')}\n` +
+      `${status.err("No running session to connect to.")}\n` +
         `  ${C.dim}Start one: ${C.reset}${C.cyan}${startHint}${C.reset}` +
         `${C.dim}, or pass a session id.${C.reset}\n`,
     );
@@ -461,21 +549,25 @@ async function waitForRunning(
   for (let i = 0; i < 75; i += 1) {
     let s: ProjectSession;
     try {
-      s = await ctx.client.get<ProjectSession>(`/projects/${ctx.projectId}/sessions/${sessionId}`);
+      s = await ctx.client.get<ProjectSession>(
+        `/projects/${ctx.projectId}/sessions/${sessionId}`,
+      );
     } catch (err) {
       surfaceApiError(err);
       return false;
     }
-    if (s.status === 'running') return true;
-    if (s.status === 'failed' || s.status === 'stopped') {
+    if (s.status === "running") return true;
+    if (s.status === "failed" || s.status === "stopped") {
       process.stderr.write(
-        `${status.err(`Session ${s.status}${s.error ? `: ${s.error}` : ''}.`)}\n`,
+        `${status.err(`Session ${s.status}${s.error ? `: ${s.error}` : ""}.`)}\n`,
       );
       return false;
     }
     await new Promise((r) => setTimeout(r, 4000));
   }
-  process.stderr.write(`${status.err('Timed out waiting for the sandbox to start.')}\n`);
+  process.stderr.write(
+    `${status.err("Timed out waiting for the sandbox to start.")}\n`,
+  );
   return false;
 }
 
@@ -503,7 +595,7 @@ them is currently doing. Aliases: \`messages\`, \`history\`.`;
  */
 export async function runSessionsLog(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(`${LOG_HELP}\n`);
     return 0;
   }
@@ -513,17 +605,17 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   let limitRaw: string | undefined;
   let json = false;
   try {
-    projectArg = takeFlagValue(rest, ['--project']);
-    hostArg = takeFlagValue(rest, ['--host']);
-    limitRaw = takeFlagValue(rest, ['--limit', '-n']);
-    json = takeFlagBool(rest, ['--json']);
+    projectArg = takeFlagValue(rest, ["--project"]);
+    hostArg = takeFlagValue(rest, ["--host"]);
+    limitRaw = takeFlagValue(rest, ["--limit", "-n"]);
+    json = takeFlagBool(rest, ["--json"]);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
-  const positional = rest.filter((a) => !a.startsWith('-'));
+  const positional = rest.filter((a) => !a.startsWith("-"));
   if (positional.length > 1) {
-    process.stderr.write(`${status.err('Pass at most one session id.')}\n`);
+    process.stderr.write(`${status.err("Pass at most one session id.")}\n`);
     return 2;
   }
   const limit = limitRaw === undefined ? 10 : Number(limitRaw);
@@ -538,11 +630,11 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   if (!sessionId) {
     const ctx = await resolveProjectContext(opts);
     if (!ctx) return 1;
-    const chosen = await chooseRunningSession(ctx, 'Pick a session to read');
-    if (chosen === 'error') return 1;
+    const chosen = await chooseRunningSession(ctx, "Pick a session to read");
+    if (chosen === "error") return 1;
     if (!chosen) {
       process.stderr.write(
-        `${status.err('No running session.')}\n` +
+        `${status.err("No running session.")}\n` +
           `  ${C.dim}List sessions with ${C.reset}${C.cyan}kortix sessions ls${C.reset}` +
           `${C.dim}, or pass a session id.${C.reset}\n`,
       );
@@ -551,7 +643,7 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
     sessionId = chosen.session_id;
   }
 
-  const resolved = await loadSessionForChat(sessionId, opts, 'sessions log');
+  const resolved = await loadSessionForChat(sessionId, opts, "sessions log");
   if (!resolved) return 1;
   const ocSessionId = await ensureOpencodeSession(resolved);
   if (!ocSessionId) return 1;
@@ -571,13 +663,15 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
   }
 
   if (json) {
-    process.stdout.write(`${JSON.stringify(messages.map(messageToJson), null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify(messages.map(messageToJson), null, 2)}\n`,
+    );
     return 0;
   }
 
   const s = resolved.session;
   process.stdout.write(
-    `\n${C.bold}${s.name ?? s.session_id.split('-')[0]}${C.reset} ` +
+    `\n${C.bold}${s.name ?? s.session_id.split("-")[0]}${C.reset} ` +
       `${C.faded}(${s.agent_name} · ${s.status})${C.reset}\n`,
   );
   if (messages.length === 0) {
@@ -585,13 +679,13 @@ export async function runSessionsLog(argv: string[]): Promise<number> {
     return 0;
   }
   for (const msg of messages) printMessage(msg);
-  process.stdout.write('\n');
+  process.stdout.write("\n");
   return 0;
 }
 
 /** Compact, ANSI-free shape of a message for `--json` consumption. */
 function messageToJson(msg: MessageWithParts): Record<string, unknown> {
-  const info = msg.info as MessageWithParts['info'] & {
+  const info = msg.info as MessageWithParts["info"] & {
     time?: { created?: number; completed?: number };
     error?: { name?: string; message?: string } | null;
     agent?: string;
@@ -599,26 +693,34 @@ function messageToJson(msg: MessageWithParts): Record<string, unknown> {
   const text = msg.parts
     .filter(
       (p) =>
-        p.type === 'text' &&
+        p.type === "text" &&
         !(p as { synthetic?: boolean }).synthetic &&
-        typeof (p as { text?: string }).text === 'string',
+        typeof (p as { text?: string }).text === "string",
     )
     .map((p) => (p as { text: string }).text)
-    .join('\n');
+    .join("\n");
   const parts = msg.parts.map((p) => {
-    if (p.type === 'tool') {
+    if (p.type === "tool") {
       const state = (p as { state?: { status?: string } }).state;
-      return { type: 'tool', tool: (p as { tool?: string }).tool, status: state?.status };
+      return {
+        type: "tool",
+        tool: (p as { tool?: string }).tool,
+        status: state?.status,
+      };
     }
-    if (p.type === 'file') {
-      return { type: 'file', filename: (p as { filename?: string }).filename };
+    if (p.type === "file") {
+      return { type: "file", filename: (p as { filename?: string }).filename };
     }
     return { type: p.type };
   });
   return {
     role: info.role,
-    created: info.time?.created ? new Date(info.time.created).toISOString() : null,
-    completed: info.time?.completed ? new Date(info.time.completed).toISOString() : null,
+    created: info.time?.created
+      ? new Date(info.time.created).toISOString()
+      : null,
+    completed: info.time?.completed
+      ? new Date(info.time.completed).toISOString()
+      : null,
     error: info.error ?? null,
     text,
     parts,
@@ -642,11 +744,11 @@ async function sendAndPrint(
       emitJson(messageToJson({ info: reply.info, parts: reply.parts }));
       return reply.info.error ? 1 : 0;
     }
-    process.stdout.write(`${' '.repeat(12)}\r`); // clear "…thinking"
+    process.stdout.write(`${" ".repeat(12)}\r`); // clear "…thinking"
     printMessage({ info: reply.info, parts: reply.parts });
     return reply.info.error ? 1 : 0;
   } catch (err) {
-    if (!json) process.stdout.write(`${' '.repeat(12)}\r`);
+    if (!json) process.stdout.write(`${" ".repeat(12)}\r`);
     return surfaceApiError(err);
   }
 }
@@ -678,7 +780,7 @@ interface SessionActivity {
   /** Short human label: "running bash…", "thinking…", "idle", a reply snippet. */
   summary: string;
   /** Role of the most recent message. */
-  last_role?: 'user' | 'assistant';
+  last_role?: "user" | "assistant";
   /** ISO timestamp of the most recent activity. */
   last_at?: string;
 }
@@ -690,7 +792,7 @@ interface SessionActivity {
  */
 export async function runSessionsStatus(argv: string[]): Promise<number> {
   const rest = [...argv];
-  if (rest.includes('-h') || rest.includes('--help')) {
+  if (rest.includes("-h") || rest.includes("--help")) {
     process.stdout.write(`${STATUS_HELP}\n`);
     return 0;
   }
@@ -700,16 +802,18 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   let all = false;
   let json = false;
   try {
-    projectArg = takeFlagValue(rest, ['--project']);
-    hostArg = takeFlagValue(rest, ['--host']);
-    all = takeFlagBool(rest, ['--all', '-a']);
-    json = takeFlagBool(rest, ['--json']);
+    projectArg = takeFlagValue(rest, ["--project"]);
+    hostArg = takeFlagValue(rest, ["--host"]);
+    all = takeFlagBool(rest, ["--all", "-a"]);
+    json = takeFlagBool(rest, ["--json"]);
   } catch (err) {
     process.stderr.write(`${status.err((err as Error).message)}\n`);
     return 2;
   }
   if (rest.length > 0) {
-    process.stderr.write(`${status.err(`Unexpected argument: ${rest[0]}`)}\n${STATUS_HELP}\n`);
+    process.stderr.write(
+      `${status.err(`Unexpected argument: ${rest[0]}`)}\n${STATUS_HELP}\n`,
+    );
     return 2;
   }
   const opts: CtxOpts = { projectArg, hostArg };
@@ -720,13 +824,19 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
 
   let sessions: ProjectSession[];
   try {
-    sessions = await ctx.client.get<ProjectSession[]>(`/projects/${ctx.projectId}/sessions`);
+    sessions = await ctx.client.get<ProjectSession[]>(
+      `/projects/${ctx.projectId}/sessions`,
+    );
   } catch (err) {
     return surfaceApiError(err);
   }
 
   const shown = (
-    all ? sessions : sessions.filter((s) => s.status !== 'stopped' && s.status !== 'completed')
+    all
+      ? sessions
+      : sessions.filter(
+          (s) => s.status !== "stopped" && s.status !== "completed",
+        )
   ).sort(
     (a, b) =>
       statusRank(a.status) - statusRank(b.status) ||
@@ -734,7 +844,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   );
 
   // Pull live activity for running sessions, concurrency-capped.
-  const running = shown.filter((s) => s.status === 'running');
+  const running = shown.filter((s) => s.status === "running");
   const activity = new Map<string, SessionActivity>();
   await mapLimit(running, 8, async (s) => {
     const a = await fetchSessionActivity(s, ctx.projectId, auth);
@@ -758,7 +868,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
 
   if (shown.length === 0) {
     process.stdout.write(
-      `  ${C.dim}No ${all ? '' : 'active '}sessions.${all ? '' : ' (pass --all to include stopped ones)'}${C.reset}\n`,
+      `  ${C.dim}No ${all ? "" : "active "}sessions.${all ? "" : " (pass --all to include stopped ones)"}${C.reset}\n`,
     );
     return 0;
   }
@@ -766,7 +876,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
   const counts = countByStatus(shown);
   const headline = Object.entries(counts)
     .map(([k, v]) => `${v} ${k}`)
-    .join(' · ');
+    .join(" · ");
   const labels = shown.map((s) => s.name ?? s.agent_name);
   const labelW = Math.max(...labels.map((l) => l.length), 4);
 
@@ -777,7 +887,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
     const id = shortId(s.session_id);
     const act = activity.get(s.session_id);
     const doing =
-      s.status === 'running'
+      s.status === "running"
         ? act
           ? `${act.working ? C.yellow : C.faded}${act.summary}${C.reset}`
           : `${C.faded}—${C.reset}`
@@ -787,7 +897,7 @@ export async function runSessionsStatus(argv: string[]): Promise<number> {
       `  ${dot} ${C.dim}${id}${C.reset}  ${pad(label, labelW)}  ${doing}  ${C.faded}${age}${C.reset}\n`,
     );
   }
-  process.stdout.write('\n');
+  process.stdout.write("\n");
   return 0;
 }
 
@@ -814,13 +924,14 @@ async function fetchSessionActivity(
       // The generated OpenCode client accepts RequestInit fields. The narrowed
       // SDK facade type currently lists only endpoint fields.
       signal: AbortSignal.timeout(SESSION_ACTIVITY_PHASE_TIMEOUT_MS),
-    } as Parameters<typeof handle.runtime.session.messages>[0] & { signal: AbortSignal };
+    } as Parameters<typeof handle.runtime.session.messages>[0] & {
+      signal: AbortSignal;
+    };
     const msgs = await withKortixScope(auth, async () =>
-      unwrapRuntime(
-        await handle.runtime.session.messages(messageRequest),
-      ),
+      unwrapRuntime(await handle.runtime.session.messages(messageRequest)),
     );
-    if (msgs.length === 0) return { working: false, summary: 'no messages yet' };
+    if (msgs.length === 0)
+      return { working: false, summary: "no messages yet" };
     return deriveActivity(msgs, s.status);
   } catch {
     // Sandbox still warming / proxy hiccup — treat as unknown, not fatal.
@@ -836,22 +947,24 @@ async function fetchSessionActivity(
  */
 export function deriveActivity(
   messages: MessageWithParts[],
-  status: ProjectSession['status'],
+  status: ProjectSession["status"],
 ): SessionActivity {
   // Lifecycle states before the agent can run describe the BOX, not a turn.
-  if (status === 'provisioning' || status === 'branching') {
-    return { working: true, summary: 'provisioning…' };
+  if (status === "provisioning" || status === "branching") {
+    return { working: true, summary: "provisioning…" };
   }
-  if (status === 'queued') {
-    return { working: true, summary: 'booting…' };
+  if (status === "queued") {
+    return { working: true, summary: "booting…" };
   }
 
   const last = messages[messages.length - 1];
-  if (!last) return { working: false, summary: 'no messages yet' };
-  const lastInfo = last.info as MessageWithParts['info'] & {
+  if (!last) return { working: false, summary: "no messages yet" };
+  const lastInfo = last.info as MessageWithParts["info"] & {
     time?: { created?: number; completed?: number };
   };
-  const at = lastInfo.time?.created ? new Date(lastInfo.time.created).toISOString() : undefined;
+  const at = lastInfo.time?.created
+    ? new Date(lastInfo.time.created).toISOString()
+    : undefined;
 
   // A running/pending tool ANYWHERE in the window means the agent is actively
   // working — even when the newest message is a (subagent) user-role prompt.
@@ -859,10 +972,11 @@ export function deriveActivity(
   let lastTool: string | undefined;
   for (const msg of messages) {
     for (const p of msg.parts) {
-      if (p.type !== 'tool') continue;
+      if (p.type !== "tool") continue;
       lastTool = (p as { tool?: string }).tool;
       const st = (p as { state?: { status?: string } }).state?.status;
-      if (st === 'running' || st === 'pending') runningTool = (p as { tool?: string }).tool;
+      if (st === "running" || st === "pending")
+        runningTool = (p as { tool?: string }).tool;
     }
   }
   if (runningTool) {
@@ -870,7 +984,7 @@ export function deriveActivity(
       working: true,
       tool: runningTool,
       summary: `running ${runningTool}…`,
-      last_role: 'assistant',
+      last_role: "assistant",
       last_at: at,
     };
   }
@@ -879,28 +993,45 @@ export function deriveActivity(
   // agent is still generating — report "working", not "queued", even if a later
   // user-role message is technically newest.
   let latestAssistant:
-    | (MessageWithParts['info'] & { time?: { completed?: number }; error?: unknown })
+    | (MessageWithParts["info"] & {
+        time?: { completed?: number };
+        error?: unknown;
+      })
     | undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (!message) continue;
     const info = message.info;
-    if (info.role === 'assistant') {
-      latestAssistant = info as MessageWithParts['info'] & {
+    if (info.role === "assistant") {
+      latestAssistant = info as MessageWithParts["info"] & {
         time?: { completed?: number };
         error?: unknown;
       };
       break;
     }
   }
-  if (latestAssistant && latestAssistant.time?.completed == null && !latestAssistant.error) {
-    return { working: true, summary: 'working…', last_role: 'assistant', last_at: at };
+  if (
+    latestAssistant &&
+    latestAssistant.time?.completed == null &&
+    !latestAssistant.error
+  ) {
+    return {
+      working: true,
+      summary: "working…",
+      last_role: "assistant",
+      last_at: at,
+    };
   }
 
   // Newest message is the user's and no assistant turn has started — genuinely
   // queued, waiting for the agent to pick it up.
-  if (lastInfo.role === 'user') {
-    return { working: true, summary: 'queued — agent picking up…', last_role: 'user', last_at: at };
+  if (lastInfo.role === "user") {
+    return {
+      working: true,
+      summary: "queued — agent picking up…",
+      last_role: "user",
+      last_at: at,
+    };
   }
 
   // Otherwise the last assistant turn is done — summarize its reply.
@@ -908,18 +1039,22 @@ export function deriveActivity(
   const text = last.parts
     .filter(
       (p) =>
-        p.type === 'text' &&
+        p.type === "text" &&
         !(p as { synthetic?: boolean }).synthetic &&
-        typeof (p as { text?: string }).text === 'string',
+        typeof (p as { text?: string }).text === "string",
     )
     .map((p) => (p as { text: string }).text)
-    .join(' ')
-    .replace(/\s+/g, ' ')
+    .join(" ")
+    .replace(/\s+/g, " ")
     .trim();
   return {
     working: false,
-    summary: text ? truncate(text, 64) : lastTool ? `idle (last: ${lastTool})` : 'idle',
-    last_role: 'assistant',
+    summary: text
+      ? truncate(text, 64)
+      : lastTool
+        ? `idle (last: ${lastTool})`
+        : "idle",
+    last_role: "assistant",
     last_at: completed ? new Date(completed).toISOString() : at,
   };
 }
@@ -940,18 +1075,20 @@ async function mapLimit<T>(
       await fn(item);
     }
   };
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, () => worker()));
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
 }
 
 function statusRank(s: string): number {
   switch (s) {
-    case 'running':
+    case "running":
       return 0;
-    case 'provisioning':
-    case 'starting':
-    case 'restarting':
+    case "provisioning":
+    case "starting":
+    case "restarting":
       return 1;
-    case 'failed':
+    case "failed":
       return 2;
     default:
       return 3;
@@ -960,13 +1097,13 @@ function statusRank(s: string): number {
 
 function statusDot(s: string): string {
   switch (s) {
-    case 'running':
+    case "running":
       return `${C.green}●${C.reset}`;
-    case 'failed':
+    case "failed":
       return `${C.red}✗${C.reset}`;
-    case 'provisioning':
-    case 'starting':
-    case 'restarting':
+    case "provisioning":
+    case "starting":
+    case "restarting":
       return `${C.yellow}◐${C.reset}`;
     default:
       return `${C.faded}○${C.reset}`;
@@ -980,7 +1117,7 @@ function countByStatus(sessions: ProjectSession[]): Record<string, number> {
 }
 
 function shortId(id: string): string {
-  return id.split('-')[0] ?? id;
+  return id.split("-")[0] ?? id;
 }
 
 function truncate(s: string, max: number): string {
@@ -989,7 +1126,7 @@ function truncate(s: string, max: number): string {
 
 function relAge(iso: string): string {
   const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60_000);
-  if (m < 1) return 'just now';
+  if (m < 1) return "just now";
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
   if (h < 24) return `${h}h ago`;

--- a/apps/cli/src/commands/sessions-chat.ts
+++ b/apps/cli/src/commands/sessions-chat.ts
@@ -232,7 +232,16 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
   const opts: CtxOpts = { projectArg, hostArg };
 
   // ── Resolve which session to chat with ──────────────────────────────────
-  const sessionId = await resolveChatSessionId(positional[0], wantNew, promptText, opts);
+  const initialPromptSubmitted =
+    positional[0] === undefined && wantNew && promptText !== undefined && !queue;
+  const sessionId = await resolveChatSessionId(
+    positional[0],
+    wantNew,
+    queue ? undefined : promptText,
+    opts,
+    json,
+    agent,
+  );
   if (!sessionId) return 1;
 
   // --queue is deliberately routed BEFORE loadSessionForChat: the whole point
@@ -252,6 +261,7 @@ export async function runSessionsChat(argv: string[]): Promise<number> {
 
   // ── One-shot ─────────────────────────────────────────────────────────────
   if (promptText !== undefined) {
+    if (initialPromptSubmitted) return waitForInitialReply(resolved, json);
     return sendAndPrint(resolved, promptText, extra, json);
   }
 
@@ -329,6 +339,39 @@ async function queuePrompt(
   return 0;
 }
 
+/** Read the reply to the `initial_prompt` submitted by session creation. */
+async function waitForInitialReply(resolved: ResolvedSession, json: boolean): Promise<number> {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    try {
+      const messages = await withKortixScope(resolved.auth, async () =>
+        unwrapRuntime(
+          await resolved.runtime.session.messages({
+            sessionID: resolved.opencodeSessionId,
+            limit: 10,
+          }),
+        ),
+      );
+      for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
+        if (!message || message.info.role !== 'assistant') continue;
+        const info = message.info as MessageWithParts['info'] & {
+          time?: { completed?: number };
+          error?: unknown;
+        };
+        if (info.time?.completed == null && !info.error) break;
+        if (json) emitJson(messageToJson(message));
+        else printMessage(message);
+        return info.error ? 1 : 0;
+      }
+    } catch (err) {
+      if (attempt === 119) return surfaceApiError(err);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  process.stderr.write(`${status.err('Timed out waiting for the initial prompt reply.')}\n`);
+  return 1;
+}
+
 /**
  * Resolve the target session id: explicit positional → --new (create) →
  * most-recent running session on the project. Prints guidance + returns null
@@ -339,6 +382,8 @@ async function resolveChatSessionId(
   wantNew: boolean,
   initialPrompt: string | undefined,
   opts: CtxOpts,
+  quiet = false,
+  agent?: string,
 ): Promise<string | null> {
   if (explicit) return explicit;
 
@@ -348,16 +393,19 @@ async function resolveChatSessionId(
   if (wantNew) {
     const body: Record<string, unknown> = {};
     if (initialPrompt) body.initial_prompt = initialPrompt;
+    if (agent) body.agent_name = agent;
     try {
       const created = await ctx.client.post<ProjectSession>(
         `/projects/${ctx.projectId}/sessions`,
         body,
       );
-      process.stdout.write(
-        `${status.ok(`Started session ${C.bold}${created.session_id.split('-')[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
-      );
+      if (!quiet) {
+        process.stdout.write(
+          `${status.ok(`Started session ${C.bold}${created.session_id.split('-')[0]}${C.reset}`)} ${C.dim}(${created.status})${C.reset}\n`,
+        );
+      }
       if (created.status !== 'running') {
-        process.stdout.write(`  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`);
+        if (!quiet) process.stdout.write(`  ${C.dim}Waiting for the sandbox to come up…${C.reset}\n`);
         const ready = await waitForRunning(ctx, created.session_id);
         if (!ready) return null;
       }


### PR DESCRIPTION
`kortix sessions chat --new --prompt` submitted the same text twice. Session creation delivered `initial_prompt`, then the CLI posted it again through OpenCode after startup. The duplicate could collide with the first turn and surface an HTTP 500 even though the first assistant reply completed.

This change reads the reply created by `initial_prompt` instead of posting again. It also preserves `--agent`, avoids duplicate queue submission, and keeps `--json` stdout valid JSON.

Verification:
- `pnpm --filter @kortix/cli test` — 1233 pass, 0 fail
- focused regression — 1 pass, 0 fail
- `git diff --check` — clean

Typecheck note: the existing CLI typecheck fails at `sessions-shell.ts:261` on the Bun BufferSource type mismatch. This change does not touch that file.