### PR TITLE
The transcript must catch up — five things stopped it

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,7 +12,7 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
-### 2026-08-24 — session `transcript-convergence` — the transcript must catch up, and four things stopped it — DONE
+### 2026-08-24 — session `transcript-convergence` — the transcript must catch up, and five things stopped it — DONE
 
 **Files:** `core/session-sync/session-sync-controller.ts` (turn-end reconcile,
 `SessionSyncReason` += `turn-end` | `visible`) + tests (+3) ·
@@ -21,7 +21,9 @@ transcript frames) + tests (+2) · `browser/session-sync/visibility.ts` (NEW) +
 tests (+4) · `react/use-session-sync.ts` (visible-reconcile effect;
 `livenessBusy` no longer gated on the health probe) + tests (+1) ·
 `react/use-opencode-events/rehydrate-targets.ts` (NEW) + tests (+3) ·
-`react/use-opencode-events/index.ts` (gap rehydrates every held transcript).
+`react/use-opencode-events/stream-revival.ts` (NEW) + tests (+6) ·
+`react/use-opencode-events/index.ts` (gap rehydrates every held transcript;
+supplies `onParked`).
 
 **What.** Reported from a live self-host with a screenshot: an 8m13s turn
 FINISHED — the runtime's own terminal shows the complete answer — and the
@@ -54,7 +56,17 @@ Plus the case the user named directly: a backgrounded tab has its timers
 clamped to about one a minute, so return is the moment the tab is least sure
 what it holds. `onTabVisible` reconciles on the way back in.
 
-**Gates:** `typecheck` clean (both projects) · `pnpm test` 2459 pass / 0 fail ·
+**5. And the stream could die for good.** `openEventStream` PARKS after 8
+consecutive hard failures and documents itself as terminal for that handle —
+correct, and the point: a dead or archived sandbox should not be hammered
+forever. But **nothing in this package supplied `onParked`**, so "terminal for
+this handle" silently became terminal for the PAGE. No error, no retry, no
+transcript updates until the user reloaded. `createStreamRevival` re-opens the
+stream on the first cheap evidence that something may have changed — the tab
+came back, the network came back, or 30s passed — exactly once per park, so a
+genuinely dead box costs one connect attempt per interval instead of a storm.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` 2456 pass / 0 fail ·
 `smoke:install` passed · apps/web tsc clean, session suite 2513 pass / 0 fail.
 
 ---

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,53 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `transcript-convergence` — the transcript must catch up, and four things stopped it — DONE
+
+**Files:** `core/session-sync/session-sync-controller.ts` (turn-end reconcile,
+`SessionSyncReason` += `turn-end` | `visible`) + tests (+3) ·
+`browser/session-sync/session-sync-registry.ts` (freshness renews only on
+transcript frames) + tests (+2) · `browser/session-sync/visibility.ts` (NEW) +
+tests (+4) · `react/use-session-sync.ts` (visible-reconcile effect;
+`livenessBusy` no longer gated on the health probe) + tests (+1) ·
+`react/use-opencode-events/rehydrate-targets.ts` (NEW) + tests (+3) ·
+`react/use-opencode-events/index.ts` (gap rehydrates every held transcript).
+
+**What.** Reported from a live self-host with a screenshot: an 8m13s turn
+FINISHED — the runtime's own terminal shows the complete answer — and the
+browser's transcript stopped mid-turn under a spinner. Not a label bug. The
+messages were never fetched.
+
+The repair for a stream that drops content is the liveness poll: one bounded
+tail read every 10s while a session is working. Four separate things could stop
+it, and each one is the same mistake — the repair was gated on a signal that
+fails in exactly the situation the repair exists for.
+
+1. **`noteActivity()` renewed on EVERY frame** carrying the session id, and
+   `checkLiveness` skips while activity is newer than the interval. A runtime
+   emitting status frames while its message frames were lost kept postponing
+   the poll built to catch the loss. Now only transcript-bearing frames renew.
+2. **`setBusy(false)` stopped the poll with no final read.** Turn end is when
+   a transcript is most likely to be short — the closing frames are the ones
+   most often lost — and stopping there made the truncation PERMANENT. A busy
+   session now always reads its own tail one last time (`turn-end`).
+3. **`livenessBusy` was gated on `runtimeHealthy`.** The health probe is the
+   thing that flaps; a loaded box that misses its deadline mid-turn lost its
+   transcript repair for as long as the probe kept missing. The probe no longer
+   decides. (`runtimeHealthy` stays on the published input shape, ignored.)
+4. **The SSE-gap rehydrate only re-read sessions whose STATUS SLOT said busy** —
+   and the slot is filled by the stream, so a gap wide enough to lose message
+   frames is wide enough to lose the frame that marks the session busy. Every
+   held transcript is re-read now.
+
+Plus the case the user named directly: a backgrounded tab has its timers
+clamped to about one a minute, so return is the moment the tab is least sure
+what it holds. `onTabVisible` reconciles on the way back in.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` 2459 pass / 0 fail ·
+`smoke:install` passed · apps/web tsc clean, session suite 2513 pass / 0 fail.
+
+---
+
 ### 2026-08-24 — session `connection-projection` — one answer for "is this session connected" — DONE
 
 **Files:** `core/session/connection.ts` (NEW — `SessionConnection`,

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.test.ts
@@ -178,6 +178,40 @@ describe('session sync events', () => {
     expect(controller.getSnapshot().freshness).toBe('fresh');
   });
 
+  /**
+   * The starvation bug. `checkLiveness` skips whenever the last activity is
+   * newer than the poll interval, so ANY frame carrying this session's id used
+   * to postpone the repair — including frames that carry no transcript at all.
+   * A stream that keeps emitting status while dropping message parts could
+   * therefore keep the browser's transcript arbitrarily stale, forever, and
+   * the poll built to catch exactly that never ran.
+   *
+   * Only a frame that MOVES the transcript is evidence the transcript moved.
+   */
+  test('a status frame is not evidence that the transcript moved', () => {
+    const sessionId = 'session-status-only';
+    const controller = getSessionSyncController(sessionId, undefined, 'runtime-a');
+
+    for (const type of ['session.status', 'session.idle', 'permission.updated']) {
+      noteSessionSyncEvent({ type, properties: { sessionID: sessionId } });
+      expect(controller.getSnapshot().freshness).toBe('idle');
+    }
+  });
+
+  test('every frame that carries transcript content renews freshness', () => {
+    const sessionId = 'session-content';
+    for (const event of [
+      { type: 'message.updated', properties: { info: { id: 'm1', sessionID: sessionId } } },
+      { type: 'message.part.updated', properties: { part: { sessionID: sessionId } } },
+      { type: 'message.removed', properties: { sessionID: sessionId, messageID: 'm1' } },
+    ]) {
+      resetSessionSyncControllers();
+      const controller = getSessionSyncController(sessionId, undefined, 'runtime-a');
+      noteSessionSyncEvent(event);
+      expect(controller.getSnapshot().freshness).toBe('fresh');
+    }
+  });
+
   test('a frame for another session never touches this one', () => {
     const controller = getSessionSyncController('session-a', undefined, 'runtime-a');
 

--- a/packages/sdk/src/browser/session-sync/session-sync-registry.ts
+++ b/packages/sdk/src/browser/session-sync/session-sync-registry.ts
@@ -262,6 +262,18 @@ export function loadSessionTranscriptMessages(
   );
 }
 
+/**
+ * The frame types that carry transcript content. Everything else the runtime
+ * emits — status, idle, permission, question, diagnostics — says something
+ * about the session but nothing about whether this tab has its messages.
+ */
+const TRANSCRIPT_EVENT_TYPES = new Set([
+  'message.updated',
+  'message.part.updated',
+  'message.removed',
+  'message.part.removed',
+]);
+
 export function noteSessionSyncEvent(event: {
   type?: string;
   properties?: unknown;
@@ -275,11 +287,18 @@ export function noteSessionSyncEvent(event: {
     info?.sessionID ||
     part?.sessionID;
   if (!sessionId) return;
-  // Every frame for this session is proof its transcript moved, and that is
-  // all this hook does now: it renews freshness. The frames themselves are
-  // applied by the event handler, and "is this session working?" is answered
-  // by `projectWorking` over the server's turn authority — not by inferring a
-  // phase from which frame arrived when.
+  // Only a frame that MOVES the transcript renews freshness — and freshness is
+  // what postpones the liveness poll, the one repair for a stream that is
+  // dropping content.
+  //
+  // It used to be every frame carrying this session's id. That inverted the
+  // repair: a runtime emitting status while its message frames were lost kept
+  // renewing the very timer built to catch the loss, so the browser's
+  // transcript could sit arbitrarily stale and the poll would never run. The
+  // frames themselves are applied by the event handler, and "is this session
+  // working?" is answered by `projectWorking` over the server's turn authority
+  // — not by inferring a phase from which frame arrived when.
+  if (!TRANSCRIPT_EVENT_TYPES.has(event.type ?? '')) return;
   findExistingSessionEntry(sessionId)?.controller.noteActivity();
 }
 

--- a/packages/sdk/src/browser/session-sync/visibility.test.ts
+++ b/packages/sdk/src/browser/session-sync/visibility.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+
+import { onTabVisible, type VisibilityTarget } from './visibility';
+
+function fakeTarget(initial = 'visible') {
+  const handlers = new Set<() => void>();
+  const target: VisibilityTarget & { fire: (state: string) => void } = {
+    visibilityState: initial,
+    addEventListener: (_type, handler) => {
+      handlers.add(handler);
+    },
+    removeEventListener: (_type, handler) => {
+      handlers.delete(handler);
+    },
+    fire: (state: string) => {
+      target.visibilityState = state;
+      for (const handler of [...handlers]) handler();
+    },
+  };
+  return target;
+}
+
+describe('onTabVisible', () => {
+  test('runs on the return to the foreground', () => {
+    const target = fakeTarget('hidden');
+    let runs = 0;
+    onTabVisible(() => {
+      runs += 1;
+    }, target);
+
+    target.fire('visible');
+    expect(runs).toBe(1);
+  });
+
+  test('leaving the tab repairs nothing, so it runs nothing', () => {
+    const target = fakeTarget('visible');
+    let runs = 0;
+    onTabVisible(() => {
+      runs += 1;
+    }, target);
+
+    target.fire('hidden');
+    expect(runs).toBe(0);
+  });
+
+  test('unsubscribing detaches the listener', () => {
+    const target = fakeTarget('hidden');
+    let runs = 0;
+    const stop = onTabVisible(() => {
+      runs += 1;
+    }, target);
+
+    stop();
+    target.fire('visible');
+    expect(runs).toBe(0);
+  });
+
+  test('no document, no listener, no throw', () => {
+    expect(() => onTabVisible(() => {}, undefined)()).not.toThrow();
+  });
+});

--- a/packages/sdk/src/browser/session-sync/visibility.ts
+++ b/packages/sdk/src/browser/session-sync/visibility.ts
@@ -1,0 +1,34 @@
+/**
+ * Run something when the tab comes back to the foreground.
+ *
+ * A backgrounded tab is throttled, not paused and not told: browsers clamp its
+ * timers (Chrome to roughly one tick a minute), so the transcript liveness
+ * poll — 10s while a session is working — effectively stops, and the SSE
+ * connection can be dropped without a visible error. Return is therefore the
+ * moment the tab is LEAST sure it has the runtime's messages, and the only
+ * moment it can find out cheaply.
+ *
+ * Framework-free and injectable so the rule is testable without a DOM.
+ */
+export interface VisibilityTarget {
+  visibilityState: string;
+  addEventListener: (type: 'visibilitychange', handler: () => void) => void;
+  removeEventListener: (type: 'visibilitychange', handler: () => void) => void;
+}
+
+export function onTabVisible(
+  run: () => void,
+  target: VisibilityTarget | undefined = typeof document === 'undefined'
+    ? undefined
+    : (document as unknown as VisibilityTarget),
+): () => void {
+  if (!target) return () => {};
+  const handler = () => {
+    // Only the transition INTO visible. `visibilitychange` fires on the way out
+    // too, and reading a tail the moment a tab is hidden repairs nothing.
+    if (target.visibilityState !== 'visible') return;
+    run();
+  };
+  target.addEventListener('visibilitychange', handler);
+  return () => target.removeEventListener('visibilitychange', handler);
+}

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -7,6 +7,7 @@ import {
   loadCompleteSessionHistory,
   type SessionSyncControllerOptions,
   type SessionSyncPage,
+  type SessionSyncReason,
   type SessionSyncScheduler,
 } from './session-sync-controller';
 
@@ -650,5 +651,75 @@ describe('SessionSyncController', () => {
     await pending;
 
     expect(hydrated).toEqual([['message-newest']]);
+  });
+  /**
+   * The screenshot that started this: the runtime finished an 8-minute turn
+   * and its terminal showed the whole answer; the browser's transcript stopped
+   * mid-turn with a spinner. The turn ENDED — and turn end was exactly the
+   * moment the repair switched itself off.
+   */
+  test('the last thing a busy session does is read its own tail', async () => {
+    const clock = createScheduler();
+    const reasons: SessionSyncReason[] = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => page([]),
+      hydrate: () => {},
+      markLoaded: () => {},
+      onTelemetry: (event) => reasons.push(event.reason),
+      scheduler: clock.scheduler,
+      livenessIntervalMs: 10_000,
+    });
+
+    await controller.start();
+    reasons.length = 0;
+    controller.setBusy(true);
+    controller.setBusy(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reasons).toEqual(['turn-end']);
+  });
+
+  test('a session that was never busy does not read a tail when it stays idle', async () => {
+    const clock = createScheduler();
+    const reasons: SessionSyncReason[] = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => page([]),
+      hydrate: () => {},
+      markLoaded: () => {},
+      onTelemetry: (event) => reasons.push(event.reason),
+      scheduler: clock.scheduler,
+      livenessIntervalMs: 10_000,
+    });
+
+    await controller.start();
+    reasons.length = 0;
+    controller.setBusy(false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reasons).toEqual([]);
+  });
+
+  test('destruction does not fire a turn-end read', async () => {
+    const clock = createScheduler();
+    const reasons: SessionSyncReason[] = [];
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => page([]),
+      hydrate: () => {},
+      markLoaded: () => {},
+      onTelemetry: (event) => reasons.push(event.reason),
+      scheduler: clock.scheduler,
+      livenessIntervalMs: 10_000,
+    });
+
+    await controller.start();
+    controller.setBusy(true);
+    reasons.length = 0;
+    controller.destroy();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reasons).toEqual([]);
   });
 });

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -51,7 +51,19 @@ export interface SessionSyncScheduler {
 }
 
 export type SessionSyncReason =
