### PR TITLE
Wait for a sandbox to wake, not for three tries

### DIFF
--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -32,6 +32,7 @@ import {
   sessionErrorSurfaceReady,
 } from '@/features/session/session-load-state';
 import {
+  AUTO_RESUME_WINDOW_MS,
   isAutoResuming,
   isRuntimeIdentityUnavailable,
   isSandboxResumable,
@@ -245,7 +246,6 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
   // the resume path and wakes the box. So: re-issue /start ourselves a few times
   // (what the refresh did) before ever surfacing a manual control.
   const sandboxResumable = isSandboxResumable(sandbox);
-  const MAX_AUTO_RESUME = 3;
   const [resumeAttempts, setResumeAttempts] = useState(0);
   // ONE restart behavior for every card on this route: optimistic exit from the
   // terminal state, a real pending state, and a SURFACED failure.
@@ -297,21 +297,36 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
       errorToast('Could not copy the prompt.');
     }
   };
+  // When THIS wake started. Stamped the first time we see a resumable box and
+  // cleared the moment it stops being one, so the window measures one wake
+  // rather than the age of the tab.
+  const [resumeStartedAt, setResumeStartedAt] = useState<number | null>(null);
   useEffect(() => {
-    if (!sandboxResumable || resumeAttempts >= MAX_AUTO_RESUME) return;
-    // First attempt fires immediately (match the refresh); back off after that.
+    if (!sandboxResumable) {
+      setResumeStartedAt(null);
+      return;
+    }
+    setResumeStartedAt((at) => at ?? Date.now());
+  }, [sandboxResumable]);
+  const resumeElapsedMs = resumeStartedAt === null ? null : Date.now() - resumeStartedAt;
+  useEffect(() => {
+    if (!sandboxResumable) return;
+    if (resumeStartedAt !== null && Date.now() - resumeStartedAt >= AUTO_RESUME_WINDOW_MS) return;
+    // First attempt fires immediately (match the refresh); back off after that,
+    // and keep re-asking for as long as the wake window allows. The budget is
+    // the WINDOW, not the attempt count — see `AUTO_RESUME_WINDOW_MS`.
     const t = setTimeout(
       () => {
         setResumeAttempts((n) => n + 1);
         queryClient.invalidateQueries({ queryKey: sessionStartKey(projectId, sessionId) });
       },
-      resumeAttempts === 0 ? 0 : 1500,
+      resumeAttempts === 0 ? 0 : Math.min(1500 * 2 ** Math.min(resumeAttempts - 1, 3), 8000),
     );
     return () => clearTimeout(t);
-  }, [sandboxResumable, resumeAttempts, projectId, sessionId, queryClient]);
-  // While we still have auto-resume attempts left, a resumable box is "waking",
-  // not "dead" — render the boot loader, never the dead-end card.
-  const autoResuming = isAutoResuming(sandbox, resumeAttempts, MAX_AUTO_RESUME);
+  }, [sandboxResumable, resumeAttempts, resumeStartedAt, projectId, sessionId, queryClient]);
+  // Inside the wake window a resumable box is "waking", not "dead" — render the
+  // boot loader, never the dead-end card.
+  const autoResuming = isAutoResuming(sandbox, { elapsedMs: resumeElapsedMs });
 
   // Belt-and-suspenders: clear the legacy active-instance cookie once on mount for
   // this route so no later navigation can be hijacked onto a stale sandbox.

--- a/apps/web/src/features/session/session-resume.test.ts
+++ b/apps/web/src/features/session/session-resume.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  AUTO_RESUME_WINDOW_MS,
   isAutoResuming,
   isRuntimeIdentityUnavailable,
   isSandboxResumable,
@@ -27,22 +28,51 @@ describe('isSandboxResumable', () => {
   });
 });
 
+/**
+ * The budget is TIME, not attempts.
+ *
+ * It used to be three attempts spaced 1500ms — `0ms, 1500ms, 1500ms`, so about
+ * THREE SECONDS in total. A sandbox resume does not fit in three seconds:
+ * measured end to end on dev, `/start` alone answers in ~1.9s and the runtime
+ * becomes reachable ~3s after that. So a perfectly healthy box that was merely
+ * asleep ran out of budget mid-wake, and the page replaced its loader with the
+ * dead-end card "session <id> is stopped — open a new session to continue"…
+ * moments before the box came up and the session loaded fine.
+ *
+ * Reported exactly that way (essentia, 2026-08-24): "ALL OF THEM WILL SHOW ME
+ * THE ERROR AFTER TRYING TO CONNECT FOR A WHILE & THEN THEY WILL CONNECT".
+ *
+ * A count cannot express "how long is it reasonable to wait for a machine to
+ * boot". A deadline can.
+ */
 describe('isAutoResuming', () => {
   const box = { status: 'stopped', external_id: 'sbx_1' };
 
-  test('resumable + attempts under the cap → still waking (show loader)', () => {
-    expect(isAutoResuming(box, 0, 3)).toBe(true);
-    expect(isAutoResuming(box, 2, 3)).toBe(true);
+  test('inside the window a resumable box is waking, however many attempts it took', () => {
+    expect(isAutoResuming(box, { elapsedMs: 0 })).toBe(true);
+    expect(isAutoResuming(box, { elapsedMs: 3_000 })).toBe(true);
+    // The old budget gave up here. A real resume is only just finishing.
+    expect(isAutoResuming(box, { elapsedMs: 20_000 })).toBe(true);
   });
 
-  test('resumable but attempts exhausted → stop auto-waking (fall through to Restart)', () => {
-    expect(isAutoResuming(box, 3, 3)).toBe(false);
-    expect(isAutoResuming(box, 4, 3)).toBe(false);
+  test('past the window it stops waking and offers Restart', () => {
+    expect(isAutoResuming(box, { elapsedMs: AUTO_RESUME_WINDOW_MS })).toBe(false);
+    expect(isAutoResuming(box, { elapsedMs: AUTO_RESUME_WINDOW_MS + 1 })).toBe(false);
   });
 
-  test('not resumable → never auto-resuming regardless of attempts', () => {
-    expect(isAutoResuming({ status: 'error', external_id: 'sbx_1' }, 0, 3)).toBe(false);
-    expect(isAutoResuming({ status: 'stopped', external_id: null }, 0, 3)).toBe(false);
+  test('the window is long enough for a real resume', () => {
+    // /start ~1.9s + runtime reachable ~3s, measured on dev 2026-08-24, and a
+    // loaded or image-heavy box is slower still.
+    expect(AUTO_RESUME_WINDOW_MS).toBeGreaterThanOrEqual(60_000);
+  });
+
+  test('not resumable → never auto-resuming, however early', () => {
+    expect(isAutoResuming({ status: 'error', external_id: 'sbx_1' }, { elapsedMs: 0 })).toBe(false);
+    expect(isAutoResuming({ status: 'stopped', external_id: null }, { elapsedMs: 0 })).toBe(false);
+  });
+
+  test('a caller with no clock yet is treated as just-started, not as expired', () => {
+    expect(isAutoResuming(box, { elapsedMs: null })).toBe(true);
   });
 });
 
@@ -96,8 +126,7 @@ describe('isSandboxResumable — a preserved-unavailable identity is never resum
           external_id: 'sbx_1',
           metadata: { runtimeIdentityState: 'unavailable' },
         },
-        0,
-        3,
+        { elapsedMs: 0 },
       ),
     ).toBe(false);
   });

--- a/apps/web/src/features/session/session-resume.ts
+++ b/apps/web/src/features/session/session-resume.ts
@@ -51,14 +51,42 @@ export function isSandboxResumable(sandbox: ResumableSandboxLike | null | undefi
 }
 
 /**
- * While auto-resume attempts remain, a resumable box is "waking", not "dead" —
- * the page shows the boot loader rather than the terminal card. Once attempts are
- * exhausted it falls through to a manual Restart.
+ * How long a resumable box is allowed to be "waking" before the page stops
+ * waiting and offers a manual Restart.
+ *
+ * This replaced an ATTEMPT budget — three tries spaced 1500ms, so roughly THREE
+ * SECONDS in total. A sandbox resume does not fit in three seconds: measured end
+ * to end on dev (2026-08-24), `/start` alone answers in ~1.9s and the runtime
+ * becomes reachable ~3s after that, and a loaded or image-heavy box is slower
+ * still. So a perfectly healthy box that was merely asleep ran out of budget
+ * MID-WAKE, and the page swapped its loader for the dead-end card
+ *
+ *     "session <id> is stopped — The sandbox for this session was stopped.
+ *      Open a new session to continue."
+ *
+ * moments before that same box came up and the session loaded fine. Reported in
+ * exactly those terms: "ALL OF THEM WILL SHOW ME THE ERROR AFTER TRYING TO
+ * CONNECT FOR A WHILE & THEN THEY WILL CONNECT".
+ *
+ * A count cannot express "how long is it reasonable to wait for a machine to
+ * boot" — it only counts how many times we asked, which says more about our
+ * retry spacing than about the sandbox. A deadline says the thing we mean.
+ */
+export const AUTO_RESUME_WINDOW_MS = 90_000;
+
+/**
+ * Is this box still within its wake window — i.e. "waking", not "dead"?
+ *
+ * The page shows the boot loader while this is true and falls through to a
+ * manual Restart once it is false.
  */
 export function isAutoResuming(
   sandbox: ResumableSandboxLike | null | undefined,
-  attempts: number,
-  maxAttempts: number,
+  clock: { elapsedMs: number | null; windowMs?: number },
 ): boolean {
-  return isSandboxResumable(sandbox) && attempts < maxAttempts;
+  if (!isSandboxResumable(sandbox)) return false;
+  // No clock yet means the wait has only just begun — never treat "unknown" as
+  // "expired", which is how a first paint would land straight on the dead end.
+  if (clock.elapsedMs === null) return true;
+  return clock.elapsedMs < (clock.windowMs ?? AUTO_RESUME_WINDOW_MS);
 }


### PR DESCRIPTION
> "ALL OF THEM WILL SHOW ME THE ERROR AFTER TRYING TO CONNECT FOR A WHILE & THEN THEY WILL CONNECT" — essentia, 2026-08-24

## The budget was three seconds

Auto-resume was an **attempt count**: `MAX_AUTO_RESUME = 3`, spaced 1500ms.

```
0ms  +  1500ms  +  1500ms   ≈  3 seconds
```

A sandbox resume does not fit in three seconds. Measured end to end on dev today:

- `POST .../start` answers in **~1.9 s**
- the runtime becomes reachable **~3 s after that**
- an image-heavy or loaded box is slower still

So a perfectly healthy box that was merely asleep **ran out of budget mid-wake**, and the page replaced its boot loader with the dead-end card:

> **session `<id>` is stopped** — The sandbox for this session was stopped. Open a new session to continue.

…moments before that same box came up and the session loaded fine. The card is a lie about a machine that is booting normally, and it appears on *every* stopped session, which is why it looked like everything was broken.

## The fix

A count cannot express *"how long is it reasonable to wait for a machine to boot"* — it counts how many times **we** asked, which says more about our retry spacing than about the sandbox.

- `AUTO_RESUME_WINDOW_MS = 90_000` — a deadline, measured from the first time we see a resumable box, reset when it stops being one, so it covers **one wake** rather than the age of the tab.
- Retries inside the window back off `1.5s → 8s` instead of stopping after three.
- `isAutoResuming(sandbox, { elapsedMs })` treats a **null** clock as *just-started*, not expired — otherwise the first paint lands straight on the dead end.
- Unchanged: a provider-lost box (`runtimeIdentityState: 'unavailable'`) still never auto-resumes. That regression guard (prod session `ad4b63ac`) keeps its test.

## Gates

`apps/web` tsc clean apart from the known `@types/bun` noise · session suite **2525 pass / 0 fail** (+2)

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH