### PR TITLE
fix(api): namespace OpenCode gateway model refs

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -1662,6 +1662,24 @@ verbatim; a constant is the production behaviour, not a fixture.
 same session. Both the path proxy and the new origin were affected, so the 502
 had been reachable long before preview origins existed.
 
+## OpenCode model references must name the runtime provider
+
+Found 2026-08-24 while diagnosing prompts that failed after session startup.
+The model catalog registered every gateway model under OpenCode provider
+`kortix`. Session creation stored nested model IDs such as
+`codex/gpt-5.6-sol` without that provider. OpenCode interpreted `codex` as the
+provider and returned `ProviderModelNotFoundError`.
+
+**Rules.**
+1. Store every gateway-backed OpenCode model as `kortix/<wire-model>`.
+2. Preserve nested provider paths. `codex/gpt-5.6-sol` becomes
+   `kortix/codex/gpt-5.6-sol`.
+3. Strip exactly one `kortix/` prefix before gateway routing.
+4. Test managed, BYOK, nested Codex, and already-prefixed references together.
+
+*Incident:* new sessions reached runtime readiness but their first prompt
+failed because the stored model named a provider that OpenCode did not expose.
+
 ## A comment saying "this was tried and reverted" is a decision record — read it before you overrule it
 
 Found 2026-08-21. PR #6692 "the inbox owns the queue" made the prompt-queue

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1966,7 +1966,7 @@ describe('project session API contract', () => {
     const env = lastProvisionInput!.extraEnvVars ?? {};
     expect(env).not.toHaveProperty('KORTIX_END_USER_REF');
     expect(env).not.toHaveProperty('KORTIX_ORIGIN_REF');
-    expect(env.KORTIX_OPENCODE_MODEL).toBe('anthropic/claude-opus-4-8');
+    expect(env.KORTIX_OPENCODE_MODEL).toBe('kortix/anthropic/claude-opus-4-8');
     expect(env.GMAIL_TOKEN).toBe('g-secret');
     expect(env.STRIPE_SECRET).toBeUndefined();
 

--- a/apps/api/src/__tests__/unit-slack-commands.test.ts
+++ b/apps/api/src/__tests__/unit-slack-commands.test.ts
@@ -201,7 +201,7 @@ describe('/kortix model <id>', () => {
   });
   test('sets a valid id', async () => {
     const resp = await handleSlashCommand('model', 'anthropic/claude-opus-4-8', ctx);
-    expect(setModelCalls).toEqual(['anthropic/claude-opus-4-8']);
+    expect(setModelCalls).toEqual(['kortix/anthropic/claude-opus-4-8']);
     expect(resp.text).toContain('set to');
   });
   test('"default" clears the override', async () => {

--- a/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
+++ b/apps/api/src/__tests__/unit-slack-interactivity-selection.test.ts
@@ -85,7 +85,7 @@ describe('agent/model picker clicks', () => {
       ...basePayload,
       actions: [{ action_id: 'set_model_anthropic/claude-opus-4-8', value: JSON.stringify({ c: 'C1', m: 'anthropic/claude-opus-4-8' }) }],
     });
-    expect(setModelCalls).toEqual(['anthropic/claude-opus-4-8']);
+    expect(setModelCalls).toEqual(['kortix/anthropic/claude-opus-4-8']);
     expect(posts[0]?.body.text).toContain('Model for this channel set to');
     expect(posts[0]?.body.replace_original).toBe(true);
   });

--- a/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
+++ b/apps/api/src/channels/slack/__tests__/commands-panel.test.ts
@@ -7,11 +7,8 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 process.env.SLACK_REQUIRE_USER_IDENTITY = 'false';
 
 mock.module('../../../config', () => ({
-  // KORTIX_MANAGED_PROVIDER_ENABLED must be on: RUNTIME_MANAGED_MODELS is empty
-  // without it, so `isRuntimeManagedModelId('glm-5.2')` is false and
-  // `toOpencodeModelRef` skips the `kortix/` prefix — which silently defeats the
-  // canonicalization this file exists to pin. (scripts/test.env sets it, but a
-  // config mock replaces the module, so it has to be restated here.)
+  // Keep the managed catalog enabled because this file exercises the real model
+  // picker. scripts/test.env sets it, but this config mock replaces that module.
   config: {
     FRONTEND_URL: 'https://app.test',
     SLACK_REQUIRE_USER_IDENTITY: false,

--- a/apps/api/src/llm-gateway/resolution/effective.test.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.test.ts
@@ -67,18 +67,23 @@ describe('toWireModel / toOpencodeModelRef', () => {
     expect(toWireModel('glm-5.2')).toBe('glm-5.2');
   });
 
-  test('re-prefixes a bare managed id to the opencode ref; leaves BYOK/codex alone', () => {
+  test('puts every gateway model under the kortix OpenCode provider', () => {
     expect(toOpencodeModelRef('glm-5.2')).toBe('kortix/glm-5.2');
     expect(toOpencodeModelRef('deepseek-v4-flash')).toBe('kortix/deepseek-v4-flash');
-    // 2026-08-10 slim-down: a deactivated managed id is no longer re-prefixed.
-    expect(toOpencodeModelRef('claude-opus-4.8')).toBe('claude-opus-4.8');
+    expect(toOpencodeModelRef('claude-opus-4.8')).toBe('kortix/claude-opus-4.8');
     expect(toOpencodeModelRef('kortix/glm-5.2')).toBe('kortix/glm-5.2');
-    expect(toOpencodeModelRef('anthropic/claude-sonnet-4.6')).toBe('anthropic/claude-sonnet-4.6');
-    expect(toOpencodeModelRef('codex/gpt-5.5')).toBe('codex/gpt-5.5');
+    expect(toOpencodeModelRef('anthropic/claude-sonnet-4.6')).toBe(
+      'kortix/anthropic/claude-sonnet-4.6',
+    );
+    expect(toOpencodeModelRef('codex/gpt-5.6-sol')).toBe('kortix/codex/gpt-5.6-sol');
   });
 
   test('round-trips a managed id through wire → opencode', () => {
     expect(toOpencodeModelRef(toWireModel('kortix/glm-5.2'))).toBe('kortix/glm-5.2');
+    expect(toWireModel(toOpencodeModelRef('codex/gpt-5.6-sol'))).toBe('codex/gpt-5.6-sol');
+    expect(toWireModel(toOpencodeModelRef('anthropic/claude-sonnet-4.6'))).toBe(
+      'anthropic/claude-sonnet-4.6',
+    );
   });
 });
 
@@ -167,7 +172,7 @@ describe('degradeUnservableDefault — stale default guard', () => {
     ).toBeNull();
   });
 
-  test('unservable default + a fallback that finds a connected provider → the fallback model, not platform (the essentia bug)', async () => {
+  test('unservable default + a fallback that finds a connected provider → the fallback model, not platform', async () => {
     // A stale/disconnected openrouter default degrades to whatever the project
     // ACTUALLY has connected (e.g. its own OpenAI BYOK key) instead of silently
     // falling all the way to a platform default that may ALSO be unusable

--- a/apps/api/src/llm-gateway/resolution/effective.ts
+++ b/apps/api/src/llm-gateway/resolution/effective.ts
@@ -22,14 +22,13 @@ export function toWireModel(ref: string): string {
 }
 
 /**
- * The OPENCODE ref form: opencode addresses a managed model as `kortix/<id>` (and
- * sends the bare id on the wire), so a bare managed id must be re-prefixed before
- * it's handed to opencode as `opencode_model`. BYOK/codex refs already carry a
- * provider segment and pass through unchanged.
+ * The OPENCODE ref form: every gateway model is registered under OpenCode's
+ * `kortix` provider. The remaining path is the gateway wire model, including
+ * nested provider paths such as `codex/gpt-5.6-sol`.
  */
 export function toOpencodeModelRef(model: string): string {
   if (model.startsWith(KORTIX_PREFIX)) return model;
-  return isRuntimeManagedModelId(model) ? `${KORTIX_PREFIX}${model}` : model;
+  return `${KORTIX_PREFIX}${model}`;
 }
 
 function isManagedRef(ref: string): boolean {


### PR DESCRIPTION
## Problem
OpenCode registers every gateway-backed model under provider `kortix`. Session creation stored nested model IDs such as `codex/gpt-5.6-sol` as though `codex` were an OpenCode provider. Prompts then failed with `ProviderModelNotFoundError`.

## Change
- Prefix every gateway-backed OpenCode model with `kortix/`.
- Preserve nested wire model paths.
- Add managed, BYOK, Codex, and round-trip regressions.
- Record the incident rule.

## Verification
- `dotenvx run --ignore=MISSING_ENV_FILE -f apps/api/.env.local -f apps/api/.env -- env KORTIX_URL=http://localhost:8008 bun test apps/api/src/llm-gateway/resolution/effective.test.ts` — 23 pass, 0 fail.
- `pnpm --filter kortix-api typecheck` — exit 0.