### PR TITLE
fix(gateway): zero-copy image passthrough, measured memory envelope, image window, framing headers

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2232,3 +2232,25 @@ above; the same code is live on dev. Enforcement: `simple-handler.test.ts`
 "drops wire-framing headers", `passthroughHeaders()` on all three response
 paths.
 
+## The edge never rewrites an origin error
+
+2026-08-24. The `api-router` Worker replaced every origin 502/503/504 with a
+synthetic `503 MAINTENANCE_MODE` "Service maintenance" page. On dev, 5 of 8
+non-streaming completions were failing with a gateway content-encoding bug
+(origin 502) and every user, log line and OpenCode retry classifier saw
+"Kortix is temporarily unavailable" instead. The gateway's own health showed
+`errors: 0` and 3.6 h of uptime: nothing was in maintenance and nothing had
+crashed.
+
+**The rule.** A proxy passes the origin's status, body and headers through
+unchanged. The only synthetic error it may produce is for an origin it could
+not reach at all, and that response names itself (`502 origin_unreachable`,
+`X-Origin-Status: fetch-error`, `Retry-After`). A maintenance page comes only
+from an explicit admin state. When a proxy catches an exception, the response
+carries the exception class and message (`gateway_proxy_error` with `cause`
+and `detail`), not a generic "unreachable".
+
+*Incident:* dev, found while verifying the gateway passthrough work above.
+Enforcement: `worker.test.mjs` origin-passthrough tests; `wire.ts` proxy
+error envelope.
+

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2181,3 +2181,54 @@ still blocked, and the own-session credential still allowed.
 
 *Incident:* essentia project `e7170bf8`, origin counts user 568 / backend 43.
 PR #6828.
+||||||| base
+
+## Measure the amplification factor; never decode what you can forward
+
+2026-08-24. The gateway's ai-sdk transport decoded every `data:` image with
+`atob(raw).split('').map(c => c.charCodeAt(0))` — one JavaScript string per
+byte, 89 MB resident for a 6.7 MB image — and then let provider-utils re-encode
+the bytes through a `String.fromCodePoint` concat loop. The admission budget
+charged 3x per wire byte on the assumption that the parsed graph was the only
+copy. Both `@ai-sdk/anthropic` and `@ai-sdk/amazon-bedrock` accept a base64
+STRING and serialize it through the identity `convertToBase64`.
+
+**The rule.** A passthrough forwards bytes in the encoding it received them.
+Before charging a memory budget, measure the real peak with a mounted request
+through the real handler and write the number next to the constant
+(`memory-envelope.test.ts`: 2.25x openai-compat, 2.9x anthropic, 0.61x steady
+state on 2026-08-24). A budget factor without a measurement is a wish.
+
+**Bound the inputs a client can grow without limit.** A screenshot-per-step
+agent re-sends every screenshot on every turn. Providers already cap images
+per request (Bedrock Converse: 20). The gateway keeps the newest 12 of >20 and
+replaces older ones with a one-line notice, with hysteresis so the prefix
+stays cache-stable for 8 turns.
+
+*Incident:* Essentia 2026-08-22, 40-screenshot / 28 MB request, cgroup OOM.
+Enforcement: `memory-envelope.test.ts` (peak factor < 6x, all 40 images
+forwarded byte-for-byte on both routes), `image-window.test.ts`.
+
+## A re-framed body must not carry the provider's framing headers
+
+2026-08-24. The gateway forwarded `upstream.headers` unchanged on both response
+paths. `fetch` had already gunzipped the provider body and the gateway
+re-materialized it (a string, or a relayed stream), but the response still
+said `content-encoding: gzip` with the compressed `content-length`. The API
+reverse proxy's `fetch` threw `ZlibError` on every non-streaming completion
+and answered `502 gateway_proxy_unreachable` while the gateway itself had
+logged a 200. Caddy on a self-host box passes the same pair straight to the
+client.
+
+**The rule.** When a proxy decodes or re-frames a body, it owns the framing.
+Strip `content-encoding`, `content-length`, `transfer-encoding` and the
+hop-by-hop set (RFC 7230 §6.1) before forwarding; keep everything else.
+`curl` without `--compressed` ignores `content-encoding`, so a curl-only
+check passes while every `fetch`-based client fails — test through the real
+next hop.
+
+*Incident:* local stack, found during the passthrough e2e for the memory work
+above; the same code is live on dev. Enforcement: `simple-handler.test.ts`
+"drops wire-framing headers", `passthroughHeaders()` on all three response
+paths.
+

--- a/apps/api/src/llm-gateway/README.md
+++ b/apps/api/src/llm-gateway/README.md
@@ -29,14 +29,41 @@ OpenAI Responses, Anthropic, and Bedrock use protocol-specific translation.
 
 ## Memory contract
 
-The standalone process reads its cgroup memory limit at boot. It reserves 75%
-for Bun, JSON objects, transports, and response streams. Request admission can
-use the remaining 25%.
+The standalone process reads its cgroup memory limit at boot. Request admission
+can use 50% of it. The other 50% is the Bun heap floor, response streams, and
+allocator slack.
 
-The admission counter charges three bytes for each request wire byte. A declared
-`Content-Length` is reserved before the first body read. A chunked body grows its
-reservation before each chunk is retained. The reservation remains active until
-the response reaches EOF or the client cancels it.
+The admission counter charges three bytes for each request wire byte. That
+factor is measured, not estimated: `packages/llm-gateway/src/pipeline/memory-envelope.test.ts`
+drives a 27 MiB, 40-screenshot request through the real handler and records the
+peak resident delta at the provider fetch. Measured on 2026-08-24: 2.25x
+(openai-compat), 2.9x (anthropic via ai-sdk), 0.61x steady state once the
+stream relay is handed back. A declared `Content-Length` is reserved before the
+first body read. A chunked body grows its reservation before each chunk is
+retained. The reservation remains active until the response reaches EOF or the
+client cancels it.
+
+Copies of one request body, in order, and when each dies:
+
+1. Byte buffer while the body arrives (`readAdmittedBody`). One preallocated
+   buffer for a declared length; freed after the single decode to a string.
+2. The string, freed after `JSON.parse`.
+3. The parsed object graph. Base64 image data stays a substring of it: the
+   ai-sdk transport hands each `data:` image to the SDK as tagged inline
+   `{type:'data', data:<base64>}`, which `@ai-sdk/anthropic` and
+   `@ai-sdk/amazon-bedrock` serialize through the identity `convertToBase64`.
+   No decode and no re-encode happen. The handler nulls its reference to the
+   graph the moment dispatch has taken it, before waiting on the provider.
+4. The serialized provider payload and its encoded request bytes, owned by
+   `fetch` until sent.
+
+Inline images are also bounded per request. `GATEWAY_MAX_INLINE_IMAGES`
+(default 20, Bedrock Converse's hard limit) caps `image_url` parts per request;
+over the cap the `GATEWAY_IMAGE_KEEP_ON_OVERFLOW` (default 12) most recent
+images survive and each older one becomes a one-line text notice. Dropping to
+12 rather than 20 keeps the conversation prefix byte-identical for the next 8
+turns so provider prompt caches stay warm. `GATEWAY_MAX_INLINE_IMAGES=0`
+disables pruning.
 
 The service returns:
 

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -343,14 +343,11 @@ function modelsRoute(path: string) {
     description: `Servable model catalog for the caller\'s account/project — a keyed object (NOT the OpenAI \`{object:"list",data:[...]}\` array shape) mapping model id → capabilities.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} -H "Authorization: Bearer $KORTIX_GATEWAY_KEY"\n\`\`\``,
     request: {
       query: z.object({
-        scope: z
-          .enum(['managed'])
-          .optional()
-          .openapi({
-            description:
-              'Set to `managed` for the platform-managed lineup only (~3KB instead of ~3.3MB). Sandboxes call this on every boot to learn the current managed set. Omit for the caller\'s full catalog.',
-            example: 'managed',
-          }),
+        scope: z.enum(['managed']).optional().openapi({
+          description:
+            "Set to `managed` for the platform-managed lineup only (~3KB instead of ~3.3MB). Sandboxes call this on every boot to learn the current managed set. Omit for the caller's full catalog.",
+          example: 'managed',
+        }),
       }),
     },
     ...auth,
@@ -367,9 +364,7 @@ export function mountLlmGateway(app: OpenAPIHono): void {
 
   const rawTarget =
     config.LLM_GATEWAY_PROXY_TARGET ||
-    (config.LLM_GATEWAY_PROXY_PORT
-      ? `http://127.0.0.1:${config.LLM_GATEWAY_PROXY_PORT}`
-      : '');
+    (config.LLM_GATEWAY_PROXY_PORT ? `http://127.0.0.1:${config.LLM_GATEWAY_PROXY_PORT}` : '');
   let proxyBase: string | null = null;
   if (rawTarget) {
     try {
@@ -421,17 +416,27 @@ export function mountLlmGateway(app: OpenAPIHono): void {
       // forwarded `content-encoding: gzip` on a body fetch had already
       // inflated) looked like to users and to the edge worker for days.
       const err = error as { code?: unknown; name?: unknown; message?: unknown };
-      const cause = typeof err?.code === 'string' ? err.code : typeof err?.name === 'string' ? err.name : 'Error';
+      const cause =
+        typeof err?.code === 'string'
+          ? err.code
+          : typeof err?.name === 'string'
+            ? err.name
+            : 'Error';
       const detail = typeof err?.message === 'string' ? err.message : String(error);
-      const unreachable = /ECONNREFUSED|ENOTFOUND|ECONNRESET|ETIMEDOUT|ConnectionRefused|FailedToOpenSocket|timed out/i.test(
-        `${cause} ${detail}`,
-      );
+      const unreachable =
+        /ECONNREFUSED|ENOTFOUND|ECONNRESET|ETIMEDOUT|ConnectionRefused|FailedToOpenSocket|timed out/i.test(
+          `${cause} ${detail}`,
+        );
       const code = unreachable ? 'gateway_proxy_unreachable' : 'gateway_proxy_error';
       const message = unreachable
         ? `Standalone LLM gateway is unreachable (${cause}: ${detail})`
         : `Standalone LLM gateway response could not be relayed (${cause}: ${detail})`;
       console.error(`[gateway] ${code}:`, error);
-      return c.json({ error: { message, type: code, code }, message, code, cause, detail }, 502);
+      // 503, not 502: Cloudflare replaces an origin 502/504 body with its own
+      // HTML page, which is how this error reached users as a blank "Bad
+      // gateway" screen. 503 passes through with this JSON intact.
+      c.header('retry-after', '5');
+      return c.json({ error: { message, type: code, code }, message, code, cause, detail }, 503);
     }
   };
 

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -403,17 +403,35 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     }
     try {
       const upstream = await fetch(`${proxyBase}${path}${query}`, init);
+      // The gateway owns the body framing (it re-materializes or relays what
+      // fetch already decoded), and so does this hop: never forward
+      // content-encoding/content-length/transfer-encoding from a response
+      // whose bytes fetch has already inflated.
+      const headers = new Headers(upstream.headers);
+      for (const name of ['content-encoding', 'content-length', 'transfer-encoding', 'connection'])
+        headers.delete(name);
       return new Response(upstream.body, {
         status: upstream.status,
         statusText: upstream.statusText,
-        headers: upstream.headers,
+        headers,
       });
     } catch (error) {
-      console.error('[gateway] standalone gateway unreachable:', error);
-      return c.json(
-        { error: 'Standalone LLM gateway is unreachable', code: 'gateway_proxy_unreachable' },
-        502,
+      // Say what actually happened. Until 2026-08-24 every throw here was
+      // reported as "unreachable", which is what a ZlibError (the gateway
+      // forwarded `content-encoding: gzip` on a body fetch had already
+      // inflated) looked like to users and to the edge worker for days.
+      const err = error as { code?: unknown; name?: unknown; message?: unknown };
+      const cause = typeof err?.code === 'string' ? err.code : typeof err?.name === 'string' ? err.name : 'Error';
+      const detail = typeof err?.message === 'string' ? err.message : String(error);
+      const unreachable = /ECONNREFUSED|ENOTFOUND|ECONNRESET|ETIMEDOUT|ConnectionRefused|FailedToOpenSocket|timed out/i.test(
+        `${cause} ${detail}`,
       );
+      const code = unreachable ? 'gateway_proxy_unreachable' : 'gateway_proxy_error';
+      const message = unreachable
+        ? `Standalone LLM gateway is unreachable (${cause}: ${detail})`
+        : `Standalone LLM gateway response could not be relayed (${cause}: ${detail})`;
+      console.error(`[gateway] ${code}:`, error);
+      return c.json({ error: { message, type: code, code }, message, code, cause, detail }, 502);
     }
   };
 

--- a/apps/llm-gateway/src/config.ts
+++ b/apps/llm-gateway/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MAX_REQUEST_BYTES } from '@kortix/llm-gateway';
+import { DEFAULT_IMAGE_WINDOW, DEFAULT_MAX_REQUEST_BYTES } from '@kortix/llm-gateway';
 import { hydrateEnvironmentSecret } from '@kortix/shared';
 
 hydrateEnvironmentSecret();
@@ -37,7 +37,17 @@ export const config = {
     secretKey: process.env.LANGFUSE_SECRET_KEY,
     baseUrl: process.env.LANGFUSE_HOST,
   },
-  // Default: 8 MiB. This accepts the measured 2,023,225-byte Aster request and
-  // rejects accidental/untrusted oversized payloads before upstream dispatch.
+  // Default: 128 MiB (DEFAULT_MAX_REQUEST_BYTES). A declared body over this is
+  // refused with 413 before a byte is read. 0 disables the per-request cap.
   maxRequestBytes: optionalInt('GATEWAY_MAX_REQUEST_BYTES', DEFAULT_MAX_REQUEST_BYTES),
+  // Inline-image cap per request (see @kortix/llm-gateway pipeline/image-window.ts).
+  // Default 20 (Bedrock Converse's hard limit); on overflow the 12 most recent
+  // images survive. GATEWAY_MAX_INLINE_IMAGES=0 disables pruning.
+  imageWindow: {
+    maxImages: optionalInt('GATEWAY_MAX_INLINE_IMAGES', DEFAULT_IMAGE_WINDOW.maxImages),
+    keepOnOverflow: optionalInt(
+      'GATEWAY_IMAGE_KEEP_ON_OVERFLOW',
+      DEFAULT_IMAGE_WINDOW.keepOnOverflow,
+    ),
+  },
 };

--- a/apps/llm-gateway/src/memory-budget.test.ts
+++ b/apps/llm-gateway/src/memory-budget.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'bun:test';
 import { deriveInflightBudgetBytes } from './memory-budget';
 
-test('in-flight budget uses 25% of the process memory limit', () => {
-  expect(deriveInflightBudgetBytes(512 * 1024 * 1024)).toBe(128 * 1024 * 1024);
-  expect(deriveInflightBudgetBytes(2 * 1024 * 1024 * 1024)).toBe(512 * 1024 * 1024);
+test('in-flight budget uses 50% of the process memory limit', () => {
+  expect(deriveInflightBudgetBytes(512 * 1024 * 1024)).toBe(256 * 1024 * 1024);
+  expect(deriveInflightBudgetBytes(2 * 1024 * 1024 * 1024)).toBe(1024 * 1024 * 1024);
 });

--- a/apps/llm-gateway/src/memory-budget.ts
+++ b/apps/llm-gateway/src/memory-budget.ts
@@ -17,7 +17,18 @@ function readLimit(path: string): number | null {
   }
 }
 
-/** Reserves 75% of process memory for Bun, parsed objects, streams, and SDKs. */
+/**
+ * Admission gets 50% of the process memory limit; the other 50% is Bun's heap
+ * floor, response streams, and allocator slack.
+ *
+ * 50% is safe because the admission counter already charges
+ * DEFAULT_BODY_AMPLIFICATION (3x) per wire byte and that factor is MEASURED,
+ * not guessed: memory-envelope.test.ts drives a 27 MiB / 40-screenshot request
+ * through the real handler and records a peak of 2.25x (openai-compat) and
+ * 2.9x (anthropic ai-sdk) over the wire size, with a 0.61x steady state once
+ * the stream is handed back. The parsed graph is therefore fully inside the
+ * charged amount; the old 25% share double-counted it.
+ */
 export function automaticInflightBudgetBytes(): number {
   const host = totalmem();
   const cgroup =
@@ -29,5 +40,5 @@ export function automaticInflightBudgetBytes(): number {
 
 export function deriveInflightBudgetBytes(limit: number | null): number {
   if (limit === null || !Number.isFinite(limit) || limit <= 0) return FALLBACK_BUDGET;
-  return Math.max(MINIMUM_BUDGET, Math.floor(limit * 0.25));
+  return Math.max(MINIMUM_BUDGET, Math.floor(limit * 0.5));
 }

--- a/apps/llm-gateway/src/server.test.ts
+++ b/apps/llm-gateway/src/server.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'bun:test';
 process.env.KORTIX_API_URL = process.env.KORTIX_API_URL ?? 'https://api.test.invalid';
 process.env.GATEWAY_INTERNAL_TOKEN = process.env.GATEWAY_INTERNAL_TOKEN ?? 'test-internal-token';
 
-const { buildServer } = await import('./server');
+const { buildServer, cloudflareSafe, UPSTREAM_STATUS_HEADER } = await import('./server');
 
 // Piece B: `POST /v1/messages` (+ the `/v1/llm/messages` and `/v1/openai/messages`
 // aliases, mirroring the `/v1/chat/completions` alias namespaces) must be
@@ -142,10 +142,6 @@ describe('standalone gateway inference routes', () => {
 });
 
 describe('cloudflareSafe', () => {
-  const { cloudflareSafe, UPSTREAM_STATUS_HEADER } = require('./server') as typeof import(
-    './server',
-  );
-
   test('maps a JSON 502 to 503, keeps the original status in header and body, sets retry-after', async () => {
     const res = await cloudflareSafe(
       new Response(

--- a/apps/llm-gateway/src/server.test.ts
+++ b/apps/llm-gateway/src/server.test.ts
@@ -84,10 +84,18 @@ describe('standalone gateway inference routes', () => {
         return Response.json({ route: { policyId: 'direct', primaryModel: 'large-model' } });
       }
       if (url.endsWith('/internal/gateway/resolve-upstream')) {
-        return Response.json({ candidates: [{
-          provider: 'mock', kind: 'openai-compat', baseUrl: 'https://provider.test/v1',
-          apiKey: 'key', billingMode: 'none', markup: 0,
-        }] });
+        return Response.json({
+          candidates: [
+            {
+              provider: 'mock',
+              kind: 'openai-compat',
+              baseUrl: 'https://provider.test/v1',
+              apiKey: 'key',
+              billingMode: 'none',
+              markup: 0,
+            },
+          ],
+        });
       }
       if (url.endsWith('/internal/gateway/usage') || url.endsWith('/internal/gateway/trace')) {
         return Response.json({ ok: true });
@@ -107,7 +115,12 @@ describe('standalone gateway inference routes', () => {
       const image = 'a'.repeat(28 * 1024 * 1024);
       const requestBody = JSON.stringify({
         model: 'large-model',
-        messages: [{ role: 'user', content: [{ type: 'image_url', image_url: { url: `data:image/png;base64,${image}` } }] }],
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'image_url', image_url: { url: `data:image/png;base64,${image}` } }],
+          },
+        ],
       });
       const response = await app.request('/v1/chat/completions', {
         method: 'POST',
@@ -126,4 +139,39 @@ describe('standalone gateway inference routes', () => {
       globalThis.fetch = originalFetch;
     }
   }, 30_000);
+});
+
+describe('cloudflareSafe', () => {
+  const { cloudflareSafe, UPSTREAM_STATUS_HEADER } = require('./server') as typeof import(
+    './server',
+  );
+
+  test('maps a JSON 502 to 503, keeps the original status in header and body, sets retry-after', async () => {
+    const res = await cloudflareSafe(
+      new Response(
+        JSON.stringify({ error: { code: 'upstream_error', message: 'provider down' } }),
+        {
+          status: 502,
+          headers: { 'content-type': 'application/json', 'x-request-id': 'req_1' },
+        },
+      ),
+    );
+    expect(res.status).toBe(503);
+    expect(res.headers.get(UPSTREAM_STATUS_HEADER)).toBe('502');
+    expect(res.headers.get('retry-after')).toBe('5');
+    expect(res.headers.get('x-request-id')).toBe('req_1');
+    expect(await res.json()).toMatchObject({
+      error: { code: 'upstream_error' },
+      upstream_status: 502,
+    });
+  });
+
+  test('maps 504 and leaves every other status untouched', async () => {
+    expect((await cloudflareSafe(new Response('x', { status: 504 }))).status).toBe(503);
+    for (const status of [200, 400, 401, 402, 413, 429, 500, 503]) {
+      const res = await cloudflareSafe(new Response('x', { status }));
+      expect(res.status).toBe(status);
+      expect(res.headers.get(UPSTREAM_STATUS_HEADER)).toBeNull();
+    }
+  });
 });

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -14,7 +14,7 @@ import { automaticInflightBudgetBytes } from './memory-budget';
 // receives a typed response before its body is retained.
 const defaultInflight = new InflightBudget({
   maxBytes: Number(process.env.GATEWAY_INFLIGHT_BUDGET_BYTES) || automaticInflightBudgetBytes(),
-  perRequestMaxBytes: DEFAULT_MAX_REQUEST_BYTES,
+  perRequestMaxBytes: Number(process.env.GATEWAY_MAX_REQUEST_BYTES) || DEFAULT_MAX_REQUEST_BYTES,
 });
 import { Hono } from 'hono';
 import { createApiClient } from './clients/api-client';
@@ -75,7 +75,7 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
         await Promise.allSettled(sinks);
       },
     },
-    { logger },
+    { logger, imageWindow: config.imageWindow },
   );
 
   // Rolling per-second traffic buckets feeding the health endpoint's error-rate
@@ -181,7 +181,7 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
     const requestId = `req_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
     try {
       // Reserve capacity before the body is materialized.
-      const body = await readAdmittedBody(c.req.raw, DEFAULT_MAX_REQUEST_BYTES, inflight);
+      const body = await readAdmittedBody(c.req.raw, config.maxRequestBytes, inflight);
       if (!body.ok) {
         const status = body.reason === 'too_large' ? 413 : 503;
         if (body.reason === 'overloaded') {
@@ -249,7 +249,7 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
     };
   }) => {
     try {
-      const body = await readAdmittedBody(c.req.raw, DEFAULT_MAX_REQUEST_BYTES, inflight);
+      const body = await readAdmittedBody(c.req.raw, config.maxRequestBytes, inflight);
       if (!body.ok) {
         const status = body.reason === 'too_large' ? 413 : 503;
         recordOutcome(status);

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -36,6 +36,36 @@ export interface GatewayServer {
   traces: TraceSink | null;
 }
 
+// Cloudflare replaces an ORIGIN 502 or 504 with its own HTML "Bad gateway"
+// page (Enterprise-only "Origin Error Page Pass-thru" turns that off). Every
+// public gateway host sits behind a proxied Cloudflare hostname, so a JSON
+// `502 upstream_error` reached OpenCode as an HTML page and surfaced as
+// "AI_APICallError: Bad Gateway" with no code, no request id and no
+// suggestion (dev 2026-08-24; Essentia 2026-08-22). 503 passes through
+// unchanged. The original status is kept on a header and in the body so
+// nothing is lost — only the transport-level rewrite is avoided.
+const CLOUDFLARE_REWRITTEN_STATUSES = new Set([502, 504]);
+export const UPSTREAM_STATUS_HEADER = 'x-kortix-upstream-status';
+
+export async function cloudflareSafe(res: Response): Promise<Response> {
+  if (!CLOUDFLARE_REWRITTEN_STATUSES.has(res.status)) return res;
+  const headers = new Headers(res.headers);
+  headers.set(UPSTREAM_STATUS_HEADER, String(res.status));
+  if (!headers.has('retry-after')) headers.set('retry-after', '5');
+  const contentType = headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    const text = await res.text();
+    try {
+      const body = JSON.parse(text) as Record<string, unknown>;
+      body.upstream_status = res.status;
+      return new Response(JSON.stringify(body), { status: 503, headers });
+    } catch {
+      return new Response(text, { status: 503, headers });
+    }
+  }
+  return new Response(res.body, { status: 503, headers });
+}
+
 export function buildServer(options: { inflight?: InflightBudget } = {}): GatewayServer {
   const inflight = options.inflight ?? defaultInflight;
   const api = createApiClient({ baseUrl: config.apiUrl, token: config.apiToken });
@@ -206,7 +236,7 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
           signal: c.req.raw?.signal,
         };
         body.body = '';
-        const res = await gateway.chatCompletions(request);
+        const res = await cloudflareSafe(await gateway.chatCompletions(request));
         recordOutcome(res.status);
         return releaseWhenResponseEnds(res, body.release);
       } catch (error) {
@@ -263,7 +293,7 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
           rawBody: body.body,
         };
         body.body = '';
-        const res = await gateway.messages(request);
+        const res = await cloudflareSafe(await gateway.messages(request));
         recordOutcome(res.status);
         return releaseWhenResponseEnds(res, body.release);
       } catch (error) {
@@ -293,9 +323,11 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
   const models = (c: {
     req: { header: (k: string) => string | undefined; query: (k: string) => string | undefined };
   }) =>
-    gateway.listModels(c.req.header('authorization'), {
-      managedOnly: c.req.query('scope') === 'managed',
-    });
+    gateway
+      .listModels(c.req.header('authorization'), {
+        managedOnly: c.req.query('scope') === 'managed',
+      })
+      .then(cloudflareSafe);
 
   app.get('/models', models);
   app.get('/v1/models', models);

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -30,41 +30,48 @@ const DEFAULT_MAINTENANCE = {
   affectedServices: [],
   updatedAt: new Date(0).toISOString(),
 };
-const AUTOMATIC_MAINTENANCE = {
-  ...DEFAULT_MAINTENANCE,
-  level: 'blocking',
-  title: 'Service maintenance',
-  message:
-    'Kortix is temporarily unavailable. Service will resume automatically.',
-};
-
-// Header a trusted CI run presents to opt OUT of maintenance laundering and see
-// the real origin response instead. Compared against the CI_PASSTHROUGH_SECRET
-// binding; absent or wrong, the request is treated as ordinary public traffic.
-const CI_PASSTHROUGH_HEADER = 'X-Kortix-CI-Passthrough';
+// Origin errors are NEVER rewritten. Until 2026-08-24 this worker replaced
+// every origin 502/503/504 with a synthetic "Service maintenance" 503, which
+// hid the real failure from users, from OpenCode's retry classifier and from
+// whoever was debugging: a gateway content-encoding bug surfaced on dev as
+// "Kortix is temporarily unavailable" for days while the gateway logged 200s.
+// A blocking maintenance page now comes ONLY from an explicit admin state
+// (readMaintenanceConfig). Everything the origin says passes through with
+// its status, body and headers intact; only an origin that cannot be reached
+// at all gets a synthetic response, and that one names itself.
 const WEBHOOK_RELAY_USER_AGENT = 'Kortix-Webhook-Relay/1.0';
 
-// Constant-time over the compared bytes. The length is not secret (a mismatched
-// length returns false immediately), the contents are.
-function timingSafeEqualStrings(a, b) {
-  const encoder = new TextEncoder();
-  const left = encoder.encode(a);
-  const right = encoder.encode(b);
-  if (left.length !== right.length) return false;
-  let diff = 0;
-  for (let i = 0; i < left.length; i += 1) diff |= left[i] ^ right[i];
-  return diff === 0;
-}
-
-// True only when the request carries the exact shared secret. An unset or empty
-// binding disables passthrough entirely, so an environment that never sets the
-// secret cannot be tricked into revealing origin failures.
-function isTrustedCiPassthrough(request, env) {
-  const secret = env?.CI_PASSTHROUGH_SECRET;
-  if (typeof secret !== 'string' || secret.length === 0) return false;
-  const presented = request.headers.get(CI_PASSTHROUGH_HEADER);
-  if (typeof presented !== 'string' || presented.length === 0) return false;
-  return timingSafeEqualStrings(presented, secret);
+// The one synthetic error this worker still produces: the origin fetch threw
+// (DNS, TLS, connection refused, timeout). 502 is the honest status — the
+// upstream did not answer. Retry-After marks it transient for retrying clients
+// and there is deliberately no x-request-id, because no origin request ran.
+function originUnreachableResponse(active, isGateway, request, reason) {
+  const origin = request.headers.get('Origin');
+  const headers = new Headers({
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'Retry-After': '30',
+    'X-Backend': active,
+    'X-Backend-Service': isGateway ? 'gateway' : 'api',
+    'X-Origin-Status': 'fetch-error',
+  });
+  if (origin) {
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.set('Access-Control-Allow-Credentials', 'true');
+    headers.set('Vary', 'Origin');
+  }
+  const message = `Kortix ${isGateway ? 'gateway' : 'API'} origin is unreachable: ${reason}`;
+  return addSecurityHeaders(
+    Response.json(
+      {
+        error: { message, type: 'origin_unreachable', code: 'origin_unreachable' },
+        message,
+        code: 'origin_unreachable',
+        retry_after_seconds: 30,
+      },
+      { status: 502, headers },
+    ),
+  );
 }
 
 function addSecurityHeaders(response) {
@@ -132,13 +139,7 @@ async function readMaintenanceConfig(env) {
   }
 }
 
-// `originFailure` is set only on the AUTOMATIC path, where a real origin failure
-// is being replaced by a synthetic 503. It carries what the origin actually did:
-//   status    — the origin HTTP status, or 'fetch-error' when the fetch threw.
-//   requestId — the origin's x-request-id, when it sent one.
-// Both are surfaced on the response so a failure is diagnosable without
-// changing the body every public client already handles.
-function maintenanceResponse(config, active, isGateway, request, originFailure) {
+function maintenanceResponse(config, active, isGateway, request) {
   const origin = request.headers.get('Origin');
   const headers = new Headers({
     'Cache-Control': 'no-store',
@@ -148,16 +149,6 @@ function maintenanceResponse(config, active, isGateway, request, originFailure) 
     'X-Backend-Service': isGateway ? 'gateway' : 'api',
     'X-Maintenance-Mode': 'blocking',
   });
-  if (originFailure) {
-    headers.set('X-Origin-Status', String(originFailure.status));
-    // Restoring the origin's x-request-id is what makes an app-generated 5xx
-    // distinguishable from an edge/infrastructure one. Laundering used to erase
-    // it, so a genuine application 503 was indistinguishable from an
-    // unreachable origin.
-    if (originFailure.requestId) {
-      headers.set('X-Request-Id', originFailure.requestId);
-    }
-  }
   if (origin) {
     headers.set('Access-Control-Allow-Credentials', 'true');
     headers.set('Access-Control-Allow-Origin', origin);
@@ -333,45 +324,12 @@ export default {
     let response;
     try {
       response = await fetch(modifiedRequest);
-    } catch {
-      // No origin response exists, so there is nothing to pass through even for
-      // CI. Say so explicitly instead of leaving the cause unnamed.
-      return maintenanceResponse(
-        { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
+    } catch (error) {
+      return originUnreachableResponse(
         active,
         isGateway,
         request,
-        { status: 'fetch-error' },
-      );
-    }
-    if (
-      response.status === 502 ||
-      response.status === 503 ||
-      response.status === 504
-    ) {
-      // A trusted CI run needs the real failure, not a maintenance page: the
-      // v0.13.0 release gate spent hours reading laundered 503s as a scheduled
-      // maintenance window while staging was simply out of capacity. Public
-      // traffic still gets the identical synthetic 503 it always got.
-      if (isTrustedCiPassthrough(request, env)) {
-        const passthrough = new Response(response.body, response);
-        passthrough.headers.set('X-Backend', active);
-        passthrough.headers.set(
-          'X-Backend-Service',
-          isGateway ? 'gateway' : 'api',
-        );
-        passthrough.headers.set('X-Origin-Status', String(response.status));
-        return addSecurityHeaders(passthrough);
-      }
-      return maintenanceResponse(
-        { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() },
-        active,
-        isGateway,
-        request,
-        {
-          status: response.status,
-          requestId: response.headers.get('x-request-id'),
-        },
+        error instanceof Error && error.message ? error.message : 'fetch failed',
       );
     }
     // Cloudflare attaches the accepted socket to response.webSocket. Creating

--- a/infra/cloudflare/workers/api-router/worker.mjs
+++ b/infra/cloudflare/workers/api-router/worker.mjs
@@ -42,9 +42,10 @@ const DEFAULT_MAINTENANCE = {
 const WEBHOOK_RELAY_USER_AGENT = 'Kortix-Webhook-Relay/1.0';
 
 // The one synthetic error this worker still produces: the origin fetch threw
-// (DNS, TLS, connection refused, timeout). 502 is the honest status — the
-// upstream did not answer. Retry-After marks it transient for retrying clients
-// and there is deliberately no x-request-id, because no origin request ran.
+// (DNS, TLS, connection refused, timeout). 503 + Retry-After marks it
+// transient for retrying clients; 503 rather than 502 because Cloudflare
+// rewrites a 502/504 body into its HTML error page and this JSON must reach
+// the client. There is deliberately no x-request-id: no origin request ran.
 function originUnreachableResponse(active, isGateway, request, reason) {
   const origin = request.headers.get('Origin');
   const headers = new Headers({
@@ -69,7 +70,7 @@ function originUnreachableResponse(active, isGateway, request, reason) {
         code: 'origin_unreachable',
         retry_after_seconds: 30,
       },
-      { status: 502, headers },
+      { status: 503, headers },
     ),
   );
 }

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -696,7 +696,7 @@ describe('api-router worker', () => {
     }
   });
 
-  test('an unreachable origin is a named 502 origin_unreachable, retryable, with no request id', async () => {
+  test('an unreachable origin is a named 503 origin_unreachable, retryable, with no request id', async () => {
     globalThis.fetch = async () => {
       throw new Error('connection refused');
     };
@@ -706,7 +706,7 @@ describe('api-router worker', () => {
       env,
     );
 
-    expect(response.status).toBe(502);
+    expect(response.status).toBe(503);
     expect(response.headers.get('X-Origin-Status')).toBe('fetch-error');
     // tests/src/core/client.ts isKe2eTransientGatewayResponse classifies a
     // 502/503/504 as transient only when x-request-id is ABSENT and retry-after

--- a/infra/cloudflare/workers/api-router/worker.test.mjs
+++ b/infra/cloudflare/workers/api-router/worker.test.mjs
@@ -654,144 +654,73 @@ describe('api-router worker', () => {
     ]);
   });
 
-  test('converts an unavailable API origin into a maintenance response', async () => {
-    const fetchedUrls = [];
-    globalThis.fetch = async (request) => {
-      fetchedUrls.push(fetchUrl(request));
-      return new Response('Service Temporarily Unavailable', { status: 503 });
-    };
-
-    const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/accounts'),
-      env,
-    );
-
-    expect(fetchedUrls).toEqual(['https://api-fargate.kortix.com/v1/accounts']);
-    expect(response.status).toBe(503);
-    expect(response.headers.get('Content-Type')).toBe('application/json');
-    expect(await response.json()).toMatchObject({
-      error: { code: 'MAINTENANCE_MODE' },
-      maintenance: { level: 'blocking' },
-    });
-  });
-
-  // ── CI origin-status passthrough ───────────────────────────────────────────
-  // The laundering above is correct for public traffic and actively harmful for
-  // the release gate: it turns "staging ran out of capacity" into "scheduled
-  // maintenance". These pin the additive escape hatch — the public shape must
-  // not move, and the passthrough must be reachable ONLY with the exact secret.
-  const CI_SECRET = 'ci-passthrough-secret-value';
-  const ciEnv = { ...env, CI_PASSTHROUGH_SECRET: CI_SECRET };
-
+  // ── Origin errors pass through verbatim ───────────────────────────────────
+  // Until 2026-08-24 every origin 502/503/504 was replaced by a synthetic
+  // "Service maintenance" 503. That hid a gateway content-encoding bug on dev
+  // for days ("Kortix is temporarily unavailable" while the gateway logged
+  // 200s). The origin's status, body and headers are now the contract.
   function originFails(status, headers = {}) {
     globalThis.fetch = async () =>
       new Response('origin body', { status, headers });
   }
 
-  test('without the CI header, an origin 503 is still laundered but names the origin status', async () => {
-    originFails(503, { 'x-request-id': 'req-abc123' });
+  test('an origin 503 passes through with its own status, body and request id', async () => {
+    originFails(503, { 'x-request-id': 'req-abc123', 'content-type': 'application/json' });
 
     const response = await worker.fetch(
       new Request('https://api.kortix.com/v1/accounts'),
-      ciEnv,
-    );
-
-    expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
-    expect(response.headers.get('X-Maintenance-Mode')).toBe('blocking');
-    expect(response.headers.get('X-Origin-Status')).toBe('503');
-    // The origin's own request id is restored, so an application 5xx is
-    // distinguishable from an unreachable origin.
-    expect(response.headers.get('X-Request-Id')).toBe('req-abc123');
-  });
-
-  test('with the correct CI header, the true origin status and body pass through', async () => {
-    originFails(502, { 'x-request-id': 'req-xyz789' });
-
-    const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/accounts', {
-        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
-      }),
-      ciEnv,
-    );
-
-    expect(response.status).toBe(502);
-    expect(await response.text()).toBe('origin body');
-    expect(response.headers.get('X-Origin-Status')).toBe('502');
-    expect(response.headers.get('x-request-id')).toBe('req-xyz789');
-    // No maintenance fiction is layered on top of a real failure.
-    expect(response.headers.get('X-Maintenance-Mode')).toBeNull();
-    expect(response.headers.get('X-Backend')).toBe('ecs-fargate');
-    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
-  });
-
-  test('a wrong CI header gets the ordinary synthetic maintenance 503', async () => {
-    originFails(504);
-
-    const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/accounts', {
-        headers: { 'X-Kortix-CI-Passthrough': 'not-the-secret-value-at-all' },
-      }),
-      ciEnv,
-    );
-
-    expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
-    expect(response.headers.get('X-Origin-Status')).toBe('504');
-  });
-
-  test('a prefix of the secret does not pass, and neither does an empty header', async () => {
-    for (const presented of [CI_SECRET.slice(0, -1), `${CI_SECRET}x`, '']) {
-      originFails(503);
-      const response = await worker.fetch(
-        new Request('https://api.kortix.com/v1/accounts', {
-          headers: { 'X-Kortix-CI-Passthrough': presented },
-        }),
-        ciEnv,
-      );
-      expect(response.status).toBe(503);
-      expect(await response.json()).toMatchObject({
-        error: { code: 'MAINTENANCE_MODE' },
-      });
-    }
-  });
-
-  test('an environment with no CI_PASSTHROUGH_SECRET binding cannot be opted out of laundering', async () => {
-    originFails(503);
-
-    const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/accounts', {
-        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
-      }),
-      // `env` deliberately has no CI_PASSTHROUGH_SECRET.
       env,
     );
 
     expect(response.status).toBe(503);
-    expect(await response.json()).toMatchObject({ error: { code: 'MAINTENANCE_MODE' } });
+    expect(await response.text()).toBe('origin body');
+    expect(response.headers.get('x-request-id')).toBe('req-abc123');
+    expect(response.headers.get('content-type')).toBe('application/json');
+    expect(response.headers.get('X-Maintenance-Mode')).toBeNull();
+    expect(response.headers.get('X-Backend')).toBe('ecs-fargate');
+    expect(response.headers.get('X-Backend-Service')).toBe('api');
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
   });
 
-  test('an unreachable origin reports fetch-error and stays retryable for the test client', async () => {
+  test('an origin 502 and 504 pass through unchanged, on the gateway host too', async () => {
+    for (const status of [502, 504]) {
+      originFails(status);
+      const response = await worker.fetch(
+        new Request('https://gateway.kortix.com/v1/chat/completions', { method: 'POST' }),
+        env,
+      );
+      expect(response.status).toBe(status);
+      expect(await response.text()).toBe('origin body');
+      expect(response.headers.get('X-Backend-Service')).toBe('gateway');
+      expect(response.headers.get('X-Maintenance-Mode')).toBeNull();
+    }
+  });
+
+  test('an unreachable origin is a named 502 origin_unreachable, retryable, with no request id', async () => {
     globalThis.fetch = async () => {
       throw new Error('connection refused');
     };
 
     const response = await worker.fetch(
-      new Request('https://api.kortix.com/v1/accounts', {
-        headers: { 'X-Kortix-CI-Passthrough': CI_SECRET },
-      }),
-      ciEnv,
+      new Request('https://api.kortix.com/v1/accounts'),
+      env,
     );
 
-    // There is no origin response to pass through, so CI gets the synthetic
-    // 503 too — but it now says why.
-    expect(response.status).toBe(503);
+    expect(response.status).toBe(502);
     expect(response.headers.get('X-Origin-Status')).toBe('fetch-error');
     // tests/src/core/client.ts isKe2eTransientGatewayResponse classifies a
     // 502/503/504 as transient only when x-request-id is ABSENT and retry-after
     // is present. An unreachable origin must keep matching that.
     expect(response.headers.get('x-request-id')).toBeNull();
     expect(response.headers.get('Retry-After')).toBe('30');
+    expect(response.headers.get('X-Maintenance-Mode')).toBeNull();
+    const body = await response.json();
+    expect(body).toMatchObject({
+      error: { code: 'origin_unreachable', type: 'origin_unreachable' },
+      code: 'origin_unreachable',
+      retry_after_seconds: 30,
+    });
+    expect(body.error.message).toBe('Kortix API origin is unreachable: connection refused');
   });
 
   test('a healthy origin response carries no origin-status header', async () => {
@@ -799,28 +728,11 @@ describe('api-router worker', () => {
 
     const response = await worker.fetch(
       new Request('https://api.kortix.com/v1/accounts'),
-      ciEnv,
+      env,
     );
 
     expect(response.status).toBe(200);
     expect(response.headers.get('X-Origin-Status')).toBeNull();
-  });
-
-  test('the staging Worker deploy binds CI_PASSTHROUGH_SECRET from the repository secret', () => {
-    const deployWorkflow = readFileSync(
-      new URL(
-        '../../../../.github/workflows/deploy-staging.yml',
-        import.meta.url,
-      ),
-      'utf8',
-    );
-
-    expect(deployWorkflow).toContain(
-      'CF_WORKER_CI_PASSTHROUGH_SECRET: ${{ secrets.CF_WORKER_CI_PASSTHROUGH_SECRET }}',
-    );
-    expect(deployWorkflow).toContain(
-      '[{type:"secret_text", name:"CI_PASSTHROUGH_SECRET", text:$secret}]',
-    );
   });
 
   test('gateway HTTPS redirect keeps the gateway hostname', async () => {

--- a/packages/llm-gateway/src/create-gateway.ts
+++ b/packages/llm-gateway/src/create-gateway.ts
@@ -51,6 +51,7 @@ export function createGateway(
     hooks,
     logger,
     fetchImpl: deps.fetchImpl,
+    imageWindow: deps.imageWindow,
   };
 
   const jsonResponse = (data: unknown, status = 200): Response =>

--- a/packages/llm-gateway/src/index.ts
+++ b/packages/llm-gateway/src/index.ts
@@ -16,6 +16,8 @@ export type {
   InflightResizeResult,
 } from './pipeline/inflight-budget';
 export type { AdmittedBodyResult } from './pipeline/read-bounded-body';
+export { DEFAULT_IMAGE_WINDOW, applyImageWindow } from './pipeline/image-window';
+export type { ImageWindowOptions, ImageWindowResult } from './pipeline/image-window';
 export type { ChatCompletionRequest, GatewayDeps } from './pipeline';
 export {
   MAX_RELAYED_RETRY_AFTER_SECONDS,

--- a/packages/llm-gateway/src/pipeline/image-window.test.ts
+++ b/packages/llm-gateway/src/pipeline/image-window.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { applyImageWindow } from './image-window';
+
+const img = (n: number) => ({
+  type: 'image_url',
+  image_url: { url: `data:image/png;base64,${n}` },
+});
+const userWithImages = (...ids: number[]) => ({
+  role: 'user',
+  content: [{ type: 'text', text: 'shot' }, ...ids.map(img)],
+});
+
+describe('applyImageWindow', () => {
+  test('leaves a request at or under the cap untouched', () => {
+    const body = { messages: [userWithImages(1, 2), userWithImages(3)] };
+    const before = JSON.stringify(body);
+    expect(applyImageWindow(body, { maxImages: 3, keepOnOverflow: 2 })).toEqual({
+      total: 3,
+      dropped: 0,
+    });
+    expect(JSON.stringify(body)).toBe(before);
+  });
+
+  test('over the cap: keeps the newest keepOnOverflow images, replaces older ones with a text notice', () => {
+    const body = {
+      messages: [
+        userWithImages(1, 2),
+        { role: 'assistant', content: 'ok' },
+        userWithImages(3, 4, 5),
+      ],
+    };
+    expect(applyImageWindow(body, { maxImages: 4, keepOnOverflow: 2 })).toEqual({
+      total: 5,
+      dropped: 3,
+    });
+    const first = body.messages[0].content as Array<{ type: string; text?: string }>;
+    const last = body.messages[2].content as Array<{ type: string; image_url?: { url: string } }>;
+    expect(first.map((p) => p.type)).toEqual(['text', 'text', 'text']);
+    expect(first[1].text).toContain('3 older images removed');
+    expect(last.map((p) => p.type)).toEqual(['text', 'text', 'image_url', 'image_url']);
+    expect(last[2].image_url?.url).toBe('data:image/png;base64,4');
+    expect(last[3].image_url?.url).toBe('data:image/png;base64,5');
+  });
+
+  test('hysteresis: after a prune the next maxImages-keepOnOverflow turns leave the prefix unchanged', () => {
+    const body = { messages: [userWithImages(1, 2, 3, 4, 5)] };
+    applyImageWindow(body, { maxImages: 4, keepOnOverflow: 2 });
+    const prefix = JSON.stringify(body.messages);
+    // One more image arrives: 3 images total, under the cap → no change to the prefix.
+    body.messages.push(userWithImages(6));
+    applyImageWindow(body, { maxImages: 4, keepOnOverflow: 2 });
+    expect(JSON.stringify(body.messages.slice(0, 1))).toBe(prefix);
+  });
+
+  test('maxImages 0 disables the window', () => {
+    const body = { messages: [userWithImages(1, 2, 3)] };
+    expect(applyImageWindow(body, { maxImages: 0, keepOnOverflow: 0 })).toEqual({
+      total: 3,
+      dropped: 0,
+    });
+  });
+
+  test('ignores string content and non-image parts', () => {
+    const body = {
+      messages: [
+        { role: 'user', content: 'plain' },
+        { role: 'user', content: [{ type: 'text', text: 'a' }] },
+      ],
+    };
+    expect(applyImageWindow(body, { maxImages: 1, keepOnOverflow: 1 })).toEqual({
+      total: 0,
+      dropped: 0,
+    });
+  });
+});

--- a/packages/llm-gateway/src/pipeline/image-window.ts
+++ b/packages/llm-gateway/src/pipeline/image-window.ts
@@ -1,0 +1,78 @@
+/**
+ * Image window: bound the number of inline images one request carries.
+ *
+ * A coding agent that takes a screenshot per step re-sends EVERY screenshot
+ * on every turn — the request that OOM-killed the Essentia gateway on
+ * 2026-08-22 carried 40 base64 screenshots (28 MB, 334k tokens) in 224
+ * messages. Two facts make an unbounded image history worthless as well as
+ * expensive: providers cap it (Bedrock Converse rejects >20 images per
+ * request; Anthropic caps at 100), and a model reasons from the last few
+ * screens, not the fortieth-last.
+ *
+ * Policy, applied once per request after parse and before dispatch:
+ *   - Count `image_url` parts across every user message.
+ *   - If the count is at or under `maxImages`, do nothing.
+ *   - Otherwise keep the most recent `keepOnOverflow` images and replace each
+ *     older image part with a short text part that says so. Dropping down to
+ *     `keepOnOverflow` (< `maxImages`) rather than to `maxImages` gives
+ *     hysteresis: the prefix of the conversation then stays byte-identical
+ *     for the next `maxImages - keepOnOverflow` turns, which is what keeps
+ *     provider prompt caches warm instead of invalidating them every turn.
+ *
+ * The replacement is a text part rather than deletion so a user message never
+ * becomes empty and the user/assistant alternation the providers depend on is
+ * preserved.
+ */
+
+export interface ImageWindowOptions {
+  /** Requests with more inline images than this are pruned. 0 disables. */
+  maxImages: number;
+  /** How many most-recent images survive a prune. Must be <= maxImages. */
+  keepOnOverflow: number;
+}
+
+export const DEFAULT_IMAGE_WINDOW: ImageWindowOptions = { maxImages: 20, keepOnOverflow: 12 };
+
+export interface ImageWindowResult {
+  total: number;
+  dropped: number;
+}
+
+const IMAGE_PART_TYPES = new Set(['image_url', 'input_image', 'image']);
+
+function isImagePart(part: unknown): boolean {
+  return (
+    !!part &&
+    typeof part === 'object' &&
+    IMAGE_PART_TYPES.has(String((part as { type?: unknown }).type))
+  );
+}
+
+/** Mutates `body.messages` in place. Returns what it counted and dropped. */
+export function applyImageWindow(
+  body: Record<string, unknown>,
+  options: ImageWindowOptions = DEFAULT_IMAGE_WINDOW,
+): ImageWindowResult {
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const slots: Array<{ content: unknown[]; index: number }> = [];
+  for (const message of messages) {
+    if (!message || typeof message !== 'object') continue;
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (let i = 0; i < content.length; i += 1) {
+      if (isImagePart(content[i])) slots.push({ content, index: i });
+    }
+  }
+  const total = slots.length;
+  const max = Math.max(0, Math.trunc(options.maxImages));
+  if (max === 0 || total <= max) return { total, dropped: 0 };
+
+  const keep = Math.min(max, Math.max(0, Math.trunc(options.keepOnOverflow)));
+  const dropped = total - keep;
+  const notice = `[image omitted by gateway: ${dropped} older image${dropped === 1 ? '' : 's'} removed; the ${keep} most recent are kept]`;
+  for (let i = 0; i < dropped; i += 1) {
+    const slot = slots[i];
+    slot.content[slot.index] = { type: 'text', text: notice };
+  }
+  return { total, dropped };
+}

--- a/packages/llm-gateway/src/pipeline/memory-envelope.test.ts
+++ b/packages/llm-gateway/src/pipeline/memory-envelope.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from 'bun:test';
+import type { GatewayHooks, UpstreamDescriptor } from '../domain';
+import { handleChatCompletions } from './simple-handler';
+
+/**
+ * Memory envelope for one mounted multimodal request.
+ *
+ * Reproduces the shape that OOM-killed the Essentia gateway on 2026-08-22:
+ * 40 base64 screenshots, ~28 MB on the wire. The assertion is on resident
+ * memory measured INSIDE the provider fetch — the moment every live copy
+ * (parsed graph, provider payload, encoded request bytes) coexists — relative
+ * to the wire size. Pre-fix numbers on the same machine: openai-compat ≈ 4x,
+ * anthropic ≈ 13x (atob().split('') decode) + provider-utils re-encode.
+ *
+ * The bound is generous on purpose (RSS is noisy: allocator slack, GC timing).
+ * It exists to catch a regression back into the 10x+ class, not to pin the
+ * exact factor. The measured factor is printed for the PR record.
+ */
+
+const IMAGE_COUNT = 40;
+const IMAGE_BYTES = 520 * 1024; // ≈ 700 KB base64 each → ≈ 28 MB request
+const MAX_FACTOR = 6;
+
+function base64Image(seed: number): string {
+  const bytes = new Uint8Array(IMAGE_BYTES);
+  for (let i = 0; i < bytes.length; i += 1) bytes[i] = (i * 31 + seed) & 255;
+  return Buffer.from(bytes).toString('base64');
+}
+
+function mountedBody(model: string, stream: boolean): string {
+  const images = Array.from({ length: IMAGE_COUNT }, (_, i) => base64Image(i));
+  const messages: unknown[] = [{ role: 'system', content: 'You are a vision agent.' }];
+  for (const [i, data] of images.entries()) {
+    messages.push({
+      role: 'user',
+      content: [
+        { type: 'text', text: `screenshot ${i}` },
+        { type: 'image_url', image_url: { url: `data:image/png;base64,${data}` } },
+      ],
+    });
+    messages.push({ role: 'assistant', content: `noted ${i}` });
+  }
+  messages.push({ role: 'user', content: 'what changed?' });
+  return JSON.stringify({ model, stream, messages });
+}
+
+const principal = { userId: 'user', accountId: 'account', projectId: 'project' };
+const hooks: GatewayHooks = {
+  authenticate: async () => principal,
+  authorize: async () => ({ ok: true, principal }),
+  resolveRoute: async () => ({
+    policyId: 'route',
+    primaryModel: 'primary-model',
+    fallbackModels: [],
+    fallbackOn: 'any-error',
+  }),
+  resolveUpstream: async () => [descriptorRef.current],
+  assertBillingActive: async () => {},
+  recordUsage: async () => {},
+  recordTrace: async () => {},
+};
+const descriptorRef: { current: UpstreamDescriptor } = {
+  current: {
+    provider: 'p',
+    kind: 'openai-compat',
+    baseUrl: 'https://p.example/v1',
+    apiKey: 'k',
+    billingMode: 'credits',
+    markup: 1,
+  },
+};
+
+function rssMiB(): number {
+  return process.memoryUsage().rss / (1024 * 1024);
+}
+
+interface Probe {
+  peakDeltaMiB: number;
+  wireMiB: number;
+  factor: number;
+  upstreamBodyBytes: number;
+  upstreamHadInlineImages: number;
+}
+
+async function probe(
+  descriptor: UpstreamDescriptor,
+  upstreamResponse: () => Response,
+  imageMarker: RegExp,
+): Promise<{ probe: Probe; response: Response }> {
+  descriptorRef.current = descriptor;
+  const rawBody = mountedBody('primary-model', false);
+  const wireBytes = Buffer.byteLength(rawBody);
+  Bun.gc(true);
+  const baseline = rssMiB();
+  let peak = baseline;
+  let upstreamBodyBytes = 0;
+  let upstreamHadInlineImages = 0;
+  const response = await handleChatCompletions(
+    {
+      hooks,
+      logger: { info() {}, warn() {}, error() {} },
+      fetchImpl: async (_input, init) => {
+        peak = Math.max(peak, rssMiB());
+        const body = typeof init.body === 'string' ? init.body : '';
+        upstreamBodyBytes = Buffer.byteLength(body);
+        upstreamHadInlineImages = (body.match(imageMarker) ?? []).length;
+        return upstreamResponse();
+      },
+      // Window wide open so the test measures the raw passthrough cost, not
+      // the pruning (which has its own tests).
+      imageWindow: { maxImages: 0, keepOnOverflow: 0 },
+    },
+    { authorization: 'Bearer t', rawBody },
+  );
+  peak = Math.max(peak, rssMiB());
+  const wireMiB = wireBytes / (1024 * 1024);
+  const peakDeltaMiB = peak - baseline;
+  return {
+    probe: {
+      peakDeltaMiB,
+      wireMiB,
+      factor: peakDeltaMiB / wireMiB,
+      upstreamBodyBytes,
+      upstreamHadInlineImages,
+    },
+    response,
+  };
+}
+
+describe('memory envelope: 40-screenshot / ~28 MB request', () => {
+  test('openai-compat passthrough stays within the envelope and forwards every image byte', async () => {
+    const { probe: p, response } = await probe(
+      descriptorRef.current,
+      () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { role: 'assistant', content: 'ok' } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        ),
+      /data:image\/png;base64,/g,
+    );
+    console.log(
+      `[memory-envelope] openai-compat wire=${p.wireMiB.toFixed(1)} MiB peakΔ=${p.peakDeltaMiB.toFixed(0)} MiB factor=${p.factor.toFixed(2)}x`,
+    );
+    expect(response.status).toBe(200);
+    expect(p.upstreamHadInlineImages).toBe(IMAGE_COUNT);
+    // Provider payload equals the wire body plus the model rewrite — no image
+    // was re-encoded or dropped.
+    expect(p.upstreamBodyBytes).toBeGreaterThan(p.wireMiB * 1024 * 1024 * 0.99);
+    expect(p.factor).toBeLessThan(MAX_FACTOR);
+  });
+
+  test('anthropic (ai-sdk) route forwards base64 without decode/re-encode and stays within the envelope', async () => {
+    const { probe: p, response } = await probe(
+      {
+        provider: 'anthropic',
+        kind: 'anthropic',
+        baseUrl: 'https://anthropic.example/v1',
+        apiKey: 'k',
+        billingMode: 'credits',
+        markup: 1,
+        resolvedModel: 'claude-sonnet-4-6',
+      },
+      () =>
+        new Response(
+          JSON.stringify({
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            model: 'claude-sonnet-4-6',
+            content: [{ type: 'text', text: 'ok' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { headers: { 'content-type': 'application/json' } },
+        ),
+      /"type":"base64"/g,
+    );
+    console.log(
+      `[memory-envelope] anthropic wire=${p.wireMiB.toFixed(1)} MiB peakΔ=${p.peakDeltaMiB.toFixed(0)} MiB factor=${p.factor.toFixed(2)}x`,
+    );
+    expect(response.status).toBe(200);
+    expect(p.upstreamHadInlineImages).toBe(IMAGE_COUNT);
+    expect(p.upstreamBodyBytes).toBeGreaterThan(p.wireMiB * 1024 * 1024 * 0.95);
+    expect(p.factor).toBeLessThan(MAX_FACTOR);
+  });
+
+  test('streaming: once the relay is handed back, resident memory drops to the stream-only floor', async () => {
+    descriptorRef.current = {
+      provider: 'p',
+      kind: 'openai-compat',
+      baseUrl: 'https://p.example/v1',
+      apiKey: 'k',
+      billingMode: 'credits',
+      markup: 1,
+    };
+    const rawBody = mountedBody('primary-model', true);
+    const wireMiB = Buffer.byteLength(rawBody) / (1024 * 1024);
+    Bun.gc(true);
+    const baseline = rssMiB();
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const response = await handleChatCompletions(
+      {
+        hooks,
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async () =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              async start(controller) {
+                const enc = new TextEncoder();
+                controller.enqueue(
+                  enc.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n\n'),
+                );
+                await gate;
+                controller.enqueue(
+                  enc.encode(
+                    'data: {"choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\ndata: [DONE]\n\n',
+                  ),
+                );
+                controller.close();
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+        imageWindow: { maxImages: 0, keepOnOverflow: 0 },
+      },
+      { authorization: 'Bearer t', rawBody },
+    );
+    expect(response.status).toBe(200);
+    // The handler has returned; the parsed graph and the serialized payload
+    // are unreachable. Only the relay + the (already-sent) fetch body remain.
+    Bun.gc(true);
+    const steady = rssMiB() - baseline;
+    console.log(
+      `[memory-envelope] streaming steady-state after handoff: ${steady.toFixed(0)} MiB over baseline for a ${wireMiB.toFixed(1)} MiB request (${(steady / wireMiB).toFixed(2)}x)`,
+    );
+    expect(steady / wireMiB).toBeLessThan(2);
+    release!();
+    const text = await response.text();
+    expect(text).toContain('[DONE]');
+  });
+});

--- a/packages/llm-gateway/src/pipeline/read-bounded-body.ts
+++ b/packages/llm-gateway/src/pipeline/read-bounded-body.ts
@@ -74,8 +74,19 @@ export async function readAdmittedBody(
     return { ok: true, body: '', bytes: 0, release: lease.release };
   }
 
-  const decoder = new TextDecoder();
-  const parts: string[] = [];
+  // Bytes are retained as bytes and decoded to ONE string at the end. The
+  // previous implementation decoded every chunk to a string and then
+  // `join`ed them, which held two full copies of the body (the parts and the
+  // joined result) at the moment of the join. Here a declared body lands in a
+  // single preallocated buffer (each network chunk is released as soon as it
+  // is copied), and an undeclared body is concatenated once. Peak is one
+  // byte buffer plus the decoded string, and the buffer is a local that dies
+  // on return.
+  let buffer: Uint8Array | null =
+    declared !== null && declared > 0 && (maxBytes <= 0 || declared <= maxBytes)
+      ? new Uint8Array(declared)
+      : null;
+  const chunks: Uint8Array[] = [];
   let bytes = 0;
   try {
     for (;;) {
@@ -99,11 +110,34 @@ export async function readAdmittedBody(
           ...(resized.reason === 'overloaded' ? { retryAfterSeconds: 1 } : {}),
         };
       }
+      if (buffer && nextBytes <= buffer.byteLength) {
+        buffer.set(value, bytes);
+      } else {
+        // `content-length` lied (or was absent): fall back to chunk collection.
+        if (buffer) {
+          chunks.push(buffer.subarray(0, bytes));
+          buffer = null;
+        }
+        chunks.push(value);
+      }
       bytes = nextBytes;
-      parts.push(decoder.decode(value, { stream: true }));
     }
-    parts.push(decoder.decode());
-    return { ok: true, body: parts.join(''), bytes, release: lease.release };
+    let whole: Uint8Array;
+    if (buffer) {
+      whole = bytes === buffer.byteLength ? buffer : buffer.subarray(0, bytes);
+    } else if (chunks.length === 1) {
+      whole = chunks[0];
+    } else {
+      whole = new Uint8Array(bytes);
+      let offset = 0;
+      for (const chunk of chunks) {
+        whole.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+    }
+    chunks.length = 0;
+    buffer = null;
+    return { ok: true, body: new TextDecoder().decode(whole), bytes, release: lease.release };
   } catch (error) {
     lease.release();
     throw error;

--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -26,8 +26,12 @@ function hooks(usage: UsageEvent[], traces: GatewayTrace[]): GatewayHooks {
     }),
     resolveUpstream: async () => [primary, fallback],
     assertBillingActive: async () => {},
-    recordUsage: async (event) => { usage.push(event); },
-    recordTrace: async (trace) => { traces.push(trace); },
+    recordUsage: async (event) => {
+      usage.push(event);
+    },
+    recordTrace: async (trace) => {
+      traces.push(trace);
+    },
   };
 }
 
@@ -36,20 +40,23 @@ describe('simple gateway pipeline', () => {
     const usage: UsageEvent[] = [];
     const traces: GatewayTrace[] = [];
     let calls = 0;
-    const response = await handleChatCompletions({
-      hooks: hooks(usage, traces),
-      logger: { info() {}, warn() {}, error() {} },
-      fetchImpl: async () => {
-        calls += 1;
-        return new Response('provider unavailable', {
-          status: 503,
-          headers: { 'x-provider': 'provider-a' },
-        });
+    const response = await handleChatCompletions(
+      {
+        hooks: hooks(usage, traces),
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async () => {
+          calls += 1;
+          return new Response('provider unavailable', {
+            status: 503,
+            headers: { 'x-provider': 'provider-a' },
+          });
+        },
       },
-    }, {
-      authorization: 'Bearer token',
-      rawBody: JSON.stringify({ model: 'requested-model', messages: [] }),
-    });
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({ model: 'requested-model', messages: [] }),
+      },
+    );
 
     expect(calls).toBe(1);
     expect(response.status).toBe(503);
@@ -69,18 +76,79 @@ describe('simple gateway pipeline', () => {
       choices: [{ message: { role: 'assistant', content: 'ok' } }],
       usage: { prompt_tokens: 10, completion_tokens: 4 },
     });
-    const response = await handleChatCompletions({
-      hooks: hooks(usage, traces),
-      logger: { info() {}, warn() {}, error() {} },
-      fetchImpl: async () => new Response(body, { headers: { 'content-type': 'application/json' } }),
-    }, {
-      authorization: 'Bearer token',
-      rawBody: JSON.stringify({ model: 'requested-model', messages: [] }),
-    });
+    const response = await handleChatCompletions(
+      {
+        hooks: hooks(usage, traces),
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async () =>
+          new Response(body, { headers: { 'content-type': 'application/json' } }),
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({ model: 'requested-model', messages: [] }),
+      },
+    );
 
     expect(await response.text()).toBe(body);
     expect(usage).toHaveLength(1);
     expect(usage[0]).toMatchObject({ promptTokens: 10, completionTokens: 4 });
     expect(traces).toHaveLength(1);
+  });
+
+  test('drops wire-framing headers the provider sent for a body fetch already decompressed', async () => {
+    const usage: UsageEvent[] = [];
+    const traces: GatewayTrace[] = [];
+    const upstreamBody = JSON.stringify({
+      choices: [{ message: { role: 'assistant', content: 'ok' } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    });
+    const runtime = {
+      hooks: hooks(usage, traces),
+      logger: { info() {}, warn() {}, error() {} },
+    };
+    const providerHeaders = {
+      'content-type': 'application/json',
+      // What OpenRouter sends: fetch gunzips the body, but the headers still
+      // describe the compressed wire.
+      'content-encoding': 'gzip',
+      'content-length': '77',
+      'transfer-encoding': 'chunked',
+      connection: 'keep-alive',
+      'x-request-id': 'upstream-1',
+    };
+
+    const json = await handleChatCompletions(
+      {
+        ...runtime,
+        fetchImpl: async () => new Response(upstreamBody, { headers: providerHeaders }),
+      },
+      { authorization: 'Bearer token', rawBody: JSON.stringify({ model: 'm', messages: [] }) },
+    );
+    expect(json.status).toBe(200);
+    expect(json.headers.get('content-encoding')).toBeNull();
+    expect(json.headers.get('content-length')).toBeNull();
+    expect(json.headers.get('transfer-encoding')).toBeNull();
+    expect(json.headers.get('connection')).toBeNull();
+    expect(json.headers.get('x-request-id')).toBe('upstream-1');
+    expect(await json.text()).toBe(upstreamBody);
+
+    const sse = await handleChatCompletions(
+      {
+        ...runtime,
+        fetchImpl: async () =>
+          new Response('data: {"choices":[]}\n\ndata: [DONE]\n\n', {
+            headers: { ...providerHeaders, 'content-type': 'text/event-stream' },
+          }),
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({ model: 'm', messages: [], stream: true }),
+      },
+    );
+    expect(sse.status).toBe(200);
+    expect(sse.headers.get('content-encoding')).toBeNull();
+    expect(sse.headers.get('content-length')).toBeNull();
+    expect(sse.headers.get('content-type')).toBe('text/event-stream');
+    expect(await sse.text()).toContain('[DONE]');
   });
 });

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -8,11 +8,12 @@ import type {
   UsageEvent,
 } from '../domain';
 import { GatewayResolutionError, UpstreamHttpError } from '../errors';
-import { callUpstream, type FetchImpl } from '../http';
-import { extractUsageFromJson, type ExtractedUsage } from '../usage';
+import { type FetchImpl, callUpstream } from '../http';
+import { type ExtractedUsage, extractUsageFromJson } from '../usage';
 import { calculateCost } from '../usage/pricing';
-import { applyGenerationDefaults } from './generation-defaults';
 import { gatewayErrorResponse } from './error-response';
+import { applyGenerationDefaults } from './generation-defaults';
+import { DEFAULT_IMAGE_WINDOW, type ImageWindowOptions, applyImageWindow } from './image-window';
 import { relayStream } from './streaming';
 import { createTraceEmitter } from './trace';
 
@@ -25,12 +26,15 @@ export interface ChatCompletionRequest {
 export interface GatewayDeps {
   fetchImpl?: FetchImpl;
   logger?: GatewayLogger;
+  /** Inline-image cap per request. See pipeline/image-window.ts. */
+  imageWindow?: ImageWindowOptions;
 }
 
 export interface HandlerRuntime {
   hooks: GatewayHooks;
   logger: GatewayLogger;
   fetchImpl?: FetchImpl;
+  imageWindow?: ImageWindowOptions;
 }
 
 const EMPTY_USAGE: TokenCounts = {
@@ -123,11 +127,38 @@ function rawProviderError(error: UpstreamHttpError): Response {
   });
 }
 
+// Headers that describe the provider's WIRE framing, not its payload. `fetch`
+// already decompressed the body and this gateway re-frames it (a relayed
+// stream or a re-materialized string), so forwarding them lies to the next
+// hop: the API reverse proxy's `fetch` saw `content-encoding: gzip` on a
+// plaintext body and threw `ZlibError` on every non-streaming completion
+// (local stack, 2026-08-24), and Caddy would hand the same pair straight to
+// the client. Hop-by-hop headers (RFC 7230 §6.1) are dropped for the same
+// reason.
+const FRAMING_HEADERS = [
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+  'proxy-connection',
+  'te',
+  'trailer',
+  'upgrade',
+];
+
+export function passthroughHeaders(upstream: Headers): Headers {
+  const headers = new Headers(upstream);
+  for (const name of FRAMING_HEADERS) headers.delete(name);
+  return headers;
+}
+
 export async function handleChatCompletions(
   runtime: HandlerRuntime,
   req: ChatCompletionRequest,
 ): Promise<Response> {
   const { hooks, logger, fetchImpl } = runtime;
+  const imageWindow = runtime.imageWindow ?? DEFAULT_IMAGE_WINDOW;
   const id = requestId();
   const startedAt = new Date().toISOString();
   const startedMs = Date.now();
@@ -160,7 +191,11 @@ export async function handleChatCompletions(
   }
   const principal = admission.principal;
 
-  let body: Record<string, unknown>;
+  // `body` is the ONLY reference to the parsed request graph from here on.
+  // It is nulled the moment dispatch has taken it (below), so a slow
+  // time-to-first-byte upstream does not pin one extra copy of a multi-MB
+  // multimodal request for the whole prefill.
+  let body: Record<string, unknown> | null;
   try {
     body = JSON.parse(req.rawBody) as Record<string, unknown>;
     req.rawBody = '';
@@ -178,6 +213,13 @@ export async function handleChatCompletions(
     });
   }
 
+  const window = applyImageWindow(body, imageWindow);
+  if (window.dropped > 0) {
+    logger.info(
+      `[gateway] image window ${id}: kept ${window.total - window.dropped} of ${window.total} inline images`,
+    );
+  }
+
   const requestedModel = typeof body.model === 'string' ? body.model : '';
   let routedModel = requestedModel;
   try {
@@ -188,8 +230,7 @@ export async function handleChatCompletions(
       })) ?? null;
     routedModel = route?.primaryModel || requestedModel;
     body.model = routedModel;
-    const defaults =
-      route?.generationDefaultsForModel?.(routedModel) ?? route?.generationDefaults;
+    const defaults = route?.generationDefaultsForModel?.(routedModel) ?? route?.generationDefaults;
     body = applyGenerationDefaults(body, defaults);
   } catch (error) {
     refundHold(hooks, principal);
@@ -246,11 +287,16 @@ export async function handleChatCompletions(
   if (streaming) body.stream_options = { include_usage: true };
   let upstream: Response;
   try {
-    upstream = await callUpstream(body, descriptor, {
+    const dispatch = callUpstream(body, descriptor, {
       fetchImpl,
       signal: req.signal,
       requestId: id,
     });
+    // Dispatch has serialized (openai-compat) or translated (ai-sdk) the
+    // body synchronously up to its first await; this frame no longer needs
+    // the parsed graph. Drop it before waiting on the provider.
+    body = null;
+    upstream = await dispatch;
   } catch (error) {
     refundHold(hooks, principal);
     emit({
@@ -338,7 +384,7 @@ export async function handleChatCompletions(
         signal: req.signal,
         settle: async (usage) => settle(usage),
       }),
-      { status: upstream.status, headers: upstream.headers },
+      { status: upstream.status, headers: passthroughHeaders(upstream.headers) },
     );
   }
 
@@ -354,6 +400,6 @@ export async function handleChatCompletions(
   return new Response(responseText, {
     status: upstream.status,
     statusText: upstream.statusText,
-    headers: upstream.headers,
+    headers: passthroughHeaders(upstream.headers),
   });
 }

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -372,7 +372,7 @@ describe('ai-sdk request conversion', () => {
     );
   });
 
-  it('translates image_url user parts, decoding data: URLs to bytes', () => {
+  it('translates a data: image_url into a file part that carries the base64 untouched', () => {
     const { messages } = toModelMessages([
       {
         role: 'user',
@@ -382,14 +382,44 @@ describe('ai-sdk request conversion', () => {
         ],
       },
     ]);
-    const imagePart = (messages[0]?.content as Array<{ type: string; image: unknown }>).find(
-      (p) => p.type === 'image',
-    );
-    expect(imagePart).toBeDefined();
-    // data: URL decoded to Uint8Array so Bedrock treats it as inline data
-    // (not a URL reference, which Bedrock rejects).
-    expect(imagePart!.image).toBeInstanceOf(Uint8Array);
-    expect(Array.from(imagePart!.image as Uint8Array)).toEqual([0, 0, 0]); // bytes of "AAAA"
+    const filePart = (
+      messages[0]?.content as Array<{ type: string; data: unknown; mediaType?: string }>
+    ).find((p) => p.type === 'file');
+    expect(filePart).toBeDefined();
+    // Tagged inline data: the AI SDK returns it as-is and both the anthropic
+    // and bedrock providers serialize a base64 STRING through the identity
+    // `convertToBase64`, so no decode and no re-encode happens anywhere.
+    expect(filePart!.data).toEqual({ type: 'data', data: 'AAAA' });
+    expect(filePart!.mediaType).toBe('image/png');
+  });
+
+  it('keeps an http(s) image_url as a URL reference and defaults the media type', () => {
+    const { messages } = toModelMessages([
+      {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'https://img.example/a.png' } }],
+      },
+    ]);
+    const filePart = (
+      messages[0]?.content as Array<{ type: string; data: { type: string; url?: URL }; mediaType?: string }>
+    ).find((p) => p.type === 'file');
+    expect(filePart!.data.type).toBe('url');
+    expect(filePart!.data.url?.toString()).toBe('https://img.example/a.png');
+    expect(filePart!.mediaType).toBe('image');
+  });
+
+  it('data: URL without a media type falls back to the top-level image type', () => {
+    const { messages } = toModelMessages([
+      {
+        role: 'user',
+        content: [{ type: 'image_url', image_url: { url: 'data:;base64,AAAA' } }],
+      },
+    ]);
+    const filePart = (
+      messages[0]?.content as Array<{ type: string; data: unknown; mediaType?: string }>
+    ).find((p) => p.type === 'file');
+    expect(filePart!.data).toEqual({ type: 'data', data: 'AAAA' });
+    expect(filePart!.mediaType).toBe('image');
   });
 
   it('defaults maxOutputTokens for anthropic/bedrock (non-thinking), maps reasoning_effort + tool_choice', () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -87,34 +87,65 @@ function textOf(content: unknown): string {
 // the provider also depends on).
 const EMPTY_CONTENT_PLACEHOLDER = '(no content)';
 
-type UserContentPart = { type: 'text'; text: string } | { type: 'image'; image: URL | Uint8Array };
+// Images travel as AI SDK `file` parts (the SDK itself rewrites `image` parts
+// to `file` parts and flags `image` as deprecated). `mediaType` is the full
+// IANA type from the data URL, or the top-level `image` segment when the URL
+// omits it — providers resolve the subtype from the base64 signature.
+type InlineImagePart = {
+  type: 'file';
+  data: { type: 'data'; data: string } | { type: 'url'; url: URL };
+  mediaType: string;
+};
+type UserContentPart = { type: 'text'; text: string } | InlineImagePart;
 
 // A user message is "empty" for Bedrock unless it carries an image or at least
 // one non-whitespace text part.
 function nonEmptyUserContent(content: string | UserContentPart[]): string | UserContentPart[] {
   if (typeof content === 'string') return content.trim() ? content : EMPTY_CONTENT_PLACEHOLDER;
-  const hasImage = content.some((p) => p.type === 'image');
+  const hasImage = content.some((p) => p.type === 'file');
   const hasText = content.some((p) => p.type === 'text' && p.text.trim().length > 0);
   return hasImage || hasText ? content : EMPTY_CONTENT_PLACEHOLDER;
 }
 
-// Decode a `data:` URL into raw bytes suitable for inline file data. The
-// AI SDK's `convertToLanguageModelV4FilePart` converts a plain string URL to
-// `{type:'url', url: URL}`, which `@ai-sdk/amazon-bedrock` rejects with
-// `UnsupportedFunctionalityError: File URL data` — Bedrock's Converse API
-// only accepts inline (base64) image data, not URL references. Converting
-// data URLs to `Uint8Array` makes them reach the SDK as inline data, which
-// Bedrock serializes correctly as `image: { format, source: { bytes } }`.
-function decodeDataUrl(url: string): Uint8Array | URL {
-  if (!url.startsWith('data:')) return new URL(url);
+// Translate an OpenAI `image_url` into the AI SDK image part WITHOUT copying
+// or decoding the image bytes.
+//
+// A `data:` URL is handed over as tagged inline data `{type:'data', data:
+// <base64>}` plus its media type. The AI SDK's `convertToLanguageModelV4FilePart`
+// returns tagged data as-is, and both `@ai-sdk/anthropic` and
+// `@ai-sdk/amazon-bedrock` serialize a base64 STRING through
+// `convertToBase64(value)`, which is the identity for strings. The base64
+// substring therefore travels from the parsed request body to the provider
+// payload with zero decode and zero re-encode.
+//
+// The previous implementation decoded to `Uint8Array` via
+// `atob(raw).split('').map(...)` — one JS string per byte — which measured at
+// ~13x the base64 length in resident memory per image (89 MB for a 6.7 MB
+// image) and then had provider-utils re-encode the bytes through a
+// `String.fromCodePoint` concat loop. A 28 MB, 40-screenshot request went
+// through that path and OOM-killed a 512 MiB gateway (Essentia, 2026-08-22).
+//
+// Bedrock's Converse API still needs inline data rather than a URL reference
+// (`UnsupportedFunctionalityError: File URL data`), which the tagged inline
+// form satisfies. A non-data URL stays a `URL`.
+export function imageContentFromUrl(url: string): InlineImagePart {
+  const remote = (): InlineImagePart => ({
+    type: 'file',
+    data: { type: 'url', url: new URL(url) },
+    mediaType: 'image',
+  });
+  if (!url.startsWith('data:')) return remote();
   const comma = url.indexOf(',');
-  if (comma === -1) return new URL(url);
-  const raw = url.slice(comma + 1);
-  try {
-    return new Uint8Array(atob(raw).split('').map((c) => c.charCodeAt(0)));
-  } catch {
-    return new URL(url);
-  }
+  if (comma === -1) return remote();
+  const header = url.slice(5, comma); // "<mediaType>[;base64]"
+  if (!header.toLowerCase().includes(';base64')) return remote();
+  const semicolon = header.indexOf(';');
+  const mediaType = (semicolon === -1 ? header : header.slice(0, semicolon)).trim();
+  return {
+    type: 'file',
+    data: { type: 'data', data: url.slice(comma + 1) },
+    mediaType: mediaType || 'image',
+  };
 }
 
 function translateUserContent(content: unknown): string | UserContentPart[] {
@@ -125,7 +156,7 @@ function translateUserContent(content: unknown): string | UserContentPart[] {
     const part = raw as { type?: string; text?: string; image_url?: { url?: string } };
     if (part?.type === 'text') parts.push({ type: 'text', text: String(part.text ?? '') });
     else if (part?.type === 'image_url' && part.image_url?.url) {
-      parts.push({ type: 'image', image: decodeDataUrl(part.image_url.url) });
+      parts.push(imageContentFromUrl(part.image_url.url));
     }
   }
   return parts.length ? parts : textOf(content);
@@ -1177,4 +1208,3 @@ export function buildAiSdkArgs(
       | undefined,
   };
 }
-


### PR DESCRIPTION
## Problem
1. The LLM gateway OOM-killed under large multimodal requests (Essentia 2026-08-22: 40 screenshots, 28 MB). #6737 bounded admission, but the ai-sdk route still decoded every image to a byte-per-string array (89 MB resident for one 6.7 MB image) and re-encoded it; the budget's 3x factor was an estimate.
2. Every **non-streaming** completion through the API reverse proxy on dev failed 5 times out of 8: the gateway forwarded `content-encoding: gzip` on a body `fetch` had already inflated → the proxy's `fetch` threw `ZlibError` → `502` → the Cloudflare `api-router` Worker **laundered it into `503 MAINTENANCE_MODE` "Service maintenance"**. Gateway health showed `errors: 0`, 3.6 h uptime. Nothing was in maintenance, nothing crashed.
3. Cloudflare replaces any **origin 502/504** body with its own HTML "Bad gateway" page, so every JSON gateway `502 upstream_error` reached OpenCode as HTML (`AI_APICallError: Bad Gateway`, no code, no request id).

## Changes
**Gateway memory (packages/llm-gateway, apps/llm-gateway)**
- `data:` images become tagged inline base64 file parts; `@ai-sdk/anthropic` / `@ai-sdk/amazon-bedrock` serialize them through the identity `convertToBase64`. No decode, no re-encode.
- `readAdmittedBody` preallocates for a declared `content-length`, frees each chunk on copy, decodes once.
- Handler nulls the parsed body once dispatch has taken it.
- `memory-envelope.test.ts`: 27 MiB / 40-image request through the real handler, peak RSS at provider fetch:

  | route | pre-fix | post-fix |
  |---|---|---|
  | openai-compat | 2.24x | 2.25x |
  | anthropic (ai-sdk) | 4.07x **and 502** | 2.90x, 200 |
  | streaming steady state after handoff | — | 0.61x |
- Admission share 25% → 50% of the cgroup limit; the 3x factor is now backed by measurement.
- **Image window**: `GATEWAY_MAX_INLINE_IMAGES` (default 20 = Bedrock Converse hard limit); over the cap the 12 most recent survive (`GATEWAY_IMAGE_KEEP_ON_OVERFLOW`), older ones become a one-line text notice; hysteresis keeps the prefix cache-stable for 8 turns. `0` disables.
- `server.ts` honours `GATEWAY_MAX_REQUEST_BYTES`.

**Real errors, end to end**
- `passthroughHeaders()` strips `content-encoding`/`content-length`/`transfer-encoding` + hop-by-hop on all gateway response paths (root cause of the ZlibError).
- **Edge worker**: origin 5xx pass through with status, body, headers intact. The only synthetic response is `503 origin_unreachable` (`X-Origin-Status: fetch-error`, `Retry-After: 30`) when the origin fetch itself throws. Blocking maintenance comes only from the explicit admin state. CI passthrough escape hatch removed with the laundering it escaped from. **Already deployed to dev** (`dev-api-kortix-router` version `108b44d8`).
- **API proxy** (`wire.ts`): relay errors carry the exception class + message (`gateway_proxy_unreachable` for connection failures, `gateway_proxy_error` otherwise, with `cause`/`detail`), as **503**; strips framing headers on relay.
- **Gateway host** `cloudflareSafe()`: 502/504 → 503 at the HTTP edge, original status in `x-kortix-upstream-status` + `upstream_status`, `retry-after: 5`. Package contract unchanged.
- README memory contract rewritten; three learnings appended.

## Verification
- `packages/llm-gateway` 294/0, `apps/llm-gateway` 33/0, `api-router` worker 33/0 (+1 pre-existing terraform-sizing failure identical on `main`). `tsc --noEmit` clean.
- Local worktree stack (API :19108 → gateway :19190, real OpenRouter/OpenAI keys), curl via the API proxy with a PAT, `gpt-5.6-luna`:
  - **before** the header fix: 4/4 non-streaming → `502 gateway_proxy_unreachable` (`ZlibError` in log); **after**: `PONG` / `Red` 200
  - streaming → frames + usage + `[DONE]`; `/models` 200; `/messages` (Anthropic ingress) with base64 image → `Red`
  - 25 images / 15.8 MiB → 200, log `kept 12 of 25`; 41 images / 26.4 MiB → 200, `kept 12 of 41`, RSS 150 → 193 MiB
  - 6 concurrent × 26.4 MiB → 6× 200, RSS peak 601 MiB → 87 MiB after, process alive
  - `content-length: 200 MiB` → 413 in 0.3 ms; bad JSON → 400; no token → 401
- ai-sdk transport against real OpenAI (`callUpstreamViaAiSdk`, gpt-5.5, red PNG): base64 forwarded verbatim, `Red` non-stream + stream.
- **Dev, before merge**: 8× non-streaming → 5× `503 MAINTENANCE_MODE` (`x-origin-status: 502`) + 3× `200` with a **0-byte body**; streaming fine. After the worker deploy: the same requests show the real origin `502` (Cloudflare HTML page — item 3 above), i.e. the laundering is gone; the 502 itself disappears with this PR's gateway fix.
- Not run locally: a real Bedrock/Anthropic provider call (local `AWS_BEDROCK_API_KEY` returns 403 on text-only); `wire.ts` relay-error branch exercised by typecheck + review only.

## After merge
Follow Deploy Dev (gateway + api surfaces), then re-run the 8× dev sample and expect 8/8 `200` with a JSON body.

https://claude.ai/code/session_018pdwWaQKfKpG1rX5L4bsHH
