### PR TITLE
Files: one header row per surface, faster change-request open, calmer review panels

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1621,7 +1621,12 @@ html[data-desktop='true'] .kx-titlebar-spacer {
    y=0, so it shares the band with the OS window controls: the macOS traffic
    lights on the left, the Win/Linux cluster on the right. Wear
    `.kx-titlebar-row` and it indents past whichever applies. Indent only — the
-   row keeps its own height, exactly like .kx-files-header below.
+   row keeps its own height.
+
+   The standalone Files header (/projects/[id]/files) wears this too. It used
+   to carry a Files-only near-duplicate of these rules, with its own md+ and
+   per-platform split, for a header that no longer exists in that shape — see
+   `drive-header.tsx`. One class, one rule.
 
    `data-sidebar-collapsed` gates the left indent: an expanded sidebar covers
    the lights (and the shell's toggle self-hides), so indenting then would
@@ -1633,25 +1638,6 @@ html[data-desktop='true'] .kx-titlebar-row {
 }
 html[data-desktop='true'] .kx-titlebar-row[data-sidebar-collapsed] {
   padding-left: var(--kx-titlebar-content-left);
-}
-
-/* Files page header (/projects/[id]/files) — the one page header that reaches
-   the top of the window with nothing above it, so it shares the title-bar row
-   with the OS window controls. No extra vertical space, indent only.
-
-   Both indents are scoped to md+ where the title shares the traffic-light row. */
-@media (min-width: 768px) {
-  /* macOS: indent past the lights AND the shell's floating sidebar toggle —
-     --kx-titlebar-content-left is exactly "after both". Only while collapsed;
-     an expanded sidebar covers the lights itself. */
-  html[data-desktop-platform='macos'] .kx-files-header[data-sidebar-collapsed] {
-    padding-left: var(--kx-titlebar-content-left);
-  }
-  /* Win/Linux: window controls live top-right, where the history / proposed-
-     changes / view-mode controls sit. Left stays at the web's `pl-14`. */
-  html[data-desktop='true']:not([data-desktop-platform='macos']) .kx-files-header {
-    padding-right: var(--kx-titlebar-controls-width);
-  }
 }
 
 /* Full-screen / top-reaching modals (e.g. the File Preview modal) start

--- a/apps/web/src/components/ui/dropdown-menu.test.ts
+++ b/apps/web/src/components/ui/dropdown-menu.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const uiDir = import.meta.dir;
+const srcDir = join(uiDir, '..', '..');
+
+const dropdownSource = readFileSync(join(uiDir, 'dropdown-menu.tsx'), 'utf8');
+const recipeSource = readFileSync(join(uiDir, 'menu-recipe.ts'), 'utf8');
+
+/**
+ * Regression pin for a defect that shipped and bit two consumers before anyone
+ * traced it to the primitive.
+ *
+ * `MENU_ROW_BASE` makes a menu row `flex items-center gap-2`, so every row
+ * component's children are flex items — EXCEPT `DropdownMenuRadioItem`, which
+ * interposed a `<span className="min-w-0 flex-1">` to push its check to the
+ * far edge. That span was a block. Tailwind's Preflight sets
+ * `svg { display: block }`, so a radio row with a leading icon rendered the
+ * icon stacked ABOVE its label.
+ *
+ * `user-menu-shared.tsx` and `reasoning-effort-selector.tsx` both worked around
+ * it by hand-wrapping their children in `<span className="flex items-center
+ * gap-2">` — the first even carrying a comment describing the workaround. The
+ * wrapper is the component's job; these tests fail if either half regresses.
+ */
+describe('DropdownMenuRadioItem label column', () => {
+  const radioLabel = /const RADIO_LABEL = '([^']+)'/.exec(dropdownSource)?.[1];
+
+  test('is declared as a single shared constant', () => {
+    expect(radioLabel).toBeDefined();
+  });
+
+  test('is a flex row, so a leading icon sits beside its label, not above it', () => {
+    expect(radioLabel).toContain('flex');
+    expect(radioLabel).toContain('items-center');
+  });
+
+  test('keeps flex-1, which is what pushes the check to the row edge', () => {
+    expect(radioLabel).toContain('flex-1');
+    expect(radioLabel).toContain('min-w-0');
+  });
+
+  test('spaces icon and label exactly like every other row type', () => {
+    // MENU_ROW_BASE is the reference: a radio row must not invent its own gap.
+    const rowGap = /gap-(\d+(?:\.\d+)?)/.exec(recipeSource.split('MENU_ROW_BASE')[1] ?? '')?.[1];
+    expect(rowGap).toBeDefined();
+    expect(radioLabel).toContain(`gap-${rowGap}`);
+  });
+});
+
+describe('no consumer re-implements the label column', () => {
+  // The exact shape both files used to carry, immediately inside a radio row.
+  const WORKAROUND = /<DropdownMenuRadioItem[^>]*>\s*(\{\/\*[\s\S]*?\*\/\}\s*)?<span className="flex items-center gap-2">/;
+
+  // A plain loop, not `test.each`: `@types/bun` does not declare `each`, and
+  // the three files that use it are the whole of this app's known tsc noise.
+  for (const relativePath of [
+    'features/layout/user-menu-shared.tsx',
+    'features/session/reasoning-effort-selector.tsx',
+  ]) {
+    test(`${relativePath} puts its icon directly in the row`, () => {
+      const source = readFileSync(join(srcDir, relativePath), 'utf8');
+      // Guard against the test passing because the file moved or stopped using
+      // radio items at all.
+      expect(source).toContain('DropdownMenuRadioItem');
+      expect(source).not.toMatch(WORKAROUND);
+    });
+  }
+});

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -182,6 +182,24 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 ));
 DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
 
+/**
+ * The label column of a radio row.
+ *
+ * `flex-1` is what pushes the check to the row's far edge — but the span used
+ * to stop there, i.e. it was a BLOCK. Tailwind's Preflight sets
+ * `svg { display: block }`, so any radio row with a leading icon rendered the
+ * icon on its own line above the label. Every other row component
+ * (`Item`, `CheckboxItem`, `SubTrigger`) escapes this because `MENU_ROW_BASE`
+ * makes the row itself the flex container and their children are direct
+ * children of it; only `RadioItem` interposes this wrapper.
+ *
+ * Two consumers had already worked around it by hand-wrapping their children
+ * in exactly this class (`user-menu-shared.tsx`, `reasoning-effort-selector.tsx`)
+ * — the workaround is now the component's job. `gap-2` matches `MENU_ROW_BASE`
+ * so an icon+label pair is spaced identically whichever row type holds it.
+ */
+const RADIO_LABEL = 'flex min-w-0 flex-1 items-center gap-2';
+
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   // `size` used to be 'default' | 'sm' | 'lg' here while every sibling row used
@@ -219,11 +237,11 @@ const DropdownMenuRadioItem = React.forwardRef<
       {side === 'left' ? (
         <>
           {indicator}
-          <span className="min-w-0 flex-1">{children}</span>
+          <span className={RADIO_LABEL}>{children}</span>
         </>
       ) : (
         <>
-          <span className="min-w-0 flex-1">{children}</span>
+          <span className={RADIO_LABEL}>{children}</span>
           {indicator}
         </>
       )}

--- a/apps/web/src/features/files/sandbox-file-explorer.tsx
+++ b/apps/web/src/features/files/sandbox-file-explorer.tsx
@@ -3,7 +3,11 @@
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { ErrorState } from '@/features/layout/section/error-state';
-import { DriveExplorer, FileExplorerSourceProvider } from '@/features/project-files';
+import {
+  DRIVE_ACTION_ROW_CLASS,
+  DriveExplorer,
+  FileExplorerSourceProvider,
+} from '@/features/project-files';
 import { useBoundedRuntimeWait } from '@/features/session/use-bounded-runtime-wait';
 import { useRuntimeStore } from '@kortix/sdk/react';
 import {
@@ -11,7 +15,7 @@ import {
   CloudSlashIcon as ServerOff,
 } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useServerHealth } from './hooks';
 import { sandboxExplorerSource } from './sandbox-explorer-source';
 
@@ -24,21 +28,44 @@ import { sandboxExplorerSource } from './sandbox-explorer-source';
 export function SandboxFileExplorer({
   embedded = false,
   shareContext,
+  leading,
+  contentPanel,
 }: {
   embedded?: boolean;
   shareContext?: { projectId: string; sessionId: string };
+  /** Host chrome for the start of the explorer's action row — see {@link DriveExplorer}. */
+  leading?: ReactNode;
+  /** ARIA wiring when `leading` is a tab strip — see {@link DriveExplorer}. */
+  contentPanel?: { id: string; labelledBy: string };
 } = {}) {
   return (
     <FileExplorerSourceProvider value={sandboxExplorerSource}>
-      <SandboxServerGate>
-        <DriveExplorer embedded={embedded} shareContext={shareContext} />
+      <SandboxServerGate leading={leading}>
+        <DriveExplorer
+          embedded={embedded}
+          shareContext={shareContext}
+          leading={leading}
+          contentPanel={contentPanel}
+        />
       </SandboxServerGate>
     </FileExplorerSourceProvider>
   );
 }
 
-/** Renders children only while the sandbox OpenCode server is reachable. */
-function SandboxServerGate({ children }: { children: React.ReactNode }) {
+/**
+ * Renders children only while the sandbox OpenCode server is reachable.
+ *
+ * `leading` (the host's tab strip) is repeated over the closed-gate states on
+ * purpose: it is how the user switches away from a workspace that is still
+ * booting or unreachable, so it must not vanish with the explorer.
+ */
+function SandboxServerGate({
+  children,
+  leading,
+}: {
+  children: React.ReactNode;
+  leading?: ReactNode;
+}) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const serverUrl = useRuntimeStore((s) => s.getActiveServerUrl());
   const { data: health, isLoading: isHealthLoading, refetch } = useServerHealth();
@@ -55,40 +82,57 @@ function SandboxServerGate({ children }: { children: React.ReactNode }) {
   // second failure UI a moment before this one replaced it.
   if (isHealthLoading && !healthWaitExpired) {
     return (
-      <div className="bg-background flex h-full flex-col gap-2 p-4">
-        <Skeleton className="h-8 w-full py-0" />
-        {Array.from({ length: 6 }).map((_, i) => (
-          <Skeleton key={i} className="h-9 w-full py-0" />
-        ))}
-      </div>
+      <GateShell leading={leading}>
+        <div className="flex flex-col gap-2 p-4">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <Skeleton key={i} className="h-9 w-full py-0" />
+          ))}
+        </div>
+      </GateShell>
     );
   }
 
   if (!health?.healthy || healthWaitExpired) {
     return (
-      <ErrorState
-        icon={ServerOff}
-        className="bg-background h-full"
-        title={tHardcodedUi.raw(
-          'featuresFilesComponentsFileExplorerPage.line546JsxTextServerNotReachable',
-        )}
-        description={
-          <>
-            {tHardcodedUi.raw(
-              'featuresFilesComponentsFileExplorerPage.line548JsxTextCouldNotConnectTo',
-            )}{' '}
-            <code className="bg-muted rounded px-1.5 py-0.5 text-xs">{serverUrl}</code>
-          </>
-        }
-        action={
-          <Button variant="outline" size="sm" className="gap-1.5" onClick={retry}>
-            <RefreshCw className="size-3.5 shrink-0" />
-            Retry
-          </Button>
-        }
-      />
+      <GateShell leading={leading}>
+        <ErrorState
+          icon={ServerOff}
+          className="min-h-0 flex-1"
+          title={tHardcodedUi.raw(
+            'featuresFilesComponentsFileExplorerPage.line546JsxTextServerNotReachable',
+          )}
+          description={
+            <>
+              {tHardcodedUi.raw(
+                'featuresFilesComponentsFileExplorerPage.line548JsxTextCouldNotConnectTo',
+              )}{' '}
+              <code className="bg-muted rounded px-1.5 py-0.5 text-xs">{serverUrl}</code>
+            </>
+          }
+          action={
+            <Button variant="outline" size="sm" className="gap-1.5" onClick={retry}>
+              <RefreshCw className="size-3.5 shrink-0" />
+              Retry
+            </Button>
+          }
+        />
+      </GateShell>
     );
   }
 
   return <>{children}</>;
+}
+
+/**
+ * Closed-gate layout: the host's action row on top, its state below. Keeps the
+ * row's height and border identical to the open explorer's, so opening the
+ * gate does not shift the content down.
+ */
+function GateShell({ leading, children }: { leading?: ReactNode; children: ReactNode }) {
+  return (
+    <div className="bg-background flex h-full min-h-0 flex-col">
+      {leading ? <div className={DRIVE_ACTION_ROW_CLASS}>{leading}</div> : null}
+      <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+    </div>
+  );
 }

--- a/apps/web/src/features/layout/user-menu-shared.tsx
+++ b/apps/web/src/features/layout/user-menu-shared.tsx
@@ -124,13 +124,8 @@ export function ThemeSubmenu() {
           <DropdownMenuRadioGroup value={theme ?? 'system'} onValueChange={setTheme}>
             {THEME_OPTIONS.map(({ value, label, Icon }) => (
               <DropdownMenuRadioItem key={value} value={value}>
-                {/* RadioItem wraps its children in a single flex-1 span to push
-                    the check to the right edge, so the icon and label need their
-                    own flex row inside it to stay aligned. */}
-                <span className="flex items-center gap-2">
-                  <Icon />
-                  {label}
-                </span>
+                <Icon />
+                {label}
               </DropdownMenuRadioItem>
             ))}
           </DropdownMenuRadioGroup>

--- a/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
+++ b/apps/web/src/features/project-files/components/change-request-detail-dialog.tsx
@@ -56,6 +56,7 @@ import {
   useMergeChangeRequest,
   useReopenChangeRequest,
 } from '../hooks/use-change-requests';
+import { EmptyState } from '@/features/layout/section/empty-state';
 import { DiffRenderer } from './diff-renderer';
 
 function StatusBadge({ status }: { status: ChangeRequestStatus }) {
@@ -457,16 +458,24 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
 
         <ModalBody className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-0 lg:flex lg:flex-col lg:overflow-hidden">
           {diffQuery.isLoading ? (
-            <div className="grid gap-3 p-3 sm:gap-4 sm:p-5 lg:grid-cols-[270px_minmax(0,1fr)]">
-              <Skeleton className="h-40 w-full rounded-lg lg:h-72" />
-              <div className="space-y-3">
-                <Skeleton className="h-24 w-full rounded-lg" />
-                <Skeleton className="h-96 w-full rounded-lg" />
+            <div className="grid min-h-full lg:min-h-0 lg:flex-1 lg:grid-cols-[270px_minmax(0,1fr)]">
+              <div className="border-border/60 space-y-2 border-b p-3 sm:p-4 lg:border-r lg:border-b-0">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-16" />
+                <div className="space-y-1.5 pt-3">
+                  {Array.from({ length: 5 }).map((_, i) => (
+                    <Skeleton key={i} className="h-8 w-full rounded-md" />
+                  ))}
+                </div>
+              </div>
+              <div className="space-y-3 p-3 sm:p-4 lg:p-5">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-64 w-full rounded-md" />
               </div>
             </div>
           ) : diff && diff.files.length > 0 ? (
             <div className="grid min-h-full grid-rows-[auto_minmax(0,1fr)] lg:min-h-0 lg:flex-1 lg:grid-cols-[270px_minmax(0,1fr)]">
-              <aside className="border-border bg-background flex flex-col gap-3 border-b p-3 sm:p-4 lg:h-full lg:min-h-0 lg:border-r lg:border-b-0">
+              <aside className="border-border/60 bg-background flex flex-col gap-3 border-b p-3 sm:p-4 lg:h-full lg:min-h-0 lg:border-r lg:border-b-0">
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <h3 className="text-foreground text-sm font-medium">
@@ -478,12 +487,12 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                       into {diff.base_ref}
                     </p>
                   </div>
-                  <span className="bg-muted text-muted-foreground shrink-0 rounded-md px-2 py-1 text-xs font-medium tabular-nums">
+                  <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
                     {diff.files.length}
                   </span>
                 </div>
 
-                <div className="border-border bg-card rounded-md border px-3 py-2">
+                <div className="border-border/60 border-t pt-3">
                   <div className="flex items-center justify-between text-xs">
                     <span className="text-muted-foreground">
                       {tI18nHardcoded.raw(
@@ -498,7 +507,7 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                   </div>
                 </div>
 
-                <div className="bg-card flex items-center gap-1 rounded-full border p-0.5">
+                <div className="bg-muted/40 flex items-center gap-0.5 rounded-md p-0.5">
                   <Hint label="Inline (unified) diff">
                     <Button
                       type="button"
@@ -507,8 +516,8 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                       onClick={() => setDiffLayout('unified')}
                       aria-pressed={diffLayout === 'unified'}
                       className={cn(
-                        'h-7 flex-1 gap-1.5 rounded-full',
-                        diffLayout === 'unified' && 'bg-primary/10 text-primary',
+                        'h-7 flex-1 gap-1.5 rounded-sm',
+                        diffLayout === 'unified' && 'bg-background text-foreground shadow-2xs',
                       )}
                     >
                       <Rows3 className="size-3.5" />
@@ -523,8 +532,8 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                       onClick={() => setDiffLayout('split')}
                       aria-pressed={diffLayout === 'split'}
                       className={cn(
-                        'h-7 flex-1 gap-1.5 rounded-full',
-                        diffLayout === 'split' && 'bg-primary/10 text-primary',
+                        'h-7 flex-1 gap-1.5 rounded-sm',
+                        diffLayout === 'split' && 'bg-background text-foreground shadow-2xs',
                       )}
                     >
                       <Columns2 className="size-3.5" />
@@ -595,8 +604,8 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
 
               <section className="min-w-0 space-y-3 p-3 pb-5 sm:space-y-4 sm:p-4 lg:h-full lg:min-h-0 lg:overflow-y-auto lg:p-5">
                 {hasReviewContext && (
-                  <div className="border-border bg-background overflow-hidden rounded-lg border">
-                    <div className="flex items-center justify-between gap-3 px-3 py-2.5">
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <div className="text-foreground text-sm font-medium">
                           {tI18nHardcoded.raw(
@@ -615,7 +624,7 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
                         </Badge>
                       )}
                     </div>
-                    <div className="border-border space-y-2.5 border-t p-3">
+                    <div className="space-y-2.5">
                       {cr?.description && (
                         <div className="text-muted-foreground text-sm wrap-break-word [&_pre]:overflow-x-auto">
                           <UnifiedMarkdown content={cr.description} />
@@ -753,13 +762,15 @@ export function ChangeRequestDetailDialog({ crId, onClose }: ChangeRequestDetail
               </section>
             </div>
           ) : (
-            <div className="p-5">
-              <p className="border-border text-muted-foreground bg-background rounded-lg border border-dashed p-5 text-center text-xs">
-                {tHardcodedUi.raw(
-                  'featuresProjectFilesComponentsChangeRequestDetailDialog.line356JsxTextNoChangesDetected',
-                )}
-              </p>
-            </div>
+            <EmptyState
+              size="sm"
+              className="py-16"
+              icon={FileDiff}
+              title="No changes detected"
+              description={
+                cr ? `Nothing differs between ${cr.head_ref} and ${cr.base_ref}.` : undefined
+              }
+            />
           )}
         </ModalBody>
 

--- a/apps/web/src/features/project-files/components/change-requests-panel.tsx
+++ b/apps/web/src/features/project-files/components/change-requests-panel.tsx
@@ -1,31 +1,33 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
-import { ScrollArea } from '@/components/ui/scroll-area';
-import { Skeleton } from '@/components/ui/skeleton';
+import Hint from '@/components/ui/hint';
 import { Tabs, TabsListCompact, TabsTriggerCompact } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { formatRelative } from '@kortix/shared';
 import {
-  WarningCircleIcon as AlertCircle,
-  CheckCircleIcon as CheckCircle2,
-  CaretDownIcon as ChevronDown,
-  GitDiffIcon as FileDiff,
-  StackIcon as Layers,
-  PlusIcon as Plus,
-  ArrowClockwiseIcon as RefreshCw,
-  XIcon as X,
-  XCircleIcon as XCircle,
+  CheckCircleIcon,
+  GitDiffIcon,
+  PlusIcon,
+  XCircleIcon,
 } from '@phosphor-icons/react';
-import { useMemo, useState } from 'react';
+
 import type { ChangeRequest, ChangeRequestStatus } from '../api/change-requests';
 import { useProjectContext } from '../context';
-import { useChangeRequests } from '../hooks/use-change-requests';
+import { useChangeRequests, usePrefetchChangeRequest } from '../hooks/use-change-requests';
 import { ChangeRequestDetailDialog } from './change-request-detail-dialog';
 import { OpenChangeRequestDialog } from './open-change-request-dialog';
+import {
+  groupByDate,
+  ReviewEmpty,
+  ReviewError,
+  ReviewGroupLabel,
+  ReviewPanel,
+  ReviewRow,
+  ReviewRowSkeleton,
+} from './review-panel';
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -39,17 +41,9 @@ const fullTimestampFormat = new Intl.DateTimeFormat(undefined, {
   minute: '2-digit',
 });
 
-function formatFull(timestamp: number): string {
-  return fullTimestampFormat.format(timestamp);
-}
-
 function tsFromCr(cr: ChangeRequest): number {
-  if (cr.status === 'merged' && cr.merged_at) {
-    return new Date(cr.merged_at).getTime();
-  }
-  if (cr.status === 'closed' && cr.closed_at) {
-    return new Date(cr.closed_at).getTime();
-  }
+  if (cr.status === 'merged' && cr.merged_at) return new Date(cr.merged_at).getTime();
+  if (cr.status === 'closed' && cr.closed_at) return new Date(cr.closed_at).getTime();
   return new Date(cr.created_at).getTime();
 }
 
@@ -63,77 +57,19 @@ function crTimeLabel(cr: ChangeRequest): string {
   return `proposed ${formatRelative(cr.created_at, { extended: 'full' }) ?? ''}`;
 }
 
-function groupByDate(crs: ChangeRequest[]) {
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const yesterday = new Date(today.getTime() - 86_400_000);
-  const thisWeekStart = new Date(today.getTime() - today.getDay() * 86_400_000);
-
-  const groups = new Map<string, ChangeRequest[]>();
-  for (const cr of crs) {
-    const d = new Date(tsFromCr(cr));
-    const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-    let label: string;
-    if (day.getTime() >= today.getTime()) label = 'Today';
-    else if (day.getTime() >= yesterday.getTime()) label = 'Yesterday';
-    else if (day.getTime() >= thisWeekStart.getTime()) label = 'This week';
-    else label = d.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
-    if (!groups.has(label)) groups.set(label, []);
-    groups.get(label)!.push(cr);
-  }
-  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
-}
-
-// ---------------------------------------------------------------------------
-// list row
-// ---------------------------------------------------------------------------
-
+/**
+ * Status as a bare glyph.
+ *
+ * It used to sit in a `size-6 rounded-full bg-muted/40` tile — the same grey
+ * for all three states, so the tile carried no information and only added a
+ * shape. The colour is the signal; the icon is the label for it.
+ */
 function CrIcon({ status }: { status: ChangeRequestStatus }) {
-  if (status === 'merged') return <CheckCircle2 className="text-kortix-purple h-3.5 w-3.5" />;
-  if (status === 'closed') {
-    return <XCircle className="text-muted-foreground h-3.5 w-3.5" />;
+  if (status === 'merged') {
+    return <CheckCircleIcon weight="fill" className="text-kortix-purple size-4" />;
   }
-  return <FileDiff className="text-kortix-green h-3.5 w-3.5" />;
-}
-
-function CrListItem({
-  cr,
-  isActive,
-  onSelect,
-}: {
-  cr: ChangeRequest;
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  const ts = tsFromCr(cr);
-  return (
-    <button
-      onClick={onSelect}
-      className={cn(
-        'group flex w-full cursor-pointer items-start gap-3 py-2.5 pr-2 pl-3 text-left',
-        'border-l-2 border-l-transparent',
-        'hover:bg-muted/40 transition-colors',
-        isActive && 'bg-primary/[0.05] border-l-primary',
-      )}
-    >
-      <div className="bg-muted/40 mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full">
-        <CrIcon status={cr.status} />
-      </div>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5">
-          <span className="text-muted-foreground font-mono text-xs">#{cr.number}</span>
-          <p className="text-foreground truncate text-sm font-medium">{cr.title}</p>
-        </div>
-        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
-          <span title={formatFull(ts)}>{crTimeLabel(cr)}</span>
-          <span className="text-muted-foreground/30">·</span>
-          <span className="truncate" title={`Applies to the "${cr.base_ref}" version`}>
-            into {cr.base_ref}
-          </span>
-        </div>
-      </div>
-    </button>
-  );
+  if (status === 'closed') return <XCircleIcon className="text-muted-foreground/60 size-4" />;
+  return <GitDiffIcon className="text-kortix-green size-4" />;
 }
 
 // ---------------------------------------------------------------------------
@@ -146,12 +82,14 @@ interface ChangeRequestsPanelProps {
 }
 
 /**
- * Right-edge slide-in panel mirroring the Checkpoints drawer. Lists CRs for
- * the active project, filterable by status. Clicking a row opens the detail
- * dialog with diff + merge/close actions.
+ * Right-edge drawer listing this project's proposed changes, filtered by
+ * status. Selecting a row opens the detail dialog (diff + apply / dismiss).
+ *
+ * Rows prefetch their own detail and diff on hover, and the dialog seeds its
+ * header straight from the row — see `usePrefetchChangeRequest` and
+ * `useChangeRequest`'s `initialData` for why opening one is no longer a wait.
  */
 export function ChangeRequestsPanel({ open = false, onClose }: ChangeRequestsPanelProps) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
   const ctx = useProjectContext();
   const activeRef = ctx?.ref ?? '';
   const defaultBranch = ctx?.defaultBranch ?? '';
@@ -159,12 +97,14 @@ export function ChangeRequestsPanel({ open = false, onClose }: ChangeRequestsPan
   const [selectedCrId, setSelectedCrId] = useState<string | null>(null);
   const [openDialogShown, setOpenDialogShown] = useState(false);
 
-  const { data, isLoading, error, refetch, isFetching } = useChangeRequests(status, {
+  const { data, isLoading, error } = useChangeRequests(status, {
     enabled: open,
     refetchInterval: open ? 6_000 : undefined,
   });
+  const prefetch = usePrefetchChangeRequest();
+
   const crs = useMemo(() => data?.change_requests ?? [], [data]);
-  const groups = useMemo(() => groupByDate(crs), [crs]);
+  const groups = useMemo(() => groupByDate(crs, tsFromCr), [crs]);
   const total = crs.length;
 
   const initialHeadForDialog =
@@ -172,58 +112,27 @@ export function ChangeRequestsPanel({ open = false, onClose }: ChangeRequestsPan
 
   return (
     <>
-      <aside
-        aria-hidden={!open}
-        className={cn(
-          'absolute top-0 right-0 bottom-0 flex w-[400px] flex-col',
-          'border-border bg-background border-l',
-          'transition-transform duration-200 ease-out',
-          'z-30',
-          open ? 'translate-x-0' : 'pointer-events-none translate-x-full',
-        )}
-      >
-        <div className="border-border flex h-12 shrink-0 items-center gap-2 border-b px-3">
-          <span className="text-sm font-medium">
-            {tHardcodedUi.raw(
-              'featuresProjectFilesComponentsChangeRequestsPanel.line131JsxTextChangeRequests',
-            )}
-          </span>
-          {activeRef && (
-            <span
-              className="bg-muted/50 text-muted-foreground/90 flex max-w-[140px] items-center gap-1 truncate rounded-full px-1.5 py-0.5 text-xs"
-              title={`Version: ${activeRef}`}
+      <ReviewPanel
+        open={open}
+        onClose={onClose}
+        title="Proposed changes"
+        // No refresh control: this list polls every 6s for as long as the panel
+        // is open, so a manual refresh could only ever repeat what already
+        // happens on its own.
+        actions={
+          <Hint label="Propose a change" side="bottom">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Propose a change"
+              onClick={() => setOpenDialogShown(true)}
+              className="text-muted-foreground hover:text-foreground active:scale-[0.96]"
             >
-              <Layers className="h-3 w-3" />
-              {activeRef}
-            </span>
-          )}
-          {total > 0 && <span className="text-muted-foreground text-xs tabular-nums">{total}</span>}
-          <Button
-            size="sm"
-            className="ml-auto h-7 gap-1 px-2 text-xs"
-            onClick={() => setOpenDialogShown(true)}
-            title={tHardcodedUi.raw(
-              'featuresProjectFilesComponentsChangeRequestsPanel.line145JsxAttrTitleOpenANewChangeRequest',
-            )}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            New
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => refetch()}
-            title="Refresh"
-          >
-            <RefreshCw className={cn('h-3.5 w-3.5', isFetching && 'animate-spin')} />
-          </Button>
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose} title="Close">
-            <X className="h-3.5 w-3.5" />
-          </Button>
-        </div>
-
-        <div className="border-border shrink-0 border-b px-3 py-2">
+              <PlusIcon className="size-4" />
+            </Button>
+          </Hint>
+        }
+        filters={
           <Tabs
             value={status}
             onValueChange={(v) => setStatus(v as ChangeRequestStatus | 'all')}
@@ -236,101 +145,88 @@ export function ChangeRequestsPanel({ open = false, onClose }: ChangeRequestsPan
               <TabsTriggerCompact value="all">All</TabsTriggerCompact>
             </TabsListCompact>
           </Tabs>
-        </div>
+        }
+      >
+        {isLoading && <ReviewRowSkeleton count={5} />}
 
-        <div className="min-h-0 flex-1">
-          <ScrollArea className="h-full">
-            {isLoading && (
-              <div className="space-y-3 p-3">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <div key={i} className="space-y-1.5">
-                    <Skeleton className="h-3 w-20" />
-                    <Skeleton className="h-14 w-full rounded-lg" />
-                  </div>
-                ))}
-              </div>
-            )}
+        {error && !isLoading && (
+          <ReviewError title="Couldn't load proposed changes" error={error} />
+        )}
 
-            {error && !isLoading && (
-              <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
-                <AlertCircle className="text-muted-foreground/30 h-6 w-6" />
-                <p className="text-muted-foreground text-xs">Failed to load change requests</p>
-                <p className="text-muted-foreground/60 text-xs">
-                  {error instanceof Error ? error.message : 'Unknown error'}
-                </p>
-              </div>
-            )}
+        {!isLoading && !error && total === 0 && (
+          <ReviewEmpty
+            size="sm"
+            className="py-10"
+            icon={GitDiffIcon}
+            title={status === 'open' ? 'Nothing waiting for review' : 'Nothing here yet'}
+            description={
+              status === 'open'
+                ? 'Changes your agents propose show up here before they reach the main version.'
+                : undefined
+            }
+            action={
+              status === 'open' ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="gap-1.5"
+                  onClick={() => setOpenDialogShown(true)}
+                >
+                  <PlusIcon className="size-3.5 shrink-0" />
+                  Propose a change
+                </Button>
+              ) : undefined
+            }
+          />
+        )}
 
-            {!isLoading && !error && total === 0 && (
-              <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
-                <FileDiff className="text-muted-foreground/30 h-6 w-6" />
-                <p className="text-muted-foreground text-xs">
-                  {tHardcodedUi.raw(
-                    'featuresProjectFilesComponentsChangeRequestsPanel.line199JsxTextChangeRequests',
-                  )}
-                </p>
-                {status === 'open' && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="mt-1 h-7 gap-1 text-xs"
-                    onClick={() => setOpenDialogShown(true)}
+        {!isLoading && !error && total > 0 && (
+          <div className="pb-3">
+            {groups.map((group, gi) => (
+              <div key={group.label}>
+                <ReviewGroupLabel first={gi === 0}>{group.label}</ReviewGroupLabel>
+                {group.items.map((cr) => (
+                  <ReviewRow
+                    key={cr.cr_id}
+                    isActive={selectedCrId === cr.cr_id}
+                    onSelect={() => setSelectedCrId(cr.cr_id)}
+                    onPrefetch={() => prefetch(cr.cr_id)}
                   >
-                    <Plus className="h-3.5 w-3.5" />
-                    {tHardcodedUi.raw(
-                      'featuresProjectFilesComponentsChangeRequestsPanel.line209JsxTextOpenTheFirstOne',
-                    )}
-                  </Button>
-                )}
-              </div>
-            )}
-
-            {!isLoading && !error && total > 0 && (
-              <div className="py-1">
-                {groups.map((group, gi) => (
-                  <Disclosure
-                    key={group.label}
-                    open
-                    className="group/cr"
-                    transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-                  >
-                    <DisclosureTrigger>
-                      <button
-                        type="button"
-                        className={cn(
-                          'bg-background/95 sticky top-0 z-[1] flex w-full items-center gap-2 px-3 py-1.5 backdrop-blur-sm',
-                          'border-border border-b',
-                          gi === 0 ? '' : 'border-border border-t',
-                        )}
+                    <span className="mt-0.5 shrink-0">
+                      <CrIcon status={cr.status} />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="flex items-baseline gap-1.5">
+                        <span className="text-muted-foreground/70 shrink-0 text-xs tabular-nums">
+                          #{cr.number}
+                        </span>
+                        <span
+                          className={cn(
+                            'text-foreground min-w-0 flex-1 truncate text-sm font-medium',
+                            cr.status === 'closed' && 'text-muted-foreground',
+                          )}
+                        >
+                          {cr.title}
+                        </span>
+                      </span>
+                      <span
+                        className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs"
+                        title={fullTimestampFormat.format(tsFromCr(cr))}
                       >
-                        <div className="flex w-full items-center justify-between gap-2 px-1">
-                          <span className="text-foreground/90 text-sm font-medium">
-                            {group.label}
-                          </span>
-                          <div className="text-muted-foreground flex items-center gap-1.5">
-                            <span className="text-[12px] tabular-nums">{group.items.length}</span>
-                            <ChevronDown className="size-3.5 shrink-0 transition-transform duration-150 ease-out group-data-[state=open]/cr:rotate-180" />
-                          </div>
-                        </div>
-                      </button>
-                    </DisclosureTrigger>
-                    <DisclosureContent>
-                      {group.items.map((cr) => (
-                        <CrListItem
-                          key={cr.cr_id}
-                          cr={cr}
-                          isActive={selectedCrId === cr.cr_id}
-                          onSelect={() => setSelectedCrId(cr.cr_id)}
-                        />
-                      ))}
-                    </DisclosureContent>
-                  </Disclosure>
+                        <span className="truncate">{crTimeLabel(cr)}</span>
+                        <span className="text-muted-foreground/30" aria-hidden>
+                          ·
+                        </span>
+                        <span className="truncate">into {cr.base_ref}</span>
+                      </span>
+                    </span>
+                  </ReviewRow>
                 ))}
               </div>
-            )}
-          </ScrollArea>
-        </div>
-      </aside>
+            ))}
+          </div>
+        )}
+      </ReviewPanel>
 
       <ChangeRequestDetailDialog crId={selectedCrId} onClose={() => setSelectedCrId(null)} />
 
@@ -340,9 +236,7 @@ export function ChangeRequestsPanel({ open = false, onClose }: ChangeRequestsPan
         projectId={ctx?.projectId ?? ''}
         defaultBranch={defaultBranch}
         initialHeadRef={initialHeadForDialog}
-        onCreated={(crId) => {
-          setSelectedCrId(crId);
-        }}
+        onCreated={(crId) => setSelectedCrId(crId)}
       />
     </>
   );

--- a/apps/web/src/features/project-files/components/checkpoints-panel.tsx
+++ b/apps/web/src/features/project-files/components/checkpoints-panel.tsx
@@ -1,35 +1,32 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import Hint from '@/components/ui/hint';
 import Loading from '@/components/ui/loading';
-import { Skeleton } from '@/components/ui/skeleton';
 import { UserAvatar } from '@/components/ui/user-avatar';
-import { cn } from '@/lib/utils';
 import type { ProjectCommit } from '@kortix/sdk';
-import {
-  WarningCircleIcon as AlertCircle,
-  CaretDownIcon as ChevronDown,
-  ClockCounterClockwiseIcon as History,
-  StackIcon as Layers,
-  ArrowClockwiseIcon as RefreshCw,
-  XIcon as X,
-} from '@phosphor-icons/react';
-import { useMemo, useState } from 'react';
+import { ClockCounterClockwiseIcon, ArrowClockwiseIcon } from '@phosphor-icons/react';
+
 import { useProjectContext } from '../context';
 import { useCommits } from '../hooks/use-commits';
 import { CheckpointDetailDialog } from './checkpoint-detail-dialog';
+import {
+  groupByDate,
+  ReviewEmpty,
+  ReviewError,
+  ReviewGroupLabel,
+  ReviewPanel,
+  ReviewRow,
+  ReviewRowSkeleton,
+} from './review-panel';
 
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 
-// Hoisted so render does not rebuild an Intl formatter per row. Output is
-// byte-identical: `toLocaleDateString()` ≡ `Intl.DateTimeFormat(undefined)`
-// and `toLocaleString(undefined, opts)` ≡ `Intl.DateTimeFormat(undefined, opts)`.
+// Hoisted so render does not rebuild an Intl formatter per row.
 const oldDateFormat = new Intl.DateTimeFormat();
 const fullDateTimeFormat = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
@@ -40,8 +37,7 @@ const fullDateTimeFormat = new Intl.DateTimeFormat(undefined, {
 });
 
 function formatRelative(timestamp: number): string {
-  const diff = Date.now() - timestamp;
-  const seconds = Math.floor(diff / 1000);
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
   const minutes = Math.floor(seconds / 60);
   const hours = Math.floor(minutes / 60);
   const days = Math.floor(hours / 24);
@@ -56,79 +52,8 @@ function formatRelative(timestamp: number): string {
   return oldDateFormat.format(new Date(timestamp));
 }
 
-function formatFull(timestamp: number): string {
-  return fullDateTimeFormat.format(new Date(timestamp));
-}
-
 function tsFromCommit(c: ProjectCommit): number {
   return Number(new Date(c.committed_at || c.authored_at).getTime()) || Date.now();
-}
-
-function groupByDate(commits: ProjectCommit[]) {
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const yesterday = new Date(today.getTime() - 86_400_000);
-  const thisWeekStart = new Date(today.getTime() - today.getDay() * 86_400_000);
-
-  const groups = new Map<string, ProjectCommit[]>();
-  for (const c of commits) {
-    const d = new Date(tsFromCommit(c));
-    const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-    let label: string;
-    if (day.getTime() >= today.getTime()) label = 'Today';
-    else if (day.getTime() >= yesterday.getTime()) label = 'Yesterday';
-    else if (day.getTime() >= thisWeekStart.getTime()) label = 'This week';
-    else label = d.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
-    if (!groups.has(label)) groups.set(label, []);
-    groups.get(label)!.push(c);
-  }
-  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
-}
-
-// ---------------------------------------------------------------------------
-// list row — minimal, Vercel-ish
-// ---------------------------------------------------------------------------
-
-function CheckpointListItem({
-  commit,
-  isActive,
-  onSelect,
-}: {
-  commit: ProjectCommit;
-  isActive: boolean;
-  onSelect: () => void;
-}) {
-  const ts = tsFromCommit(commit);
-  return (
-    <button
-      onClick={onSelect}
-      className={cn(
-        'group flex w-full cursor-pointer items-start gap-3 py-2.5 pr-2 pl-3 text-left',
-        'border-l-2 border-l-transparent',
-        'hover:bg-muted/40 transition-colors',
-        isActive && 'bg-primary/[0.05] border-l-primary',
-      )}
-    >
-      <UserAvatar
-        email={commit.author_email}
-        name={commit.author_name}
-        size="sm"
-        className="mt-0.5"
-      />
-      <div className="min-w-0 flex-1">
-        <p className="text-foreground line-clamp-2 text-sm leading-snug font-medium">
-          {commit.subject || '(no message)'}
-        </p>
-        <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
-          <span className="truncate" title={commit.author_email}>
-            {commit.author_name}
-          </span>
-          <span className="text-muted-foreground/30">·</span>
-          <span title={formatFull(ts)}>{formatRelative(ts)}</span>
-        </div>
-      </div>
-    </button>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -142,169 +67,115 @@ interface CheckpointsPanelProps {
 }
 
 /**
- * Overlay drawer pinned to the right edge of its (relative) parent. The file
- * content underneath does NOT reflow when this opens — the drawer slides in
- * with a subtle shadow and stays out of the document flow.
+ * Right-edge drawer listing every saved version of the active ref, newest
+ * first. Selecting a row opens the checkpoint detail dialog.
+ *
+ * Shares its chrome with `ChangeRequestsPanel` through `ReviewPanel` — the two
+ * were near-identical copies that had drifted apart.
  *
  * Caller is expected to render this inside a `position: relative` container
- * (typically the main content area of the file explorer page).
+ * (typically the main content area of the file explorer page); the drawer
+ * overlays that area rather than reflowing it.
  */
 export function CheckpointsPanel({ open = false, onClose }: CheckpointsPanelProps) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
-  const ctx = useProjectContext();
-  const activeRef = ctx?.ref ?? '';
   const [selectedSha, setSelectedSha] = useState<string | null>(null);
-  const { data, isLoading, error, refetch, isFetching } = useCommits({
-    limit: 50,
-    enabled: open,
-  });
+  const { data, isLoading, error, refetch, isFetching } = useCommits({ limit: 50, enabled: open });
 
-  const groups = useMemo(() => groupByDate(data?.commits ?? []), [data?.commits]);
-  const total = data?.commits.length ?? 0;
-  const shaList = useMemo(() => (data?.commits ?? []).map((c) => c.hash), [data?.commits]);
+  const commits = useMemo(() => data?.commits ?? [], [data?.commits]);
+  const groups = useMemo(() => groupByDate(commits, tsFromCommit), [commits]);
+  const total = commits.length;
+  const shaList = useMemo(() => commits.map((c) => c.hash), [commits]);
 
   return (
     <>
-      <aside
-        aria-hidden={!open}
-        className={cn(
-          'absolute top-0 right-0 bottom-0 flex w-[400px] flex-col',
-          'border-border bg-background border-l',
-          'transition-transform duration-200 ease-out',
-          'z-30',
-          open ? 'translate-x-0' : 'pointer-events-none translate-x-full',
-        )}
-      >
-        <div className="border-border flex h-12 shrink-0 items-center gap-2 border-b px-3">
-          <span className="text-sm font-medium">Version history</span>
-          {activeRef && (
-            <span
-              className="bg-muted/50 text-muted-foreground/90 flex max-w-[140px] items-center gap-1 truncate rounded-full px-1.5 py-0.5 text-xs"
-              title={`Version: ${activeRef}`}
+      <ReviewPanel
+        open={open}
+        onClose={onClose}
+        title="Version history"
+        // Unlike the proposed-changes list this one does not poll
+        // (`useCommits` is `staleTime: 30s`, no interval), so a manual refresh
+        // is the only way to pull a checkpoint that landed while it was open.
+        actions={
+          <Hint label="Refresh" side="bottom">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Refresh"
+              onClick={() => refetch()}
+              disabled={isFetching}
+              className="text-muted-foreground hover:text-foreground active:scale-[0.96]"
             >
-              <Layers className="h-3 w-3" />
-              {activeRef}
-            </span>
-          )}
-          {total > 0 && (
-            <span className="text-muted-foreground text-xs tabular-nums">
-              {total}
-              {data?.hasMore ? '+' : ''}
-            </span>
-          )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="ml-auto h-7 w-7"
-            onClick={() => refetch()}
-            title="Refresh"
-          >
-            {isFetching ? (
-              <Loading className="h-3.5 w-3.5" />
-            ) : (
-              <RefreshCw className="h-3.5 w-3.5" />
-            )}
-          </Button>
-          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose} title="Close">
-            <X className="h-3.5 w-3.5" />
-          </Button>
-        </div>
+              {isFetching ? (
+                <Loading className="size-4 shrink-0" />
+              ) : (
+                <ArrowClockwiseIcon className="size-4" />
+              )}
+            </Button>
+          </Hint>
+        }
+      >
+        {isLoading && <ReviewRowSkeleton count={7} />}
 
-        {/* Body */}
-        <div className="min-h-0 flex-1">
-          <ScrollArea className="h-full">
-            {isLoading && (
-              <div className="space-y-3 p-3">
-                {Array.from({ length: 6 }).map((_, i) => (
-                  <div key={i} className="space-y-1.5">
-                    <Skeleton className="h-3 w-20" />
-                    <Skeleton className="h-14 w-full rounded-lg" />
-                  </div>
-                ))}
-              </div>
-            )}
+        {error && !isLoading && <ReviewError title="Couldn't load version history" error={error} />}
 
-            {error && !isLoading && (
-              <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
-                <AlertCircle className="text-muted-foreground/30 h-6 w-6" />
-                <p className="text-muted-foreground text-xs">
-                  {tHardcodedUi.raw(
-                    'featuresProjectFilesComponentsCheckpointsPanel.line230JsxTextFailedToLoadCheckpoints',
-                  )}
-                </p>
-                <p className="text-muted-foreground/60 text-xs">
-                  {error instanceof Error ? error.message : 'Unknown error'}
-                </p>
-              </div>
-            )}
+        {!isLoading && !error && total === 0 && (
+          <ReviewEmpty
+            size="sm"
+            className="py-10"
+            icon={ClockCounterClockwiseIcon}
+            title="No saved versions yet"
+            description="Every time your agents save work, that version appears here."
+          />
+        )}
 
-            {!isLoading && !error && total === 0 && (
-              <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
-                <History className="text-muted-foreground/30 h-6 w-6" />
-                <p className="text-muted-foreground text-xs">
-                  {tHardcodedUi.raw(
-                    'featuresProjectFilesComponentsCheckpointsPanel.line241JsxTextNoCheckpointsYet',
-                  )}
-                </p>
-              </div>
-            )}
-
-            {!isLoading && !error && total > 0 && (
-              <div className="py-1">
-                {groups.map((group, gi) => (
-                  <Disclosure
-                    key={group.label}
-                    open
-                    className="group/checkpoint"
-                    transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
-                  >
-                    <DisclosureTrigger>
-                      <button
-                        type="button"
-                        className={cn(
-                          'bg-background/95 sticky top-0 z-[1] flex w-full items-center gap-2 px-3 py-1.5 backdrop-blur-sm',
-                          'border-border border-b',
-                          gi === 0 ? '' : 'border-border border-t',
-                        )}
-                      >
-                        <div className="flex w-full items-center justify-between gap-2 px-1">
-                          <span className="text-foreground/90 text-sm font-medium">
-                            {group.label}
+        {!isLoading && !error && total > 0 && (
+          <div className="pb-3">
+            {groups.map((group, gi) => (
+              <div key={group.label}>
+                <ReviewGroupLabel first={gi === 0}>{group.label}</ReviewGroupLabel>
+                {group.items.map((c) => {
+                  const ts = tsFromCommit(c);
+                  return (
+                    <ReviewRow
+                      key={c.hash}
+                      isActive={selectedSha === c.hash}
+                      onSelect={() => setSelectedSha(c.hash)}
+                    >
+                      <UserAvatar
+                        email={c.author_email}
+                        name={c.author_name}
+                        size="sm"
+                        className="mt-0.5 shrink-0"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="text-foreground line-clamp-2 text-sm leading-snug font-medium">
+                          {c.subject || '(no message)'}
+                        </span>
+                        <span className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
+                          <span className="truncate" title={c.author_email}>
+                            {c.author_name}
                           </span>
-                          <div className="text-muted-foreground flex items-center gap-1.5">
-                            <span className="text-[12px] tabular-nums">{group.items.length}</span>
-                            <ChevronDown className="size-3.5 shrink-0 transition-transform duration-150 ease-out group-data-[state=open]/checkpoint:rotate-180" />
-                          </div>
-                        </div>
-                      </button>
-                    </DisclosureTrigger>
-                    <DisclosureContent>
-                      {group.items.map((c) => (
-                        <CheckpointListItem
-                          key={c.hash}
-                          commit={c}
-                          isActive={selectedSha === c.hash}
-                          onSelect={() => setSelectedSha(c.hash)}
-                        />
-                      ))}
-                    </DisclosureContent>
-                  </Disclosure>
-                ))}
-                {data?.hasMore && (
-                  <div className="py-2 text-center">
-                    <span className="text-muted-foreground/50 text-xs">
-                      {tHardcodedUi.raw(
-                        'featuresProjectFilesComponentsCheckpointsPanel.line278JsxTextShowingTheMostRecent',
-                      )}{' '}
-                      {total} versions
-                    </span>
-                  </div>
-                )}
+                          <span className="text-muted-foreground/30" aria-hidden>
+                            ·
+                          </span>
+                          <span className="shrink-0" title={fullDateTimeFormat.format(ts)}>
+                            {formatRelative(ts)}
+                          </span>
+                        </span>
+                      </span>
+                    </ReviewRow>
+                  );
+                })}
               </div>
+            ))}
+            {data?.hasMore && (
+              <p className="text-muted-foreground/60 px-3 pt-4 text-xs">
+                Showing the {total} most recent versions.
+              </p>
             )}
-          </ScrollArea>
-        </div>
-      </aside>
+          </div>
+        )}
+      </ReviewPanel>
 
       <CheckpointDetailDialog
         sha={selectedSha}

--- a/apps/web/src/features/project-files/components/drive-explorer.tsx
+++ b/apps/web/src/features/project-files/components/drive-explorer.tsx
@@ -44,7 +44,12 @@ import {
 } from '../upload-batch';
 import { DriveGridView } from './drive-grid-view';
 import { DriveListView } from './drive-list-view';
-import { DriveToolbar } from './drive-toolbar';
+import {
+  DRIVE_ACTION_ROW_CLASS,
+  DriveNewMenu,
+  DrivePathBar,
+  DriveViewMenu,
+} from './drive-toolbar';
 import { FileHistoryPopoverContent } from './file-history-popover';
 import { FilePreviewModal } from './file-preview-modal';
 import { FileSearch } from './file-search';
@@ -52,25 +57,25 @@ import { FileSearch } from './file-search';
 /** System directories always pinned at the top of the listing. */
 const ELEVATED_DIRS = new Set(['.kortix', '.opencode']);
 
-export interface DriveExplorerToolbarOptions {
-  showVersionSelector?: boolean;
-  checkpointsToggle?: { open: boolean; onToggle: () => void };
-  changeRequestsToggle?: { open: boolean; onToggle: () => void; openCount?: number };
-  openChangeRequestAction?: { onClick: () => void; disabled?: boolean };
-}
-
 /**
  * Google Drive-style file explorer — the ONE explorer implementation, shared
  * by every surface. Data access comes from the injected FileExplorerSource
  * (live sandbox vs. project git-ref); capabilities on the source decide which
  * affordances render (mutations, search overlay, dotfile toggle, …).
  *
- * Layout:
+ * Layout — ONE action row, and a path strip that only appears once there is
+ * a path to show:
  * +---------------------------------------------------+
- * | DriveToolbar (breadcrumbs + actions)               |
+ * | {leading}                          [+ New]  [ ⋯ ]  |
+ * +---------------------------------------------------+
+ * | workspace › src › ui          (hidden at the root) |
  * +---------------------------------------------------+
  * | Main area (grid or list view) + injected panels    |
  * +---------------------------------------------------+
+ *
+ * `leading` is how a host puts its own identity — the session panel's
+ * All files / Changes tabs — in that row instead of stacking a second full
+ * header above it.
  *
  * Opening a file (single- or double-click, context menu) always opens the
  * full-screen preview modal overlay.
@@ -78,13 +83,24 @@ export interface DriveExplorerToolbarOptions {
 export function DriveExplorer({
   embedded = false,
   shareContext,
-  toolbar,
+  leading,
+  contentPanel,
   panels,
   children,
 }: {
   embedded?: boolean;
   shareContext?: { projectId: string; sessionId: string };
-  toolbar?: DriveExplorerToolbarOptions;
+  /**
+   * Host chrome for the START of the action row — the session panel's tab
+   * strip. Sharing the row is what lets that host drop its own header.
+   */
+  leading?: ReactNode;
+  /**
+   * ARIA wiring for the listing region when `leading` is a tab strip. The
+   * tabs live in this component's row, so only this component can stamp the
+   * panel they control.
+   */
+  contentPanel?: { id: string; labelledBy: string };
   /** Rendered inside the relative content area (slide-in side panels). */
   panels?: ReactNode;
   /** Rendered at the root (portal dialogs owned by the wrapping surface). */
@@ -650,24 +666,33 @@ export function DriveExplorer({
       onDragOver={handlePageDragOver}
       onDrop={handlePageDrop}
     >
-      <DriveToolbar
-        showSearch={capabilities.search}
-        showHiddenToggle={capabilities.hiddenToggle}
-        showVersionSelector={toolbar?.showVersionSelector}
-        onRefresh={() => refetchFiles()}
-        isRefreshing={isFetching}
-        onDownloadDir={() => {
-          const dirName = isRootPath
-            ? 'workspace'
-            : currentPath.split('/').filter(Boolean).pop() || 'directory';
-          const dirPath = isRootPath ? '/workspace' : currentPath;
-          downloadDir(dirPath, dirName);
-        }}
-        isDownloading={isDirDownloading(isRootPath ? '/workspace' : currentPath)}
-        onUpload={canWrite ? handleUpload : undefined}
-        onNewFile={canWrite ? () => setIsCreatingFile(true) : undefined}
-        onNewFolder={canWrite ? () => setIsCreatingFolder(true) : undefined}
-      />
+      <div className={DRIVE_ACTION_ROW_CLASS}>
+        {leading}
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <DriveNewMenu
+            compact={embedded}
+            onUpload={canWrite ? handleUpload : undefined}
+            onNewFile={canWrite ? () => setIsCreatingFile(true) : undefined}
+            onNewFolder={canWrite ? () => setIsCreatingFolder(true) : undefined}
+          />
+          <DriveViewMenu
+            showSearch={capabilities.search}
+            showHiddenToggle={capabilities.hiddenToggle}
+            onRefresh={() => refetchFiles()}
+            isRefreshing={isFetching}
+            onDownloadDir={() => {
+              const dirName = isRootPath
+                ? 'workspace'
+                : currentPath.split('/').filter(Boolean).pop() || 'directory';
+              const dirPath = isRootPath ? '/workspace' : currentPath;
+              downloadDir(dirPath, dirName);
+            }}
+            isDownloading={isDirDownloading(isRootPath ? '/workspace' : currentPath)}
+          />
+        </div>
+      </div>
+
+      <DrivePathBar as="row" />
 
       {/* Search overlay */}
       {capabilities.search && isSearchOpen && <FileSearch />}
@@ -749,7 +774,12 @@ export function DriveExplorer({
         </div>
       )}
 
-      <div className="relative min-h-0 flex-1">
+      <div
+        className="relative min-h-0 flex-1"
+        id={contentPanel?.id}
+        role={contentPanel ? 'tabpanel' : undefined}
+        aria-labelledby={contentPanel?.labelledBy}
+      >
         <div className="absolute inset-0 overflow-y-auto">
           {isLoading && showSkeleton && (
             <div className="animate-in fade-in-0 p-4 duration-200">

--- a/apps/web/src/features/project-files/components/drive-header.test.ts
+++ b/apps/web/src/features/project-files/components/drive-header.test.ts
@@ -54,6 +54,11 @@ const headerCode = headerSource
   .replace(/\/\*[\s\S]*?\*\//g, '')
   .replace(/^[ \t]*\/\/.*$/gm, '');
 
+const capabilityTabsSource = readFileSync(
+  join(repoRoot, 'apps/web/src/features/workspace/capabilities/shared/capability-tabs.tsx'),
+  'utf8',
+);
+
 describe('standalone Files header sidebar opener', () => {
   // ProjectShell draws a web opener only on the desktop shell. On the web
   // each view owns its own, gated by useShowPageSidebarOpener(). DriveHeader
@@ -65,7 +70,7 @@ describe('standalone Files header sidebar opener', () => {
     expect(headerSource).toContain('peekLeave');
   });
 
-  test('the opener sits in flow with the title, not absolute over it', () => {
+  test('the opener sits in flow with the path bar, not absolute over it', () => {
     const toggleStart = headerCode.indexOf('function FilesSidebarToggle');
     const toggleEnd = headerCode.indexOf('export function DriveHeader');
     expect(toggleStart).toBeGreaterThan(-1);
@@ -78,21 +83,52 @@ describe('standalone Files header sidebar opener', () => {
 
 describe('driveHeaderClass', () => {
   test('standalone header does not reserve overlay space for a missing toggle', () => {
-    const className = driveHeaderClass(true, true);
+    const className = driveHeaderClass(true);
     expect(className).not.toContain('md:pl-14');
     expect(className).not.toContain('pt-14');
   });
 
   test('opts the embedded session view out of the title-bar offsets entirely', () => {
-    const className = driveHeaderClass(false, true);
+    const className = driveHeaderClass(false);
     expect(className).not.toContain(FILES_HEADER_DESKTOP_CLASS);
     expect(className).not.toContain('md:pl-14');
-    expect(className).toContain('py-2');
   });
 
   test('tags every standalone header with the desktop title-bar hook', () => {
-    expect(driveHeaderClass(true, true)).toContain(FILES_HEADER_DESKTOP_CLASS);
-    expect(driveHeaderClass(true, false)).toContain(FILES_HEADER_DESKTOP_CLASS);
+    expect(driveHeaderClass(true)).toContain(FILES_HEADER_DESKTOP_CLASS);
+  });
+
+  /**
+   * The whole point of the redesign: Files is ONE row, the same row every
+   * other project surface draws. A wrapping multi-line header is what let a
+   * second full-width toolbar look normal underneath it.
+   */
+  test('is a single fixed-height row, not a wrapping block', () => {
+    const className = driveHeaderClass(true);
+    expect(className).toContain('h-11');
+    expect(className).not.toContain('flex-wrap');
+    expect(className).not.toContain('gap-y-');
+  });
+});
+
+describe('parity with the capability tab row', () => {
+  /**
+   * Files used to carry `.kx-files-header`, a near-duplicate of the capability
+   * row's hook with its own platform split — two rules for one behaviour, and
+   * they were free to drift. Same class now, so they cannot.
+   */
+  test('wears the SAME desktop title-bar hook as the capability header', () => {
+    expect(FILES_HEADER_DESKTOP_CLASS).toBe('kx-titlebar-row');
+    expect(capabilityTabsSource).toContain(FILES_HEADER_DESKTOP_CLASS);
+  });
+
+  test('the retired Files-only hook is gone from the stylesheet', () => {
+    expect(globalsCss).not.toContain('kx-files-header');
+  });
+
+  test('matches the capability row height so the two surfaces share a rhythm', () => {
+    // `h-11` == the capability row's `py-3` triggers around `text-sm` (44px).
+    expect(driveHeaderClass(true)).toContain('h-11');
   });
 });
 
@@ -101,9 +137,9 @@ describe('desktop title-bar clearance rules', () => {
     expect(globalsCss).toContain(`.${FILES_HEADER_DESKTOP_CLASS}`);
   });
 
-  test('macOS clears the traffic lights and the shell toggle while collapsed', () => {
+  test('the left indent clears the traffic lights and the shell toggle while collapsed', () => {
     const rule = new RegExp(
-      `html\\[data-desktop-platform='macos'\\] \\.${FILES_HEADER_DESKTOP_CLASS}\\[data-sidebar-collapsed\\] \\{\\s*padding-left: var\\((--[\\w-]+)\\);`,
+      `html\\[data-desktop='true'\\] \\.${FILES_HEADER_DESKTOP_CLASS}\\[data-sidebar-collapsed\\] \\{\\s*padding-left: var\\((--[\\w-]+)\\);`,
     ).exec(globalsCss);
 
     expect(rule).not.toBeNull();
@@ -113,9 +149,9 @@ describe('desktop title-bar clearance rules', () => {
     expect(bandVarPx(rule![1], 'macos')).toBe(band.contentLeft);
   });
 
-  test('Win/Linux clears the top-right window controls instead', () => {
+  test('the right indent clears the Win/Linux window controls', () => {
     const rule = new RegExp(
-      `html\\[data-desktop='true'\\]:not\\(\\[data-desktop-platform='macos'\\]\\) \\.${FILES_HEADER_DESKTOP_CLASS} \\{\\s*padding-right: var\\((--[\\w-]+)\\);`,
+      `html\\[data-desktop='true'\\] \\.${FILES_HEADER_DESKTOP_CLASS} \\{\\s*padding-right: calc\\([^)]*var\\((--[\\w-]+)\\)`,
     ).exec(globalsCss);
 
     expect(rule).not.toBeNull();
@@ -126,9 +162,7 @@ describe('desktop title-bar clearance rules', () => {
   // zero there — otherwise every row wearing it reserves a phantom right
   // gutter on the platform that does not need one.
   test('the right-edge reservation is platform-scoped, not global', () => {
-    const macBlock = globalsCss.match(
-      /html\[data-desktop-platform='macos'\]\s*\{([^}]*)\}/,
-    );
+    const macBlock = globalsCss.match(/html\[data-desktop-platform='macos'\]\s*\{([^}]*)\}/);
     expect(macBlock).not.toBeNull();
     expect(macBlock![1]).toMatch(/--kx-titlebar-controls-width:\s*0px/);
   });

--- a/apps/web/src/features/project-files/components/drive-header.tsx
+++ b/apps/web/src/features/project-files/components/drive-header.tsx
@@ -2,10 +2,8 @@
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { ButtonGroup } from '@/components/ui/button-group';
 import Hint from '@/components/ui/hint';
-import { useOptionalSidebar, useSidebar } from '@/components/ui/sidebar';
-import { useFilesStore } from '@/features/file-browser/store/files-store';
+import { useOptionalSidebar } from '@/components/ui/sidebar';
 import {
   sidebarOpenerLabel,
   useShowPageSidebarOpener,
@@ -14,14 +12,19 @@ import { cn } from '@/lib/utils';
 import {
   GitDiffIcon as FileDiff,
   ClockCounterClockwiseIcon as History,
-  SquaresFourIcon as LayoutGrid,
-  ListIcon as ListSolid,
   SidebarSimpleIcon as PanelLeft,
 } from '@phosphor-icons/react';
+
+import { DrivePathBar, DriveViewMenu } from './drive-toolbar';
+import { VersionSelector } from './version-selector';
 
 interface DriveHeaderProps {
   historyToggle: { open: boolean; onToggle: () => void };
   reviewsToggle: { open: boolean; onToggle: () => void; openCount?: number };
+  /** `⋯` menu wiring — the page owns the queries these act on. */
+  onRefresh: () => void;
+  onDownloadDir: () => void;
+  isDownloading?: boolean;
   /**
    * Draw the page-level sidebar opener. Only the standalone Files page needs
    * it: ProjectShell does not render a web opener, and the embedded session
@@ -31,24 +34,32 @@ interface DriveHeaderProps {
 }
 
 /**
- * Hook the desktop shell's title-bar rules in globals.css key off. Only the
- * standalone Files page reaches the top of the window, so only it opts in;
- * the rules widen the indents so the row clears the OS window controls
- * (macOS traffic lights + the shell's sidebar toggle on the left, the
- * Win/Linux control cluster on the right).
+ * The desktop shell's title-bar hook — the SAME class the capability tab row
+ * wears (`capability-tabs.tsx`). Both rows are the first in-flow child of
+ * their layout, so both start at y=0 and share the band with the OS window
+ * controls; the rules in globals.css widen the indents so neither renders
+ * under the macOS traffic lights or the Win/Linux control cluster.
+ *
+ * Files used to carry its own near-duplicate (`.kx-files-header`) with its own
+ * platform split. One class, one rule, one behaviour.
  */
-export const FILES_HEADER_DESKTOP_CLASS = 'kx-files-header';
+export const FILES_HEADER_DESKTOP_CLASS = 'kx-titlebar-row';
 
-export function driveHeaderClass(offsetForSidebarToggle: boolean, _sidebarCollapsed: boolean) {
+/**
+ * One row, `h-11`, matching the capability tab row's height exactly. This used
+ * to be a `flex-wrap` two-line block sitting on top of a SECOND full-width
+ * toolbar; see `drive-toolbar.tsx` for what moved where.
+ */
+export function driveHeaderClass(offsetForSidebarToggle: boolean) {
   return cn(
-    'flex flex-wrap gap-1 border-b px-2 items-center justify-between gap-x-4 gap-y-3 py-2 pr-4',
+    'relative flex h-11 shrink-0 items-center gap-1 border-b px-2',
     offsetForSidebarToggle && FILES_HEADER_DESKTOP_CLASS,
   );
 }
 
 /**
  * Same rules as capability tabs / project-home / session header. In flow
- * with the Files title — do not absolute-position it over the header.
+ * with the path bar — do not absolute-position it over the header.
  */
 function FilesSidebarToggle() {
   const sidebar = useOptionalSidebar();
@@ -76,51 +87,66 @@ function FilesSidebarToggle() {
 }
 
 /**
- * Drive-style page header for the project Files section: plain-language
- * title + purpose line on the left, version-history / proposed-changes
- * toggles and the list⇄grid switch on the right.
+ * Header for the standalone project Files page. One row:
+ *
+ *   [☰]  Files › src › ui        [main ▾]  [⏱]  [Proposed changes ②]  [⋯]
+ *
+ * The breadcrumb chain IS the title — `Files` is its root crumb, so at the
+ * root the row reads exactly like any other page header, and navigating a
+ * folder deep costs no extra chrome. That replaced a static `<h2>Files</h2>`
+ * that only repeated the sidebar entry the user had just clicked, plus the
+ * separate toolbar row underneath that carried the real path.
+ *
+ * Right-hand order is by frequency: which version you are reading, then the
+ * two review panels, then everything rare behind `⋯`.
  */
 export function DriveHeader({
   historyToggle,
   reviewsToggle,
+  onRefresh,
+  onDownloadDir,
+  isDownloading,
   offsetForSidebarToggle = false,
 }: DriveHeaderProps) {
-  const viewMode = useFilesStore((s) => s.viewMode);
-  const setViewMode = useFilesStore((s) => s.setViewMode);
-  const { state } = useSidebar();
-  const sidebarCollapsed = state === 'collapsed';
+  const sidebar = useOptionalSidebar();
+  const sidebarCollapsed = sidebar?.state === 'collapsed';
 
   const reviewCount = reviewsToggle.openCount ?? 0;
 
   return (
     <header
-      className={driveHeaderClass(offsetForSidebarToggle, sidebarCollapsed)}
-      // The macOS rule keys off this: the left indent is only needed while the
-      // sidebar is collapsed, since an expanded sidebar covers the lights.
+      className={driveHeaderClass(offsetForSidebarToggle)}
+      // The desktop rule keys off this: the left indent is only needed while
+      // the sidebar is collapsed, since an expanded sidebar covers the lights.
       data-sidebar-collapsed={sidebarCollapsed || undefined}
     >
-      <div className="flex min-w-0 items-center gap-1">
-        {offsetForSidebarToggle ? <FilesSidebarToggle /> : null}
-        <div className="min-w-0 space-y-1">
-          <h2 className="text-foreground text-xl font-medium">Files</h2>
-        </div>
-      </div>
+      {offsetForSidebarToggle ? <FilesSidebarToggle /> : null}
 
-      <div className="flex shrink-0 items-center gap-1.5">
+      <DrivePathBar rootLabel="Files" />
+
+      <div className="flex shrink-0 items-center gap-1">
+        <VersionSelector />
+
+        <Hint label="Browse every saved version of this project" side="bottom">
+          <Button
+            type="button"
+            aria-label="Version history"
+            aria-pressed={historyToggle.open}
+            variant={historyToggle.open ? 'secondary' : 'ghost'}
+            size="icon-sm"
+            onClick={historyToggle.onToggle}
+            className={cn(
+              'active:scale-[0.96]',
+              !historyToggle.open && 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            <History className="size-4" />
+          </Button>
+        </Hint>
+
         <Button
           type="button"
-          variant={historyToggle.open ? 'secondary' : 'ghost'}
-          size="sm"
-          onClick={historyToggle.onToggle}
-          title="Browse every saved version of this project"
-          className={cn(!historyToggle.open && 'text-muted-foreground hover:text-foreground')}
-        >
-          <History className="size-4 shrink-0" />
-          <span className="hidden sm:inline">History</span>
-        </Button>
-
-        <Button
-          type="button"
+          aria-pressed={reviewsToggle.open}
           variant={reviewsToggle.open ? 'secondary' : 'ghost'}
           size="sm"
           onClick={reviewsToggle.onToggle}
@@ -130,9 +156,8 @@ export function DriveHeader({
               : 'Review changes proposed by your agents'
           }
           className={cn(
-            !reviewsToggle.open &&
-              reviewCount === 0 &&
-              'text-muted-foreground hover:text-foreground',
+            'active:scale-[0.96]',
+            !reviewsToggle.open && reviewCount === 0 && 'text-muted-foreground hover:text-foreground',
           )}
         >
           <FileDiff className="size-4 shrink-0" />
@@ -144,30 +169,11 @@ export function DriveHeader({
           )}
         </Button>
 
-        <ButtonGroup className="ml-1">
-          <Hint label="List view">
-            <Button
-              type="button"
-              variant={viewMode === 'list' ? 'secondary' : 'outline'}
-              size="icon-sm"
-              aria-pressed={viewMode === 'list'}
-              onClick={() => setViewMode('list')}
-            >
-              <ListSolid weight="fill" className="size-4" />
-            </Button>
-          </Hint>
-          <Hint label="Grid view">
-            <Button
-              type="button"
-              variant={viewMode === 'grid' ? 'secondary' : 'outline'}
-              size="icon-sm"
-              aria-pressed={viewMode === 'grid'}
-              onClick={() => setViewMode('grid')}
-            >
-              <LayoutGrid className="size-4" />
-            </Button>
-          </Hint>
-        </ButtonGroup>
+        <DriveViewMenu
+          onRefresh={onRefresh}
+          onDownloadDir={onDownloadDir}
+          isDownloading={isDownloading}
+        />
       </div>
     </header>
   );

--- a/apps/web/src/features/project-files/components/drive-toolbar.test.tsx
+++ b/apps/web/src/features/project-files/components/drive-toolbar.test.tsx
@@ -3,7 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { DriveNewMenuItems, DriveToolbar, hasWriteActions } from './drive-toolbar';
+import { DriveNewMenu, DriveNewMenuItems, DrivePathBar, hasWriteActions } from './drive-toolbar';
 
 /**
  * `apps/web` has no jsdom/happy-dom and no `@testing-library/react` (see
@@ -16,33 +16,28 @@ import { DriveNewMenuItems, DriveToolbar, hasWriteActions } from './drive-toolba
  * `FolderDriveMenuItems` — so they can be rendered and driven without a live
  * Radix portal (portal content is absent from static markup).
  */
-function renderToolbar(props: Partial<Parameters<typeof DriveToolbar>[0]> = {}) {
+function render(node: ReactNode) {
   // Every label under test is literal English in the component. next-intl only
   // supplies `title`/placeholder copy here, so missing-message and
   // server-render fallbacks are swallowed rather than dragging a 644 KB
   // catalogue into the run.
   return renderToStaticMarkup(
     <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
-      <DriveToolbar onDownloadDir={() => {}} onRefresh={() => {}} {...props} />
+      {node}
     </NextIntlClientProvider>,
   );
 }
 
-describe('DriveToolbar write actions', () => {
-  test('a writable source gets a New menu trigger in the toolbar', () => {
-    const html = renderToolbar({
-      onUpload: () => {},
-      onNewFile: () => {},
-      onNewFolder: () => {},
-    });
+describe('DriveNewMenu write actions', () => {
+  test('a writable source gets a New menu trigger', () => {
+    const html = render(
+      <DriveNewMenu onUpload={() => {}} onNewFile={() => {}} onNewFolder={() => {}} />,
+    );
     expect(html).toContain('>New</button>');
   });
 
-  test('a read-only source sees no write control', () => {
-    const html = renderToolbar();
-    expect(html).not.toContain('>New</button>');
-    // The read-only toolbar still renders — this is not an empty-string pass.
-    expect(html).toContain('workspace');
+  test('a read-only source sees no write control at all', () => {
+    expect(render(<DriveNewMenu />)).toBe('');
   });
 
   test('the gate needs all three handlers — a half-wired menu never renders', () => {
@@ -51,7 +46,31 @@ describe('DriveToolbar write actions', () => {
     expect(hasWriteActions({ onUpload: noop, onNewFile: noop })).toBe(false);
     expect(hasWriteActions({ onUpload: noop })).toBe(false);
     expect(hasWriteActions({})).toBe(false);
-    expect(renderToolbar({ onUpload: () => {} })).not.toContain('>New</button>');
+    expect(render(<DriveNewMenu onUpload={() => {}} />)).toBe('');
+  });
+
+  test('the compact trigger keeps an accessible name once the label is gone', () => {
+    const html = render(
+      <DriveNewMenu compact onUpload={() => {}} onNewFile={() => {}} onNewFolder={() => {}} />,
+    );
+    expect(html).toContain('aria-label="New"');
+    expect(html).not.toContain('>New</button>');
+  });
+});
+
+describe('DrivePathBar', () => {
+  test('inline mode always shows a root crumb, and takes the host label', () => {
+    expect(render(<DrivePathBar />)).toContain('workspace');
+    expect(render(<DrivePathBar rootLabel="Files" />)).toContain('Files');
+  });
+
+  /**
+   * The whole reason the strip is separable: at the root it has nothing to
+   * say, and a bordered bar carrying one word is exactly the chrome this
+   * redesign removed. `/workspace` IS the root.
+   */
+  test('row mode renders nothing at the root', () => {
+    expect(render(<DrivePathBar as="row" />)).toBe('');
   });
 });
 

--- a/apps/web/src/features/project-files/components/drive-toolbar.tsx
+++ b/apps/web/src/features/project-files/components/drive-toolbar.tsx
@@ -3,29 +3,36 @@
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
+import Hint from '@/components/ui/hint';
 import Loading from '@/components/ui/loading';
-import { Separator } from '@/components/ui/separator';
-import type { SortField } from '@/features/file-browser/store/files-store';
+import type {
+  SortField,
+  SortOrder,
+  ViewMode,
+} from '@/features/file-browser/store/files-store';
 import { isWithinRoot, useFilesStore } from '@/features/file-browser/store/files-store';
 import { cn } from '@/lib/utils';
 import {
-  ArrowsDownUpIcon as ArrowUpDown,
   CaretRightIcon as ChevronRight,
   DownloadIcon as Download,
-  EyeIcon as Eye,
-  EyeSlashIcon as EyeOff,
+  DotsThreeIcon as DotsThree,
   FilePlusIcon,
   FolderPlusIcon,
-  HouseIcon as HomeSolid,
+  SquaresFourIcon as LayoutGrid,
+  ListIcon as ListSolid,
   PlusIcon,
   ArrowClockwiseIcon as RefreshCw,
   MagnifyingGlassIcon as Search,
@@ -41,106 +48,71 @@ import {
   type ComponentType,
   type ReactNode,
 } from 'react';
-import { VersionSelector } from './version-selector';
 
-interface DriveToolbarProps {
-  onDownloadDir: () => void;
-  onRefresh: () => void;
-  isRefreshing?: boolean;
-  isDownloading?: boolean;
-  showVersionSelector?: boolean;
-  /** Toolbar button for the Cmd+P file-name search overlay. */
-  showSearch?: boolean;
-  /** Dotfile visibility toggle (list is pre-filtered by the data hook). */
-  showHiddenToggle?: boolean;
+/**
+ * The Drive chrome, split into three pieces a surface composes itself.
+ *
+ * There used to be one `DriveToolbar` that owned all of it — breadcrumbs plus
+ * eight always-visible controls — and it sat under a SECOND full-width header
+ * on both surfaces that render it. Thirteen controls on the Files page, ten in
+ * a ~400px session panel, before a single file is visible.
+ *
+ * The split ranks by frequency instead:
+ *   • {@link DrivePathBar}  — navigation. Constant, so it stays in flow.
+ *   • {@link DriveNewMenu}  — creating things. Frequent, so it stays a button.
+ *   • {@link DriveViewMenu} — sort / view mode / dotfiles / search / refresh /
+ *     download. All rare, all one `⋯` away.
+ *
+ * Each host then needs ONE header row, not two.
+ */
+
+/**
+ * The one action row every Drive surface draws. `h-11` is the capability tab
+ * row's height (`capability-tabs.tsx`), so Files reads at the same rhythm as
+ * every other project surface.
+ */
+export const DRIVE_ACTION_ROW_CLASS =
+  'border-border/60 flex h-11 shrink-0 items-center gap-1 border-b px-2';
+
+/* ------------------------------------------------------------------ *
+ * Path bar
+ * ------------------------------------------------------------------ */
+
+interface DrivePathBarProps {
   /**
-   * Write affordances, rendered together in the "New" menu. Read-only sources
-   * (`capabilities.write === false`) pass none of them and the menu is absent —
-   * a viewer must never see an action they cannot perform.
+   * Word for the root crumb. The standalone page passes its own page title
+   * ("Files") because the crumb chain IS that page's header — see
+   * {@link DriveHeader}. In a session panel the root is the sandbox workspace.
    */
-  onUpload?: () => void;
-  onNewFile?: () => void;
-  onNewFolder?: () => void;
+  rootLabel?: string;
+  /**
+   * `inline` sits in a row the host already draws (the standalone page's
+   * header, where the crumb chain IS the title).
+   *
+   * `row` draws its own bordered strip AND renders nothing at the root: a
+   * lone root crumb is a whole strip that repeats what the surface above it
+   * already said. Session panels take that deal; the standalone page, whose
+   * root crumb is its page title, does not.
+   */
+  as?: 'inline' | 'row';
+  className?: string;
 }
 
 /**
- * The "New" menu renders only when the explorer supplied all three write
- * handlers. Partial wiring is a bug, not a half-menu.
+ * Breadcrumbs for the current directory, and nothing else.
+ *
+ * Double-clicking swaps the chain for a raw path input — the one power
+ * affordance kept from the old toolbar, because it costs no pixels.
  */
-export function hasWriteActions(
-  props: Pick<DriveToolbarProps, 'onUpload' | 'onNewFile' | 'onNewFolder'>,
-): boolean {
-  return Boolean(props.onUpload && props.onNewFile && props.onNewFolder);
-}
-
-type DriveMenuItemComponent = ComponentType<{
-  onClick?: () => void;
-  children: ReactNode;
-}>;
-
-/**
- * Contents of the toolbar's "New" menu, injectable like
- * `FolderDriveMenuItems` so the entries can be rendered — and their handlers
- * driven — without a live Radix portal.
- */
-export function DriveNewMenuItems({
-  Item,
-  Separator: MenuSeparator,
-  onUpload,
-  onNewFile,
-  onNewFolder,
-}: {
-  Item: DriveMenuItemComponent;
-  Separator: ComponentType;
-  onUpload?: () => void;
-  onNewFile?: () => void;
-  onNewFolder?: () => void;
-}) {
-  return (
-    <>
-      <Item onClick={onUpload}>
-        <UploadSimpleIcon className="size-3.5 shrink-0" />
-        Upload files
-      </Item>
-      <MenuSeparator />
-      <Item onClick={onNewFile}>
-        <FilePlusIcon className="size-3.5 shrink-0" />
-        New file
-      </Item>
-      <Item onClick={onNewFolder}>
-        <FolderPlusIcon className="size-3.5 shrink-0" />
-        New folder
-      </Item>
-    </>
-  );
-}
-
-export function DriveToolbar({
-  onDownloadDir,
-  onRefresh,
-  isRefreshing,
-  isDownloading,
-  showVersionSelector = false,
-  showSearch = false,
-  showHiddenToggle = false,
-  onUpload,
-  onNewFile,
-  onNewFolder,
-}: DriveToolbarProps) {
+export function DrivePathBar({ rootLabel, as = 'inline', className }: DrivePathBarProps) {
   const tHardcodedUi = useTranslations('hardcodedUi');
   const currentPath = useFilesStore((s) => s.currentPath);
   const navigateToPath = useFilesStore((s) => s.navigateToPath);
-  const sortBy = useFilesStore((s) => s.sortBy);
-  const sortOrder = useFilesStore((s) => s.sortOrder);
-  const setSortBy = useFilesStore((s) => s.setSortBy);
-  const toggleSortOrder = useFilesStore((s) => s.toggleSortOrder);
   const rootPath = useFilesStore((s) => s.rootPath);
-  const showHidden = useFilesStore((s) => s.showHidden);
-  const toggleHidden = useFilesStore((s) => s.toggleHidden);
-  const toggleSearch = useFilesStore((s) => s.toggleSearch);
 
   const homePath = rootPath || '/workspace';
-  const homeLabel = rootPath ? rootPath.split('/').filter(Boolean).pop() || 'root' : '/workspace';
+  const homeLabel =
+    rootLabel ?? (rootPath ? rootPath.split('/').filter(Boolean).pop() || 'root' : 'workspace');
 
   // Outside the home root (e.g. /tmp) the crumbs render as an absolute chain
   // instead of pretending the path nests under /workspace
@@ -185,8 +157,6 @@ export function DriveToolbar({
     return () => document.removeEventListener('click', handleClickOutside);
   }, [isEditing]);
 
-  const showWriteActions = hasWriteActions({ onUpload, onNewFile, onNewFolder });
-
   const handleSegmentClick = useCallback(
     (index: number) => {
       const absoluteIndex = rootPath ? index + rootSegments.length : index;
@@ -196,205 +166,358 @@ export function DriveToolbar({
     [allSegments, rootSegments, rootPath, navigateToPath],
   );
 
+  // Everything after the (skipped) implicit `workspace` segment. Drives the
+  // hide-at-root decision so a path of exactly `/workspace` counts as root.
+  const visibleSegments = useMemo(
+    () =>
+      segments.filter(
+        (segment, index) => !(!rootPath && !outsideHome && index === 0 && segment === 'workspace'),
+      ),
+    [segments, rootPath, outsideHome],
+  );
+
+  const isRow = as === 'row';
+  if (isRow && !isEditing && visibleSegments.length === 0) return null;
+
+  const rowClass = isRow
+    ? 'border-border/60 h-9 w-full shrink-0 border-b px-2'
+    : 'min-w-0 flex-1';
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={editValue}
+        onChange={(e) => setEditValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            if (e.nativeEvent.isComposing) return;
+            navigateToPath(editValue.trim() || homePath);
+            setIsEditing(false);
+          }
+          if (e.key === 'Escape') setIsEditing(false);
+        }}
+        onBlur={() => setIsEditing(false)}
+        className={cn(
+          'bg-card focus:ring-primary/50 h-8 min-w-0 rounded-md border px-3 font-mono text-sm outline-none focus:ring-2',
+          // In `row` mode the parent is a COLUMN, so `flex-1` would stretch the
+          // input vertically instead of filling the row.
+          isRow ? 'mx-2 my-0.5 w-auto shrink-0' : 'flex-1',
+          className,
+        )}
+        placeholder={homePath}
+      />
+    );
+  }
+
   return (
-    <div className="border-border bg-background w-full min-w-0 shrink-0 border-b">
-      <div className="flex w-full flex-col md:flex-row md:items-center md:gap-1.5 md:px-4 md:py-2">
-        <div className="border-border/40 flex w-full min-w-0 items-center gap-1.5 border-b px-3 py-2 md:flex-1 md:border-b-0 md:px-0 md:py-0">
-          {showVersionSelector && (
-            <>
-              <div className="max-w-36 shrink-0 md:max-w-none">
-                <VersionSelector />
-              </div>
-              <Separator orientation="vertical" className="data-[orientation=vertical]:h-[70%]" />
-            </>
-          )}
+    <div
+      className={cn('flex items-center gap-0.5', rowClass, className)}
+      onDoubleClick={handleDoubleClick}
+      title={tHardcodedUi.raw(
+        'featuresProjectFilesComponentsDriveToolbar.line191JsxAttrTitleDoubleClickToEditPath',
+      )}
+    >
+      <Button
+        onClick={() => navigateToPath(homePath)}
+        variant="ghost"
+        size="xs"
+        className="text-foreground shrink-0 text-sm font-medium"
+      >
+        {homeLabel}
+      </Button>
 
-          {isEditing ? (
-            <input
-              ref={inputRef}
-              type="text"
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  if (e.nativeEvent.isComposing) return;
-                  navigateToPath(editValue.trim() || homePath);
-                  setIsEditing(false);
-                }
-                if (e.key === 'Escape') setIsEditing(false);
-              }}
-              onBlur={() => setIsEditing(false)}
-              className="bg-card focus:ring-primary/50 h-8 min-w-0 flex-1 rounded-md border px-3 font-mono text-sm outline-none focus:ring-2"
-              placeholder={homePath}
-            />
-          ) : (
-            <div
-              className="flex min-w-0 flex-1 items-center gap-0.5"
-              onDoubleClick={handleDoubleClick}
-              title={tHardcodedUi.raw(
-                'featuresProjectFilesComponentsDriveToolbar.line191JsxAttrTitleDoubleClickToEditPath',
-              )}
-            >
-              <Button
-                onClick={() => navigateToPath(homePath)}
-                variant="ghost"
-                size="xs"
-                className={cn('text-foreground shrink-0 font-medium')}
-              >
-                <HomeSolid weight="fill" className="size-4" />
-                <span className="text-xs">{rootPath ? homeLabel : 'workspace'}</span>
-              </Button>
+      {segments.length > 0 && (
+        <FadedScrollArea
+          orientation="horizontal"
+          fadeColor="from-background"
+          className="min-w-0 flex-1 overscroll-x-contain"
+        >
+          <nav className="flex w-max min-w-0 items-center gap-0.5">
+            {segments.map((segment, index) => {
+              if (!rootPath && !outsideHome && index === 0 && segment === 'workspace') return null;
+              const isLast = index === segments.length - 1;
+              // First crumb of an outside-home path anchors the absolute chain
+              const isAbsoluteAnchor = outsideHome && index === 0;
+              const pathKey = segments.slice(0, index + 1).join('/');
 
-              {segments.length > 0 && (
-                <FadedScrollArea
-                  orientation="horizontal"
-                  fadeColor="from-background"
-                  className="min-w-0 flex-1 overscroll-x-contain"
-                >
-                  <nav className="flex w-max min-w-0 items-center gap-0.5">
-                    {segments.map((segment, index) => {
-                      if (!rootPath && !outsideHome && index === 0 && segment === 'workspace')
-                        return null;
-                      const isLast = index === segments.length - 1;
-                      // First crumb of an outside-home path anchors the absolute chain
-                      const isAbsoluteAnchor = outsideHome && index === 0;
-                      const pathKey = segments.slice(0, index + 1).join('/');
-
-                      return (
-                        <div key={pathKey} className="flex shrink-0 items-center gap-0.5">
-                          {isAbsoluteAnchor ? (
-                            <span className="text-muted-foreground/40 shrink-0 px-1 text-xs select-none">
-                              ·
-                            </span>
-                          ) : (
-                            <ChevronRight className="text-muted-foreground size-3.5 shrink-0" />
-                          )}
-                          <Button
-                            onClick={() => handleSegmentClick(index)}
-                            variant="ghost"
-                            size="xs"
-                            className={cn(
-                              'max-w-[140px] shrink-0 truncate sm:max-w-[200px]',
-                              isLast ? 'text-foreground font-medium' : 'text-muted-foreground',
-                              isAbsoluteAnchor && 'font-mono text-xs',
-                            )}
-                          >
-                            {isAbsoluteAnchor ? `/${segment}` : segment}
-                          </Button>
-                        </div>
-                      );
-                    })}
-                  </nav>
-                </FadedScrollArea>
-              )}
-            </div>
-          )}
-        </div>
-
-        <div className="flex w-full shrink-0 items-center gap-0.5 px-3 py-1.5 md:w-auto md:justify-end md:px-0 md:py-0">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-sm" title="Sort">
-                <ArrowUpDown />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              <DropdownMenuLabel>
-                {tHardcodedUi.raw(
-                  'featuresProjectFilesComponentsDriveToolbar.line262JsxTextSortBy',
-                )}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={sortBy}
-                onValueChange={(v) => setSortBy(v as SortField)}
-              >
-                <DropdownMenuRadioItem value="name">Name</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="type">Type</DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={toggleSortOrder} className="justify-between">
-                {sortOrder === 'asc' ? 'Descending' : 'Ascending'}
-                <ArrowUpDown className="size-4" />
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {showHiddenToggle && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className={cn(!showHidden && 'text-muted-foreground')}
-              onClick={toggleHidden}
-              title={showHidden ? 'Hide dotfiles' : 'Show dotfiles'}
-            >
-              {showHidden ? <Eye /> : <EyeOff />}
-            </Button>
-          )}
-
-          {showSearch && (
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={toggleSearch}
-              title={tHardcodedUi.raw(
-                'featuresFilesComponentsDriveToolbar.line270JsxAttrTitleSearchFilesCtrlP',
-              )}
-            >
-              <Search />
-            </Button>
-          )}
-
-          <Separator orientation="vertical" className="data-[orientation=vertical]:h-[70%]" />
-
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={onRefresh}
-            disabled={isRefreshing}
-            title="Refresh"
-          >
-            <RefreshCw className={cn(isRefreshing && 'animate-spin')} />
-          </Button>
-
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={onDownloadDir}
-            disabled={isDownloading}
-            title={tHardcodedUi.raw(
-              'featuresProjectFilesComponentsDriveToolbar.line295JsxAttrTitleDownloadDirectoryAsZip',
-            )}
-          >
-            {isDownloading ? <Loading /> : <Download />}
-          </Button>
-
-          {showWriteActions && (
-            <>
-              <Separator
-                orientation="vertical"
-                className="ml-0.5 data-[orientation=vertical]:h-[70%]"
-              />
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="secondary" size="sm" className="ml-1 gap-1.5">
-                    <PlusIcon className="size-3.5 shrink-0" />
-                    New
+              return (
+                <div key={pathKey} className="flex shrink-0 items-center gap-0.5">
+                  {isAbsoluteAnchor ? (
+                    <span className="text-muted-foreground/40 shrink-0 px-1 text-sm select-none">
+                      ·
+                    </span>
+                  ) : (
+                    <ChevronRight className="text-muted-foreground/50 size-3.5 shrink-0" />
+                  )}
+                  <Button
+                    onClick={() => handleSegmentClick(index)}
+                    variant="ghost"
+                    size="xs"
+                    className={cn(
+                      'max-w-[140px] shrink-0 truncate text-sm sm:max-w-[200px]',
+                      isLast ? 'text-foreground font-medium' : 'text-muted-foreground',
+                      isAbsoluteAnchor && 'font-mono',
+                    )}
+                  >
+                    {isAbsoluteAnchor ? `/${segment}` : segment}
                   </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-48">
-                  <DriveNewMenuItems
-                    Item={DropdownMenuItem}
-                    Separator={DropdownMenuSeparator}
-                    onUpload={onUpload}
-                    onNewFile={onNewFile}
-                    onNewFolder={onNewFolder}
-                  />
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </>
-          )}
-        </div>
-      </div>
+                </div>
+              );
+            })}
+          </nav>
+        </FadedScrollArea>
+      )}
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * Overflow menu
+ * ------------------------------------------------------------------ */
+
+/** Submenu trigger summaries — the current value, shown without opening. */
+const VIEW_LABEL: Record<ViewMode, string> = { list: 'List', grid: 'Grid' };
+
+/**
+ * Covers all four `SortField`s so a value persisted in `localStorage` still
+ * gets a label, but only `name` and `type` are OFFERED below: the comparators
+ * for `size` and `modified` fall through to a name compare
+ * (`file-explorer-page.tsx`, `drive-explorer.tsx`), so listing them would be a
+ * control that silently does nothing.
+ */
+const SORT_LABEL: Record<SortField, string> = {
+  name: 'Name',
+  type: 'Type',
+  size: 'Size',
+  modified: 'Modified',
+};
+
+export interface DriveViewMenuProps {
+  onDownloadDir: () => void;
+  onRefresh: () => void;
+  isRefreshing?: boolean;
+  isDownloading?: boolean;
+  /** Offer the Cmd+P file-name search overlay. */
+  showSearch?: boolean;
+  /** Offer the dotfile visibility toggle (list is pre-filtered by the hook). */
+  showHiddenToggle?: boolean;
+}
+
+/**
+ * Every rare Drive control behind one `⋯`: view mode, sort, dotfiles, search,
+ * refresh, download. Each of these was its own always-visible button; together
+ * they were most of the crowding on both surfaces, and none of them is reached
+ * more than once a session.
+ */
+export function DriveViewMenu({
+  onDownloadDir,
+  onRefresh,
+  isRefreshing,
+  isDownloading,
+  showSearch = false,
+  showHiddenToggle = false,
+}: DriveViewMenuProps) {
+  const viewMode = useFilesStore((s) => s.viewMode);
+  const setViewMode = useFilesStore((s) => s.setViewMode);
+  const sortBy = useFilesStore((s) => s.sortBy);
+  const sortOrder = useFilesStore((s) => s.sortOrder);
+  const setSortBy = useFilesStore((s) => s.setSortBy);
+  const setSortOrder = useFilesStore((s) => s.setSortOrder);
+  const showHidden = useFilesStore((s) => s.showHidden);
+  const toggleHidden = useFilesStore((s) => s.toggleHidden);
+  const toggleSearch = useFilesStore((s) => s.toggleSearch);
+
+  return (
+    <DropdownMenu>
+      <Hint label="View options" side="bottom">
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="View options"
+            className="text-muted-foreground hover:text-foreground active:scale-[0.96]"
+          >
+            <DotsThree className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+      </Hint>
+      <DropdownMenuContent align="end" className="w-56">
+        {/* The two pickers are submenus, not eleven flat rows: each is a set
+            of mutually exclusive options you touch once and forget, and the
+            trigger already answers "what is it set to?" without opening. */}
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="min-w-0 flex-1">View</span>
+            <span className="text-muted-foreground/70">{VIEW_LABEL[viewMode]}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-40">
+            <DropdownMenuRadioGroup
+              value={viewMode}
+              onValueChange={(v) => setViewMode(v as ViewMode)}
+            >
+              <DropdownMenuRadioItem value="list">
+                <ListSolid />
+                List
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="grid">
+                <LayoutGrid />
+                Grid
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="min-w-0 flex-1">Sort by</span>
+            <span className="text-muted-foreground/70">{SORT_LABEL[sortBy]}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-44">
+            <DropdownMenuRadioGroup value={sortBy} onValueChange={(v) => setSortBy(v as SortField)}>
+              <DropdownMenuRadioItem value="name">Name</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="type">Type</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+            <DropdownMenuSeparator />
+            {/* Two named options, not one button labelled with the state it is
+                NOT in. "Descending" as a single row read as both "it is
+                descending" and "click to make it descending". */}
+            <DropdownMenuRadioGroup
+              value={sortOrder}
+              onValueChange={(v) => setSortOrder(v as SortOrder)}
+            >
+              <DropdownMenuRadioItem value="asc">Ascending</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="desc">Descending</DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSeparator />
+
+        {showHiddenToggle && (
+          // `reverse` puts the check on the RIGHT edge, where the radio rows
+          // above already put theirs. One column for "this is the current
+          // value", one column for action icons.
+          <DropdownMenuCheckboxItem reverse checked={showHidden} onCheckedChange={toggleHidden}>
+            Show hidden files
+          </DropdownMenuCheckboxItem>
+        )}
+        {showSearch && (
+          <DropdownMenuItem onClick={toggleSearch}>
+            <Search />
+            Find a file
+            <DropdownMenuShortcut>⌘P</DropdownMenuShortcut>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem onClick={onRefresh} disabled={isRefreshing}>
+          {isRefreshing ? <Loading className="size-4 shrink-0" /> : <RefreshCw />}
+          Refresh
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={onDownloadDir} disabled={isDownloading}>
+          {isDownloading ? <Loading className="size-4 shrink-0" /> : <Download />}
+          Download folder
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ * New menu
+ * ------------------------------------------------------------------ */
+
+interface DriveNewMenuProps {
+  /**
+   * Write affordances, rendered together. Read-only sources
+   * (`capabilities.write === false`) pass none of them and the menu is absent —
+   * a viewer must never see an action they cannot perform.
+   */
+  onUpload?: () => void;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
+  /** Drop the label and render a `+` square. For narrow panels. */
+  compact?: boolean;
+}
+
+/**
+ * The "New" menu renders only when the explorer supplied all three write
+ * handlers. Partial wiring is a bug, not a half-menu.
+ */
+export function hasWriteActions(
+  props: Pick<DriveNewMenuProps, 'onUpload' | 'onNewFile' | 'onNewFolder'>,
+): boolean {
+  return Boolean(props.onUpload && props.onNewFile && props.onNewFolder);
+}
+
+type DriveMenuItemComponent = ComponentType<{
+  onClick?: () => void;
+  children: ReactNode;
+}>;
+
+/**
+ * Contents of the "New" menu, injectable like `FolderDriveMenuItems` so the
+ * entries can be rendered — and their handlers driven — without a live Radix
+ * portal.
+ */
+export function DriveNewMenuItems({
+  Item,
+  Separator: MenuSeparator,
+  onUpload,
+  onNewFile,
+  onNewFolder,
+}: {
+  Item: DriveMenuItemComponent;
+  Separator: ComponentType;
+  onUpload?: () => void;
+  onNewFile?: () => void;
+  onNewFolder?: () => void;
+}) {
+  return (
+    <>
+      <Item onClick={onUpload}>
+        <UploadSimpleIcon className="size-3.5 shrink-0" />
+        Upload files
+      </Item>
+      <MenuSeparator />
+      <Item onClick={onNewFile}>
+        <FilePlusIcon className="size-3.5 shrink-0" />
+        New file
+      </Item>
+      <Item onClick={onNewFolder}>
+        <FolderPlusIcon className="size-3.5 shrink-0" />
+        New folder
+      </Item>
+    </>
+  );
+}
+
+export function DriveNewMenu({ onUpload, onNewFile, onNewFolder, compact }: DriveNewMenuProps) {
+  if (!hasWriteActions({ onUpload, onNewFile, onNewFolder })) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {compact ? (
+          <Button variant="secondary" size="icon-sm" aria-label="New" className="active:scale-[0.96]">
+            <PlusIcon className="size-4" />
+          </Button>
+        ) : (
+          <Button variant="secondary" size="sm" className="gap-1.5 active:scale-[0.96]">
+            <PlusIcon className="size-3.5 shrink-0" />
+            New
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DriveNewMenuItems
+          Item={DropdownMenuItem}
+          Separator={DropdownMenuSeparator}
+          onUpload={onUpload}
+          onNewFile={onNewFile}
+          onNewFolder={onNewFolder}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/src/features/project-files/components/file-explorer-page.tsx
+++ b/apps/web/src/features/project-files/components/file-explorer-page.tsx
@@ -38,7 +38,6 @@ import { CheckpointsPanel } from './checkpoints-panel';
 import { DriveGridView } from './drive-grid-view';
 import { DriveHeader } from './drive-header';
 import { DriveListView } from './drive-list-view';
-import { DriveToolbar } from './drive-toolbar';
 import { FileHistoryPopoverContent } from './file-history-popover';
 import { FilePreviewModal } from './file-preview-modal';
 import { type FilesRightPanel, requestedFilesRightPanel } from './file-route-state';
@@ -382,10 +381,7 @@ export function FileExplorerPage({ embedded = false }: { embedded?: boolean } = 
           onToggle: () => toggleRightPanel('proposed-changes'),
           openCount: openCrCount,
         }}
-      />
-
-      <DriveToolbar
-        showVersionSelector
+        onRefresh={() => refetchFiles()}
         onDownloadDir={() => {
           const dirName = isRootPath
             ? 'workspace'
@@ -394,7 +390,6 @@ export function FileExplorerPage({ embedded = false }: { embedded?: boolean } = 
           downloadDir(dirPath, dirName);
         }}
         isDownloading={isDirDownloading(isRootPath ? '/workspace' : currentPath)}
-        onRefresh={() => refetchFiles()}
       />
 
       <div className="relative min-h-0 flex-1">

--- a/apps/web/src/features/project-files/components/index.ts
+++ b/apps/web/src/features/project-files/components/index.ts
@@ -8,7 +8,12 @@ export { FileTreeItem } from '@/features/file-browser/components/file-tree-item'
 export { FileHistoryPopoverContent } from './file-history-popover';
 export { getFileIcon } from './file-icon';
 export { FileExplorerPage } from './file-explorer-page';
-export { DriveToolbar } from './drive-toolbar';
+export {
+  DRIVE_ACTION_ROW_CLASS,
+  DriveNewMenu,
+  DrivePathBar,
+  DriveViewMenu,
+} from './drive-toolbar';
 export { DriveGridView } from './drive-grid-view';
 export { DriveListView } from './drive-list-view';
 export { FilePreviewModal } from './file-preview-modal';

--- a/apps/web/src/features/project-files/components/review-panel.test.ts
+++ b/apps/web/src/features/project-files/components/review-panel.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+
+import { groupByDate } from './review-panel';
+
+const DAY = 86_400_000;
+
+/**
+ * `groupByDate` used to exist twice — a byte-identical private copy in
+ * `change-requests-panel.tsx` and `checkpoints-panel.tsx`, differing only in
+ * how each read a timestamp off its item. Neither copy was tested. It is one
+ * generic function now, so the buckets are worth pinning once.
+ */
+const ts = (item: { ts: number }) => item.ts;
+
+/** Noon today — so a "one day earlier" item cannot land back on today
+ *  whatever the wall clock says when this runs. */
+function noonToday() {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d.getTime();
+}
+
+describe('groupByDate', () => {
+  test('keeps input order within a bucket', () => {
+    const noon = noonToday();
+    const [group] = groupByDate([{ ts: noon }, { ts: noon - 1_000 }, { ts: noon - 2_000 }], ts);
+    expect(group.label).toBe('Today');
+    expect(group.items.map((i) => i.ts)).toEqual([noon, noon - 1_000, noon - 2_000]);
+  });
+
+  test('buckets today separately from earlier days', () => {
+    const noon = noonToday();
+    const groups = groupByDate([{ ts: noon }, { ts: noon - DAY }], ts);
+    expect(groups[0].label).toBe('Today');
+    expect(groups).toHaveLength(2);
+    expect(groups[1].label).not.toBe('Today');
+  });
+
+  test('falls back to a "Month Year" label well outside this week', () => {
+    const old = new Date();
+    old.setMonth(old.getMonth() - 3);
+    const [group] = groupByDate([{ ts: old.getTime() }], ts);
+    expect(group.label).toMatch(/\d{4}/);
+    expect(['Today', 'Yesterday', 'This week']).not.toContain(group.label);
+  });
+
+  test('emits one group per distinct bucket, in first-seen order', () => {
+    const noon = noonToday();
+    const old = new Date();
+    old.setMonth(old.getMonth() - 3);
+    const groups = groupByDate(
+      [{ ts: noon }, { ts: old.getTime() }, { ts: noon - 60_000 }],
+      ts,
+    );
+    expect(groups[0].label).toBe('Today');
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups).toHaveLength(2);
+  });
+
+  test('an empty list produces no groups', () => {
+    expect(groupByDate([], ts)).toEqual([]);
+  });
+});

--- a/apps/web/src/features/project-files/components/review-panel.tsx
+++ b/apps/web/src/features/project-files/components/review-panel.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import Hint from '@/components/ui/hint';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Skeleton } from '@/components/ui/skeleton';
+import { EmptyState } from '@/features/layout/section/empty-state';
+import { ErrorState } from '@/features/layout/section/error-state';
+import { cn } from '@/lib/utils';
+import { XIcon } from '@phosphor-icons/react';
+
+/**
+ * Shared chrome for the two right-edge review drawers over the project repo —
+ * `ChangeRequestsPanel` (proposed changes) and `CheckpointsPanel` (version
+ * history).
+ *
+ * They were two ~300-line files with the same aside, the same header, the same
+ * `groupByDate`, and the same hand-rolled loading / error / empty blocks. That
+ * duplication is why they drifted, and it is where the border noise came from:
+ * a header rule, a filter rule, and a group header carrying BOTH `border-t`
+ * and `border-b` stacked four hairlines into the top 160px of a 400px panel.
+ *
+ * The rules here:
+ *   • ONE hairline in the whole panel body — under the top block, where the
+ *     controls stop and the content starts. Everything else separates by
+ *     spacing and type weight.
+ *   • Group labels are labels: no border, no fill, no backdrop blur, no sticky
+ *     layer, no count, no collapse chevron.
+ *   • Rows are soft chips (`mx-1 rounded-md`), not full-bleed bands with a
+ *     `border-l-2` accent rail.
+ */
+
+/* ------------------------------------------------------------------ *
+ * Grouping
+ * ------------------------------------------------------------------ */
+
+export interface DateGroup<T> {
+  label: string;
+  items: T[];
+}
+
+/**
+ * Bucket newest-first items under Today / Yesterday / This week / "Month Year".
+ *
+ * One generic implementation. Both panels shipped a byte-identical private
+ * copy of this, differing only in how they read a timestamp off the item.
+ */
+export function groupByDate<T>(items: T[], timestampOf: (item: T) => number): DateGroup<T>[] {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  const thisWeekStart = new Date(today.getTime() - now.getDay() * 86_400_000);
+
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const d = new Date(timestampOf(item));
+    const day = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    let label: string;
+    if (day.getTime() >= today.getTime()) label = 'Today';
+    else if (day.getTime() >= yesterday.getTime()) label = 'Yesterday';
+    else if (day.getTime() >= thisWeekStart.getTime()) label = 'This week';
+    else label = d.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(item);
+  }
+  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
+}
+
+/* ------------------------------------------------------------------ *
+ * Shell
+ * ------------------------------------------------------------------ */
+
+export function ReviewPanel({
+  open,
+  onClose,
+  title,
+  actions,
+  filters,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  /** Icon buttons for the header's right edge, before Close. */
+  actions?: ReactNode;
+  /** Filter row under the title. Shares the header block's single hairline. */
+  filters?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <aside
+      aria-hidden={!open}
+      aria-label={title}
+      className={cn(
+        'absolute top-0 right-0 bottom-0 z-30 flex w-[400px] max-w-full flex-col',
+        'border-border bg-background border-l',
+        'transition-transform duration-200 ease-out motion-reduce:transition-none',
+        open ? 'translate-x-0' : 'pointer-events-none translate-x-full',
+      )}
+    >
+      {/* Header + filters are ONE block with ONE rule beneath it. */}
+      <div className="border-border/60 shrink-0 border-b">
+        <div className="flex h-11 items-center gap-1 pr-2 pl-3">
+          <h2 className="text-foreground min-w-0 flex-1 truncate text-sm font-medium">{title}</h2>
+          {actions}
+          <Hint label="Close" side="bottom">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={onClose}
+              aria-label="Close"
+              className="text-muted-foreground hover:text-foreground active:scale-[0.96]"
+            >
+              <XIcon className="size-4" />
+            </Button>
+          </Hint>
+        </div>
+        {filters ? <div className="px-3 pb-2">{filters}</div> : null}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <ScrollArea className="h-full">{children}</ScrollArea>
+      </div>
+    </aside>
+  );
+}
+
+/**
+ * A date bucket's heading. Deliberately just a label — the old version was a
+ * sticky, blurred, double-bordered `Disclosure` trigger with a count badge and
+ * a rotating chevron, i.e. five pieces of chrome to say one word.
+ */
+export function ReviewGroupLabel({ children, first }: { children: ReactNode; first?: boolean }) {
+  return (
+    <h3
+      className={cn(
+        'text-muted-foreground px-3 pb-1 text-xs font-medium',
+        first ? 'pt-3' : 'pt-5',
+      )}
+    >
+      {children}
+    </h3>
+  );
+}
+
+/**
+ * A list row. Soft chip rather than a full-bleed band: hover and selection
+ * read as a shape you can point at instead of a stripe across the panel.
+ */
+export function ReviewRow({
+  isActive,
+  onSelect,
+  onPrefetch,
+  children,
+}: {
+  isActive: boolean;
+  onSelect: () => void;
+  /** Warm the row's detail data on hover / touch, before the click lands. */
+  onPrefetch?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      onPointerEnter={onPrefetch}
+      onFocus={onPrefetch}
+      aria-current={isActive || undefined}
+      className={cn(
+        'mx-1 flex w-[calc(100%-0.5rem)] cursor-pointer items-start gap-2.5 rounded-md px-2 py-2 text-left',
+        'transition-colors',
+        isActive ? 'bg-primary/[0.06]' : 'hover:bg-foreground/[0.04]',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Row skeleton shaped like a real row, so the swap does not jump. */
+export function ReviewRowSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="space-y-1 px-3 pt-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-start gap-2.5 py-2">
+          <Skeleton className="mt-0.5 size-4 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Panel-sized error state — the system component, not a hand-rolled block. */
+export function ReviewError({ title, error }: { title: string; error: unknown }) {
+  return (
+    <ErrorState
+      size="sm"
+      className="py-10"
+      title={title}
+      description={error instanceof Error ? error.message : undefined}
+    />
+  );
+}
+
+export { EmptyState as ReviewEmpty };

--- a/apps/web/src/features/project-files/hooks/use-change-requests.test.ts
+++ b/apps/web/src/features/project-files/hooks/use-change-requests.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { ChangeRequest } from '../api/change-requests';
+import { findCachedChangeRequest, type CachedListEntry } from './use-change-requests';
+
+/**
+ * Opening a proposed change used to cost two SERIAL round trips before its
+ * merge button worked:
+ *
+ *   1. `GET /change-requests/:id` — whose entire body is `{ change_request }`,
+ *      i.e. the very object the list response already held.
+ *   2. `GET .../merge-preview` — which could not even START until (1) landed,
+ *      because the dialog gates it on `status === 'open'`.
+ *
+ * Seeding the detail cache from the list collapses both: the header paints on
+ * the click frame and the preview fires in parallel. These tests pin the
+ * lookup that makes that possible.
+ */
+function cr(id: string, extra: Partial<ChangeRequest> = {}): ChangeRequest {
+  return {
+    cr_id: id,
+    number: 1,
+    title: `CR ${id}`,
+    status: 'open',
+    base_ref: 'main',
+    head_ref: 'feat',
+    created_at: new Date().toISOString(),
+    ...extra,
+  } as ChangeRequest;
+}
+
+const entry = (key: readonly unknown[], rows: ChangeRequest[] | undefined): CachedListEntry => [
+  key,
+  rows ? { change_requests: rows } : undefined,
+];
+
+describe('findCachedChangeRequest', () => {
+  test('finds a change request in the only cached bucket', () => {
+    const target = cr('a');
+    const hit = findCachedChangeRequest([entry(['list', 'open'], [cr('z'), target])], 'a');
+    expect(hit?.cr).toBe(target);
+  });
+
+  /**
+   * The panel's filter decides which bucket is populated, and "All" overlaps
+   * every other one — so the scan cannot assume a single list.
+   */
+  test('searches every status bucket, not just the first', () => {
+    const target = cr('b', { status: 'merged' });
+    const hit = findCachedChangeRequest(
+      [
+        entry(['list', 'open'], [cr('x')]),
+        entry(['list', 'closed'], []),
+        entry(['list', 'merged'], [target]),
+      ],
+      'b',
+    );
+    expect(hit?.cr).toBe(target);
+  });
+
+  /**
+   * The caller reads `dataUpdatedAt` off the returned key to date the seed.
+   * Reporting the wrong list would stamp it with another bucket's fetch time,
+   * which decides whether the background refetch fires.
+   */
+  test('reports which bucket the row came from', () => {
+    const hit = findCachedChangeRequest(
+      [entry(['list', 'open'], [cr('x')]), entry(['list', 'all'], [cr('c')])],
+      'c',
+    );
+    expect(hit?.key).toEqual(['list', 'all']);
+  });
+
+  test('tolerates a cache entry that has no data yet', () => {
+    expect(findCachedChangeRequest([entry(['list', 'open'], undefined)], 'a')).toBeUndefined();
+  });
+
+  test('returns undefined when nothing is cached', () => {
+    expect(findCachedChangeRequest([], 'a')).toBeUndefined();
+  });
+
+  test('does not match a different change request', () => {
+    expect(findCachedChangeRequest([entry(['list', 'open'], [cr('a')])], 'b')).toBeUndefined();
+  });
+
+  test('an empty id never matches', () => {
+    expect(findCachedChangeRequest([entry(['list', 'open'], [cr('')])], '')).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/project-files/hooks/use-change-requests.ts
+++ b/apps/web/src/features/project-files/hooks/use-change-requests.ts
@@ -35,6 +35,9 @@ export const changeRequestKeys = {
    *  project's CRs changed" invalidation; `all` above is unscoped (every
    *  project) and too broad for that. */
   project: (projectId: string) => ['project-files', 'change-requests', projectId] as const,
+  /** Every status bucket for one project — the prefix `list` nests under. */
+  listScope: (projectId: string) =>
+    ['project-files', 'change-requests', projectId, 'list'] as const,
   list: (projectId: string, status: ChangeRequestStatus | 'all') =>
     ['project-files', 'change-requests', projectId, 'list', status] as const,
   detail: (projectId: string, crId: string) =>
@@ -56,6 +59,93 @@ const versionDiffKeys = {
   idle: ['project-files', 'version-diff', 'idle'] as const,
 };
 
+/**
+ * The `ChangeRequest` for `crId` already sitting in a cached LIST response.
+ *
+ * `ChangeRequestDetailResponse` is `{ change_request: ChangeRequest }` and the
+ * list endpoint returns those very objects — same server, same shape, one
+ * request earlier. So a CR opened from a loaded list needs no round trip to
+ * paint; the detail fetch becomes a background refresh instead of a gate.
+ *
+ * Scans every status bucket (`open` / `merged` / `closed` / `all`), because the
+ * panel's filter decides which list is populated and a CR can be reached from
+ * more than one of them.
+ */
+export type CachedListEntry = readonly [
+  readonly unknown[],
+  { change_requests: ChangeRequest[] } | undefined,
+];
+
+/**
+ * Find `crId` in a set of cached list responses, and say WHICH list it came
+ * from.
+ *
+ * Pure so the lookup can be tested without a QueryClient. The key matters as
+ * much as the hit: the seed's `initialDataUpdatedAt` has to be that list's
+ * timestamp (see the caller), so the function that finds the row is the one
+ * that must report where it found it.
+ */
+export function findCachedChangeRequest(
+  entries: readonly CachedListEntry[],
+  crId: string,
+): { cr: ChangeRequest; key: readonly unknown[] } | undefined {
+  if (!crId) return undefined;
+  for (const [key, data] of entries) {
+    const cr = data?.change_requests.find((row) => row.cr_id === crId);
+    if (cr) return { cr, key };
+  }
+  return undefined;
+}
+
+function cachedChangeRequest(
+  qc: ReturnType<typeof useQueryClient>,
+  projectId: string,
+  crId: string,
+): { data: ChangeRequestDetailResponse; updatedAt: number } | undefined {
+  if (!projectId || !crId) return undefined;
+  const hit = findCachedChangeRequest(
+    qc.getQueriesData<{ change_requests: ChangeRequest[] }>({
+      queryKey: changeRequestKeys.listScope(projectId),
+    }),
+    crId,
+  );
+  if (!hit) return undefined;
+  return {
+    data: { change_request: hit.cr },
+    // The LIST's timestamp, not `Date.now()`. Passing "fresh right now" would
+    // suppress the background refetch for `staleTime`, so a CR whose status
+    // changed server-side would show the stale row until the poll caught up.
+    updatedAt: qc.getQueryState(hit.key)?.dataUpdatedAt ?? 0,
+  };
+}
+
+/**
+ * Warm a change request's detail + diff before it is opened.
+ *
+ * The diff is the expensive half and the only thing the dialog genuinely has
+ * to wait for, so starting it on pointer-enter buys the ~150-300ms of hover
+ * before the click lands. Both are plain `prefetchQuery` calls: they respect
+ * `staleTime`, so re-hovering the same row costs nothing.
+ */
+export function usePrefetchChangeRequest() {
+  const qc = useQueryClient();
+  const ctx = useProjectContext();
+  const projectId = ctx?.projectId ?? '';
+  return (crId: string) => {
+    if (!projectId || !crId) return;
+    void qc.prefetchQuery({
+      queryKey: changeRequestKeys.detail(projectId, crId),
+      queryFn: () => fetchChangeRequest(projectId, crId),
+      staleTime: 5_000,
+    });
+    void qc.prefetchQuery({
+      queryKey: changeRequestKeys.diff(projectId, crId),
+      queryFn: () => fetchChangeRequestDiff(projectId, crId),
+      staleTime: 10_000,
+    });
+  };
+}
+
 export function useChangeRequests(
   status: ChangeRequestStatus | 'all' = 'all',
   options?: { enabled?: boolean; refetchInterval?: number },
@@ -73,7 +163,9 @@ export function useChangeRequests(
 
 export function useChangeRequest(crId: string | null, options?: { enabled?: boolean }) {
   const ctx = useProjectContext();
+  const qc = useQueryClient();
   const projectId = ctx?.projectId ?? '';
+  const seed = crId ? cachedChangeRequest(qc, projectId, crId) : undefined;
   return useQuery<ChangeRequestDetailResponse>({
     queryKey: crId
       ? changeRequestKeys.detail(projectId, crId)
@@ -82,6 +174,11 @@ export function useChangeRequest(crId: string | null, options?: { enabled?: bool
     enabled: Boolean(projectId && crId) && options?.enabled !== false,
     staleTime: 5_000,
     refetchInterval: 8_000,
+    // Opening a CR from the panel paints its header on the click frame. The
+    // dialog's merge-preview query is gated on `status === 'open'`, so this
+    // also breaks a detail -> preview waterfall into two parallel requests.
+    initialData: seed?.data,
+    initialDataUpdatedAt: seed?.updatedAt,
   });
 }
 

--- a/apps/web/src/features/project-files/index.ts
+++ b/apps/web/src/features/project-files/index.ts
@@ -121,6 +121,7 @@ export { useVersionStore, useSelectedVersion } from './store/version-store';
 
 // Components
 export {
+  DRIVE_ACTION_ROW_CLASS,
   DriveExplorer,
   FileContentRenderer,
   FileSearch,

--- a/apps/web/src/features/session/reasoning-effort-selector.tsx
+++ b/apps/web/src/features/session/reasoning-effort-selector.tsx
@@ -314,17 +314,13 @@ export function ReasoningEffortSelector({
               model's own default once an override is set, and without it the
               control would be a one-way door. */}
           <DropdownMenuRadioItem value={AUTO} disabled={pending}>
-            <span className="flex items-center gap-2">
-              <EffortIcon value={null} className="size-4 shrink-0" />
-              Auto
-            </span>
+            <EffortIcon value={null} className="size-4 shrink-0" />
+            Auto
           </DropdownMenuRadioItem>
           {values.map((value) => (
             <DropdownMenuRadioItem key={value} value={value} disabled={pending}>
-              <span className="flex items-center gap-2">
-                <EffortIcon value={value} className="size-4 shrink-0" />
-                {label(value)}
-              </span>
+              <EffortIcon value={value} className="size-4 shrink-0" />
+              {label(value)}
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/apps/web/src/features/session/session-files-explorer.tsx
+++ b/apps/web/src/features/session/session-files-explorer.tsx
@@ -9,7 +9,8 @@ import {
 } from '@/features/session/session-files-explorer-logic';
 import { getSessionFilesStore } from '@/features/session/session-files-store-registry';
 import {
-  SessionVersionHeader,
+  SessionChangesHeader,
+  SessionFilesTabs,
   sessionVersionTabId,
   type SessionPanelMode,
 } from '@/features/session/session-version-header';
@@ -19,13 +20,18 @@ import { useEffect, useId, useRef, useState } from 'react';
 /**
  * Session side-panel "Files" surface.
  *
- * An elegant version header frames the screen as a standalone copy of the
- * project's main version, with two plain tabs:
+ * ONE row of chrome, with two plain tabs at its left:
  *   • All files (default) — the SAME Drive-style explorer the /files page
  *                uses ({@link DriveExplorer}), pointed at the live sandbox
  *                via {@link sandboxExplorerSource} (writable, searchable).
  *   • Changes (secondary) — the real per-file diff viewer
  *                ({@link SessionDiffViewer}), the same diff UI used elsewhere.
+ *
+ * On All files the tabs are handed to the explorer as its action row's
+ * `leading` slot, so the row carries tabs + [+ New] + [⋯] and the path strip
+ * below it appears only once you are inside a folder. On Changes the explorer
+ * is gone, so `SessionChangesHeader` draws the row itself and adds the
+ * "Propose changes" action.
  *
  * The sub-mode is addressable through the shared panel-view store (the `files`
  * view value means "Changes"), so the header chip's "View changes" lands the
@@ -145,31 +151,38 @@ function SessionFilesExplorerInner({
   // in the DOM at once, so the tab/panel wiring must not collide.
   const panelId = useId();
 
+  // All files: the tabs ride INSIDE the explorer's action row, so the surface
+  // shows one row of chrome instead of a tab bar stacked on a toolbar. That
+  // makes the explorer the only thing that can stamp the tab panel, hence
+  // `contentPanel`.
+  //
+  // Changes: the explorer is unmounted, so that branch draws its own row.
+  const tabs = { mode, onModeChange, panelId };
+
   return (
     <div className="flex h-full flex-col">
-      <SessionVersionHeader
-        chatSessionId={chatSessionId}
-        mode={mode}
-        onModeChange={onModeChange}
-        panelId={panelId}
-      />
-      <div
-        id={panelId}
-        role="tabpanel"
-        aria-labelledby={sessionVersionTabId(panelId, mode)}
-        className="min-h-0 flex-1"
-      >
-        {showDiff ? (
-          <SessionDiffViewer />
-        ) : (
-          <SandboxFileExplorer
-            embedded
-            shareContext={
-              projectId && projectSessionId ? { projectId, sessionId: projectSessionId } : undefined
-            }
-          />
-        )}
-      </div>
+      {showDiff ? (
+        <>
+          <SessionChangesHeader chatSessionId={chatSessionId} {...tabs} />
+          <div
+            id={panelId}
+            role="tabpanel"
+            aria-labelledby={sessionVersionTabId(panelId, mode)}
+            className="min-h-0 flex-1"
+          >
+            <SessionDiffViewer />
+          </div>
+        </>
+      ) : (
+        <SandboxFileExplorer
+          embedded
+          leading={<SessionFilesTabs {...tabs} />}
+          contentPanel={{ id: panelId, labelledBy: sessionVersionTabId(panelId, mode) }}
+          shareContext={
+            projectId && projectSessionId ? { projectId, sessionId: projectSessionId } : undefined
+          }
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/session/session-version-header.tsx
+++ b/apps/web/src/features/session/session-version-header.tsx
@@ -1,39 +1,38 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
 /**
- * SessionVersionHeader — the top of the session's Files / Changes panel.
+ * Chrome for the session panel's Files surface.
  *
- * It frames the surface in plain, version-first language: a **separate version**
- * of the project's main version. The agent works here without touching the live
- * version, so changes made in this session aren't in the main version until you
- * open a change request and merge them in.
+ * Two plain underline tabs — **All files** (default) and **Changes** (the real
+ * diff viewer) — plus, on the Changes tab only, the action that gets this
+ * version's work reviewed.
  *
- * Below the framing sit two plain underline tabs (matching the panel's own tab
- * style): **All files** (default) and **Changes** (the real diff viewer).
+ * On All files the tabs do NOT get a bar of their own: they are handed to the
+ * explorer as its row's `leading` slot, so the panel shows one row, not two.
+ * See `SessionFilesExplorer`.
+ *
+ * What used to live here and no longer does:
+ *   • a `⧉ a1b2c3d4` version chip on every tab — the id only means something
+ *     next to the changes it labels, so it moved into the Changes line below.
+ *   • an "Open change request" button on every tab — it is meaningless on
+ *     All files, and "change request" is jargon the rest of Files does not
+ *     use. It is now **Propose changes**, on the tab that has changes.
+ *   • a four-line `InfoBanner` paragraph re-explaining branches. One line.
  */
 
-import {
-  GitDiffIcon as FileDiff,
-  InfoIcon as Info,
-  StackIcon as Layers,
-} from '@phosphor-icons/react';
 import { useParams } from 'next/navigation';
 import { useRef } from 'react';
 
-import Hint from '@/components/ui/hint';
-import { InfoBanner } from '@/components/ui/info-banner';
-import Loading from '@/components/ui/loading';
-
-import { cn } from '@/lib/utils';
-
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
+
 import {
   useOpenChangeRequest,
   useSessionBaseRef,
   useSessionChanges,
 } from '@/features/session/session-changes-shared';
+import { cn } from '@/lib/utils';
 
 export type SessionPanelMode = 'changes' | 'files';
 
@@ -79,7 +78,7 @@ function SubTab({
       className={cn(
         // Constant weight in every state — only color + the underline change,
         // so selecting a tab never shifts the layout.
-        'relative inline-flex h-9 cursor-pointer items-center gap-1.5 text-sm font-medium tracking-tight transition-colors',
+        'relative inline-flex h-11 cursor-pointer items-center gap-1.5 text-sm font-medium tracking-tight transition-colors',
         active ? 'text-foreground' : 'text-muted-foreground/70 hover:text-foreground/90',
       )}
     >
@@ -96,37 +95,21 @@ function SubTab({
   );
 }
 
-export function SessionVersionHeader({
-  /** OpenCode chat session id — the agent we message to open the change request. */
-  chatSessionId,
-  mode,
-  onModeChange,
-  panelId,
-}: {
-  chatSessionId?: string;
+interface TabsProps {
   mode: SessionPanelMode;
   onModeChange: (mode: SessionPanelMode) => void;
   /** DOM id of the tab panel this strip controls — owned by the parent. */
   panelId: string;
-}) {
-  // The git branch == the ROUTE session id; the chat session id is passed in.
+}
 
-  const tI18nHardcoded = useTranslations('hardcodedUi');
-  const { id: projectId, sessionId: gitSessionId } = useParams<{
-    id: string;
-    sessionId: string;
-  }>();
-
+/**
+ * The tab strip on its own, with no bar of its own — it is dropped into a row
+ * the host already draws.
+ */
+export function SessionFilesTabs({ mode, onModeChange, panelId }: TabsProps) {
   // The SAME query the Changes panel below renders — one array, so the badge
   // and the body cannot contradict each other.
   const { count: changedCount } = useSessionChanges();
-  const baseRef = useSessionBaseRef(projectId, gitSessionId);
-
-  // Short, stable handle for this version — the session id is its identity.
-  const shortVersionId = gitSessionId ? gitSessionId.slice(0, 8) : '—';
-  const { asking, openChangeRequest } = useOpenChangeRequest(chatSessionId, baseRef);
-
-  const hasChanges = changedCount > 0;
 
   const tabRefs = useRef<Partial<Record<SessionPanelMode, HTMLButtonElement | null>>>({});
   const handleTabKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -149,130 +132,87 @@ export function SessionVersionHeader({
   };
 
   return (
-    <div className="border-border/60 shrink-0 border-b">
-      {/* Compact header row — tabs (left) + version chip & CTA (right). */}
-      <div className="flex items-center gap-3 px-4">
-        {/* Tabs — All files (default) · Changes (secondary). */}
-        <div
-          role="tablist"
-          aria-label={tI18nHardcoded.raw(
-            'autoFeaturesSessionSessionVersionHeaderJsxAttrAriaLabelFiles9fd01463',
-          )}
-          className="flex items-center gap-5"
-          onKeyDown={handleTabKeyDown}
-        >
-          <SubTab
-            active={mode === 'files'}
-            onClick={() => onModeChange('files')}
-            id={sessionVersionTabId(panelId, 'files')}
-            controls={panelId}
-            tabRef={(node) => {
-              tabRefs.current.files = node;
-            }}
-            label={tI18nHardcoded.raw(
-              'autoFeaturesSessionSessionVersionHeaderJsxAttrLabelAllFiles4f423738',
-            )}
-          />
-          <SubTab
-            active={mode === 'changes'}
-            onClick={() => onModeChange('changes')}
-            id={sessionVersionTabId(panelId, 'changes')}
-            controls={panelId}
-            tabRef={(node) => {
-              tabRefs.current.changes = node;
-            }}
-            label="Changes"
-            count={changedCount}
-          />
-        </div>
+    <div
+      role="tablist"
+      aria-label="Files"
+      className="flex min-w-0 items-center gap-5"
+      onKeyDown={handleTabKeyDown}
+    >
+      <SubTab
+        active={mode === 'files'}
+        onClick={() => onModeChange('files')}
+        id={sessionVersionTabId(panelId, 'files')}
+        controls={panelId}
+        tabRef={(node) => {
+          tabRefs.current.files = node;
+        }}
+        label="All files"
+      />
+      <SubTab
+        active={mode === 'changes'}
+        onClick={() => onModeChange('changes')}
+        id={sessionVersionTabId(panelId, 'changes')}
+        controls={panelId}
+        tabRef={(node) => {
+          tabRefs.current.changes = node;
+        }}
+        label="Changes"
+        count={changedCount}
+      />
+    </div>
+  );
+}
 
-        {/* Version chip + change-request CTA, right-aligned on the same row.
-            On "All files" the verbose framing lives in the tooltip; on
-            "Changes" it's spelled out in the explanation strip below. */}
-        <div className="ml-auto flex min-w-0 items-center gap-2">
-          <Hint
-            label={`Version ${shortVersionId} · alternative version of ${baseRef}`}
-            side="bottom"
+/**
+ * The Changes tab's own row: the same tabs, plus **Propose changes** — the one
+ * action this surface exists to lead to — and a single line saying where these
+ * edits currently live.
+ */
+export function SessionChangesHeader({
+  /** OpenCode chat session id — the agent we message to propose the changes. */
+  chatSessionId,
+  mode,
+  onModeChange,
+  panelId,
+}: TabsProps & { chatSessionId?: string }) {
+  // The git branch == the ROUTE session id; the chat session id is passed in.
+  const { id: projectId, sessionId: gitSessionId } = useParams<{
+    id: string;
+    sessionId: string;
+  }>();
+
+  const { count: changedCount } = useSessionChanges();
+  const baseRef = useSessionBaseRef(projectId, gitSessionId);
+
+  // Short, stable handle for this version — the session id is its identity.
+  const shortVersionId = gitSessionId ? gitSessionId.slice(0, 8) : '—';
+  const { asking, openChangeRequest } = useOpenChangeRequest(chatSessionId, baseRef);
+
+  const hasChanges = changedCount > 0;
+
+  return (
+    <div className="border-border/60 shrink-0 border-b">
+      <div className="flex h-11 items-center gap-3 px-2">
+        <SessionFilesTabs mode={mode} onModeChange={onModeChange} panelId={panelId} />
+
+        {hasChanges && (
+          <Button
+            size="sm"
+            className="ml-auto shrink-0 gap-1.5 active:scale-[0.96]"
+            onClick={openChangeRequest}
+            disabled={asking}
           >
-            <span
-              tabIndex={0}
-              aria-label={`Version ${shortVersionId} · alternative version of ${baseRef}`}
-              className="text-muted-foreground focus-visible:ring-kortix-base flex min-w-0 items-center gap-1.5 rounded-sm text-xs outline-none focus-visible:ring-[0.6px]"
-            >
-              <Layers className="text-muted-foreground/70 size-3.5 shrink-0" />
-              <span className="text-foreground/80 truncate font-mono">{shortVersionId}</span>
-            </span>
-          </Hint>
-          {hasChanges && (
-            <Button
-              size="sm"
-              className="h-7 shrink-0 gap-1.5"
-              onClick={openChangeRequest}
-              disabled={asking}
-            >
-              {asking ? (
-                <Loading className="size-3.5 shrink-0" />
-              ) : (
-                <FileDiff className="size-3.5" />
-              )}
-              {tI18nHardcoded.raw(
-                'autoFeaturesSessionSessionVersionHeaderJsxTextOpenChangeRequesta0b45de3',
-              )}
-            </Button>
-          )}
-        </div>
+            {asking ? <Loading className="size-3.5 shrink-0" /> : null}
+            Propose changes
+          </Button>
+        )}
       </div>
 
-      {/* Contextual explanation — only on the Changes tab, where the version
-          framing matters most: what these changes are and how they reach main. */}
-      {mode === 'changes' && (
-        <div className="border-border/60 border-t px-4 py-2.5">
-          <InfoBanner
-            tone="neutral"
-            icon={<Info className="text-muted-foreground/60 mt-px size-3.5" />}
-            // Flat inline note: the strip's own top border already draws the
-            // seam, so the banner keeps only its icon + text layout.
-            className="items-start gap-2 border-0 bg-transparent px-0 py-0"
-          >
-            <p className="text-muted-foreground text-xs leading-relaxed">
-              {tI18nHardcoded.raw(
-                'autoFeaturesSessionSessionVersionHeaderJsxTextWhatThisSession2da8e6ce',
-              )}{' '}
-              <span className="text-foreground/80 font-mono">{shortVersionId}</span>{' '}
-              {tI18nHardcoded.raw(
-                'autoFeaturesSessionSessionVersionHeaderJsxTextASeparateVersionc3d7a454',
-              )}{' '}
-              <span className="text-foreground/80 font-mono">{baseRef}</span>
-              {tI18nHardcoded.raw(
-                'autoFeaturesSessionSessionVersionHeaderJsxTextTheseEditsStaya67c1667',
-              )}{' '}
-              <span className="text-foreground/80 font-mono">{baseRef}</span>{' '}
-              {tI18nHardcoded.raw('autoFeaturesSessionSessionVersionHeaderJsxTextUntilYou3cf21807')}{' '}
-              {hasChanges ? (
-                <button
-                  type="button"
-                  onClick={openChangeRequest}
-                  disabled={asking}
-                  className="text-foreground font-medium underline decoration-dotted underline-offset-2 hover:decoration-solid disabled:opacity-60"
-                >
-                  {tI18nHardcoded.raw(
-                    'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
-                  )}
-                </button>
-              ) : (
-                <span className="text-foreground/80 font-medium">
-                  {tI18nHardcoded.raw(
-                    'autoFeaturesSessionSessionVersionHeaderJsxTextOpenAChange52446e59',
-                  )}
-                </span>
-              )}{' '}
-              {tI18nHardcoded.raw(
-                'autoFeaturesSessionSessionVersionHeaderJsxTextToMergeThemde828b03',
-              )}
-            </p>
-          </InfoBanner>
-        </div>
-      )}
+      <p className="text-muted-foreground px-2 pb-2 text-xs text-pretty">
+        Version <span className="text-foreground/80 font-mono">{shortVersionId}</span> — edits stay
+        out of <span className="text-foreground/80 font-mono">{baseRef}</span> until you propose
+        them for review.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/features/workspace/project-layout/project-files-skeleton.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-files-skeleton.tsx
@@ -17,23 +17,17 @@ import { Skeleton } from '@/components/ui/skeleton';
 export function ProjectFilesSkeleton() {
   return (
     <div className="bg-background flex h-full flex-col" data-slot="project-files-skeleton">
-      {/* DriveHeader — h-12 with a bottom border, matching drive-header.tsx */}
-      <div className="border-border/40 flex h-12 shrink-0 items-center gap-2 border-b px-3">
+      {/* The one header row — h-11, matching drive-header.tsx. There is no
+          second toolbar row to placehold any more: the path strip below it
+          only renders once you are inside a folder, and this boundary always
+          paints at the root. */}
+      <div className="border-border/60 flex h-11 shrink-0 items-center gap-2 border-b px-2">
         <Skeleton className="size-7 rounded-md" />
-        <Skeleton className="h-4 w-28 rounded" />
-        <div className="ml-auto flex items-center gap-2">
+        <Skeleton className="h-4 w-16 rounded" />
+        <div className="ml-auto flex items-center gap-1.5">
+          <Skeleton className="h-8 w-30 rounded-md" />
           <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="size-7 rounded-md" />
-        </div>
-      </div>
-
-      {/* DriveToolbar — breadcrumbs on the left, version selector on the right */}
-      <div className="border-border/40 flex h-10 shrink-0 items-center gap-2 border-b px-3">
-        <Skeleton className="h-4 w-20 rounded" />
-        <Skeleton className="size-3 rounded" />
-        <Skeleton className="h-4 w-24 rounded" />
-        <div className="ml-auto flex items-center gap-2">
-          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="h-8 w-36 rounded-md" />
           <Skeleton className="size-7 rounded-md" />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Three related passes over the Files surfaces, driven by the chrome being louder than the content and by opening a proposed change feeling slow.

### 1. One header row per Files surface, not two

Both surfaces stacked two full-width bars before showing a file — 10 controls on `/projects/[id]/files`, 11 in a ~400px session panel. The problem was ranking, not spacing: rare controls (sort, dotfiles, refresh, download-zip, list⇄grid) carried the same weight as constant ones (navigate, create).

`drive-toolbar.tsx` splits into three pieces a host composes — `DrivePathBar` (navigation, constant), `DriveNewMenu` (creating, frequent), `DriveViewMenu` (everything rare, behind one `⋯`).

- **Standalone page:** the breadcrumb *is* the title. `Files` is its root crumb, so at the root the row reads like any page header and going a folder deep costs no new chrome — the static `<h2>Files</h2>` only repeated the sidebar entry just clicked. It now wears `kx-titlebar-row`, the same desktop title-bar hook the capability tab row uses, at the same `h-11`; the Files-only `.kx-files-header` was a near-duplicate with its own md+ and per-platform split and is deleted from `globals.css`.
- **Session panel:** the tabs ride inside the explorer's action row via a `leading` slot, so the surface shows one row; the path strip below appears only inside a folder. The version chip left every tab (its id moved into the Changes line, where it labels something), and **"Open change request" → "Propose changes"** — it was meaningless on All files and is jargon the rest of Files doesn't use. The four-line `InfoBanner` re-explaining branches is one line.
- `SandboxServerGate` keeps the row over its skeleton/error states at identical height and border, so a booting sandbox no longer takes the tab strip with it.
- Drops `DriveExplorerToolbarOptions` — four session-review hooks no caller ever passed and the toolbar never read.

The `⋯` menu itself uses submenus for View and Sort (with the current value on the trigger) rather than 13 flat rows, and sort direction is a named `Ascending`/`Descending` pair instead of one row labelled with the state it is *not* in. `size`/`modified` stay unoffered — their comparators fall through to a name compare, so listing them would be a control that does nothing.

### 2. `DropdownMenuRadioItem` stacked a leading icon above its label

`MENU_ROW_BASE` makes a menu row `flex items-center gap-2`, so every row component's children are flex items — except `RadioItem`, which interposed a `<span className="min-w-0 flex-1">` to push its check to the far edge. That span was a block, and Preflight sets `svg { display: block }`.

Two consumers had already worked around this by hand-wrapping their children in `<span className="flex items-center gap-2">`; `user-menu-shared.tsx` carried a comment describing the workaround. Fixed in the primitive, both copies deleted. The check stays on the right — four other menus rely on that default.

### 3. Opening a proposed change cost two serial round trips

`GET /change-requests/:id` returns a body that is literally `{ change_request }` — the object the list response already held — and the dialog gates its merge-preview query on `status === 'open'`, so the preview could not *start* until that redundant fetch landed.

Seeding the detail cache from any cached list bucket collapses both: the header paints on the click frame and the preview fires in parallel. `initialDataUpdatedAt` uses the list's own `dataUpdatedAt`, not `Date.now()`, so a status that changed server-side still triggers the background refetch. `usePrefetchChangeRequest` warms detail + diff on hover, covering the diff — the one call the dialog genuinely waits for.

### 4. Review panels

`ChangeRequestsPanel` and `CheckpointsPanel` were ~300-line copies of the same aside, header, `groupByDate` and hand-rolled loading/error/empty blocks. That duplication is why they drifted and where the border noise came from: header, filter, and a group header carrying **both** `border-t` and `border-b` stacked four hairlines into the top 160px. `review-panel.tsx` holds the shared shell; both panels shrink (341→243, 303→188).

- One rule in the whole body, under the header+filter block.
- Group headings are labels — no border, fill, backdrop blur, sticky layer, count, or collapse chevron.
- Rows are `rounded-md` chips instead of full-bleed bands with a `border-l-2` rail, and use `<span>` throughout (`<div>` inside `<button>` is not valid content).
- The status glyph loses its `bg-muted/40` tile — the same grey for all three states, so it carried no information.
- Proposed changes drops its manual refresh (the list polls every 6s while open); Version history keeps its own, since `useCommits` has no interval.
- `ErrorState` / `EmptyState` replace the hand-rolled blocks.

The detail dialog gets the same pass: the bordered card around one line of diff stats, the bordered pill around the layout switch, and the `rounded-lg` review card with its internal divider are flattened; the layout switch's `rounded-sm` children now sit concentrically inside its `rounded-md` padding.

List/detail shape follows GitBook's Change requests, with Graphite and Devin confirming the file rail is a plain list rather than boxes.

## Test plan

Automated, from the committed tree:

- `npx tsc --noEmit` — clean. Only the pre-existing `@/.source` (ungenerated fumadocs) and known `@types/bun` `test.each` errors remain; the new tests use a plain loop rather than adding to that set.
- `npx eslint src/features/project-files src/components/ui/dropdown-menu.tsx` — 0 errors. Remaining warnings are pre-existing `react-hooks/*` on untouched lines.
- `bun test src/` — **8263 pass, 0 fail** across 639 files.

New tests, each verified to actually fail when the fix is reverted:

- `dropdown-menu.test.ts` (6) — pins the radio label column as a flex row using `MENU_ROW_BASE`'s own gap, and that neither ex-victim re-implements the wrapper. Reverting `RADIO_LABEL` turns 2 red.
- `use-change-requests.test.ts` (7) — `findCachedChangeRequest` was extracted as a pure function specifically so the seeding claim is testable without a QueryClient. Limiting the scan to the first cached bucket turns 2 red.
- `review-panel.test.ts` (5) — `groupByDate` bucketing, previously duplicated in both panels and untested in either.
- `drive-header.test.ts` / `drive-toolbar.test.tsx` — rewritten to assert the new structure: single fixed-height non-wrapping row, same title-bar hook as `capability-tabs.tsx`, retired hook gone from the stylesheet, `DrivePathBar as="row"` empty at root, compact `+` keeps an accessible name. The numeric traffic-light/window-control clearance checks against `window-chrome.js` are kept.

Needs a human pass (not verified here):

- `/projects/[id]/files` — header at the root and a few folders deep, narrow widths, light + dark, and the desktop shell on macOS (traffic-light clearance) and Windows/Linux (right-edge controls).
- Session panel Files at ~400px — tab row, path strip appearing on navigation, and the Changes tab with and without changes.
- Click a proposed change and confirm the header is immediate rather than a skeleton; hover a row first and confirm the diff is already there.
- The `⋯` submenus (hover-open behaviour) and the redesigned review drawers.

Out of scope: `file-search.tsx` and `content-timestamps.json` were modified in the worktree by something other than this work and are deliberately left uncommitted.
