### PR TITLE
fix(web): keep session previews loaded

### DIFF
--- a/apps/web/src/features/session/action-panel/browser-panel.tsx
+++ b/apps/web/src/features/session/action-panel/browser-panel.tsx
@@ -16,6 +16,7 @@ import Loading from '@/components/ui/loading';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { isKortixAppUrl } from '@/features/session/kortix-app-url';
+import { useSharedPreview, useSharedPreviewDestination } from '@/features/session/shared-preview';
 import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-url';
 import { usePublicShareLink } from '@/hooks/use-public-share-link';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
@@ -93,9 +94,8 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
   const updateTabMetadata = useTabStore((s) => s.openTab);
   const recents = useBrowserRecentsStore((s) => s.recents);
   const addRecent = useBrowserRecentsStore((s) => s.addRecent);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const [standaloneIsLoading, setIsLoading] = useState(true);
+  const [standaloneHasError, setHasError] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   // Set when the address bar gets something that isn't a sandbox port, so we
   // can flag it inline instead of attempting to browse it.
@@ -144,6 +144,14 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
     () => proxyUrl(rawPreviewUrl) ?? rawPreviewUrl,
     [proxyUrl, rawPreviewUrl],
   );
+  const sharedPreview = useSharedPreview(proxiedPreviewUrl);
+  const [sharedDestination, setSharedDestination] = useState<HTMLDivElement | null>(null);
+  const focusSharedPreview = useSharedPreviewDestination(
+    sharedPreview ? proxiedPreviewUrl : '',
+    sharedDestination,
+  );
+  const isLoading = sharedPreview?.isLoading ?? standaloneIsLoading;
+  const hasError = sharedPreview?.hasError ?? standaloneHasError;
 
   // Navigation history
   const [history, setHistory] = useState<string[]>(() => [proxiedPreviewUrl].filter(Boolean));
@@ -152,7 +160,8 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
   // Inject auth token for cloud preview proxy URLs.
   // Returns null while auth is in progress — the landing state below renders
   // until the token is ready.
-  const previewUrl = useAuthenticatedPreviewUrl(proxiedPreviewUrl);
+  const standalonePreviewUrl = useAuthenticatedPreviewUrl(sharedPreview ? '' : proxiedPreviewUrl);
+  const previewUrl = sharedPreview?.previewUrl ?? standalonePreviewUrl;
 
   useEffect(() => {
     if (!proxiedPreviewUrl) return;
@@ -186,10 +195,14 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
   }, []);
 
   const handleRefresh = useCallback(() => {
+    if (sharedPreview) {
+      sharedPreview.handleRefresh();
+      return;
+    }
     setIsLoading(true);
     setHasError(false);
     setRefreshKey((k) => k + 1);
-  }, []);
+  }, [sharedPreview]);
 
   const handleLoad = useCallback(() => {
     clearLoadTimeout();
@@ -428,13 +441,13 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
   // Fallback: if onLoad doesn't fire within 5s, dismiss the loading state.
   // Cross-origin iframes frequently fail to fire onLoad events.
   useEffect(() => {
-    if (!isLoading) return;
+    if (sharedPreview || !isLoading) return;
     clearLoadTimeout();
     loadTimeoutRef.current = setTimeout(() => {
       setIsLoading(false);
     }, 5000);
     return clearLoadTimeout;
-  }, [isLoading, refreshKey, clearLoadTimeout]);
+  }, [sharedPreview, isLoading, refreshKey, clearLoadTimeout]);
 
   // At rest the bar always shows the full URL; the overlay below re-renders it
   // with the hostname highlighted (an input can't mix text colors).
@@ -658,16 +671,25 @@ export function BrowserPanel({ tabId, projectId, projectSessionId }: PreviewTabC
             />
           )}
 
-          <iframe
-            key={refreshKey}
-            ref={iframeRef}
-            src={previewUrl}
-            title={isExternalBrowsing ? `Browse: ${originalUrl}` : `Preview :${port}`}
-            className="h-full w-full border-0"
-            sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
-            onLoad={handleLoad}
-            onError={handleError}
-          />
+          {sharedPreview ? (
+            <div
+              ref={setSharedDestination}
+              tabIndex={0}
+              aria-label="Preview content"
+              onFocus={focusSharedPreview}
+              className="h-full w-full"
+            />
+          ) : (
+            <iframe
+              key={refreshKey}
+              src={previewUrl}
+              title={isExternalBrowsing ? `Browse: ${originalUrl}` : `Preview :${port}`}
+              className="h-full w-full border-0"
+              sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
+              onLoad={handleLoad}
+              onError={handleError}
+            />
+          )}
         </div>
       ) : (
         /* Landing — recent URLs when we have them, helper copy otherwise */

--- a/apps/web/src/features/session/action-panel/easy/app-preview.tsx
+++ b/apps/web/src/features/session/action-panel/easy/app-preview.tsx
@@ -25,6 +25,7 @@ import Hint from '@/components/ui/hint';
 import { Input } from '@/components/ui/input';
 import Loading from '@/components/ui/loading';
 import { ErrorState } from '@/features/layout/section/error-state';
+import { useSharedPreview, useSharedPreviewDestination } from '@/features/session/shared-preview';
 import { useAuthenticatedPreviewUrl } from '@/hooks/use-authenticated-preview-url';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { useIsMobile } from '@/hooks/utils';
@@ -133,13 +134,22 @@ export function AppPreview({
   const port = useMemo(() => parseLocalhostUrl(current)?.port ?? 0, [current]);
 
   const proxied = useMemo(() => proxyUrl(current) ?? current, [proxyUrl, current]);
+  const sharedPreview = useSharedPreview(proxied);
   // Null while the auth token is still being fetched — the landing state holds.
-  const previewUrl = useAuthenticatedPreviewUrl(proxied);
+  const standalonePreviewUrl = useAuthenticatedPreviewUrl(sharedPreview ? '' : proxied);
+  const previewUrl = sharedPreview?.previewUrl ?? standalonePreviewUrl;
   const hasPreview = !!previewUrl;
 
   const [refreshKey, setRefreshKey] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const [standaloneIsLoading, setStandaloneIsLoading] = useState(true);
+  const [standaloneHasError, setStandaloneHasError] = useState(false);
+  const isLoading = sharedPreview?.isLoading ?? standaloneIsLoading;
+  const hasError = sharedPreview?.hasError ?? standaloneHasError;
+  const [sharedDestination, setSharedDestination] = useState<HTMLDivElement | null>(null);
+  const focusSharedPreview = useSharedPreviewDestination(
+    sharedPreview ? proxied : '',
+    sharedDestination,
+  );
 
   const [addressValue, setAddressValue] = useState(current);
   const [isEditing, setIsEditing] = useState(false);
@@ -188,7 +198,8 @@ export function AppPreview({
   // token fetch that produces `previewUrl` can itself take a few seconds, and
   // arming at mount burned that wait against the app's budget.
   useEffect(() => {
-    if (!shouldArmLoadTimeout({ isLoading, noApp, hasPreview }) || !previewUrl) return;
+    if (sharedPreview || !shouldArmLoadTimeout({ isLoading, noApp, hasPreview }) || !previewUrl)
+      return;
 
     const startedAt = Date.now();
     let unreachableSince = 0;
@@ -198,8 +209,8 @@ export function AppPreview({
 
     const fail = () => {
       alive = false;
-      setIsLoading(false);
-      setHasError(true);
+      setStandaloneIsLoading(false);
+      setStandaloneHasError(true);
     };
 
     // Sandbox health is read from the store at decision time, not closed over:
@@ -251,7 +262,7 @@ export function AppPreview({
       clearTimeout(deadline);
       if (timer) clearTimeout(timer);
     };
-  }, [isLoading, refreshKey, noApp, hasPreview, previewUrl]);
+  }, [sharedPreview, isLoading, refreshKey, noApp, hasPreview, previewUrl]);
 
   // Nothing to load, so land the cursor on the address bar — the fastest way
   // in once you know the port. `focusWithoutScroll`: this fires while the
@@ -263,9 +274,19 @@ export function AppPreview({
   }, [noApp]);
 
   const reload = useCallback(() => {
-    setIsLoading(true);
-    setHasError(false);
+    if (sharedPreview) {
+      sharedPreview.handleRefresh();
+      return;
+    }
+    setStandaloneIsLoading(true);
+    setStandaloneHasError(false);
     setRefreshKey((k) => k + 1);
+  }, [sharedPreview]);
+
+  const resetNavigationLoad = useCallback(() => {
+    setStandaloneIsLoading(true);
+    setStandaloneHasError(false);
+    setRefreshKey((key) => key + 1);
   }, []);
 
   const navigateTo = useCallback(
@@ -275,9 +296,9 @@ export function AppPreview({
       useBrowserRecentsStore.getState().addRecent(next);
       setHistory((prev) => [...prev.slice(0, index + 1), next]);
       setIndex((i) => i + 1);
-      reload();
+      resetNavigationLoad();
     },
-    [index, reload],
+    [index, resetNavigationLoad],
   );
 
   const canGoBack = index > 0;
@@ -286,14 +307,14 @@ export function AppPreview({
   const goBack = useCallback(() => {
     if (!canGoBack) return;
     setIndex((i) => i - 1);
-    reload();
-  }, [canGoBack, reload]);
+    resetNavigationLoad();
+  }, [canGoBack, resetNavigationLoad]);
 
   const goForward = useCallback(() => {
     if (!canGoForward) return;
     setIndex((i) => i + 1);
-    reload();
-  }, [canGoForward, reload]);
+    resetNavigationLoad();
+  }, [canGoForward, resetNavigationLoad]);
 
   /**
    * Sandbox ports only. A bare port, `:port`, `localhost:port`, `127.0.0.1:port`
@@ -517,6 +538,14 @@ export function AppPreview({
               </div>
             </div>
           )
+        ) : sharedPreview ? (
+          <div
+            ref={setSharedDestination}
+            tabIndex={0}
+            aria-label={`${name} content`}
+            onFocus={focusSharedPreview}
+            className="h-full w-full"
+          />
         ) : hasPreview ? (
           <iframe
             key={refreshKey}
@@ -532,13 +561,13 @@ export function AppPreview({
               // `isLoading` also disarms the port watch: its effect is gated on
               // `shouldArmLoadTimeout`, so the state change tears it down.
               const next = previewLoadSuccessState();
-              setIsLoading(next.isLoading);
-              setHasError(next.hasError);
+              setStandaloneIsLoading(next.isLoading);
+              setStandaloneHasError(next.hasError);
             }}
             onError={() => {
               // A real error event is its own evidence — no probe needed.
-              setIsLoading(false);
-              setHasError(true);
+              setStandaloneIsLoading(false);
+              setStandaloneHasError(true);
             }}
           />
         ) : (

--- a/apps/web/src/features/session/action-panel/session-panel-provider.tsx
+++ b/apps/web/src/features/session/action-panel/session-panel-provider.tsx
@@ -28,6 +28,7 @@
 
 import { SessionAuditPanel } from '@/features/session/session-audit-panel';
 import { SessionFilesExplorer } from '@/features/session/session-files-explorer';
+import { SharedPreviewProvider } from '@/features/session/shared-preview';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { track } from '@/lib/track';
 import { parseLocalhostUrl } from '@/lib/utils/sandbox-url';
@@ -52,12 +53,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import { collectAllToolParts } from './shared/collect-tool-parts';
-import { type OutputItem, deriveContext, deriveOutputs } from './shared/derive-panels';
-import { groupSteps } from './shared/group-steps';
-import { latestRunCallIds, latestRunMessages } from './shared/latest-run';
-import { selectPrimaryDeliverable, sortOutputs } from './shared/output-priority';
-import { deriveRunOutcome } from './shared/run-outcome';
 import { AppPreview } from './easy/app-preview';
 import type { Detail } from './easy/detail-view';
 import {
@@ -74,6 +69,12 @@ import {
 import { FilePreview, reportsIntrinsicSize } from './easy/file-preview';
 import { StepDetailBody } from './easy/step-detail-body';
 import { StepIcon } from './easy/step-icon';
+import { collectAllToolParts } from './shared/collect-tool-parts';
+import { deriveContext, deriveOutputs, type OutputItem } from './shared/derive-panels';
+import { groupSteps } from './shared/group-steps';
+import { latestRunCallIds, latestRunMessages } from './shared/latest-run';
+import { selectPrimaryDeliverable, sortOutputs } from './shared/output-priority';
+import { deriveRunOutcome } from './shared/run-outcome';
 
 /** Where an open was triggered from. Telemetry only (W5) — never read for
  *  behavior, only reported alongside `deliverable_opened`. */
@@ -805,5 +806,9 @@ export function SessionPanelProvider({
     ],
   );
 
-  return <SessionPanelContext.Provider value={value}>{children}</SessionPanelContext.Provider>;
+  return (
+    <SessionPanelContext.Provider value={value}>
+      <SharedPreviewProvider>{children}</SharedPreviewProvider>
+    </SessionPanelContext.Provider>
+  );
 }

--- a/apps/web/src/features/session/shared-preview.test.ts
+++ b/apps/web/src/features/session/shared-preview.test.ts
@@ -1,0 +1,44 @@
+import type { ServicePreviewState } from '@/features/session/tool/shared/infrastructure';
+import { describe, expect, test } from 'bun:test';
+import {
+  createSharedPreviewStore,
+  publishSharedPreview,
+  removeSharedPreview,
+} from './shared-preview';
+
+const preview = (refreshKey: number, previewUrl = 'https://preview.test/authenticated') =>
+  ({ refreshKey, previewUrl }) as ServicePreviewState;
+
+describe('shared preview ownership', () => {
+  test('keeps one owner for duplicate URLs and promotes the next owner', () => {
+    const store = createSharedPreviewStore();
+    const first = Symbol('first');
+    const second = Symbol('second');
+
+    publishSharedPreview(store, 'https://preview.test', first, preview(0));
+    publishSharedPreview(store, 'https://preview.test', second, preview(0));
+
+    expect(store.previews.get('https://preview.test')?.keys().next().value).toBe(first);
+    expect(store.previews.get('https://preview.test')?.size).toBe(2);
+
+    removeSharedPreview(store, 'https://preview.test', first);
+
+    expect(store.previews.get('https://preview.test')?.keys().next().value).toBe(second);
+    expect(store.frameUrls.get('https://preview.test')).toBe('https://preview.test/authenticated');
+    expect(store.refreshVersions.get('https://preview.test')).toBe(0);
+  });
+
+  test('updates one owner without changing ownership order', () => {
+    const store = createSharedPreviewStore();
+    const first = Symbol('first');
+    const second = Symbol('second');
+    const refreshed = preview(1);
+
+    publishSharedPreview(store, 'https://preview.test', first, preview(0));
+    publishSharedPreview(store, 'https://preview.test', second, preview(0));
+    publishSharedPreview(store, 'https://preview.test', first, refreshed);
+
+    expect(store.previews.get('https://preview.test')?.keys().next().value).toBe(first);
+    expect(store.previews.get('https://preview.test')?.get(first)).toBe(refreshed);
+  });
+});

--- a/apps/web/src/features/session/shared-preview.tsx
+++ b/apps/web/src/features/session/shared-preview.tsx
@@ -1,0 +1,527 @@
+'use client';
+
+/**
+ * Session-local registry for live sandbox previews. The inline tool result owns
+ * one iframe. Desktop and mobile browser surfaces register visual destinations
+ * for that iframe instead of mounting another document.
+ */
+
+import type { ServicePreviewState } from '@/features/session/tool/shared/infrastructure';
+import { INTERACTIVE_PREVIEW_IFRAME_SANDBOX } from '@/lib/security/iframe-sandbox';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+type SharedPreviewStore = {
+  previews: Map<string, Map<symbol, ServicePreviewState>>;
+  destinations: Map<string, HTMLElement[]>;
+  inlineDestinations: Map<string, Map<symbol, HTMLElement>>;
+  frames: Map<string, HTMLIFrameElement>;
+  frameUrls: Map<string, string>;
+  refreshVersions: Map<string, number>;
+  activeRefreshKeys: Map<string, number>;
+  listeners: Set<() => void>;
+  revision: number;
+};
+type SharedPreviewContextValue = {
+  store: SharedPreviewStore;
+  publish: (key: string, owner: symbol, preview: ServicePreviewState) => void;
+  remove: (key: string, owner: symbol) => void;
+  setDestination: (key: string, element: HTMLElement, mounted: boolean) => void;
+};
+
+const SharedPreviewContext = createContext<SharedPreviewContextValue | null>(null);
+
+function notify(store: SharedPreviewStore) {
+  store.revision += 1;
+  store.listeners.forEach((listener) => listener());
+}
+
+export function createSharedPreviewStore(): SharedPreviewStore {
+  return {
+    previews: new Map(),
+    destinations: new Map(),
+    inlineDestinations: new Map(),
+    frames: new Map(),
+    frameUrls: new Map(),
+    refreshVersions: new Map(),
+    activeRefreshKeys: new Map(),
+    listeners: new Set(),
+    revision: 0,
+  };
+}
+
+export function publishSharedPreview(
+  store: SharedPreviewStore,
+  key: string,
+  owner: symbol,
+  preview: ServicePreviewState,
+) {
+  const records = store.previews.get(key) ?? new Map();
+  if (records.get(owner) === preview) return;
+  const activeOwner = records.keys().next().value;
+  const previous = records.get(owner);
+  if (activeOwner === owner && previous && previous.refreshKey !== preview.refreshKey) {
+    store.refreshVersions.set(key, (store.refreshVersions.get(key) ?? 0) + 1);
+    if (preview.previewUrl) store.frameUrls.set(key, preview.previewUrl);
+  }
+  records.set(owner, preview);
+  store.previews.set(key, records);
+  if (activeOwner === undefined) {
+    store.activeRefreshKeys.set(key, preview.refreshKey);
+    store.refreshVersions.set(key, store.refreshVersions.get(key) ?? 0);
+  } else if (activeOwner === owner) {
+    store.activeRefreshKeys.set(key, preview.refreshKey);
+  }
+  if (!store.frameUrls.has(key) && preview.previewUrl) store.frameUrls.set(key, preview.previewUrl);
+  notify(store);
+}
+
+export function removeSharedPreview(store: SharedPreviewStore, key: string, owner: symbol) {
+  const records = store.previews.get(key);
+  const wasActive = records?.keys().next().value === owner;
+  if (!records?.delete(owner)) return;
+  store.inlineDestinations.get(key)?.delete(owner);
+  if (records.size === 0) {
+    store.previews.delete(key);
+    store.destinations.delete(key);
+    store.inlineDestinations.delete(key);
+    store.frames.delete(key);
+    store.frameUrls.delete(key);
+    store.refreshVersions.delete(key);
+    store.activeRefreshKeys.delete(key);
+  } else if (wasActive) {
+    const next = records.values().next().value;
+    if (next) store.activeRefreshKeys.set(key, next.refreshKey);
+  }
+  notify(store);
+}
+
+export function SharedPreviewProvider({ children }: { children: React.ReactNode }) {
+  const [store] = useState(createSharedPreviewStore);
+
+  const publish = useCallback(
+    (key: string, owner: symbol, preview: ServicePreviewState) => {
+      publishSharedPreview(store, key, owner, preview);
+    },
+    [store],
+  );
+
+  const remove = useCallback(
+    (key: string, owner: symbol) => {
+      removeSharedPreview(store, key, owner);
+    },
+    [store],
+  );
+
+  const setDestination = useCallback(
+    (key: string, element: HTMLElement, mounted: boolean) => {
+      const destinations = store.destinations.get(key) ?? [];
+      if (mounted) {
+        store.destinations.set(key, [...destinations.filter((item) => item !== element), element]);
+      } else {
+        const remaining = destinations.filter((item) => item !== element);
+        if (remaining.length > 0) store.destinations.set(key, remaining);
+        else store.destinations.delete(key);
+      }
+      notify(store);
+    },
+    [store],
+  );
+  const value = useMemo(
+    () => ({ store, publish, remove, setDestination }),
+    [store, publish, remove, setDestination],
+  );
+
+  return (
+    <SharedPreviewContext.Provider value={value}>
+      {children}
+      <SharedPreviewFrames context={value} />
+    </SharedPreviewContext.Provider>
+  );
+}
+
+export function usePublishSharedPreview(
+  key: string | null,
+  preview: ServicePreviewState,
+): { owner: symbol; isOwner: boolean; shared: boolean } {
+  const context = useContext(SharedPreviewContext);
+  const [owner] = useState(() => Symbol('shared-preview'));
+
+  useEffect(() => {
+    if (!context || !key) return;
+    return () => context.remove(key, owner);
+  }, [context, key, owner]);
+
+  useEffect(() => {
+    if (!context || !key) return;
+    context.publish(key, owner, preview);
+  }, [context, key, owner, preview]);
+
+  useStoreRevision(context);
+  return {
+    owner,
+    shared: !!context,
+    isOwner: !context || !key || context.store.previews.get(key)?.keys().next().value === owner,
+  };
+}
+
+function useStoreRevision(context: SharedPreviewContextValue | null) {
+  useSyncExternalStore(
+    useCallback(
+      (listener) => {
+        if (!context) return () => {};
+        context.store.listeners.add(listener);
+        return () => {
+          context.store.listeners.delete(listener);
+        };
+      },
+      [context],
+    ),
+    () => context?.store.revision ?? 0,
+    () => 0,
+  );
+}
+
+export function useSharedPreview(key: string): ServicePreviewState | null {
+  const context = useContext(SharedPreviewContext);
+  useStoreRevision(context);
+  return context?.store.previews.get(key)?.values().next().value ?? null;
+}
+
+export function useSharedPreviewDestination(key: string, element: HTMLElement | null): () => void {
+  const context = useContext(SharedPreviewContext);
+  useEffect(() => {
+    if (!context || !key || !element) return;
+    context.setDestination(key, element, true);
+    return () => context.setDestination(key, element, false);
+  }, [context, element, key]);
+  return useCallback(() => context?.store.frames.get(key)?.focus(), [context, key]);
+}
+
+export function useSharedPreviewInlineDestination(
+  key: string | null,
+  owner: symbol,
+  element: HTMLElement | null,
+): () => void {
+  const context = useContext(SharedPreviewContext);
+  useEffect(() => {
+    if (!context || !key || !element) return;
+    const destinations = context.store.inlineDestinations.get(key) ?? new Map();
+    destinations.set(owner, element);
+    context.store.inlineDestinations.set(key, destinations);
+    notify(context.store);
+    return () => {
+      const current = context.store.inlineDestinations.get(key);
+      if (current?.get(owner) !== element) return;
+      current.delete(owner);
+      if (current.size === 0) context.store.inlineDestinations.delete(key);
+      notify(context.store);
+    };
+  }, [context, element, key, owner]);
+  return useCallback(() => context?.store.frames.get(key ?? '')?.focus(), [context, key]);
+}
+
+export function useSharedPreviewHasPanelDestination(key: string | null): boolean {
+  const context = useContext(SharedPreviewContext);
+  useStoreRevision(context);
+  const destinations = key ? (context?.store.destinations.get(key) ?? []) : [];
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (destinations.length === 0) {
+      const frame = requestAnimationFrame(() => setVisible(false));
+      return () => cancelAnimationFrame(frame);
+    }
+    const update = () => {
+      setVisible(
+        destinations.some((destination) => {
+          const rect = destination.getBoundingClientRect();
+          const style = getComputedStyle(destination);
+          return (
+            rect.width > 0 &&
+            rect.height > 0 &&
+            style.display !== 'none' &&
+            style.visibility !== 'hidden'
+          );
+        }),
+      );
+    };
+    const frame = requestAnimationFrame(update);
+    const observer = new MutationObserver(update);
+    for (const destination of destinations) {
+      for (
+        let element: HTMLElement | null = destination;
+        element;
+        element = element.parentElement
+      ) {
+        observer.observe(element, {
+          attributes: true,
+          attributeFilter: ['class', 'style'],
+        });
+      }
+    }
+    window.addEventListener('resize', update);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [destinations]);
+
+  return visible;
+}
+
+function SharedPreviewFrames({ context }: { context: SharedPreviewContextValue }) {
+  useStoreRevision(context);
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(
+    [...context.store.previews].map(([key, records]) => {
+      const active = records.entries().next().value as [symbol, ServicePreviewState] | undefined;
+      if (!active) return null;
+      const [owner, preview] = active;
+      const panelDestinations = context.store.destinations.get(key) ?? [];
+      const inlineDestination = context.store.inlineDestinations.get(key)?.get(owner) ?? null;
+      const src = context.store.frameUrls.get(key) ?? preview.previewUrl;
+      if ((panelDestinations.length === 0 && !inlineDestination) || !src) return null;
+      return (
+        <SharedPreviewFrame
+          key={key}
+          previewKey={key}
+          preview={preview}
+          panelDestinations={panelDestinations}
+          inlineDestination={inlineDestination}
+          src={src}
+          refreshVersion={context.store.refreshVersions.get(key) ?? 0}
+          store={context.store}
+        />
+      );
+    }),
+    document.body,
+  );
+}
+
+function SharedPreviewFrame({
+  previewKey,
+  preview,
+  panelDestinations,
+  inlineDestination,
+  src,
+  refreshVersion,
+  store,
+}: {
+  previewKey: string;
+  preview: ServicePreviewState;
+  panelDestinations: HTMLElement[];
+  inlineDestination: HTMLElement | null;
+  src: string;
+  refreshVersion: number;
+  store: SharedPreviewStore;
+}) {
+  const [iframeElement, setIframeElement] = useState<HTMLIFrameElement | null>(null);
+
+  useEffect(() => {
+    if (!iframeElement) return;
+    store.frames.set(previewKey, iframeElement);
+    return () => {
+      if (store.frames.get(previewKey) === iframeElement) store.frames.delete(previewKey);
+    };
+  }, [iframeElement, previewKey, store]);
+
+  useEffect(() => {
+    if (!iframeElement) return;
+
+    const allDestinations = [...panelDestinations, inlineDestination].filter(
+      (element): element is HTMLElement => !!element,
+    );
+    const allAncestors = new Set<HTMLElement>();
+    for (const destination of allDestinations) {
+      for (let ancestor = destination.parentElement; ancestor; ancestor = ancestor.parentElement) {
+        allAncestors.add(ancestor);
+      }
+    }
+
+    const clippingAncestors = (destination: HTMLElement) => {
+      const result: Array<{
+        element: HTMLElement;
+        x: boolean;
+        y: boolean;
+        radii: [string, string, string, string];
+      }> = [];
+      for (let ancestor = destination.parentElement; ancestor; ancestor = ancestor.parentElement) {
+        const style = getComputedStyle(ancestor);
+        const x = /(auto|clip|hidden|scroll)/.test(style.overflowX);
+        const y = /(auto|clip|hidden|scroll)/.test(style.overflowY);
+        if (x || y) {
+          result.push({
+            element: ancestor,
+            x,
+            y,
+            radii: [
+              style.borderTopLeftRadius,
+              style.borderTopRightRadius,
+              style.borderBottomRightRadius,
+              style.borderBottomLeftRadius,
+            ],
+          });
+        }
+      }
+      return result;
+    };
+    const clippingByDestination = new Map(
+      allDestinations.map((destination) => [destination, clippingAncestors(destination)]),
+    );
+
+    const isVisible = (element: HTMLElement | null) => {
+      if (!element) return false;
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return (
+        rect.width > 0 &&
+        rect.height > 0 &&
+        style.display !== 'none' &&
+        style.visibility !== 'hidden'
+      );
+    };
+
+    const placeFrame = () => {
+      const destination = [...panelDestinations].reverse().find(isVisible) ?? inlineDestination;
+      if (!destination) {
+        iframeElement.style.visibility = 'hidden';
+        iframeElement.style.pointerEvents = 'none';
+        return;
+      }
+      const rect = destination.getBoundingClientRect();
+      let clipTop = 0;
+      let clipRight = window.innerWidth;
+      let clipBottom = window.innerHeight;
+      let clipLeft = 0;
+      let topLeft = '0px';
+      let topRight = '0px';
+      let bottomRight = '0px';
+      let bottomLeft = '0px';
+
+      for (const ancestor of clippingByDestination.get(destination) ?? []) {
+        const bounds = ancestor.element.getBoundingClientRect();
+        if (ancestor.x) {
+          clipLeft = Math.max(clipLeft, bounds.left);
+          clipRight = Math.min(clipRight, bounds.right);
+        }
+        if (ancestor.y) {
+          clipTop = Math.max(clipTop, bounds.top);
+          clipBottom = Math.min(clipBottom, bounds.bottom);
+        }
+        if (Math.abs(rect.left - bounds.left) < 2) {
+          if (Math.abs(rect.top - bounds.top) < 2 && topLeft === '0px') {
+            topLeft = ancestor.radii[0];
+          }
+          if (Math.abs(rect.bottom - bounds.bottom) < 2 && bottomLeft === '0px') {
+            bottomLeft = ancestor.radii[3];
+          }
+        }
+        if (Math.abs(rect.right - bounds.right) < 2) {
+          if (Math.abs(rect.top - bounds.top) < 2 && topRight === '0px') {
+            topRight = ancestor.radii[1];
+          }
+          if (Math.abs(rect.bottom - bounds.bottom) < 2 && bottomRight === '0px') {
+            bottomRight = ancestor.radii[2];
+          }
+        }
+      }
+
+      const insetTop = Math.max(0, clipTop - rect.top);
+      const insetRight = Math.max(0, rect.right - clipRight);
+      const insetBottom = Math.max(0, rect.bottom - clipBottom);
+      const insetLeft = Math.max(0, clipLeft - rect.left);
+      const visible =
+        !preview.isLoading &&
+        !preview.hasError &&
+        rect.width - insetLeft - insetRight > 0 &&
+        rect.height - insetTop - insetBottom > 0;
+      Object.assign(iframeElement.style, {
+        position: 'fixed',
+        top: `${rect.top}px`,
+        left: `${rect.left}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        visibility: visible ? 'visible' : 'hidden',
+        pointerEvents: visible ? 'auto' : 'none',
+        clipPath: `inset(${insetTop}px ${insetRight}px ${insetBottom}px ${insetLeft}px)`,
+        borderTopLeftRadius: topLeft,
+        borderTopRightRadius: topRight,
+        borderBottomRightRadius: bottomRight,
+        borderBottomLeftRadius: bottomLeft,
+        zIndex: panelDestinations.includes(destination) ? '60' : '15',
+      });
+    };
+
+    let animationFrame = 0;
+    let trackingUntil = 0;
+    const trackTransition = () => {
+      placeFrame();
+      if (performance.now() < trackingUntil)
+        animationFrame = requestAnimationFrame(trackTransition);
+      else animationFrame = 0;
+    };
+    const trackTransitionWindow = () => {
+      trackingUntil = performance.now() + 500;
+      if (!animationFrame) animationFrame = requestAnimationFrame(trackTransition);
+    };
+    trackTransitionWindow();
+
+    const observer = new ResizeObserver(placeFrame);
+    allDestinations.forEach((element) => observer.observe(element));
+    allAncestors.forEach((element) => observer.observe(element));
+    const mutationObserver = new MutationObserver(trackTransitionWindow);
+    allAncestors.forEach((element) => {
+      mutationObserver.observe(element, {
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+      });
+    });
+    allDestinations.forEach((element) => {
+      if (!element.parentElement) return;
+      mutationObserver.observe(element.parentElement, { childList: true, subtree: true });
+    });
+    window.addEventListener('resize', placeFrame);
+    window.addEventListener('scroll', placeFrame, true);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+      mutationObserver.disconnect();
+      window.removeEventListener('resize', placeFrame);
+      window.removeEventListener('scroll', placeFrame, true);
+    };
+  }, [iframeElement, inlineDestination, panelDestinations, preview.hasError, preview.isLoading]);
+
+  const handleLoad = () => {
+    store.previews.get(previewKey)?.forEach((record) => record.onLoad());
+  };
+  const handleError = () => {
+    store.previews.get(previewKey)?.forEach((record) => record.onError());
+  };
+
+  return (
+    <iframe
+      ref={setIframeElement}
+      key={refreshVersion}
+      src={src}
+      title={preview.displayLabel}
+      tabIndex={-1}
+      data-shared-preview={previewKey}
+      style={{ visibility: 'hidden' }}
+      className="bg-secondary border-0"
+      sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
+      onLoad={handleLoad}
+      onError={handleError}
+    />
+  );
+}

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -15,6 +15,12 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 import { openSessionQuickView } from '@/features/session/open-session-quick-view';
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import { isEmptyShowPart } from '@/features/session/session-activity-groups';
+import {
+  usePublishSharedPreview,
+  useSharedPreview,
+  useSharedPreviewHasPanelDestination,
+  useSharedPreviewInlineDestination,
+} from '@/features/session/shared-preview';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import {
   ToolSurfaceContext,
@@ -191,20 +197,36 @@ export function useServicePreview(url: string, label?: string, sessionId?: strin
     setHasError(true);
   }, []);
 
-  return {
-    navigationEnabled,
-    proxy,
-    previewUrl,
-    isLoading,
-    hasError,
-    refreshKey,
-    handleRefresh,
-    displayLabel,
-    navigateToPreviewTab,
-    openInBrowser,
-    onLoad,
-    onError,
-  };
+  return useMemo(
+    () => ({
+      navigationEnabled,
+      proxy,
+      previewUrl,
+      isLoading,
+      hasError,
+      refreshKey,
+      handleRefresh,
+      displayLabel,
+      navigateToPreviewTab,
+      openInBrowser,
+      onLoad,
+      onError,
+    }),
+    [
+      navigationEnabled,
+      proxy,
+      previewUrl,
+      isLoading,
+      hasError,
+      refreshKey,
+      handleRefresh,
+      displayLabel,
+      navigateToPreviewTab,
+      openInBrowser,
+      onLoad,
+      onError,
+    ],
+  );
 }
 
 export type ServicePreviewState = ReturnType<typeof useServicePreview>;
@@ -213,6 +235,7 @@ export type ServicePreviewState = ReturnType<typeof useServicePreview>;
 // so they never render twice around the same iframe.
 export function ServicePreviewActions({ preview }: { preview: ServicePreviewState }) {
   const tHardcodedUi = useTranslations('hardcodedUi');
+  const sharedPreview = useSharedPreview(preview.proxy?.proxyUrl ?? '');
   const {
     navigationEnabled,
     proxy,
@@ -221,7 +244,7 @@ export function ServicePreviewActions({ preview }: { preview: ServicePreviewStat
     handleRefresh,
     navigateToPreviewTab,
     openInBrowser,
-  } = preview;
+  } = sharedPreview ?? preview;
 
   return (
     <div className="flex shrink-0 items-center gap-1">
@@ -266,8 +289,9 @@ export function ServicePreviewActions({ preview }: { preview: ServicePreviewStat
 
 export function ServicePreviewUrlFallback({ preview }: { preview: ServicePreviewState }) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
+  const sharedPreview = useSharedPreview(preview.proxy?.proxyUrl ?? '');
   const { previewUrl, displayLabel, handleRefresh, openInBrowser, isLoading, navigationEnabled } =
-    preview;
+    sharedPreview ?? preview;
   // NEVER the previewUrl: on a preview origin it carries a one-shot `?token=`
   // (the user's live Supabase JWT), and this renders as visible page text —
   // screenshot- and screen-share-capturable. previewUrl stays in the click
@@ -316,12 +340,32 @@ export function ServicePreviewUrlFallback({ preview }: { preview: ServicePreview
 
 export function ServicePreviewViewport({ preview }: { preview: ServicePreviewState }) {
   const fill = useContext(ToolSurfaceContext) === 'panel';
-  const { previewUrl, displayLabel, isLoading, hasError, refreshKey, onLoad, onError } = preview;
+  const { previewUrl, displayLabel, isLoading, hasError } = preview;
   const linkOnlyPreview = prefersPreviewLink(previewUrl);
   const tHardcodedUi = useTranslations('hardcodedUi');
+  const previewKey = preview.proxy?.proxyUrl ?? null;
+  const sharedPreviewKey = linkOnlyPreview ? null : previewKey;
+  const [inlineDestination, setInlineDestination] = useState<HTMLDivElement | null>(null);
+  const { owner, isOwner, shared } = usePublishSharedPreview(sharedPreviewKey, preview);
+  const focusSharedPreview = useSharedPreviewInlineDestination(
+    sharedPreviewKey,
+    owner,
+    inlineDestination,
+  );
+  const hasPanelDestination = useSharedPreviewHasPanelDestination(sharedPreviewKey);
 
   return (
     <div
+      ref={setInlineDestination}
+      tabIndex={previewUrl && !linkOnlyPreview && isOwner && !hasPanelDestination ? 0 : undefined}
+      aria-label={
+        previewUrl && !linkOnlyPreview && isOwner && !hasPanelDestination
+          ? `${displayLabel} content`
+          : undefined
+      }
+      onFocus={() => {
+        if (!hasPanelDestination) focusSharedPreview();
+      }}
       className={cn(
         'bg-secondary relative w-full overflow-hidden',
         fill ? 'h-full' : 'aspect-video',
@@ -338,15 +382,15 @@ export function ServicePreviewViewport({ preview }: { preview: ServicePreviewSta
         </div>
       )}
       {(hasError || linkOnlyPreview) && <ServicePreviewUrlFallback preview={preview} />}
-      {previewUrl && !linkOnlyPreview && (
+      {!shared && previewUrl && !linkOnlyPreview && (
         <iframe
-          key={refreshKey}
+          key={preview.refreshKey}
           src={previewUrl}
           title={displayLabel}
           className="bg-secondary absolute inset-0 h-full w-full border-0"
           sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
-          onLoad={onLoad}
-          onError={onError}
+          onLoad={preview.onLoad}
+          onError={preview.onError}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- Keep one provider-owned iframe for inline, desktop, and mobile preview surfaces.
- Preserve live document state when users open, close, hide, and reopen preview panels.
- Route refresh controls through the shared iframe while retaining standalone browser navigation.
- Preserve clipping, transitions, duplicate-owner promotion, and no-provider fallback behavior.

## Verification
- `pnpm test`: 383/383 API/CLI flows; SDK 2426 pass; all core lanes pass.
- `pnpm --dir apps/web test`: 8098 pass, 0 fail.
- `pnpm --dir apps/web build`: production build completed; 203/203 static pages generated.
- Focused ESLint: 0 errors; existing React hook warnings only.
- Desktop Chromium: Counter 1 and the DOM marker survive open, close, hide, and reopen; HAR records 0 preview document requests.
- Mobile Chromium: Counter 1 and the DOM marker survive drawer open and close; HAR records 0 preview document requests.
- Refresh from inline, desktop, and mobile resets the same iframe to Counter 0.