-  'initial' | 'poll' | 'sse-gap' | 'compaction' | 'session-error' | 'send-recovery' | 'manual';
+  | 'initial'
+  | 'poll'
+  | 'sse-gap'
+  | 'compaction'
+  | 'session-error'
+  | 'send-recovery'
+  /** The turn ended. The last read of a busy session, and the one that catches
+   *  a final answer whose closing frames the stream never delivered. */
+  | 'turn-end'
+  /** The tab became visible again. A backgrounded tab is throttled, not
+   *  notified, so return is a moment to re-read rather than to assume. */
+  | 'visible'
+  | 'manual';
 
 export interface SessionSyncTelemetryEvent {
   operation: 'tail' | 'older';
@@ -298,7 +310,20 @@ export class SessionSyncController {
    */
   setBusy(isBusy: boolean): void {
     if (!isBusy) {
+      // The turn is over — and that is exactly when the transcript is most
+      // likely to be short. A stream that dropped its last frames leaves the
+      // browser holding a truncated answer while the runtime holds the whole
+      // one, and stopping the poll here used to make that state PERMANENT:
+      // nothing read the tail again until the session was reopened. Reported
+      // from a live self-host (2026-08-24): an 8m13s turn finished in the
+      // runtime's own terminal while the tab still showed a spinner under a
+      // half-written answer.
+      //
+      // One bounded read, only for a session that was actually busy, so an
+      // idle session churns nothing.
+      const wasBusy = this.livenessTimer !== undefined;
       this.stopLivenessTimer();
+      if (wasBusy && !this.destroyed) void this.reconcile('turn-end');
       return;
     }
     if (this.livenessTimer !== undefined) return;
@@ -310,6 +335,9 @@ export class SessionSyncController {
   }
 
   destroy(): void {
+    // `destroyed` FIRST: `stopLivenessTimer` is also reached through
+    // `setBusy(false)`, which now fires a turn-end read, and a controller being
+    // torn down must not start a request it can never hydrate.
     this.destroyed = true;
     this.stopLivenessTimer();
     this.listeners.clear();

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -19,7 +19,7 @@ import {
 import { useServerStore } from '../../browser/stores/server-store';
 import { useCurrentRuntime } from '../use-current-runtime';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { opencodeKeys } from '../use-opencode-sessions';
 import { useKortixRouteProjectId } from '../route-project';
 import { resetPrefetchState } from '../use-session-prefetch';
@@ -30,6 +30,7 @@ import {
   resolveClientEvictionUrl,
 } from './helpers';
 import { sessionsNeedingRehydrate } from './rehydrate-targets';
+import { createStreamRevival } from './stream-revival';
 import { useEventStreamRefs } from './use-event-stream-refs';
 import { openEventStream } from '../../core/stream/event-stream';
 
@@ -71,6 +72,15 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
   const isMountRef = useRef(true);
   const prevRuntimeVersionRef = useRef(runtimeVersion);
   const prevServerUrlRef = useRef(activeServerUrl);
+  // Bumped when a parked stream earns another attempt. It is an effect DEP, so
+  // the bump tears the dead handle down and opens a fresh one — the same path
+  // a runtime switch takes, rather than a second reconnect mechanism.
+  const [streamGeneration, setStreamGeneration] = useState(0);
+  const revival = useMemo(
+    () => createStreamRevival(() => setStreamGeneration((generation) => generation + 1)),
+    [],
+  );
+  useEffect(() => revival.stop, [revival]);
 
   const {
     normalizeDiagnosticPaths,
@@ -292,6 +302,17 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
     // the QueryClient-dependent event handler and the gap-rehydrate hook.
     const handle = openEventStream({
       client,
+      // A park is not a verdict about the sandbox — only about the last few
+      // attempts. Nothing supplied this callback before, so the stream's
+      // documented "terminal for this handle" silently became terminal for the
+      // PAGE: the session view kept rendering a transcript nobody was updating
+      // until the user reloaded. See `createStreamRevival`.
+      onParked: (info) => {
+        logger.warn('SSE stream parked — arming revival', {
+          consecutiveFailures: info.consecutiveFailures,
+        });
+        revival.park();
+      },
       onEvent: (event) => {
         // Every delivered frame is live proof the runtime is reachable — it
         // vetoes concurrent health-probe failures (a loaded box can miss the
@@ -304,6 +325,7 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
     });
 
     return () => {
+      revival.stop();
       handle.close();
     };
     // NOTE: urlVersion is intentionally excluded from deps. We only reconnect
@@ -325,6 +347,10 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
     applySyncEvent,
     stopCompaction,
     projectId,
+    revival,
+    // A revived park re-opens the stream through this effect. Without it the
+    // park stayed terminal for the page.
+    streamGeneration,
   ]);
 }
 

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -29,6 +29,7 @@ import {
   reserveMessageRehydrate,
   resolveClientEvictionUrl,
 } from './helpers';
+import { sessionsNeedingRehydrate } from './rehydrate-targets';
 import { useEventStreamRefs } from './use-event-stream-refs';
 import { openEventStream } from '../../core/stream/event-stream';
 
@@ -269,10 +270,11 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
 
       if (options?.rehydrateMessages) {
         const syncState = useSyncStore.getState();
-        const loadedSessionIds = Object.keys(syncState.messages);
-        for (const sid of loadedSessionIds) {
-          const status = syncState.sessionStatus[sid];
-          if (status?.type !== 'busy' && status?.type !== 'retry') continue;
+        // EVERY held transcript, not only the ones the status slot calls busy
+        // — see `sessionsNeedingRehydrate`. The slot is filled by the stream,
+        // so a gap wide enough to lose message frames is wide enough to lose
+        // the frame that would have marked the session busy.
+        for (const sid of sessionsNeedingRehydrate(Object.keys(syncState.messages))) {
           if (!reserveMessageRehydrate(sid)) continue;
           reconcileSessionTail(sid, 'sse-gap')
             .catch(() => {})

--- a/packages/sdk/src/react/use-opencode-events/rehydrate-targets.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/rehydrate-targets.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { sessionsNeedingRehydrate } from './rehydrate-targets';
+
+describe('sessionsNeedingRehydrate', () => {
+  /**
+   * The rule this replaced filtered on the status slot — which the stream
+   * fills. A gap that loses message frames loses status frames too, so the
+   * sessions most likely to be stale were exactly the ones skipped.
+   */
+  test('after a gap every held transcript is re-read, whatever its status slot says', () => {
+    expect(sessionsNeedingRehydrate(['idle-one', 'busy-one'])).toEqual(['idle-one', 'busy-one']);
+  });
+
+  test('a session held twice is read once', () => {
+    expect(sessionsNeedingRehydrate(['a', 'a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  test('nothing held, nothing read', () => {
+    expect(sessionsNeedingRehydrate([])).toEqual([]);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/rehydrate-targets.ts
+++ b/packages/sdk/src/react/use-opencode-events/rehydrate-targets.ts
@@ -1,0 +1,19 @@
+/**
+ * Which sessions get their transcript re-read after an SSE gap.
+ *
+ * The old rule was "the ones whose status slot says busy", and it could not
+ * work: the status slot is filled BY the stream, so a gap long enough to lose
+ * message frames is long enough to lose the status frame that would have
+ * marked the session busy. The sessions most likely to be missing content were
+ * therefore the ones most likely to be skipped — and a session that went
+ * silently idle during the gap kept a truncated final answer with nothing left
+ * to correct it.
+ *
+ * A gap means: for some interval, this tab is not sure what the runtime said.
+ * The honest response is to re-read every transcript this tab is holding. That
+ * is bounded — a tab holds one open session plus a handful of recently viewed
+ * ones — and each read is a single tail page.
+ */
+export function sessionsNeedingRehydrate(loadedSessionIds: string[]): string[] {
+  return [...new Set(loadedSessionIds)];
+}

--- a/packages/sdk/src/react/use-opencode-events/stream-revival.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/stream-revival.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createStreamRevival } from './stream-revival';
+
+function harness() {
+  const timers: Array<{ handler: () => void; ms: number; id: number }> = [];
+  let nextId = 1;
+  const listeners = new Map<string, Set<() => void>>();
+  let revives = 0;
+  const revival = createStreamRevival(() => {
+    revives += 1;
+  }, {
+    reviveAfterMs: 30_000,
+    setTimeout: (handler, ms) => {
+      const id = nextId++;
+      timers.push({ handler, ms, id });
+      return id;
+    },
+    clearTimeout: (handle) => {
+      const index = timers.findIndex((timer) => timer.id === handle);
+      if (index >= 0) timers.splice(index, 1);
+    },
+    listen: (event, handler) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+      return () => listeners.get(event)!.delete(handler);
+    },
+  });
+  return {
+    revival,
+    revives: () => revives,
+    fire: (event: string) => {
+      for (const handler of [...(listeners.get(event) ?? [])]) handler();
+    },
+    tick: () => {
+      const due = timers.splice(0, timers.length);
+      for (const timer of due) timer.handler();
+    },
+    armedEvents: () => [...listeners.keys()].filter((key) => (listeners.get(key)?.size ?? 0) > 0),
+  };
+}
+
+/**
+ * A parked stream is terminal by design — it stops hammering a dead sandbox.
+ * Nothing revived it, so "terminal for this handle" became "terminal for this
+ * page": the session view kept rendering a transcript nobody was updating
+ * until the user reloaded.
+ */
+describe('createStreamRevival', () => {
+  test('an idle park revives on its own after the delay', () => {
+    const h = harness();
+    h.revival.park();
+    expect(h.revives()).toBe(0);
+
+    h.tick();
+    expect(h.revives()).toBe(1);
+  });
+
+  test('coming back to the tab revives immediately', () => {
+    const h = harness();
+    h.revival.park();
+
+    h.fire('visibilitychange');
+    expect(h.revives()).toBe(1);
+  });
+
+  test('the network coming back revives immediately', () => {
+    const h = harness();
+    h.revival.park();
+
+    h.fire('online');
+    expect(h.revives()).toBe(1);
+  });
+
+  test('whichever trigger lands first, the stream is revived exactly once', () => {
+    const h = harness();
+    h.revival.park();
+
+    h.fire('online');
+    h.fire('visibilitychange');
+    h.tick();
+    expect(h.revives()).toBe(1);
+    expect(h.armedEvents()).toEqual([]);
+  });
+
+  test('parking twice arms one revival, not two', () => {
+    const h = harness();
+    h.revival.park();
+    h.revival.park();
+
+    h.tick();
+    expect(h.revives()).toBe(1);
+  });
+
+  test('teardown before any trigger revives nothing', () => {
+    const h = harness();
+    h.revival.park();
+    h.revival.stop();
+
+    h.fire('online');
+    h.tick();
+    expect(h.revives()).toBe(0);
+  });
+});

--- a/packages/sdk/src/react/use-opencode-events/stream-revival.ts
+++ b/packages/sdk/src/react/use-opencode-events/stream-revival.ts
@@ -1,0 +1,91 @@
+/**
+ * Bring a PARKED event stream back.
+ *
+ * `openEventStream` parks after a run of hard failures and documents itself as
+ * terminal for that handle — correct, and the point: a dead or archived sandbox
+ * should not be hammered forever. But nothing in this package supplied
+ * `onParked`, so "terminal for this handle" silently became "terminal for this
+ * page". The session view went on rendering a transcript nobody was updating,
+ * with no error and no retry, until the user reloaded. That is the "it just
+ * loses connection" report.
+ *
+ * Parking is not a verdict about the sandbox, only about the last few attempts.
+ * So revive on the cheapest evidence that something may have changed —
+ *
+ *   - the tab came back (it was throttled; the world moved without us)
+ *   - the network came back
+ *   - nothing happened for `reviveAfterMs`, so try once anyway
+ *
+ * — and revive exactly ONCE per park, so a genuinely dead box costs one connect
+ * attempt per interval instead of a retry storm.
+ */
+export interface StreamRevivalOptions {
+  /** Self-heal delay when no external signal arrives. Default 30s. */
+  reviveAfterMs?: number;
+  setTimeout?: (handler: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+  /** Subscribe to a global event; returns its unsubscribe. Injected for tests. */
+  listen?: (event: string, handler: () => void) => () => void;
+}
+
+export interface StreamRevival {
+  /** The stream parked. Arm the triggers. */
+  park: () => void;
+  /** Tear down, whether or not a revival is armed. */
+  stop: () => void;
+}
+
+const DEFAULT_REVIVE_AFTER_MS = 30_000;
+
+function defaultListen(event: string, handler: () => void): () => void {
+  if (typeof globalThis.addEventListener !== 'function') return () => {};
+  const target = event === 'visibilitychange' && typeof document !== 'undefined' ? document : globalThis;
+  const wrapped = () => {
+    // A hidden tab is not evidence of anything; only the return is.
+    if (event === 'visibilitychange' && typeof document !== 'undefined') {
+      if (document.visibilityState !== 'visible') return;
+    }
+    handler();
+  };
+  target.addEventListener(event, wrapped);
+  return () => target.removeEventListener(event, wrapped);
+}
+
+export function createStreamRevival(
+  revive: () => void,
+  options: StreamRevivalOptions = {},
+): StreamRevival {
+  const reviveAfterMs = options.reviveAfterMs ?? DEFAULT_REVIVE_AFTER_MS;
+  const setTimer = options.setTimeout ?? ((handler, ms) => setTimeout(handler, ms));
+  const clearTimer = options.clearTimeout ?? ((handle) => clearTimeout(handle as never));
+  const listen = options.listen ?? defaultListen;
+
+  let armed = false;
+  let timer: unknown;
+  let unsubscribers: Array<() => void> = [];
+
+  const disarm = () => {
+    if (!armed) return;
+    armed = false;
+    if (timer !== undefined) clearTimer(timer);
+    timer = undefined;
+    for (const unsubscribe of unsubscribers) unsubscribe();
+    unsubscribers = [];
+  };
+
+  const fire = () => {
+    if (!armed) return;
+    disarm();
+    revive();
+  };
+
+  return {
+    park: () => {
+      if (armed) return;
+      armed = true;
+      timer = setTimer(fire, reviveAfterMs);
+      unsubscribers = [listen('visibilitychange', fire), listen('online', fire)];
+    },
+    stop: disarm,
+  };
+}

--- a/packages/sdk/src/react/use-session-sync.test.ts
+++ b/packages/sdk/src/react/use-session-sync.test.ts
@@ -36,13 +36,31 @@ describe('livenessBusy', () => {
     ).toBe(true);
   });
 
-  test('a poll that cannot reach the runtime never runs', () => {
+  test('an offline tab never polls', () => {
     expect(
       livenessBusy({ networkEnabled: false, runtimeHealthy: true, working: true, streamBusy: true }),
     ).toBe(false);
+  });
+
+  /**
+   * The feedback loop this whole file keeps paying for: the repair for a
+   * broken stream was gated on the health probe, and the health probe is the
+   * thing that flaps. A loaded box that misses its probe deadline mid-turn got
+   * its transcript repair switched off at the exact moment the repair was
+   * needed — and stayed off for as long as the probe kept missing.
+   *
+   * The probe does not decide this. A working session polls; if the box really
+   * is unreachable the read fails, bounded, and costs one request per interval.
+   */
+  test('a failing health probe never switches the repair off', () => {
     expect(
-      livenessBusy({ networkEnabled: true, runtimeHealthy: false, working: true, streamBusy: true }),
-    ).toBe(false);
+      livenessBusy({
+        networkEnabled: true,
+        runtimeHealthy: false,
+        working: true,
+        streamBusy: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -15,6 +15,7 @@ import {
   resetSessionSyncControllersForSession,
   retainSessionSyncController,
 } from '../browser/session-sync/session-sync-registry';
+import { onTabVisible } from '../browser/session-sync/visibility';
 import { useSandboxConnectionStore } from '../browser/stores/sandbox-connection-store';
 import { useSyncStore } from '../browser/stores/sync-store';
 import { useCurrentRuntime } from './use-current-runtime';
@@ -81,11 +82,23 @@ export function sessionSyncBusy(input: {
  */
 export function livenessBusy(input: {
   networkEnabled: boolean;
-  runtimeHealthy: boolean;
+  /**
+   * Read, and deliberately IGNORED. Retained because this object is a
+   * published parameter shape.
+   *
+   * It used to gate the poll, which inverted the whole point of having one:
+   * the repair for a broken stream was switched off by the health probe, and
+   * the health probe is the signal that flaps. A loaded box that misses its
+   * probe deadline mid-turn lost its transcript repair at the exact moment it
+   * needed it, for as long as the probe kept missing. If the box truly is
+   * unreachable the tail read fails on its own — bounded by the controller's
+   * deadline — at a cost of one request per interval.
+   */
+  runtimeHealthy?: boolean;
   working: boolean | undefined;
   streamBusy: boolean;
 }): boolean {
-  if (!input.networkEnabled || !input.runtimeHealthy) return false;
+  if (!input.networkEnabled) return false;
   return sessionSyncBusy(input);
 }
 
@@ -167,6 +180,19 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
     void controller.reconcile('initial');
     return release;
   }, [controller, networkEnabled, runtimeHealthy, runtimeScope, sessionId]);
+
+  // Coming back to the tab is a moment of MAXIMUM uncertainty, so it is a
+  // moment to re-read. A backgrounded tab has its timers clamped (Chrome: about
+  // one tick a minute), so the 10s liveness poll effectively stops, and the SSE
+  // connection can be dropped with no visible error. Whatever the transcript
+  // shows on return was assembled from a stream nobody was watching. One
+  // bounded tail read settles it.
+  useEffect(() => {
+    if (!networkEnabled || !canQueryOpenCodeSession(sessionId)) return;
+    return onTabVisible(() => {
+      void controller.reconcile('visible');
+    });
+  }, [controller, networkEnabled, sessionId]);
 
   const messages = useSyncStore((state) =>
     state.buildSessionMessages(


### PR DESCRIPTION
## The report

A live self-host, screenshot: an **8m13s turn finished** — the runtime's own terminal shows the complete answer — and the browser's transcript stopped mid-turn under a spinner.

> "it straight up didn't even sync the latest messages… the messages from the open code session are not the same as shown to me in the front end so it seems like it just ended prematurely but it didn't. it actually finished."

This is not the connection *label*. Those messages were never fetched.

## The mechanism

The repair for a stream that drops content is the **liveness poll**: one bounded tail read every 10s while a session is working. Five separate things could stop it — and each one is the same mistake, *the repair gated on a signal that fails in exactly the situation the repair exists for*.

**1. Any frame at all silenced the repair.** `noteActivity()` renewed freshness on *every* frame carrying the session id, and `checkLiveness` skips while activity is newer than the poll interval. A runtime emitting status frames while its message frames were lost kept postponing the poll built to catch the loss — indefinitely. Only transcript-bearing frames (`message.updated`, `message.part.updated`, `message.removed`, `message.part.removed`) renew now.

**2. Turn end stopped the poll with no final read.** `setBusy(false)` cleared the timer and left. Turn end is exactly when a transcript is most likely to be short — the closing frames are the ones most often lost — so stopping there made the truncation **permanent**: nothing read that tail again until the session was reopened. A busy session now always reads its own tail one last time (`reason: 'turn-end'`). An idle session still reads nothing; a destroyed controller starts no request.

**3. The health probe could switch the repair off.** `livenessBusy` returned false when `runtimeHealthy !== true`. The probe is the thing that flaps — a loaded box that misses its deadline mid-turn lost its transcript repair for as long as the probe kept missing. The probe no longer decides. `runtimeHealthy` stays on the published input shape and is ignored.

**4. The SSE-gap rehydrate skipped the sessions most likely to be stale.** It re-read only sessions whose *status slot* said busy — and that slot is filled by the stream. A gap wide enough to lose message frames is wide enough to lose the frame that marks the session busy. Every held transcript is re-read now (`sessionsNeedingRehydrate`).

**5. And the stream could die for good.** `openEventStream` **parks** after 8 consecutive hard failures and documents itself as terminal for that handle — correct, and the point: a dead sandbox must not be hammered forever. But **nothing in the SDK supplied `onParked`**, so "terminal for this handle" silently became terminal for the **page**. No error, no retry, no transcript updates, recovery only by reload. That is the "it just keeps losing connection" report. `createStreamRevival` re-opens the stream on the first cheap evidence something may have changed — the tab came back, the network came back, or 30s passed — exactly once per park, so a genuinely dead box costs one connect attempt per interval instead of a storm.

**Plus the case named directly:** "It might happen when I leave a tab." A backgrounded tab has its timers clamped (Chrome: about one tick a minute) and its SSE connection can drop with no visible error, so return is the moment the tab is least sure what it holds. `onTabVisible` reconciles on the way back in.

## Gates

- `packages/sdk`: `pnpm typecheck` clean (both projects) · `pnpm test` **2465 pass / 0 fail** (+19 new) · `pnpm smoke:install` passed
- `apps/web`: `tsc --noEmit` clean apart from the known `@types/bun` `test.each` noise · `bun test src/features/session` **2513 pass / 0 fail**
- Public surface unchanged — the new modules are internal, and `runtimeHealthy` only widened to optional.

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH