### PR TITLE
fix(ci): preserve frontend channel promotion

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,17 @@ linked, not inlined.
 
 ## Register
 
+### A successful surface deploy must not inherit skipped unrelated ancestors (2026-08-24)
+
+**When:** chaining Dev deployment, canonical verification, and self-host channel
+promotion jobs. Add `always()` and assert the direct prerequisite result for
+each post-deploy job. A normal `if:` can inherit a skipped transitive ancestor,
+skip verification, and leave the mutable self-host tag on an older image even
+after the immutable image deployed successfully.
+*Incident:* a Dev frontend deployed a transcript fix, but its DNS verification
+and `:dev` promotion skipped. Self-host frontends kept a stale blank transcript.
+*Enforcer:* `tests/unit/web-ecs-workflow.test.ts` pins the post-deploy conditions.
+
 ### Submit an initial session prompt exactly once (2026-08-23)
 
 **When:** creating a session with `initial_prompt`. Do not submit the same

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -863,7 +863,11 @@ jobs:
   publish-web-ecs-dns:
     name: Publish canonical Dev ECS DNS
     needs: [detect-changes, deploy-web-ecs]
-    if: needs.detect-changes.outputs.frontend == 'true'
+    # `always()` prevents a skipped unrelated ancestor from suppressing this
+    # job after deploy-web-ecs has already succeeded.
+    if: ${{ always()
+      && needs.detect-changes.outputs.frontend == 'true'
+      && needs.deploy-web-ecs.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -891,7 +895,9 @@ jobs:
   verify-web-dev:
     name: Verify canonical Dev frontend on ECS
     needs: [detect-changes, dev-version, publish-web-ecs-dns]
-    if: needs.detect-changes.outputs.frontend == 'true'
+    if: ${{ always()
+      && needs.detect-changes.outputs.frontend == 'true'
+      && needs.publish-web-ecs-dns.result == 'success' }}
     runs-on: ubuntu-latest
     env:
       EXPECTED_COMMIT: ${{ github.sha }}

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -44,6 +44,16 @@ describe('web ECS migration', () => {
     expect(webDeploy).toContain('${{ needs.build-frontend.outputs.image }}');
     expect(workflow).toContain('base=https://dev.kortix.com');
     expect(workflow).toContain('  publish-web-ecs-dns:');
+    const webDnsStart = workflow.indexOf('  publish-web-ecs-dns:');
+    const webDns = workflow.slice(webDnsStart, webVerifyStart);
+    expect(webDns).toContain('if: ${{ always()');
+    expect(webDns).toContain("needs.deploy-web-ecs.result == 'success'");
+    const webVerify = workflow.slice(
+      webVerifyStart,
+      workflow.indexOf('  promote-dev-channel-frontend:'),
+    );
+    expect(webVerify).toContain('if: ${{ always()');
+    expect(webVerify).toContain("needs.publish-web-ecs-dns.result == 'success'");
     expect(workflow).toContain('node infra/scripts/sync-web-dns.mjs dev "$alb"');
     expect(workflow).not.toContain('detach-web-dev-vercel-domain');
     expect(workflow).not.toContain('detach-vercel-web-domain.mjs');


### PR DESCRIPTION
## Problem

A successful frontend build and ECS deployment could still skip canonical DNS verification. GitHub propagated a skipped unrelated ancestor through the post-deploy jobs. The self-host `:dev` tag then remained on an older frontend image.

## Change

- Evaluate the canonical DNS and frontend verification jobs with `always()`.
- Require each direct prerequisite to report `success`.
- Pin both conditions with workflow unit tests.
- Record the incident rule in the learning register.

## Verification

```text
pnpm --filter @kortix/tests exec vitest run --config unit/vitest.config.ts unit/web-ecs-workflow.test.ts unit/dev-channel-promotion-workflow.test.ts
Test Files 2 passed (2)
Tests 14 passed (14)
```