### PR TITLE
fix(sandbox): recover missing OpenCode runtime

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2083,3 +2083,22 @@ installed shim's `cmd-shim-target` metadata and validate that exact target.
 
 *Incident:* the live E2B build installed OpenCode 1.18.19 and printed its
 version, then failed before the native-binary assertion.
+
+## Missing managed runtime binaries are recoverable drift, not an unreadable runtime
+
+2026-08-23. Existing sandbox disks created before the managed OpenCode link
+could update their CLI and agent, but never became ready. Runtime convergence
+treated an unreadable OpenCode health endpoint as a busy or transient runtime.
+The required managed binary did not exist, so the endpoint could never recover.
+
+**The rule.** Distinguish a missing managed binary from a temporarily
+unreadable process. Install and restart when the managed link is absent. Defer
+when the managed link exists but the process cannot report its version.
+
+**The enforcement.** Runtime convergence tests cover both states. A missing
+managed link installs the manifest version and restarts OpenCode. An existing
+link with unreadable health performs no install and no restart.
+
+*Incident:* old session disks remained in `runtimeReady=false` after a runtime
+upgrade because OpenCode convergence reported `opencode did not report its
+version` on every start.

--- a/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/runtime-convergence.test.ts
@@ -547,7 +547,7 @@ describe('opencode convergence — idle only', () => {
     expect(installs).toEqual([])
   })
 
-  test('an unreadable opencode converges nothing', async () => {
+  test('a missing managed opencode binary is installed when the runtime is unreadable', async () => {
     const ws = await workspace()
     await Bun.write(ws.cliPath, CLI_BYTES)
     await Bun.write(ws.agentBakedPath, AGENT_BYTES)
@@ -557,7 +557,29 @@ describe('opencode convergence — idle only', () => {
       ...opencodeSeam(),
       opencodeDepsDir: ws.depsDir,
       readOpencodeVersion: async () => null,
+      opencodeBinaryExists: async () => false,
       turnProbe: async () => false,
+      installOpencode: async (v: string) => {
+        installs.push(v)
+      },
+    })
+
+    expect(result.opencode).toBe('updated')
+    expect(result.reasons?.opencode).toBeUndefined()
+    expect(installs).toEqual(['1.18.19'])
+  })
+
+  test('an existing managed binary is not replaced during a transient unreadable runtime', async () => {
+    const ws = await workspace()
+    await Bun.write(ws.cliPath, CLI_BYTES)
+    await Bun.write(ws.agentBakedPath, AGENT_BYTES)
+    const installs: string[] = []
+
+    const result = await run(ws, stubFetch(), {
+      ...opencodeSeam(),
+      opencodeDepsDir: ws.depsDir,
+      readOpencodeVersion: async () => null,
+      opencodeBinaryExists: async () => true,
       installOpencode: async (v: string) => {
         installs.push(v)
       },

--- a/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
@@ -168,6 +168,8 @@ export interface RuntimeAssetsOptions {
   /** Test seams. The production installer also publishes the stable native link. */
   installOpencode?: (version: string) => Promise<void>
   readOpencodeVersion?: (baseUrl: string) => Promise<string | null>
+  /** Test seam for old snapshots that predate the managed OpenCode link. */
+  opencodeBinaryExists?: () => Promise<boolean>
   turnProbe?: (baseUrl: string, workspace: string) => Promise<boolean | null>
   /** Baked dependency dir holding the `@opencode-ai/plugin` pin. */
   opencodeDepsDir?: string
@@ -1036,20 +1038,36 @@ export async function reconcileRuntimeAssets(
         const readVersion = options.readOpencodeVersion ?? readOpencodeVersion
         const installed = await readVersion(seam.opencodeBaseUrl())
         const pin = await readPluginPin(depsDir)
+        const binaryExists =
+          installed !== null ||
+          (await (options.opencodeBinaryExists ?? (async () => {
+            try {
+              await stat(OPENCODE_CURRENT_LINK)
+              return true
+            } catch {
+              return false
+            }
+          }))())
+        const binaryMissing = installed === null && !binaryExists
         const binaryStale = installed !== null && installed !== expected
         // The pin can drift from the binary on its own — a pass that installed
         // the binary and then failed the pin refresh leaves exactly that — and
         // a pin that does not match makes opencode refetch the plugin on every
         // boot. It is worth one idle-only repair even when the binary is fine.
         const pinStale = pin !== null && pin !== expected
-        if (installed === null) {
+        if (installed === null && !binaryMissing) {
           reasons.opencode = 'opencode did not report its version'
-        } else if (!binaryStale && !pinStale) {
+        } else if (installed !== null && !binaryMissing && !binaryStale && !pinStale) {
           opencode = 'current'
           nextState.opencode_version = installed
         } else {
           const probe = options.turnProbe ?? opencodeTurnInFlight
-          const turnInFlight = await probe(seam.opencodeBaseUrl(), seam.workspace)
+          // A missing managed binary cannot own a turn. Probing its absent
+          // runtime returns "unreadable" forever and previously prevented old
+          // snapshots from ever repairing themselves.
+          const turnInFlight = binaryMissing
+            ? false
+            : await probe(seam.opencodeBaseUrl(), seam.workspace)
           if (turnInFlight !== false) {
             reasons.opencode =
               turnInFlight === null ? 'turn state unreadable' : 'a turn is in flight'
@@ -1060,7 +1078,7 @@ export async function reconcileRuntimeAssets(
             })
           } else {
             const install = options.installOpencode ?? installOpencodeVersion
-            if (binaryStale) await install(expected)
+            if (binaryStale || binaryMissing) await install(expected)
             // SAME STEP as the binary, always. A binary and a plugin that
             // disagree is the state this whole block exists to avoid.
             const pinResult = await refreshOpencodePluginPin(depsDir, expected)
@@ -1070,14 +1088,14 @@ export async function reconcileRuntimeAssets(
             // Only a NEW BINARY needs the process replaced: the plugin is read
             // when opencode boots, so a refreshed pin takes effect on its own at
             // the next start and buys nothing by cutting this one short.
-            if (binaryStale) await seam.restartOpencode()
+            if (binaryStale || binaryMissing) await seam.restartOpencode()
             opencode = 'updated'
             nextState.opencode_version = expected
             logger.info('[runtime-assets] opencode converged', {
               from: installed,
               to: expected,
               pin: pinResult,
-              restarted: binaryStale,
+              restarted: binaryStale || binaryMissing,
             })
           }
         }


### PR DESCRIPTION
## Problem

Existing sandbox disks that predate the managed OpenCode link cannot become ready after a runtime upgrade. Convergence treats an unreadable OpenCode endpoint as transient and skips installation forever.

## Fix

- Detect whether the managed OpenCode link exists.
- Install the manifest version when the link is absent.
- Preserve the idle-only guard for existing binaries with transient unreadable health.
- Add regression coverage for both states.

## Verification

- `bun test`: 832 pass, 0 fail
- `bun run typecheck`: exit 0
- Live recovery: two existing E2B sandbox disks reached `runtimeReady=true` and completed prompts after in-place installation.