### PR TITLE
A human is not a sandbox: backend-origin sessions open again

### DIFF
--- a/apps/api/src/__tests__/unit-connector-share.test.ts
+++ b/apps/api/src/__tests__/unit-connector-share.test.ts
@@ -480,3 +480,72 @@ describe('KaaB: sharing is not exempt from the isolation narrowing', () => {
     ).toBe(false);
   });
 });
+
+/**
+ * The SAME regression the manager-override gate already fixed, still live in
+ * the sibling narrowing.
+ *
+ * `resolveSupabaseAuth` puts the SUPABASE LOGIN session id in `callerSessionId`
+ * for every signed-in human, so reading that field made all three narrowing
+ * conditions true for ANY human opening ANY `backend`-origin session: the
+ * session 404'd from `/start` while sitting in the sidebar.
+ *
+ * Measured on a live self-host (essentia, 2026-08-24): 43 backend-origin
+ * sessions in one project, none openable, while `user`- and `schedule`-origin
+ * sessions in the same project opened normally.
+ */
+describe('isSessionTargetVisibleToCaller — the binding, not the login id', () => {
+  const BACKEND = { origin: 'backend', sessionId: 'backend-session-a' };
+
+  test('a human never trips the sibling gate, whatever their login session id', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        ...BACKEND,
+        // A Supabase LOGIN session id — non-null, and never a Kortix session id.
+        callerSessionId: 'supabase-login-abc',
+        boundCredentialSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test('a sandbox credential still cannot reach a SIBLING backend session', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        ...BACKEND,
+        callerSessionId: 'backend-session-b',
+        boundCredentialSessionId: 'backend-session-b',
+      }),
+    ).toBe(false);
+  });
+
+  test('a sandbox credential still reaches its OWN backend session', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        ...BACKEND,
+        callerSessionId: 'backend-session-a',
+        boundCredentialSessionId: 'backend-session-a',
+      }),
+    ).toBe(true);
+  });
+
+  test('non-backend origins were never narrowed and still are not', () => {
+    expect(
+      isSessionTargetVisibleToCaller({
+        origin: 'schedule',
+        sessionId: 'scheduled-session',
+        callerSessionId: 'supabase-login-abc',
+        boundCredentialSessionId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test('a caller that never sourced the binding keeps its old behaviour', () => {
+    // Field ABSENT (not null): fall back rather than silently widen.
+    expect(
+      isSessionTargetVisibleToCaller({ ...BACKEND, callerSessionId: 'backend-session-b' }),
+    ).toBe(false);
+    expect(
+      isSessionTargetVisibleToCaller({ ...BACKEND, callerSessionId: 'backend-session-a' }),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/connectors/share.ts
+++ b/apps/api/src/connectors/share.ts
@@ -196,10 +196,41 @@ export function isSessionTargetVisibleToCaller(
    *  do sibling-isolation alone stay unchanged. */
   ownership: SessionNarrowingContext,
 ): boolean {
+  // The AGENT binding, never the raw `callerSessionId`.
+  //
+  // `resolveSupabaseAuth` sets `c.get('sessionId')` to the SUPABASE LOGIN
+  // session id for every signed-in human (middleware/auth.ts), so
+  // `callerSessionId` is non-null for ordinary dashboard users and can never
+  // equal a Kortix session id. Reading it here made all three conditions below
+  // true for ANY human opening ANY backend-origin session, so the narrowing
+  // returned false and `/start` answered 404 — a session listed in the sidebar
+  // that could never be opened. Measured on a live self-host (essentia,
+  // 2026-08-24): 43 backend-origin sessions in one project, all unopenable,
+  // while `user`- and `schedule`-origin sessions in the same project opened
+  // fine.
+  //
+  // `callerKortixSessionId()` is the value this guard always wanted — it
+  // returns null for a Supabase browser JWT and the real session id for
+  // anything session-bound, and its own doc says the isolation guards "read
+  // this as 'narrow me'". `access.ts` already threads it in as
+  // `boundCredentialSessionId`.
+  //
+  // This does NOT widen sandbox access. A session-bound credential still
+  // carries its real id, so it still reaches only its own backend session; a
+  // human simply stops being mistaken for one and falls through to the
+  // ordinary ownership/visibility/grant checks below.
+  //
+  // The field stays optional, so a caller that does narrowing alone and never
+  // sourced the binding keeps its previous behaviour rather than silently
+  // widening.
+  const binding =
+    ownership.boundCredentialSessionId !== undefined
+      ? ownership.boundCredentialSessionId
+      : ownership.callerSessionId;
   return !(
     ownership.origin === 'backend' &&
-    ownership.callerSessionId != null &&
-    ownership.callerSessionId !== ownership.sessionId
+    binding != null &&
+    binding !== ownership.sessionId
   );
 }
 


### PR DESCRIPTION
Found by going onto the live Essentia box. In one project, **43 `backend`-origin sessions were listed in the sidebar and every one answered `404`** from `POST .../sessions/:id/start`, while `user`- and `schedule`-origin sessions in the same project opened fine.

## The gate

`isSessionTargetVisibleToCaller` narrows a session-bound **sandbox** credential to its own backend session:

```ts
origin === 'backend' && callerSessionId != null && callerSessionId !== sessionId
```

But `resolveSupabaseAuth` puts the **Supabase LOGIN session id** in `callerSessionId` for every signed-in human. That value is non-null and can never equal a Kortix session id — so all three conditions hold for **any human opening any backend-origin session**.

## The codebase already knew

`unit-connector-share.test.ts` documents this precise regression — for the *manager-override* gate:

> "The regression: gating that on `callerSessionId` instead 403s ordinary dashboard users, because `resolveSupabaseAuth` puts the SUPABASE LOGIN session id in that field for every signed-in human. **Hence the separate `boundCredentialSessionId`.**"

The remedy was applied there and not to this narrowing.

## The fix

Read that same binding. `callerKortixSessionId()` returns `null` for a Supabase browser JWT and the real session id for anything session-bound — its own doc says the isolation guards *"read this as 'narrow me'"*. `access.ts` already threads it in as `boundCredentialSessionId`.

**This does not widen sandbox access.** A session-bound credential still carries its real id and still reaches only its own backend session; a human stops being mistaken for one and falls through to the ordinary ownership/visibility/grant checks. The field stays **optional**, so a caller that never sourced the binding keeps its previous behaviour rather than silently widening.

## Evidence — live, `/v1/projects/e7170bf8-…`

```
2b43f962   origin=backend    ->  POST /start  404
a8c52128   origin=schedule   ->  POST /start  200
origin counts:  user 568 | backend 43 | schedule 38 | trigger 10 | system 1
```

## Gates

`apps/api` tsc clean · `unit-connector-share` **48 pass / 0 fail** (+5, incl. sibling-isolation still blocked, own-session still allowed) · `r8-session-turn` green

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH