### PR TITLE
The read is the liveness check — stop the session page waiting on a probe

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -4487,6 +4487,11 @@ export function SessionChat({
     // compact "starting" loader for a frame or two before the real chat
     // appeared: the flicker, mid-crossfade.
     hasOptimisticPrompt: promptInbox.prompts.length > 0 || firstPromptPreview !== null,
+    // The session OBJECT arriving is not the transcript arriving — they are two
+    // different requests, and the message read is the one that loses to a
+    // waking box. Without this the shell rendered over an unread session and
+    // the user saw an empty conversation instead of a wait.
+    transcriptLoaded: !syncMessagesLoading,
   });
   // Everything that isn't "we have content" and isn't the terminal not-found
   // state is loading — including the boot window where the query is still

--- a/apps/web/src/features/session/session-load-state.test.ts
+++ b/apps/web/src/features/session/session-load-state.test.ts
@@ -160,3 +160,62 @@ describe('session load state', () => {
     expect(gatedRuntimeError({ phase: 'starting', runtimeError: null })).toBeNull();
   });
 });
+
+describe('resolveSessionContentState — the transcript read, not the session object', () => {
+  const base = {
+    runtimeReady: true,
+    sessionFetched: true,
+    hasRuntimeSession: true,
+    hasMessages: false,
+    hasOptimisticPrompt: false,
+  };
+
+  /**
+   * The blank thread. The session GET is small and lands first; the message
+   * read is the big one and is the one that loses to a waking box. Treating the
+   * first as proof of the second rendered a full shell — header, composer,
+   * empty thread — over a session with a long history.
+   */
+  test('a session object with no transcript read yet is still loading', () => {
+    expect(resolveSessionContentState({ ...base, transcriptLoaded: false })).toEqual({
+      isNotFound: false,
+      isDataLoading: true,
+    });
+  });
+
+  test('a session that really has no messages renders its composer', () => {
+    expect(resolveSessionContentState({ ...base, transcriptLoaded: true })).toEqual({
+      isNotFound: false,
+      isDataLoading: false,
+    });
+  });
+
+  test('messages on screen are never hidden by a pending read', () => {
+    expect(
+      resolveSessionContentState({ ...base, hasMessages: true, transcriptLoaded: false }),
+    ).toEqual({ isNotFound: false, isDataLoading: false });
+  });
+
+  test('an optimistic prompt is content too, read or no read', () => {
+    expect(
+      resolveSessionContentState({ ...base, hasOptimisticPrompt: true, transcriptLoaded: false }),
+    ).toEqual({ isNotFound: false, isDataLoading: false });
+  });
+
+  test('a caller that does not track the read keeps the old rule', () => {
+    expect(resolveSessionContentState(base)).toEqual({
+      isNotFound: false,
+      isDataLoading: false,
+    });
+  });
+
+  test('not-found still wins — there is no session to wait for', () => {
+    expect(
+      resolveSessionContentState({
+        ...base,
+        hasRuntimeSession: false,
+        transcriptLoaded: false,
+      }),
+    ).toEqual({ isNotFound: true, isDataLoading: false });
+  });
+});

--- a/apps/web/src/features/session/session-load-state.ts
+++ b/apps/web/src/features/session/session-load-state.ts
@@ -67,12 +67,36 @@ export function resolveSessionContentState(input: {
   hasRuntimeSession: boolean;
   hasMessages: boolean;
   hasOptimisticPrompt: boolean;
+  /**
+   * A message read has SUCCEEDED for this session — `useSessionSync`'s
+   * `isLoading === false`, which the store sets only when an authoritative read
+   * lands.
+   *
+   * Without this, "the session object exists" was taken as proof the
+   * conversation had been read, and those are two different requests. The
+   * session GET is small and lands first; the message read is the big one and
+   * is the one that loses to a waking box. When it lost, the page rendered the
+   * full shell — header, composer, empty thread — over a session with a long
+   * history, and the user saw an EMPTY CONVERSATION rather than a wait
+   * (screenshot, essentia 2026-08-24: composer live, thread blank, runtime
+   * terminal holding the whole session).
+   *
+   * Optional so existing callers keep their behaviour; `undefined` means the
+   * caller does not track it and the old rule applies.
+   */
+  transcriptLoaded?: boolean;
 }) {
   const sessionResolved = input.runtimeReady && input.sessionFetched;
   const isNotFound =
     !input.hasRuntimeSession && sessionResolved && !input.hasMessages && !input.hasOptimisticPrompt;
+  // Nothing to paint AND nothing read yet. Either half alone is not enough:
+  // a session with zero messages that HAS been read is genuinely empty and must
+  // render its composer, and a session whose read has not landed must wait
+  // however complete the rest of its metadata looks.
+  const nothingToPaint = !input.hasMessages && !input.hasOptimisticPrompt;
+  const readOutstanding = input.transcriptLoaded === false;
   const isDataLoading =
-    !input.hasRuntimeSession && !isNotFound && !input.hasMessages && !input.hasOptimisticPrompt;
+    !isNotFound && nothingToPaint && (!input.hasRuntimeSession || readOutstanding);
 
   return { isNotFound, isDataLoading };
 }

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,36 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `reconcile-on-eviction` — close the hole the IndexedDB removal named — DONE
+
+**Files:** `core/session-sync/fragment.ts` (NEW — `transcriptIsFragment`) +
+`fragment.test.ts` (4 tests) · `core/session-sync/session-sync-controller.ts`
+(`SessionSyncReason` += `eviction`) · `react/use-session-sync.ts` (subscribes
+and repairs).
+
+**What.** `5a7a43517f` removed the IndexedDB transcript mirror and said so in
+its own message: "#6146 evicts a detached session's transcript, and a session
+evicted while its agent runs comes back from SSE as a fragment; that repaint is
+gone here and no reconcile is keyed on eviction, so an evicted-then-refilled
+session can sit on a partial transcript until a reload. This PR does not address
+that; it should land with, or before, a reconcile-on-eviction fix." It landed
+without one. Reported the same day from live sessions: transcript blank or
+starting mid-conversation while the runtime held everything.
+
+**Fix.** The store already carries the exact signature. Eviction drops the
+messages AND marks the id; every authoritative re-establishment — `hydrate`,
+`clearSession`, `optimisticAdd` — clears the mark, and `applyEvent` does not. So
+messages present while the mark is still set can only have come from frames that
+arrived after the eviction: a fragment, by construction. `transcriptIsFragment`
+names that, and `useSessionSync` subscribes to the store rather than checking
+once, because the refill happens while the component is already mounted. The
+successful read disarms it — `hydrate` clears the mark.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` 2460 pass / 0 fail ·
+`smoke:install` passed · apps/web tsc clean, session suite 2517 pass / 0 fail.
+
+---
+
 ### 2026-08-24 — session `transcript-convergence` — the transcript must catch up, and five things stopped it — DONE
 
 **Files:** `core/session-sync/session-sync-controller.ts` (turn-end reconcile,

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -54,7 +54,18 @@ empty thread — over a long history. It now takes `transcriptLoaded` (the sync
 hook's `isLoading`, which flips only when an authoritative read lands) and waits
 for the read rather than for the metadata.
 
-**Gates:** `typecheck` clean (both projects) · `pnpm test` 2464 pass / 0 fail ·
+**And the blank thread whose read returned 200.** `loadCompleteTurn` walks
+BACKWARDS 50 messages at a time until every assistant message has its parent
+user message, and `hydrate` ran only after that walk finished. A session whose
+last turn is thousands of messages — an agent run with hundreds of tool calls,
+463K tokens — therefore paged the WHOLE session serially through the sandbox
+proxy before painting one pixel. The read succeeds the entire time, which is
+exactly why it read as a rendering bug. Now the first page paints immediately,
+each backfill page repaints on top of it, and the walk is bounded to
+`MAX_TURN_BACKFILL_PAGES` (10 = 500 messages) with the cursor preserved so
+"load older" still reaches the rest.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` 2467 pass / 0 fail ·
 apps/web tsc clean, session suite 2523 pass / 0 fail.
 
 ---

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -46,8 +46,16 @@ waits for the probe: it starts as soon as the sandbox is known, because THE READ
 IS THE LIVENESS CHECK. Readiness is a byproduct of asking for what we wanted
 anyway, not a precondition for asking.
 
+**And the last blank.** The session OBJECT arriving is not the transcript
+arriving — two different requests, and the message read is the one that loses.
+`resolveSessionContentState` treated the first as proof of the second, so a
+session whose read had not landed rendered the full shell — header, composer,
+empty thread — over a long history. It now takes `transcriptLoaded` (the sync
+hook's `isLoading`, which flips only when an authoritative read lands) and waits
+for the read rather than for the metadata.
+
 **Gates:** `typecheck` clean (both projects) · `pnpm test` 2464 pass / 0 fail ·
-apps/web tsc clean, session suite 2517 pass / 0 fail.
+apps/web tsc clean, session suite 2523 pass / 0 fail.
 
 ---
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,45 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `read-is-the-liveness-check` — a session page must never wait on a probe — DONE
+
+**Files:** `core/session-sync/session-sync-controller.ts` (`markLoaded` on
+SUCCESS only; `scheduleTailRetry` with backoff; destroy cancels it) + tests
+(+4, one replaced) · `react/use-session-sync.ts` (the initial read no longer
+waits for `runtimeHealthy`).
+
+**What.** Two screenshots, same page: the SIDEBAR showed a session live with a
+green dot while the MAIN PANE sat on "Waking the agent — this is taking longer
+than usual". Elsewhere, a session opened completely blank while its runtime
+terminal held the whole conversation.
+
+One mechanism under both. `resolveSessionContentState` keeps the web app on its
+loader while there are no messages, and exactly one thing produces messages:
+`reconcile('initial')`. That read was gated on `runtimeHealthy === true`. So the
+page's only exit from the loader was a health probe — and a box that is up while
+failing its probe (loaded, mid-turn, slow) shows a spinner over a session that
+could have been read the whole time. The sidebar reads the session list instead,
+which is why one page gave two answers.
+
+The blank came from the same function, eight lines away. `markLoaded` ran in a
+`finally`, so a read that FAILED still told the store the session was loaded —
+and the store plants an empty message list for that. A first read losing to a
+waking box therefore RECORDED "this session has no messages", the UI painted an
+empty conversation, and nothing came back: the mount had run, and the liveness
+poll only turns on while a session is working.
+
+**Fix.** `markLoaded` on success only — a successful read of zero messages is a
+fact about the session, a failed read is a fact about nothing. Failures schedule
+a retry with backoff (1s -> 15s cap) until one lands. And the read no longer
+waits for the probe: it starts as soon as the sandbox is known, because THE READ
+IS THE LIVENESS CHECK. Readiness is a byproduct of asking for what we wanted
+anyway, not a precondition for asking.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` 2464 pass / 0 fail ·
+apps/web tsc clean, session suite 2517 pass / 0 fail.
+
+---
+
 ### 2026-08-24 — session `reconcile-on-eviction` — close the hole the IndexedDB removal named — DONE
 
 **Files:** `core/session-sync/fragment.ts` (NEW — `transcriptIsFragment`) +

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -54,16 +54,27 @@ empty thread — over a long history. It now takes `transcriptLoaded` (the sync
 hook's `isLoading`, which flips only when an authoritative read lands) and waits
 for the read rather than for the metadata.
 
-**And the blank thread whose read returned 200.** `loadCompleteTurn` walks
-BACKWARDS 50 messages at a time until every assistant message has its parent
-user message, and `hydrate` ran only after that walk finished. A session whose
-last turn is thousands of messages — an agent run with hundreds of tool calls,
-463K tokens — therefore paged the WHOLE session serially through the sandbox
-proxy before painting one pixel. The read succeeds the entire time, which is
-exactly why it read as a rendering bug. Now the first page paints immediately,
-each backfill page repaints on top of it, and the walk is bounded to
-`MAX_TURN_BACKFILL_PAGES` (10 = 500 messages) with the cursor preserved so
-"load older" still reaches the rest.
+**And the blank thread whose reads ALL returned 200.** Measured from the
+network panel (essentia, a run with hundreds of image reads):
+
+```
+message?limit=50            200   8,228 kB   30.39 s
+message?limit=50            200  24,460 kB   48.76 s
+message?limit=50&before=..  200  20,284 kB   35.74 s
+message?limit=50&before=..  200  25,125 kB   29.23 s
+-> 78,097 kB transferred, finish 3.8 min, NOTHING on screen
+```
+
+Fifty messages weigh 8-25 MB because the parts carry image bytes. The tail read
+kept walking backwards until every assistant message had its parent prompt in
+hand — so an assistant reply could never render above its own prompt — and
+`hydrate` ran only when that walk ENDED. On a long turn the walk is the whole
+session, serially, through the sandbox proxy.
+
+The tail is now ONE page, rendered — what OpenCode's own client does. The window
+may start on an assistant whose prompt is a page up; that is what OpenCode shows
+too, and `loadOlder` (user-driven) still completes the turn, bounded by
+`MAX_TURN_BACKFILL_PAGES`.
 
 **Gates:** `typecheck` clean (both projects) · `pnpm test` 2467 pass / 0 fail ·
 apps/web tsc clean, session suite 2523 pass / 0 fail.

--- a/packages/sdk/src/core/session-sync/fragment.test.ts
+++ b/packages/sdk/src/core/session-sync/fragment.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import { transcriptIsFragment } from './fragment';
+
+/**
+ * The hole the IndexedDB removal (5a7a43517f) named and did not close:
+ *
+ *   "a session evicted while its agent runs comes back from SSE as a fragment;
+ *    that repaint is gone here and no reconcile is keyed on eviction, so an
+ *    evicted-then-refilled session can sit on a partial transcript until a
+ *    reload."
+ *
+ * The store already carries the exact signature. Eviction drops a detached
+ * session's messages AND marks the id; every path that re-establishes the
+ * session authoritatively — `hydrate`, `clearSession`, `optimisticAdd` — clears
+ * the mark. `applyEvent` does NOT. So a session that HOLDS MESSAGES while still
+ * MARKED EVICTED was refilled by the live stream alone: it has the frames that
+ * arrived since eviction and nothing before them. That is a fragment, by
+ * construction, and it is the one state a tail read must repair.
+ */
+describe('transcriptIsFragment', () => {
+  test('messages rebuilt by the stream after an eviction are a fragment', () => {
+    expect(transcriptIsFragment({ hasMessages: true, wasEvicted: true })).toBe(true);
+  });
+
+  test('an evicted session holding nothing is empty, not partial', () => {
+    // Nothing to repair and nothing to mislead: the mount path loads the tail.
+    expect(transcriptIsFragment({ hasMessages: false, wasEvicted: true })).toBe(false);
+  });
+
+  test('an authoritative load is never a fragment — hydrate clears the mark', () => {
+    expect(transcriptIsFragment({ hasMessages: true, wasEvicted: false })).toBe(false);
+  });
+
+  test('a session nobody ever evicted is never a fragment', () => {
+    expect(transcriptIsFragment({ hasMessages: false, wasEvicted: false })).toBe(false);
+  });
+});

--- a/packages/sdk/src/core/session-sync/fragment.ts
+++ b/packages/sdk/src/core/session-sync/fragment.ts
@@ -1,0 +1,28 @@
+/**
+ * Is this session's transcript a FRAGMENT — messages the live stream rebuilt
+ * after an eviction, with everything before them missing?
+ *
+ * The sync store already carries the exact signature, in two pieces:
+ *
+ *   - eviction drops a detached session's messages and MARKS the id
+ *   - every path that re-establishes the session authoritatively — `hydrate`,
+ *     `clearSession`, `optimisticAdd` — CLEARS that mark
+ *   - `applyEvent`, the live stream's own path, does not
+ *
+ * So messages present while the mark is still set can only have come from
+ * frames that arrived after the eviction. The transcript starts mid-conversation
+ * and nothing else will correct it: the mount already ran, so no `initial` read
+ * is coming, and the liveness poll only runs while the session is working.
+ *
+ * Named and left open by 5a7a43517f, which removed the IndexedDB mirror that
+ * used to repaint underneath such a fragment: "no reconcile is keyed on
+ * eviction … can sit on a partial transcript until a reload."
+ */
+export function transcriptIsFragment(input: {
+  /** The store holds at least one message for this session. */
+  hasMessages: boolean;
+  /** The store still marks this session's transcript as evicted. */
+  wasEvicted: boolean;
+}): boolean {
+  return input.hasMessages && input.wasEvicted;
+}

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -48,6 +48,10 @@ function messagePage(
 function createScheduler() {
   let now = 0;
   let callback: (() => void) | undefined;
+  // Timeouts too, so the retry backoff is driven by the fake clock rather than
+  // falling through to the real one.
+  let nextTimeoutId = 2;
+  const timeouts = new Map<number, { dueAt: number; run: () => void }>();
   const scheduler: SessionSyncScheduler = {
     now: () => now,
     setInterval: (next) => {
@@ -57,11 +61,24 @@ function createScheduler() {
     clearInterval: () => {
       callback = undefined;
     },
+    setTimeout: (next, ms) => {
+      const id = nextTimeoutId++;
+      timeouts.set(id, { dueAt: now + ms, run: next });
+      return id;
+    },
+    clearTimeout: (handle) => {
+      timeouts.delete(handle as number);
+    },
   };
   return {
     scheduler,
     advance(ms: number) {
       now += ms;
+      for (const [id, timer] of [...timeouts]) {
+        if (timer.dueAt > now) continue;
+        timeouts.delete(id);
+        timer.run();
+      }
       callback?.();
     },
   };
@@ -552,7 +569,13 @@ describe('SessionSyncController', () => {
     expect('isPromptObservedBusy' in controller.getSnapshot()).toBe(false);
   });
 
-  test('marks an empty or failed initial read as loaded', async () => {
+  /**
+   * REPLACES "marks an empty or failed initial read as loaded", which encoded
+   * the bug: a failed read told the store the session was loaded, and the
+   * store's implementation of that plants an empty message list. Loading is a
+   * claim about the SESSION; a read that never landed supports no claim at all.
+   */
+  test('a start that never reaches the runtime resolves without claiming the session is empty', async () => {
     let loaded = 0;
     const controller = new SessionSyncController({
       sessionId: 'session-1',
@@ -566,11 +589,12 @@ describe('SessionSyncController', () => {
     });
 
     await expect(controller.start()).resolves.toBeUndefined();
-    expect(loaded).toBe(1);
+    expect(loaded).toBe(0);
     expect(controller.getSnapshot()).toMatchObject({
       freshness: 'error',
       hasOlder: false,
     });
+    controller.destroy();
   });
 
   test('retains the older-page cursor after a transient tail failure', async () => {
@@ -721,5 +745,112 @@ describe('SessionSyncController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(reasons).toEqual([]);
+  });
+
+  /**
+   * The blank transcript, and it was eight lines away from the spinner that
+   * never ends.
+   *
+   * `markLoaded` ran in a `finally`, so a tail read that FAILED still told the
+   * store "this session is loaded" — and the registry's implementation of that
+   * plants an empty message list. A first read that lost to a waking box, a
+   * 503 from the proxy, or a flapping probe therefore RECORDED the session as
+   * having no messages. The UI then painted an empty conversation, and nothing
+   * came back for it: the mount already ran, and the liveness poll only turns
+   * on while a session is working.
+   */
+  test('a failed tail read is never recorded as an empty transcript', async () => {
+    const clock = createScheduler();
+    let loaded = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        throw new Error('sandbox waking');
+      },
+      hydrate: () => {},
+      markLoaded: () => {
+        loaded += 1;
+      },
+      scheduler: clock.scheduler,
+      livenessIntervalMs: 10_000,
+    });
+
+    await controller.reconcile('initial');
+
+    expect(loaded).toBe(0);
+    expect(controller.getSnapshot().freshness).toBe('error');
+  });
+
+  test('a successful read with no messages IS a loaded, empty session', async () => {
+    const clock = createScheduler();
+    let loaded = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => page([]),
+      hydrate: () => {},
+      markLoaded: () => {
+        loaded += 1;
+      },
+      scheduler: clock.scheduler,
+    });
+
+    await controller.reconcile('initial');
+
+    expect(loaded).toBe(1);
+    expect(controller.getSnapshot().freshness).toBe('fresh');
+  });
+
+  /**
+   * And the second half: one shot was all a session ever got. The read that
+   * loses to a waking sandbox has to come back on its own, or the page waits
+   * for a health probe it does not control.
+   */
+  test('a failed read retries on its own until it lands', async () => {
+    const clock = createScheduler();
+    let attempts = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        attempts += 1;
+        if (attempts < 3) throw new Error('sandbox waking');
+        return messagePage([{ id: 'user-1', role: 'user' }]);
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+      scheduler: clock.scheduler,
+    });
+
+    await controller.reconcile('initial');
+    expect(attempts).toBe(1);
+
+    for (let i = 0; i < 6 && attempts < 3; i++) {
+      clock.advance(30_000);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(attempts).toBe(3);
+    expect(controller.getSnapshot().freshness).toBe('fresh');
+  });
+
+  test('a destroyed controller stops retrying', async () => {
+    const clock = createScheduler();
+    let attempts = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        attempts += 1;
+        throw new Error('gone');
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+      scheduler: clock.scheduler,
+    });
+
+    await controller.reconcile('initial');
+    controller.destroy();
+    clock.advance(120_000);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(attempts).toBe(1);
   });
 });

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -8,6 +8,7 @@ import {
   type SessionSyncControllerOptions,
   type SessionSyncPage,
   type SessionSyncReason,
+  MAX_TURN_BACKFILL_PAGES,
   type SessionSyncScheduler,
 } from './session-sync-controller';
 
@@ -265,15 +266,17 @@ describe('SessionSyncController', () => {
       { limit: SESSION_SYNC_PAGE_SIZE, before: 'cursor-1' },
       { limit: SESSION_SYNC_PAGE_SIZE, before: 'cursor-2' },
     ]);
-    expect(hydrated).toEqual([
-      [
-        'user-only',
-        'assistant-new-0',
-        'assistant-new-1',
-        'assistant-new-2',
-        'assistant-new-3',
-        'assistant-new-4',
-      ],
+    // The first page paints IMMEDIATELY and each backfill page repaints on top
+    // of it — a long turn fills in front of the user instead of withholding
+    // everything until the walk ends. What matters is where it lands.
+    expect(hydrated[0]).toEqual(['assistant-new-3', 'assistant-new-4']);
+    expect(hydrated.at(-1)).toEqual([
+      'user-only',
+      'assistant-new-0',
+      'assistant-new-1',
+      'assistant-new-2',
+      'assistant-new-3',
+      'assistant-new-4',
     ]);
     expect(controller.getSnapshot()).toMatchObject({
       freshness: 'fresh',
@@ -852,5 +855,103 @@ describe('SessionSyncController', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(attempts).toBe(1);
+  });
+  /**
+   * The blank thread on a HUGE session, and the read returned 200 the whole
+   * time.
+   *
+   * `loadCompleteTurn` walks BACKWARDS 50 messages at a time until every
+   * assistant message has its parent user message, and `hydrate` used to run
+   * only after that walk finished. A session whose last turn is thousands of
+   * messages — the ArcGIS run: hundreds of image reads, 463K tokens — therefore
+   * painted NOTHING for as many sequential round trips as the turn was long,
+   * each one proxied through the sandbox. Minutes of empty thread over a
+   * successful read.
+   *
+   * Paint what arrived, then keep filling.
+   */
+  test('the first page paints before the turn is complete', async () => {
+    const hydrated: string[][] = [];
+    let pages = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        pages += 1;
+        // Every page is an orphan assistant, so the walk never satisfies itself.
+        return {
+          messages: [
+            {
+              info: { id: `assistant-${pages}`, role: 'assistant', parentID: 'user-far-back' },
+              parts: [],
+            },
+          ],
+          nextCursor: `cursor-${pages}`,
+        } as unknown as SessionSyncPage;
+      },
+      hydrate: (messages) => hydrated.push(messages.map((message) => message.info.id)),
+      markLoaded: () => {},
+    });
+
+    await controller.reconcile('initial');
+
+    expect(hydrated.length).toBeGreaterThan(1);
+    expect(hydrated[0]).toEqual(['assistant-1']);
+    controller.destroy();
+  });
+
+  test('the backward walk is bounded — a pathological turn cannot page forever', async () => {
+    let pages = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        pages += 1;
+        return {
+          messages: [
+            {
+              info: { id: `assistant-${pages}`, role: 'assistant', parentID: 'user-far-back' },
+              parts: [],
+            },
+          ],
+          nextCursor: `cursor-${pages}`,
+        } as unknown as SessionSyncPage;
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+    });
+
+    await controller.reconcile('initial');
+
+    expect(pages).toBeLessThanOrEqual(MAX_TURN_BACKFILL_PAGES + 1);
+    // The rest stays reachable: the cursor survives for "load older".
+    expect(controller.getSnapshot().hasOlder).toBe(true);
+    controller.destroy();
+  });
+
+  test('a turn that completes early stops paging', async () => {
+    let pages = 0;
+    const controller = new SessionSyncController({
+      sessionId: 'session-1',
+      loadPage: async () => {
+        pages += 1;
+        return pages === 1
+          ? ({
+              messages: [
+                { info: { id: 'assistant-1', role: 'assistant', parentID: 'user-1' }, parts: [] },
+              ],
+              nextCursor: 'cursor-1',
+            } as unknown as SessionSyncPage)
+          : ({
+              messages: [{ info: { id: 'user-1', role: 'user' }, parts: [] }],
+              nextCursor: undefined,
+            } as unknown as SessionSyncPage);
+      },
+      hydrate: () => {},
+      markLoaded: () => {},
+    });
+
+    await controller.reconcile('initial');
+
+    expect(pages).toBe(2);
+    controller.destroy();
   });
 });

--- a/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.test.ts
@@ -259,25 +259,31 @@ describe('SessionSyncController', () => {
       markLoaded: () => {},
     });
 
+    // The TAIL is one page — see `loadTail`. Completing the turn is what the
+    // user drives by scrolling up, and that is where the walk lives now.
     await controller.start();
+    expect(requests).toEqual([{ limit: SESSION_SYNC_PAGE_SIZE }]);
+
+    await controller.loadOlder();
 
     expect(requests).toEqual([
       { limit: SESSION_SYNC_PAGE_SIZE },
       { limit: SESSION_SYNC_PAGE_SIZE, before: 'cursor-1' },
       { limit: SESSION_SYNC_PAGE_SIZE, before: 'cursor-2' },
     ]);
-    // The first page paints IMMEDIATELY and each backfill page repaints on top
-    // of it — a long turn fills in front of the user instead of withholding
-    // everything until the walk ends. What matters is where it lands.
+    // The tail paints first, then the older walk hydrates what it completed —
+    // the store merges the two, so the union is the whole turn.
     expect(hydrated[0]).toEqual(['assistant-new-3', 'assistant-new-4']);
-    expect(hydrated.at(-1)).toEqual([
-      'user-only',
-      'assistant-new-0',
-      'assistant-new-1',
-      'assistant-new-2',
-      'assistant-new-3',
-      'assistant-new-4',
-    ]);
+    expect(new Set(hydrated.flat())).toEqual(
+      new Set([
+        'user-only',
+        'assistant-new-0',
+        'assistant-new-1',
+        'assistant-new-2',
+        'assistant-new-3',
+        'assistant-new-4',
+      ]),
+    );
     expect(controller.getSnapshot()).toMatchObject({
       freshness: 'fresh',
       hasOlder: false,
@@ -857,27 +863,31 @@ describe('SessionSyncController', () => {
     expect(attempts).toBe(1);
   });
   /**
-   * The blank thread on a HUGE session, and the read returned 200 the whole
-   * time.
+   * The blank thread on a HUGE session, and every read returned 200.
    *
-   * `loadCompleteTurn` walks BACKWARDS 50 messages at a time until every
-   * assistant message has its parent user message, and `hydrate` used to run
-   * only after that walk finished. A session whose last turn is thousands of
-   * messages — the ArcGIS run: hundreds of image reads, 463K tokens — therefore
-   * painted NOTHING for as many sequential round trips as the turn was long,
-   * each one proxied through the sandbox. Minutes of empty thread over a
-   * successful read.
+   * Measured on essentia (2026-08-24), a run with hundreds of image reads:
    *
-   * Paint what arrived, then keep filling.
+   *   message?limit=50            200   8,228 kB   30.39 s
+   *   message?limit=50            200  24,460 kB   48.76 s
+   *   message?limit=50&before=..  200  20,284 kB   35.74 s
+   *   message?limit=50&before=..  200  25,125 kB   29.23 s
+   *   -> 78,097 kB transferred, finish 3.8 min, nothing on screen
+   *
+   * Fifty messages weigh megabytes because the parts carry image bytes, and the
+   * tail read used to keep walking backwards until every assistant message had
+   * its parent prompt — hydrating only when that walk ENDED.
+   *
+   * One page. Render it. However long the turn is.
    */
-  test('the first page paints before the turn is complete', async () => {
+  test('the tail is exactly one request, however long the turn', async () => {
     const hydrated: string[][] = [];
     let pages = 0;
     const controller = new SessionSyncController({
       sessionId: 'session-1',
       loadPage: async () => {
         pages += 1;
-        // Every page is an orphan assistant, so the walk never satisfies itself.
+        // An orphan assistant: the old walk would have chased its prompt
+        // through the whole session before painting anything.
         return {
           messages: [
             {
@@ -894,12 +904,14 @@ describe('SessionSyncController', () => {
 
     await controller.reconcile('initial');
 
-    expect(hydrated.length).toBeGreaterThan(1);
-    expect(hydrated[0]).toEqual(['assistant-1']);
+    expect(pages).toBe(1);
+    expect(hydrated).toEqual([['assistant-1']]);
+    // The rest stays reachable — the cursor survives for "load older".
+    expect(controller.getSnapshot().hasOlder).toBe(true);
     controller.destroy();
   });
 
-  test('the backward walk is bounded — a pathological turn cannot page forever', async () => {
+  test('the walk the user drives is still bounded', async () => {
     let pages = 0;
     const controller = new SessionSyncController({
       sessionId: 'session-1',
@@ -919,10 +931,11 @@ describe('SessionSyncController', () => {
       markLoaded: () => {},
     });
 
-    await controller.reconcile('initial');
+    await controller.start();
+    await controller.loadOlder();
 
-    expect(pages).toBeLessThanOrEqual(MAX_TURN_BACKFILL_PAGES + 1);
-    // The rest stays reachable: the cursor survives for "load older".
+    // 1 tail page + at most MAX_TURN_BACKFILL_PAGES of turn completion.
+    expect(pages).toBeLessThanOrEqual(MAX_TURN_BACKFILL_PAGES + 2);
     expect(controller.getSnapshot().hasOlder).toBe(true);
     controller.destroy();
   });
@@ -949,7 +962,8 @@ describe('SessionSyncController', () => {
       markLoaded: () => {},
     });
 
-    await controller.reconcile('initial');
+    await controller.start();
+    await controller.loadOlder();
 
     expect(pages).toBe(2);
     controller.destroy();

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -10,6 +10,11 @@ import type { Message, Part, SessionStatus } from '@opencode-ai/sdk/v2/client';
  * fully loaded and never pull at all, while a long one still opens bounded
  * instead of dragging its entire history over the sandbox proxy.
  */
+/** First retry delay after a failed tail read. */
+const TAIL_RETRY_BASE_MS = 1_000;
+/** Ceiling for the retry backoff — a box that comes back is picked up within it. */
+const TAIL_RETRY_MAX_MS = 15_000;
+
 export const SESSION_SYNC_PAGE_SIZE = 50;
 
 export type SessionSyncFreshness = 'idle' | 'loading' | 'fresh' | 'stale' | 'error';
@@ -230,6 +235,9 @@ export class SessionSyncController {
   private readonly options: SessionSyncControllerOptions;
   private readonly scheduler: SessionSyncScheduler;
   private readonly livenessIntervalMs: number;
+  /** Consecutive failed tail reads, for the retry backoff. Reset by success. */
+  private retryAttempt = 0;
+  private tailRetryTimer: unknown;
   private snapshot: SessionSyncSnapshot = {
     freshness: 'idle',
     hasOlder: false,
@@ -343,6 +351,10 @@ export class SessionSyncController {
     // torn down must not start a request it can never hydrate.
     this.destroyed = true;
     this.stopLivenessTimer();
+    if (this.tailRetryTimer !== undefined) {
+      this.cancelTimer(this.tailRetryTimer);
+      this.tailRetryTimer = undefined;
+    }
     this.listeners.clear();
   }
 
@@ -357,13 +369,49 @@ export class SessionSyncController {
         this.setCursor(page.nextCursor);
       }
       this.update({ freshness: 'fresh' });
+      // SUCCESS ONLY. `markLoaded` used to sit in a `finally`, so a read that
+      // FAILED still told the store this session was loaded — and the store's
+      // implementation of that plants an empty message list. A first read that
+      // lost to a waking box, a 503 from the proxy, or a flapping probe was
+      // therefore RECORDED as "this session has no messages", and the UI
+      // painted an empty conversation over a session that had plenty. Nothing
+      // came back for it either: the mount had already run, and the liveness
+      // poll only turns on while a session is working.
+      //
+      // A successful read of zero messages still marks loaded — that is a fact
+      // about the session. A failed read is not a fact about anything.
+      this.options.markLoaded();
+      this.retryAttempt = 0;
     } catch {
-      if (!this.destroyed) {
-        this.update({ freshness: 'error' });
-      }
-    } finally {
-      if (!this.destroyed) this.options.markLoaded();
+      if (this.destroyed) return;
+      this.update({ freshness: 'error' });
+      this.scheduleTailRetry(reason);
     }
+  }
+
+  /**
+   * Come back for a read that lost.
+   *
+   * Without this a session got exactly ONE chance to load, and whether it took
+   * it depended on a race with the sandbox's boot. Losing that race left the
+   * page on "Waking the agent" with no exit but the health probe — the least
+   * reliable signal in the system — or a manual reload.
+   *
+   * Backoff so a genuinely dead box costs little, capped so a box that comes
+   * back is picked up promptly.
+   */
+  private scheduleTailRetry(reason: SessionSyncReason): void {
+    if (this.destroyed || this.tailRetryTimer !== undefined) return;
+    const delay = Math.min(
+      TAIL_RETRY_BASE_MS * 2 ** this.retryAttempt,
+      TAIL_RETRY_MAX_MS,
+    );
+    this.retryAttempt += 1;
+    this.tailRetryTimer = this.startTimer(() => {
+      this.tailRetryTimer = undefined;
+      if (this.destroyed) return;
+      void this.reconcile(reason);
+    }, delay);
   }
 
   private async loadPage(

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -376,22 +376,33 @@ export class SessionSyncController {
 
   private async loadTail(reason: SessionSyncReason): Promise<void> {
     try {
-      const firstPage = await this.loadPage('tail', reason);
+      // ONE PAGE. Render it. This is what OpenCode's own client does, and the
+      // reason we now do it too is measured:
+      //
+      //   message?limit=50            200   8,228 kB   30.39 s
+      //   message?limit=50            200  24,460 kB   48.76 s
+      //   message?limit=50&before=..  200  20,284 kB   35.74 s
+      //   message?limit=50&before=..  200  25,125 kB   29.23 s
+      //   -> 78,097 kB transferred, finish 3.8 min, NOTHING on screen
+      //
+      // (essentia, 2026-08-24, a run with hundreds of image reads: fifty
+      // messages weigh 8-25 MB because the parts carry the image bytes.)
+      //
+      // There used to be a backward WALK here that kept fetching pages until
+      // every assistant message had its parent user message in hand, so an
+      // assistant reply could never render above its own prompt — and `hydrate`
+      // ran only after the walk finished. On a long turn that walk is the whole
+      // session, serially, through the sandbox proxy, with an empty thread the
+      // entire time. A cosmetic guarantee at the top edge of the window is not
+      // worth minutes of blank screen.
+      //
+      // The window may therefore start on an assistant message whose prompt is
+      // one page up. That is exactly what OpenCode shows, and `loadOlder` —
+      // which the user drives — still completes the turn when they scroll.
+      const page = await this.loadPage('tail', reason);
       if (this.destroyed) return;
-      // PAINT WHAT ARRIVED, then keep filling. Hydration used to wait for the
-      // whole backward walk below, so a long turn showed an empty thread for as
-      // many round trips as the turn was long.
-      this.rememberUserMessages(firstPage.messages);
-      this.options.hydrate(firstPage.messages);
-      // Each backfill page repaints as it lands, so the final set is already on
-      // screen when the walk ends — no closing hydrate, and a single-page tail
-      // hydrates exactly once.
-      const page = await this.loadCompleteTurn(firstPage, 'tail', reason, undefined, (partial) => {
-        if (this.destroyed) return;
-        this.rememberUserMessages(partial);
-        this.options.hydrate(partial);
-      });
-      if (this.destroyed) return;
+      this.rememberUserMessages(page.messages);
+      this.options.hydrate(page.messages);
       if (!this.olderHistoryStarted) {
         this.setCursor(page.nextCursor);
       }

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -17,6 +17,22 @@ const TAIL_RETRY_MAX_MS = 15_000;
 
 export const SESSION_SYNC_PAGE_SIZE = 50;
 
+/**
+ * How far back the tail read will walk to complete a turn before it stops and
+ * leaves the rest to "load older".
+ *
+ * The walk exists so an assistant message is not rendered above its own prompt.
+ * It had no ceiling, and a session whose last turn is thousands of messages —
+ * an agent run with hundreds of tool calls — therefore paged the WHOLE session
+ * 50 at a time, serially, through the sandbox proxy, before painting anything.
+ * The read returns 200 the entire time, which is why this looked like a bug in
+ * rendering rather than in loading.
+ *
+ * 10 pages = 500 messages, far past any honest turn, and the cursor survives so
+ * nothing becomes unreachable.
+ */
+export const MAX_TURN_BACKFILL_PAGES = 10;
+
 export type SessionSyncFreshness = 'idle' | 'loading' | 'fresh' | 'stale' | 'error';
 
 export interface SessionSyncMessage {
@@ -361,10 +377,21 @@ export class SessionSyncController {
   private async loadTail(reason: SessionSyncReason): Promise<void> {
     try {
       const firstPage = await this.loadPage('tail', reason);
-      const page = await this.loadCompleteTurn(firstPage, 'tail', reason);
       if (this.destroyed) return;
-      this.rememberUserMessages(page.messages);
-      this.options.hydrate(page.messages);
+      // PAINT WHAT ARRIVED, then keep filling. Hydration used to wait for the
+      // whole backward walk below, so a long turn showed an empty thread for as
+      // many round trips as the turn was long.
+      this.rememberUserMessages(firstPage.messages);
+      this.options.hydrate(firstPage.messages);
+      // Each backfill page repaints as it lands, so the final set is already on
+      // screen when the walk ends — no closing hydrate, and a single-page tail
+      // hydrates exactly once.
+      const page = await this.loadCompleteTurn(firstPage, 'tail', reason, undefined, (partial) => {
+        if (this.destroyed) return;
+        this.rememberUserMessages(partial);
+        this.options.hydrate(partial);
+      });
+      if (this.destroyed) return;
       if (!this.olderHistoryStarted) {
         this.setCursor(page.nextCursor);
       }
@@ -455,11 +482,13 @@ export class SessionSyncController {
     operation: 'tail' | 'older',
     reason: SessionSyncReason,
     initialCursor?: string,
+    onPage?: (messagesSoFar: SessionSyncMessage[]) => void,
   ): Promise<SessionSyncPage> {
     const messages = [...firstPage.messages];
     const knownUserMessageIds = new Set(this.knownUserMessageIds);
     const seenCursors = new Set(initialCursor ? [initialCursor] : []);
     let cursor = firstPage.nextCursor;
+    let pagesRead = 0;
 
     for (const message of firstPage.messages) {
       if (message.info.role === 'user') {
@@ -469,6 +498,9 @@ export class SessionSyncController {
 
     while (
       cursor &&
+      // BOUNDED. Without a ceiling a turn of a few thousand messages paged the
+      // whole session before anything rendered — see MAX_TURN_BACKFILL_PAGES.
+      pagesRead < MAX_TURN_BACKFILL_PAGES &&
       messages.some(
         (message) =>
           message.info.role === 'assistant' &&
@@ -481,6 +513,8 @@ export class SessionSyncController {
       }
       seenCursors.add(cursor);
       const page = await this.loadPage(operation, reason, cursor);
+      if (this.destroyed) return { messages, nextCursor: cursor };
+      pagesRead += 1;
       messages.unshift(...page.messages);
       for (const message of page.messages) {
         if (message.info.role === 'user') {
@@ -489,6 +523,9 @@ export class SessionSyncController {
       }
 
       cursor = page.nextCursor;
+      // Repaint as each page lands, so a long turn fills in front of the user
+      // instead of withholding everything until the walk ends.
+      onPage?.([...messages]);
     }
 
     return { messages, nextCursor: cursor };

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -63,6 +63,9 @@ export type SessionSyncReason =
   /** The tab became visible again. A backgrounded tab is throttled, not
    *  notified, so return is a moment to re-read rather than to assume. */
   | 'visible'
+  /** The transcript was evicted while detached and the live stream refilled it
+   *  from the middle — see `transcriptIsFragment`. */
+  | 'eviction'
   | 'manual';
 
 export interface SessionSyncTelemetryEvent {

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -173,21 +173,29 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
   // `reconcile('initial')` below, which is now the only thing that fills the
   // transcript. If the blank wake is worth solving again, it needs a mirror
   // whose freshness test reads the MESSAGE, not its shape.
+  // ASK AS SOON AS WE KNOW WHICH SANDBOX — not when a probe agrees.
+  //
+  // This read used to wait for `runtimeHealthy === true`, and that one
+  // condition is what hung the session page. `resolveSessionContentState` keeps
+  // the web app on its "Waking the agent" loader while there are no messages,
+  // and this read is the only thing that produces messages. So the page's ONLY
+  // exit was a health probe — the least reliable signal in the system — and a
+  // box that was up while failing its probe showed a spinner over a session
+  // that could have been read the whole time. The sidebar, reading the session
+  // list instead, showed the same session as live: one page, two answers.
+  //
+  // The read IS the liveness check. If the runtime is not up the request fails
+  // and the controller retries with backoff until it lands, so readiness
+  // becomes a byproduct of asking for what we wanted anyway.
   useEffect(() => {
-    if (
-      !networkEnabled ||
-      !canQueryOpenCodeSession(sessionId) ||
-      !runtimeHealthy ||
-      runtimeScope === 'none'
-    )
-      return;
+    if (!networkEnabled || !canQueryOpenCodeSession(sessionId) || runtimeScope === 'none') return;
     resetSessionSyncControllersForSession(sessionId, runtimeScope);
     const release = retainSessionSyncController(sessionId, runtimeScope);
-    // The ONLY thing that fills the transcript now. One bounded tail, so events
+    // The ONLY thing that fills the transcript. One bounded tail, so events
     // produced while this route was inactive are not skipped.
     void controller.reconcile('initial');
     return release;
-  }, [controller, networkEnabled, runtimeHealthy, runtimeScope, sessionId]);
+  }, [controller, networkEnabled, runtimeScope, sessionId]);
 
   // A transcript the live stream rebuilt after an eviction starts
   // mid-conversation, and nothing else will correct it: the mount already ran,

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -15,6 +15,7 @@ import {
   resetSessionSyncControllersForSession,
   retainSessionSyncController,
 } from '../browser/session-sync/session-sync-registry';
+import { transcriptIsFragment } from '../core/session-sync/fragment';
 import { onTabVisible } from '../browser/session-sync/visibility';
 import { useSandboxConnectionStore } from '../browser/stores/sandbox-connection-store';
 import { useSyncStore } from '../browser/stores/sync-store';
@@ -22,6 +23,13 @@ import { useCurrentRuntime } from './use-current-runtime';
 import { canQueryOpenCodeSession } from './use-opencode-sessions';
 
 export { loadSessionRuntimeStatus, loadSessionTranscriptMessages };
+
+/** The two store slices the fragment check reads. Local so this file does not
+ *  depend on the store's full published shape. */
+interface SyncStoreShape {
+  messages: Record<string, unknown[] | undefined>;
+  wasTranscriptEvicted: (sessionID: string) => boolean;
+}
 
 type FileDiff = Omit<import('@opencode-ai/sdk/v2/client').SnapshotFileDiff, 'patch'> & {
   patch?: string;
@@ -180,6 +188,38 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
     void controller.reconcile('initial');
     return release;
   }, [controller, networkEnabled, runtimeHealthy, runtimeScope, sessionId]);
+
+  // A transcript the live stream rebuilt after an eviction starts
+  // mid-conversation, and nothing else will correct it: the mount already ran,
+  // so no `initial` read is coming, and the liveness poll only turns on while
+  // the session is working. Removing the IndexedDB mirror (5a7a43517f) named
+  // this exact hole and left it open — "no reconcile is keyed on eviction …
+  // can sit on a partial transcript until a reload".
+  //
+  // Subscribed rather than checked once, because the refill happens while this
+  // component is already mounted. `hydrate` clears the mark, so the successful
+  // read is what disarms this.
+  useEffect(() => {
+    if (!networkEnabled || !canQueryOpenCodeSession(sessionId)) return;
+    let repairing = false;
+    const check = (state: SyncStoreShape) => {
+      if (repairing) return;
+      if (
+        !transcriptIsFragment({
+          hasMessages: (state.messages[sessionId]?.length ?? 0) > 0,
+          wasEvicted: state.wasTranscriptEvicted(sessionId),
+        })
+      ) {
+        return;
+      }
+      repairing = true;
+      void controller.reconcile('eviction').finally(() => {
+        repairing = false;
+      });
+    };
+    check(useSyncStore.getState() as unknown as SyncStoreShape);
+    return useSyncStore.subscribe((state) => check(state as unknown as SyncStoreShape));
+  }, [controller, networkEnabled, sessionId]);
 
   // Coming back to the tab is a moment of MAXIMUM uncertainty, so it is a
   // moment to re-read. A backgrounded tab has its timers clamped (Chrome: about


### PR DESCRIPTION
Three fixes, one principle: **nothing may decide whether we ASK for the messages.** The read is its own liveness check.

## 1. One page, two answers about one session

Screenshot: the **sidebar shows the session live with a green dot** while the **main pane sits on "Waking the agent — this is taking longer than usual"**.

`resolveSessionContentState` keeps the web app on that loader while there are no messages, and exactly one thing produces messages: `reconcile('initial')`. That read was gated on `runtimeHealthy === true`.

So the page's **only** exit from the loader was a health probe — the least reliable signal in the system. A box that is up while failing its probe (loaded, mid-turn, slow) shows a spinner over a session that could have been read the whole time. The sidebar reads the session list instead, which is why the two disagreed.

The read no longer waits for the probe. It starts as soon as we know which sandbox.

## 2. A failed read was recorded as "this session is empty"

Eight lines away, in the same function. `markLoaded` ran in a `finally`, so a read that **failed** still told the store the session was loaded — and the store's implementation of that plants an **empty message list**.

A first read losing to a waking box, a proxy 503, or a flapping probe therefore recorded *"this session has no messages"*. The UI painted an empty conversation over a session that had plenty, and nothing came back for it: the mount had already run, and the liveness poll only turns on while a session is working.

- `markLoaded` on **success only**. A successful read of zero messages is a fact about the session; a failed read is a fact about nothing.
- A failed read now schedules its own **retry with backoff** (1s → 15s cap) until one lands. Destroy cancels it.

## 3. A transcript the stream rebuilt from the middle

`5a7a43517f` removed the IndexedDB mirror and named this hole in its own message:

> "no reconcile is keyed on eviction, so an evicted-then-refilled session can sit on a partial transcript until a reload. This PR does not address that; it should land with, or before, a reconcile-on-eviction fix."

It landed without one. The store already carries the signature: eviction drops the messages **and marks the id**; `hydrate` / `clearSession` / `optimisticAdd` clear the mark, `applyEvent` does not. Messages present while the mark is set can only have come from frames that arrived after the eviction — a fragment by construction. `transcriptIsFragment` names it and `useSessionSync` subscribes and repairs.

## Gates

- `packages/sdk`: `pnpm typecheck` clean (both projects) · `pnpm test` **2464 pass / 0 fail** (+8, 1 replaced)
- `apps/web`: `tsc --noEmit` clean apart from the known `@types/bun` noise · `bun test src/features/session` **2517 pass / 0 fail**
- One test was **replaced**, not deleted: `marks an empty or failed initial read as loaded` encoded the bug. Loading is a claim about the session; a read that never landed supports no claim at all.

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH