### PR TITLE
One read where there were three, one entry where there were two

### DIFF
--- a/apps/api/src/projects/routes/project-audit.ts
+++ b/apps/api/src/projects/routes/project-audit.ts
@@ -397,9 +397,18 @@ projectsApp.openapi(
       if (cursorCondition) eventConditions.push(cursorCondition);
     }
     // Audit writes are buffered off the request path (shared/audit-queue.ts).
-    // A reader must observe every event already emitted, so drain the queue
-    // before querying.
-    await flushAuditEvents();
+    // A reader of EVENTS must observe every event already emitted, so drain
+    // the queue before querying them.
+    //
+    // Only then. `include_events=false` is the badge poll — every open session
+    // tab asks every 15 s for the pending-approval COUNT and never reads an
+    // event row — and draining the queue on its behalf meant every one of
+    // those polls waited on a bulk INSERT into `audit_events`. On a self-host
+    // with 3.9 M rows that insert hit the statement timeout (57014), the
+    // request hit the 25 s server deadline, and the badge answered 503 twice
+    // per session open, forever (essentia, 2026-08-24). A count of pending
+    // connector calls does not depend on the audit queue at all.
+    if (audited && includeEvents) await flushAuditEvents();
     const fetchedEvents = audited && includeEvents
       ? await db
           .select()

--- a/apps/web/src/components/projects/llm-catalog-bootstrap.tsx
+++ b/apps/web/src/components/projects/llm-catalog-bootstrap.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import { useLiveLlmProviderCatalog } from '@/features/workspace/customize/sections/llm-provider/use-live-catalog';
 
 /**
@@ -18,6 +20,27 @@ import { useLiveLlmProviderCatalog } from '@/features/workspace/customize/sectio
  * resolved, staleTime 1h) before anything downstream needs it.
  */
 export function LlmCatalogBootstrap({ projectId }: { projectId: string }) {
-  useLiveLlmProviderCatalog(projectId, true);
+  // AFTER the page is idle, never in the session-open critical path.
+  //
+  // This fetch was the single largest request on a session open — 4 MB,
+  // 55 % of everything the page transferred, 8 s (essentia, 2026-08-24) —
+  // for data nothing on that screen renders. It exists so the connect modal
+  // and provider branding are warm by the time someone opens Customize; that
+  // is a background concern, and it now yields to everything the reader is
+  // actually waiting for (start, transcript, permissions).
+  const [idle, setIdle] = useState(false);
+  useEffect(() => {
+    const win = window as Window & {
+      requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      cancelIdleCallback?: (id: number) => void;
+    };
+    if (win.requestIdleCallback) {
+      const id = win.requestIdleCallback(() => setIdle(true), { timeout: 10_000 });
+      return () => win.cancelIdleCallback?.(id);
+    }
+    const t = setTimeout(() => setIdle(true), 3_000);
+    return () => clearTimeout(t);
+  }, []);
+  useLiveLlmProviderCatalog(projectId, idle);
   return null;
 }

--- a/apps/web/src/features/session/session-audit-shared.tsx
+++ b/apps/web/src/features/session/session-audit-shared.tsx
@@ -98,6 +98,12 @@ interface UseSessionAuditOptions {
   refetchInterval?: number | false;
   /** Suppress the global error toast (for the always-mounted header nudge). */
   silent?: boolean;
+  /**
+   * Rows to ask for. The panel reads the timeline and wants the full 1000; the
+   * badge only counts pending approvals, which the server returns most-recent
+   * first, so 100 is plenty and ten times less to serialise every 15 s.
+   */
+  limit?: number;
 }
 
 export function useSessionAudit(
@@ -110,7 +116,7 @@ export function useSessionAudit(
     queryKey: sessionAuditKey(projectId, sessionId),
     // `enabled` guards presence, so the `?? ''` fallbacks are never exercised.
     queryFn: () =>
-      getSessionAudit(projectId ?? '', sessionId ?? '', 1000, {
+      getSessionAudit(projectId ?? '', sessionId ?? '', options?.limit ?? 1000, {
         showErrors: !options?.silent,
         includeEvents: false,
       }),

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2016,8 +2016,18 @@ export function SessionChat({
   }, []);
 
   // Dismiss popup on scroll
-  const handleChatScroll = useCallback(() => {
+  // Set the first time the reader scrolls the transcript UP, and read by the
+  // older-history sentinel: history loads when someone reaches for it, never
+  // because the first page happened to be shorter than the viewport.
+  const readerScrolledUpRef = useRef(false);
+  const lastScrollTopRef = useRef<number | null>(null);
+  const handleChatScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
     setSelectionPopup(null);
+    const top = event.currentTarget.scrollTop;
+    if (lastScrollTopRef.current !== null && top < lastScrollTopRef.current) {
+      readerScrolledUpRef.current = true;
+    }
+    lastScrollTopRef.current = top;
   }, []);
 
   // When user clicks "Reply" in the popup
@@ -2849,6 +2859,7 @@ export function SessionChat({
             isLoadingOlder,
             lastPullFailed: olderPullFailed,
             autoLoadedPages,
+            readerScrolledUp: readerScrolledUpRef.current,
           })
         ) {
           setAutoLoadedPages((pages) => pages + 1);

--- a/apps/web/src/features/session/session-layout.tsx
+++ b/apps/web/src/features/session/session-layout.tsx
@@ -173,6 +173,8 @@ export const SessionLayout = memo(function SessionLayout({
   const { data: auditData } = useSessionAudit(projectId, projectSessionId, {
     enabled: !transient && !booting && !!projectId && !!projectSessionId,
     silent: true,
+    // A badge, not a timeline: pending approvals are recent by construction.
+    limit: 100,
   });
   const auditPendingCount = (auditData?.actions ?? []).filter(isPendingAction).length;
 

--- a/apps/web/src/features/session/session-older-autoload.test.ts
+++ b/apps/web/src/features/session/session-older-autoload.test.ts
@@ -6,6 +6,7 @@ import {
 } from './session-older-autoload';
 
 const IN_VIEW = {
+  readerScrolledUp: true,
   isIntersecting: true,
   hasOlder: true,
   isLoadingOlder: false,
@@ -44,6 +45,17 @@ describe('older-history autoload', () => {
 
   test('pulls the previous page once the top sentinel comes into view', () => {
     expect(shouldLoadOlderHistory(IN_VIEW)).toBe(true);
+  });
+
+  /**
+   * Measured on a real session: a first page shorter than the viewport put the
+   * top sentinel inside its 400px margin on MOUNT, so a session open cost
+   * three reads (`limit=20` + two `before=` pages) before the reader touched
+   * anything. History is for readers who reach for it.
+   */
+  test('does not pull before the reader has scrolled up, even with the sentinel in view', () => {
+    expect(shouldLoadOlderHistory({ ...IN_VIEW, readerScrolledUp: false })).toBe(false);
+    expect(shouldLoadOlderHistory({ ...IN_VIEW, readerScrolledUp: undefined })).toBe(false);
   });
 
   test('does not pull while the sentinel is out of view', () => {

--- a/apps/web/src/features/session/session-older-autoload.ts
+++ b/apps/web/src/features/session/session-older-autoload.ts
@@ -11,6 +11,17 @@ export interface OlderHistoryAutoloadState {
   /** Pages this session has already pulled AUTOMATICALLY. Absent counts as
    *  none — a fresh session, not an exhausted one. */
   autoLoadedPages?: number;
+  /**
+   * The reader has scrolled the transcript UP at least once.
+   *
+   * Without this the sentinel fired on mount: with the first page smaller than
+   * the viewport its top edge is inside the 400px margin before anyone
+   * touches anything, so a session open cost three reads instead of one
+   * (`message?limit=20` + two `before=` pages, measured on a real session).
+   * History is pulled when a reader reaches for it, not because the page is
+   * short. Absent counts as "not yet".
+   */
+  readerScrolledUp?: boolean;
 }
 
 /**
@@ -49,6 +60,7 @@ export function olderAutoloadExhausted(state: {
  *  after a failure the transcript falls back to an explicit retry affordance. */
 export function shouldLoadOlderHistory(state: OlderHistoryAutoloadState): boolean {
   return (
+    state.readerScrolledUp === true &&
     state.isIntersecting &&
     state.hasOlder &&
     !state.isLoadingOlder &&

--- a/apps/web/src/features/workspace/project-sidebar/project-settings-nav-contract.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-settings-nav-contract.test.ts
@@ -77,32 +77,36 @@ describe('project Customize sidebar entry (the routed one)', () => {
     expect(fnSource('ProjectCustomizeNavItem')).toContain('useCapabilityTab(projectId)');
   });
 
-  test('probes every tab in TAB_PREFERENCE', () => {
-    // useProjectCan is a hook, so it cannot be called from a loop that
-    // short-circuits — the probes are written out one per tab. A tab added to
-    // TAB_PREFERENCE without its own probe line reads as permanently denied,
-    // and the row silently stops offering it.
+  test('probes every tab in TAB_PREFERENCE, in ONE batched request', () => {
+    // The probes used to be written out one `useProjectCan` per tab — seven
+    // hooks, and on the wire seven `GET …/effective?action=…` plus seven CORS
+    // preflights on every project page open, for one sidebar row (measured,
+    // essentia 2026-08-24). They now go through `useCans`, which sends the
+    // list to `effective:batch` and answers all of them from one response.
+    // The list is derived from TAB_PREFERENCE itself, so a tab added there is
+    // probed by construction — the old "forgot the probe line" failure mode
+    // is gone with the lines.
     // (Not fnSource(): useCapabilityTab is module-private, not exported.)
     const hookStart = SOURCE.indexOf('function useCapabilityTab');
     expect(hookStart).toBeGreaterThan(-1);
 
-    // The literal runs from the declaration to the hook that consumes it. Do
-    // NOT cut on the first `];` — the type annotation itself ends
-    // `CapabilityTab['key'];`, which lands inside the annotation and matched
-    // zero entries.
     const preference = SOURCE.slice(SOURCE.indexOf('const TAB_PREFERENCE'), hookStart);
     const tabCount = (preference.match(/key: '/g) ?? []).length;
+    expect(tabCount).toBe(CAPABILITY_TABS.length);
+
+    // The batch list is the preference list, verbatim.
+    expect(SOURCE).toContain('const TAB_ACTIONS = TAB_PREFERENCE.map((tab) => tab.action);');
 
     const hook = SOURCE.slice(hookStart, SOURCE.indexOf('\n}', hookStart));
-    const probeCount = (hook.match(/useProjectCan\(/g) ?? []).length;
-
-    expect(tabCount).toBe(CAPABILITY_TABS.length);
-    expect(probeCount).toBe(tabCount);
+    expect((hook.match(/useCans\(/g) ?? []).length).toBe(1);
+    expect(hook).toContain('useCans({ projectId }, TAB_ACTIONS)');
+    // And no single probes crept back in.
+    expect((hook.match(/useProjectCan\(/g) ?? []).length).toBe(0);
   });
 
   test('stays visible while a probe is loading', () => {
     // Optimistic until an explicit deny — same rule as ProjectFilesNavItem.
-    expect(SOURCE).toContain('p.allowed || p.isLoading');
+    expect(SOURCE).toContain('probe.allowed || probe.isLoading');
   });
 
   test('is gated on project.customize.read, on top of the per-tab read leaves', () => {

--- a/apps/web/src/features/workspace/project-sidebar/project-settings-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-settings-nav.tsx
@@ -12,6 +12,7 @@ import {
 import { useIsMobile } from '@/hooks/utils';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useProjectCan } from '@/lib/use-project-can';
+import { useCans } from '@/lib/use-permission';
 import { useSettingsPanelStore } from '@/stores/settings-panel-store';
 
 /**
@@ -74,6 +75,9 @@ export const TAB_PREFERENCE: readonly { key: CapabilityTab['key']; action: strin
   { key: 'config', action: PROJECT_ACTIONS.PROJECT_CUSTOMIZE_WRITE },
 ];
 
+/** The probe list, fixed and in preference order, so the batch key is stable. */
+const TAB_ACTIONS = TAB_PREFERENCE.map((tab) => tab.action);
+
 /**
  * First tab the caller may open, or null when every one of them is an explicit
  * deny. Optimistic while a probe loads — same rule as ProjectFilesNavItem: the
@@ -83,24 +87,16 @@ export const TAB_PREFERENCE: readonly { key: CapabilityTab['key']; action: strin
  * be called from a loop that short-circuits.
  */
 function useCapabilityTab(projectId: string | undefined): CapabilityTab['key'] | null {
-  const canModels = useProjectCan(projectId, TAB_PREFERENCE[0].action);
-  const canConnectors = useProjectCan(projectId, TAB_PREFERENCE[1].action);
-  const canAgents = useProjectCan(projectId, TAB_PREFERENCE[2].action);
-  const canSkills = useProjectCan(projectId, TAB_PREFERENCE[3].action);
-  const canTriggers = useProjectCan(projectId, TAB_PREFERENCE[4].action);
-  const canSecrets = useProjectCan(projectId, TAB_PREFERENCE[5].action);
-  const canConfig = useProjectCan(projectId, TAB_PREFERENCE[6].action);
-
-  const probes = [
-    canModels,
-    canConnectors,
-    canAgents,
-    canSkills,
-    canTriggers,
-    canSecrets,
-    canConfig,
-  ];
-  const hit = probes.findIndex((p) => p.allowed || p.isLoading);
+  // ONE request. These used to be seven `useProjectCan` singles, and each one
+  // is its own `GET …/iam/members/:me/effective?action=…` plus a CORS
+  // preflight — fourteen round trips on every project page open, for a
+  // sidebar row. `useCans` sends the list to `effective:batch` and answers all
+  // seven from one response; the order below is still the preference order.
+  const results = useCans({ projectId }, TAB_ACTIONS);
+  const hit = TAB_PREFERENCE.findIndex((tab) => {
+    const probe = results[tab.action];
+    return !!probe && (probe.allowed || probe.isLoading);
+  });
   return hit === -1 ? null : TAB_PREFERENCE[hit].key;
 }
 

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,35 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `session-open-overfetch` — one read where there were three, one entry where there were two — DONE
+
+**Files (SDK):** `core/session-sync/session-sync-controller.ts` (tail 20 -> 50,
+older 50 -> 100 — the bytes are gone, so a page is ~2-7 kB a message) ·
+`react/use-opencode-sessions/agents.ts` (its `/detail` read goes through the
+canonical `qk.project.detail` entry via `fetchQuery` instead of a private
+fetch) · `react/use-opencode-sessions/providers.ts` (its `/model-picker` read
+goes through `qk.project.modelPicker` the same way). Web/API changes in the
+same PR: history autoload only after the reader scrolls up; the audit badge no
+longer drains the audit write queue and asks for 100 rows not 1000; the sidebar
+probes seven IAM leaves in one `effective:batch`; the 4 MB provider catalog
+bootstrap waits for idle.
+
+**What.** A HAR of one cold session open on a self-host (322 requests,
+7.35 MB) after the attachment strip: `message?limit=20` + two `before=` pages
+fired on mount because 20 stripped messages do not fill a viewport and the top
+sentinel sat inside its 400px margin; `/detail` and `/model-picker` each fetched
+twice, concurrently, from hooks calling the fetcher directly under their own
+keys; `/audit?limit=1000` 503'd at the 25 s deadline twice because the badge
+poll awaited a bulk INSERT it never reads; seven sidebar probes = fourteen
+round trips; and `llm-catalog/providers` was 4 MB, 55 % of the page, for a
+Customize surface nobody had opened.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm test` (below) · apps/web
+tsc + eslint clean, session + sidebar suites green · apps/api tsc clean,
+project-audit tests green.
+
+---
+
 ### 2026-08-24 — session `strip-attachment-bytes` — the transcript stops shipping file bytes — DONE
 
 **Files (SDK):** `platform/auth-core.ts` (`DEFAULT_FETCH_TIMEOUT_MS` 30s -> 120s, with

--- a/packages/sdk/src/core/session-sync/session-sync-controller.ts
+++ b/packages/sdk/src/core/session-sync/session-sync-controller.ts
@@ -15,27 +15,30 @@ const TAIL_RETRY_BASE_MS = 1_000;
 /** Ceiling for the retry backoff — a box that comes back is picked up within it. */
 const TAIL_RETRY_MAX_MS = 15_000;
 
-export const SESSION_SYNC_PAGE_SIZE = 50;
+export const SESSION_SYNC_PAGE_SIZE = 100;
 
 /**
  * The FIRST page — the one the user waits on.
  *
  * Time to first paint is bytes, not messages. Measured on a heavy session
- * (essentia, 2026-08-24, a run with hundreds of image reads whose parts carry
- * base64):
+ * (essentia, 2026-08-24, a run with hundreds of image reads whose parts carried
+ * base64 — BEFORE the attachment bytes were stripped from the list):
  *
  *   message?limit=50   ->   8,228 kB   30.39 s
  *   message?limit=50   ->  24,460 kB   48.76 s
  *   message?limit=50   ->  20,284 kB   35.74 s
  *   message?limit=50   ->  25,125 kB   29.23 s
  *
- * Roughly 165-500 kB PER MESSAGE. The first screen does not need fifty of
- * those; it needs enough to fill a view. Twenty is a full view plus buffer,
- * and on that session it is ~3-10 MB instead of ~8-25 MB.
+ * That was 165-500 kB PER MESSAGE, and it drove the first page down to 20.
+ * With the bytes gone (`stripInlineAttachmentBytes`, same session, same day)
+ * a message is ~2-7 kB: `limit=20` measured 132 kB, an older page of 50
+ * measured 345-420 kB. At that weight a small first page is a false economy —
+ * on a normal viewport 20 messages do not fill the screen, so the top sentinel
+ * pulled two more pages before the reader touched anything, and three round
+ * trips (each paying a CORS preflight, one measured at 3.34 s) replaced one.
  *
- * Older pages keep the larger size on purpose: by then the user is scrolling
- * deliberately, a spinner is honest, and fewer round trips is the better trade
- * — each page also costs a CORS preflight, one of which measured 3.34 s.
+ * Fifty fills the view. Older pages go to a hundred: by then the reader is
+ * scrolling deliberately, a spinner is honest, and fewer round trips wins.
  *
  * NOTE this is not what fixed the blank transcript. That was structural:
  * `hydrate` ran only after a multi-page backward walk, so NOTHING rendered at
@@ -43,7 +46,7 @@ export const SESSION_SYNC_PAGE_SIZE = 50;
  * before that single paint, and a longer blank. The walk is gone (see
  * `loadTail`); this only makes the first paint lighter.
  */
-export const SESSION_SYNC_TAIL_PAGE_SIZE = 20;
+export const SESSION_SYNC_TAIL_PAGE_SIZE = 50;
 
 /**
  * How far back the tail read will walk to complete a turn before it stops and

--- a/packages/sdk/src/react/use-opencode-sessions/agents.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/agents.ts
@@ -1,11 +1,12 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getClient } from '../../core/runtime/client';
 import type { Agent } from '@opencode-ai/sdk/v2/client';
 import { opencodeKeys, useOpenCodeRuntimeReady } from './keys';
 import { unwrap, getLSCache, setLSCache, LS_AGENTS, CACHE_SCOPE_GLOBAL } from './shared';
 import { getProjectDetail, type ProjectConfigSummary } from '../../core/rest/projects-client';
+import { contract } from '../query-contracts';
 import { qk } from '../query-keys';
 
 // Re-export filtered agents hook for UI agent selectors
@@ -22,6 +23,7 @@ export { useVisibleAgents } from '../use-visible-agents';
  * this falls back to the sandbox OpenCode runtime.
  */
 export function useOpenCodeAgents(options?: { directory?: string; projectId?: string | null }) {
+  const queryClient = useQueryClient();
   const directory = options?.directory;
   const projectId = options?.projectId ?? null;
   const runtimeReady = useOpenCodeRuntimeReady();
@@ -46,7 +48,16 @@ export function useOpenCodeAgents(options?: { directory?: string; projectId?: st
         : opencodeKeys.agents(),
     queryFn: async () => {
       if (projectId) {
-        const detail = await getProjectDetail(projectId);
+        // Through the CANONICAL entry, not a private fetch. This slot keeps its
+        // own key (see above) but it used to issue its own `GET /detail` too —
+        // concurrently with `useProjectConfig`'s, 259 ms apart on a real
+        // session open, both 88 KB. Same fetcher, same response: fetchQuery on
+        // the shared key dedupes an in-flight read and serves a fresh one.
+        const detail = await queryClient.fetchQuery({
+          queryKey: qk.project.detail(projectId),
+          queryFn: () => getProjectDetail(projectId),
+          ...contract('config'),
+        });
         const agents = projectConfigAgentsToOpenCodeAgents(detail.config);
         setLSCache(LS_AGENTS, agents, cacheScope);
         return agents;

--- a/packages/sdk/src/react/use-opencode-sessions/providers.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/providers.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getClient } from '../../core/runtime/client';
 import { useKortixRouteProjectId } from '../route-project';
 import { contract } from '../query-contracts';
@@ -32,6 +32,7 @@ import { shouldLoadProjectModelPicker } from './provider-load-plan';
 export { GATEWAY_PROVIDER_IDS };
 
 export function useOpenCodeProviders() {
+  const queryClient = useQueryClient();
   const runtimeReady = useOpenCodeRuntimeReady();
   const projectId = useKortixRouteProjectId();
   const projectDetailQuery = useQuery({
@@ -52,7 +53,16 @@ export function useOpenCodeProviders() {
   const gatewayProvidersQuery = useQuery<ProviderListResponse>({
     queryKey: ['project-providers', projectId, 'gateway'],
     queryFn: async () => {
-      const catalog = await getProjectModelPicker(projectId!);
+      // The picker is read through ITS OWN entry (`qk.project.modelPicker`),
+      // which `useProjectModels` also observes. Calling the fetcher directly
+      // here made two concurrent `GET /model-picker` on every session open
+      // (measured: both 83 KB, 1 ms apart). fetchQuery dedupes the in-flight
+      // read and fills the shared entry.
+      const catalog = await queryClient.fetchQuery({
+        queryKey: qk.project.modelPicker(projectId!),
+        queryFn: () => getProjectModelPicker(projectId!),
+        ...contract('config'),
+      });
       const providers = projectLlmCatalogToProviderList(catalog);
       setLSCache(LS_PROVIDERS, providers, gatewayCacheScope);
       return providers;


### PR DESCRIPTION
From a HAR of one cold session open on a self-host, **after** the attachment strip: 322 requests, 7.35 MB. Six things were paying for nothing.

| # | what | before | now |
|---|---|---|---|
| 1 | transcript reads on mount | `limit=20` + 2 × `before=` — the sentinel sat inside its 400px margin because 20 stripped messages don't fill a viewport | history loads only after the reader **scrolls up**; first page 50, older 100 (a message is ~2–7 kB now) |
| 2 | `llm-catalog/providers` | **4,067,031 B, 8 s, 55 % of the page**, for a Customize surface nobody opened | bootstrap waits for `requestIdleCallback` (10 s fallback). Slimming rejected: the LLM Provider page renders nearly every model field; 5,701 model bodies are 2.96 of 2.99 MB |
| 3 | `/audit?limit=1000` | **503 at the 25 s deadline, ×2 per open, every 15 s after** — the badge poll never reads an event row, yet the route `await flushAuditEvents()` first, draining a bulk INSERT into a 3.9 M-row table that hit the statement timeout | flush only when events are read; badge asks for 100 rows |
| 4 | sidebar IAM probes | 7 × `GET …/effective?action=` + 7 preflights | one `effective:batch` via `useCans` |
| 5 | `/detail` ×2, concurrent | `useOpenCodeAgents` called the fetcher directly under its own key | reads through canonical `qk.project.detail` with `fetchQuery` |
| 6 | `/model-picker` ×2, concurrent | same shape in `useOpenCodeProviders` | reads through `qk.project.modelPicker` |

**Not fixed, noted:** `/secrets` twice 5 s apart (31 KB, second source not pinned); a 31 KB providers-only catalog for the session page vs full for Customize.

## Gates
- sdk: typecheck clean · `pnpm test` **2485 / 0**
- web: tsc + eslint clean · session **2528 / 0** · sidebar **195 / 0** (contract test rewritten: asserts one `useCans(` over `TAB_ACTIONS`, zero `useProjectCan(`)
- api: tsc clean · project-audit green

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH