### PR TITLE
Refresh rotated E2B ingress tokens

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Provider traffic credentials need a cross-replica refresh bound (2026-08-24)
+
+**When:** caching a provider handle that carries a private ingress token. Bound
+the cache lifetime and refresh it with single-flight connection work. A resume
+can rotate the token in one API replica while every other replica retains the
+old handle indefinitely. *Incident:* an Essentia E2B guest was locally ready in
+12.9 seconds, but `/start` failed because another API replica used its stale
+traffic token and received repeated `502 port not ready` responses.
+*Enforcer:* E2B ingress rotation and concurrent-refresh tests.
+
 ### A deliberate runtime failure park must require explicit restart (2026-08-24)
 
 **When:** returning a stopped sandbox after `runtime_boot_failed` or

--- a/apps/api/src/platform/providers/e2b.test.ts
+++ b/apps/api/src/platform/providers/e2b.test.ts
@@ -149,7 +149,8 @@ mock.module('../service-key', () => ({
 }));
 
 const { config } = await import('../../config');
-const { E2BProvider, E2B_RUNNING_STATUS_CACHE_TTL_MS } = await import('./e2b');
+const { E2BProvider, E2B_INGRESS_HANDLE_TTL_MS, E2B_RUNNING_STATUS_CACHE_TTL_MS } =
+  await import('./e2b');
 const { getProvider } = await import('./index');
 
 beforeEach(() => {
@@ -596,6 +597,169 @@ describe('E2B provider lifecycle', () => {
       headers: { 'e2b-traffic-access-token': 'traffic-private' },
       effectivePort: 3000,
     });
+  });
+
+  test('ingress refreshes the private traffic token after the bounded cache window', async () => {
+    const originalNow = Date.now;
+    let now = 1_000;
+    Date.now = () => now;
+    let connects = 0;
+    connectFactory = (sandboxId) => {
+      connects += 1;
+      return fakeSandbox(sandboxId, `traffic-${connects}`);
+    };
+    try {
+      const provider = new E2BProvider();
+      const first = await provider.resolveIngress('sb-ingress-rotation', {
+        port: 8000,
+        transport: 'http',
+      });
+      now += 1_000;
+      const cached = await provider.resolveIngress('sb-ingress-rotation', {
+        port: 8000,
+        transport: 'http',
+      });
+      now += 5_000;
+      const refreshed = await provider.resolveIngress('sb-ingress-rotation', {
+        port: 8000,
+        transport: 'http',
+      });
+
+      expect(E2B_INGRESS_HANDLE_TTL_MS).toBe(5_000);
+      expect(first.headers).toEqual({ 'e2b-traffic-access-token': 'traffic-1' });
+      expect(cached.headers).toEqual({ 'e2b-traffic-access-token': 'traffic-1' });
+      expect(refreshed.headers).toEqual({ 'e2b-traffic-access-token': 'traffic-2' });
+      expect(connects).toBe(2);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  test('concurrent ingress refreshes share one E2B connect', async () => {
+    let finishConnect!: () => void;
+    const connectGate = new Promise<void>((resolve) => {
+      finishConnect = resolve;
+    });
+    let connects = 0;
+    connectFactory = async (sandboxId) => {
+      connects += 1;
+      await connectGate;
+      return fakeSandbox(sandboxId, 'traffic-single-flight');
+    };
+    const provider = new E2BProvider();
+
+    const first = provider.resolveIngress('sb-ingress-single-flight', {
+      port: 8000,
+      transport: 'http',
+    });
+    const second = provider.resolveIngress('sb-ingress-single-flight', {
+      port: 8000,
+      transport: 'http',
+    });
+    for (let attempt = 0; attempt < 10 && connects === 0; attempt += 1) {
+      await Promise.resolve();
+    }
+
+    expect(connects).toBe(1);
+    finishConnect();
+    expect(await Promise.all([first, second])).toEqual([
+      expect.objectContaining({
+        headers: { 'e2b-traffic-access-token': 'traffic-single-flight' },
+      }),
+      expect.objectContaining({
+        headers: { 'e2b-traffic-access-token': 'traffic-single-flight' },
+      }),
+    ]);
+  });
+
+  test('a start and concurrent ingress refresh share one E2B connect', async () => {
+    let finishConnect!: () => void;
+    const connectGate = new Promise<void>((resolve) => {
+      finishConnect = resolve;
+    });
+    let connects = 0;
+    connectFactory = async (sandboxId) => {
+      connects += 1;
+      await connectGate;
+      return fakeSandbox(sandboxId, 'traffic-start-single-flight');
+    };
+    const provider = new E2BProvider();
+
+    const starting = provider.start('sb-start-ingress-single-flight');
+    const ingress = provider.resolveIngress('sb-start-ingress-single-flight', {
+      port: 8000,
+      transport: 'http',
+    });
+    await Promise.resolve();
+
+    expect(connects).toBe(1);
+    finishConnect();
+    await starting;
+    expect(await ingress).toMatchObject({
+      headers: { 'e2b-traffic-access-token': 'traffic-start-single-flight' },
+    });
+  });
+
+  test('an ingress refresh and later start share one E2B connect', async () => {
+    let finishConnect!: () => void;
+    const connectGate = new Promise<void>((resolve) => {
+      finishConnect = resolve;
+    });
+    let connects = 0;
+    connectFactory = async (sandboxId) => {
+      connects += 1;
+      await connectGate;
+      return fakeSandbox(sandboxId, 'traffic-ingress-first-single-flight');
+    };
+    const provider = new E2BProvider();
+
+    const ingress = provider.resolveIngress('sb-ingress-start-single-flight', {
+      port: 8000,
+      transport: 'http',
+    });
+    for (let attempt = 0; attempt < 10 && connects === 0; attempt += 1) {
+      await Promise.resolve();
+    }
+    const starting = provider.start('sb-ingress-start-single-flight');
+
+    expect(connects).toBe(1);
+    finishConnect();
+    await starting;
+    expect(await ingress).toMatchObject({
+      headers: { 'e2b-traffic-access-token': 'traffic-ingress-first-single-flight' },
+    });
+  });
+
+  test('a cold start begins the ingress TTL after runtime readiness', async () => {
+    let now = 1_000;
+    let connects = 0;
+    connectFactory = (sandboxId) => {
+      connects += 1;
+      const sandbox = fakeSandbox(sandboxId, 'traffic-ready-ttl');
+      const run = sandbox.commands.run;
+      sandbox.commands.run = async (command, opts) => {
+        const result = await run(command, opts);
+        if (command.includes('/kortix/health')) now += E2B_INGRESS_HANDLE_TTL_MS + 1;
+        return result;
+      };
+      return sandbox;
+    };
+    const provider = new E2BProvider(25_000, 25_000, 25_000, () => now);
+
+    await provider.start('sb-ready-ttl');
+    await provider.resolveIngress('sb-ready-ttl', { port: 8000, transport: 'http' });
+
+    expect(connects).toBe(1);
+  });
+
+  test('ingress refresh never resumes a provider-paused sandbox', async () => {
+    infoState = 'paused';
+    const provider = new E2BProvider();
+
+    await expect(
+      provider.resolveIngress('sb-paused-ingress', { port: 8000, transport: 'http' }),
+    ).rejects.toThrow('is not running');
+    expect(connected).toHaveLength(0);
   });
 
   test('ingress fails closed rather than exposing a tokenless private URL', async () => {

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -310,6 +310,7 @@ async function ensureAppEntrypoint(
 
 export class E2BProvider implements SandboxProvider {
   readonly name: ProviderName = 'e2b';
+  readonly ingressCacheTtlMs = 0;
 
   constructor(
     private readonly removeTimeoutMs = E2B_REMOVE_TIMEOUT_MS,

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -89,6 +89,12 @@ function isMissingSandboxError(error: unknown): boolean {
  * after API restarts recovers a fresh token and explicitly resumes a paused box.
  */
 const connectedSandboxes = new Map<string, E2BSandbox>();
+export const E2B_INGRESS_HANDLE_TTL_MS = 5_000;
+const connectedSandboxCachedAt = new Map<string, number>();
+const connectOperations = new Map<
+  string,
+  { generation: object; promise: Promise<E2BSandbox> }
+>();
 export const E2B_RUNNING_STATUS_CACHE_TTL_MS = 3_000;
 const runningStatusCache = new Map<string, number>();
 const statusCacheGeneration = new Map<string, object>();
@@ -105,6 +111,12 @@ function currentStatusGeneration(externalId: string): object {
 function invalidateRunningStatus(externalId: string): void {
   runningStatusCache.delete(externalId);
   statusCacheGeneration.set(externalId, {});
+}
+
+function invalidateConnectedSandbox(externalId: string): void {
+  connectedSandboxes.delete(externalId);
+  connectedSandboxCachedAt.delete(externalId);
+  connectOperations.delete(externalId);
 }
 
 function validateRuntimeEnv(value: unknown, externalId: string): Record<string, string> {
@@ -303,6 +315,7 @@ export class E2BProvider implements SandboxProvider {
     private readonly removeTimeoutMs = E2B_REMOVE_TIMEOUT_MS,
     private readonly renewTimeoutMs = E2B_RENEW_TIMEOUT_MS,
     private readonly stopTimeoutMs = E2B_STOP_TIMEOUT_MS,
+    private readonly now: () => number = Date.now,
   ) {}
 
   readonly provisioning: ProvisioningTraits = {
@@ -365,6 +378,7 @@ export class E2BProvider implements SandboxProvider {
     }
 
     connectedSandboxes.set(sandbox.sandboxId, sandbox);
+    connectedSandboxCachedAt.set(sandbox.sandboxId, this.now());
     try {
       // E2B preserves the filesystem but not Sandbox.create(...envs) across a
       // keepMemory:false pause. Persist the complete per-session environment on
@@ -376,7 +390,7 @@ export class E2BProvider implements SandboxProvider {
       if (workloadType === 'app') await ensureAppEntrypoint(sandbox, envVars);
       else await ensureKortixEntrypoint(sandbox, envVars);
     } catch (error) {
-      connectedSandboxes.delete(sandbox.sandboxId);
+      invalidateConnectedSandbox(sandbox.sandboxId);
       await sandbox.kill({ requestTimeoutMs: 20_000 }).catch(() => false);
       throw new Error(
         `[e2b] failed to launch Kortix entrypoint: ${error instanceof Error ? error.message : String(error)}`,
@@ -402,11 +416,11 @@ export class E2BProvider implements SandboxProvider {
 
   private async startOnce(externalId: string, generation: object): Promise<void> {
     try {
-      const sandbox = await Sandbox.connect(externalId, {
-        ...apiOpts(),
-        timeoutMs: E2B_RUNTIME_BACKSTOP_MS,
-      });
-      connectedSandboxes.set(externalId, sandbox);
+      const sandbox = await this.connectFresh(externalId, generation);
+      if (statusCacheGeneration.get(externalId) === generation) {
+        connectedSandboxes.set(externalId, sandbox);
+        connectedSandboxCachedAt.set(externalId, this.now());
+      }
       // A filesystem-only pause cold-boots on connect. E2B normally runs the
       // template start command during that boot; this explicit check makes the
       // Kortix runtime invariant independent of provider startup behavior.
@@ -415,9 +429,10 @@ export class E2BProvider implements SandboxProvider {
       else await ensureKortixEntrypoint(sandbox, envVars);
       if (statusCacheGeneration.get(externalId) === generation) {
         runningStatusCache.set(externalId, Date.now());
+        connectedSandboxCachedAt.set(externalId, this.now());
       }
     } catch (error) {
-      connectedSandboxes.delete(externalId);
+      invalidateConnectedSandbox(externalId);
       invalidateRunningStatus(externalId);
       throw error;
     }
@@ -484,11 +499,11 @@ export class E2BProvider implements SandboxProvider {
       `E2B stop(${externalId})`,
     );
     invalidateRunningStatus(externalId);
-    connectedSandboxes.delete(externalId);
+    invalidateConnectedSandbox(externalId);
   }
 
   async remove(externalId: string): Promise<void> {
-    connectedSandboxes.delete(externalId);
+    invalidateConnectedSandbox(externalId);
     invalidateRunningStatus(externalId);
     try {
       await withTimeout(
@@ -535,13 +550,44 @@ export class E2BProvider implements SandboxProvider {
 
   private async connected(externalId: string): Promise<E2BSandbox> {
     const cached = connectedSandboxes.get(externalId);
-    if (cached) return cached;
-    const sandbox = await Sandbox.connect(externalId, {
+    const cachedAt = connectedSandboxCachedAt.get(externalId);
+    if (
+      cached &&
+      cachedAt !== undefined &&
+      this.now() - cachedAt < E2B_INGRESS_HANDLE_TTL_MS
+    )
+      return cached;
+
+    const providerStatus = await this.getStatus(externalId);
+    if (providerStatus !== 'running') {
+      throw new Error(`[e2b] sandbox ${externalId} is not running (status: ${providerStatus})`);
+    }
+    const generation = currentStatusGeneration(externalId);
+    return this.connectFresh(externalId, generation);
+  }
+
+  private connectFresh(externalId: string, generation: object): Promise<E2BSandbox> {
+    const inFlight = connectOperations.get(externalId);
+    if (inFlight) return inFlight.promise;
+
+    const promise = Sandbox.connect(externalId, {
       ...apiOpts(),
       timeoutMs: E2B_RUNTIME_BACKSTOP_MS,
-    });
-    connectedSandboxes.set(externalId, sandbox);
-    return sandbox;
+    })
+      .then((sandbox) => {
+        if (statusCacheGeneration.get(externalId) === generation) {
+          connectedSandboxes.set(externalId, sandbox);
+          connectedSandboxCachedAt.set(externalId, this.now());
+        }
+        return sandbox;
+      })
+      .finally(() => {
+        if (connectOperations.get(externalId)?.promise === promise) {
+          connectOperations.delete(externalId);
+        }
+      });
+    connectOperations.set(externalId, { generation, promise });
+    return promise;
   }
 
   async resolveIngress(

--- a/apps/api/src/platform/providers/index.ts
+++ b/apps/api/src/platform/providers/index.ts
@@ -241,6 +241,11 @@ export function effectiveAppMachine(
 export interface SandboxProvider {
   readonly name: ProviderName;
   readonly provisioning: ProvisioningTraits;
+  /**
+   * How long the shared proxy may cache one resolved ingress. Omit for the
+   * default cache. Use zero when the provider owns a shorter credential cache.
+   */
+  readonly ingressCacheTtlMs?: number;
   /** Absent means the provider enforces the whole App machine specification. */
   readonly appMachineSupport?: AppMachineSupport;
   create(opts: CreateSandboxOpts): Promise<ProvisionResult>;

--- a/apps/api/src/sandbox-proxy/backend.test.ts
+++ b/apps/api/src/sandbox-proxy/backend.test.ts
@@ -79,6 +79,16 @@ describe('resolveSandboxIngress cache key — http', () => {
     expect(resolveCalls.length).toBe(1);
     expect(second).toEqual(first);
   });
+
+  test('E2B ingress bypasses the outer cache so rotated traffic tokens can refresh', async () => {
+    resolveCalls = [];
+    const record = { ...BASE_RECORD, provider: 'e2b', externalId: 'ext-e2b-token-rotation' };
+
+    await resolveSandboxIngress(record, { port: 8000, transport: 'http', path: '/foo' });
+    await resolveSandboxIngress(record, { port: 8000, transport: 'http', path: '/bar' });
+
+    expect(resolveCalls.length).toBe(2);
+  });
 });
 
 describe('resolveSandboxIngress cache key — websocket', () => {

--- a/apps/api/src/sandbox-proxy/backend.test.ts
+++ b/apps/api/src/sandbox-proxy/backend.test.ts
@@ -40,7 +40,8 @@ let resolveCalls: Array<{ port: number; transport?: string; path?: string }> = [
 
 mock.module('../platform/providers', () => ({
   ...realProviders,
-  getProvider: () => ({
+  getProvider: (provider: string) => ({
+    ingressCacheTtlMs: provider === 'e2b' ? 0 : undefined,
     async resolveIngress(_externalId: string, request: { port: number; transport?: string; path?: string }) {
       resolveCalls.push(request);
       const isPty = request.transport === 'websocket' && request.path?.includes('/pty/');

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -256,7 +256,12 @@ export async function resolveSandboxIngress(
   if (!record) throw new Error(`[proxy] no sandbox row for ${sandboxId}`);
   const ingress = await getProvider(record.provider as ProviderName).resolveIngress(record.externalId, request);
 
-  previewLinkCache.set(key, { ingress, expiresAt: Date.now() + CACHE_TTL_MS });
+  // E2B traffic tokens rotate when a paused sandbox resumes. Provider handles
+  // already carry their own short, single-flight cache; an outer five-minute
+  // cache would keep stale tokens alive across API replicas.
+  if (record.provider !== 'e2b') {
+    previewLinkCache.set(key, { ingress, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
   return ingress;
 }
 

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -254,13 +254,12 @@ export async function resolveSandboxIngress(
 
   const record = typeof sandboxRef === 'string' ? await loadSandbox(sandboxRef) : sandboxRef;
   if (!record) throw new Error(`[proxy] no sandbox row for ${sandboxId}`);
-  const ingress = await getProvider(record.provider as ProviderName).resolveIngress(record.externalId, request);
+  const provider = getProvider(record.provider as ProviderName);
+  const ingress = await provider.resolveIngress(record.externalId, request);
 
-  // E2B traffic tokens rotate when a paused sandbox resumes. Provider handles
-  // already carry their own short, single-flight cache; an outer five-minute
-  // cache would keep stale tokens alive across API replicas.
-  if (record.provider !== 'e2b') {
-    previewLinkCache.set(key, { ingress, expiresAt: Date.now() + CACHE_TTL_MS });
+  const cacheTtlMs = provider.ingressCacheTtlMs ?? CACHE_TTL_MS;
+  if (cacheTtlMs > 0) {
+    previewLinkCache.set(key, { ingress, expiresAt: Date.now() + cacheTtlMs });
   }
   return ingress;
 }


### PR DESCRIPTION
## Problem
E2B rotates its private traffic token when a paused sandbox resumes. Each API replica cached its E2B handle indefinitely, and the sandbox proxy cached the resulting ingress headers for five minutes. A replica that did not perform the resume kept the stale token: the guest was locally ready in 12.9 seconds, while every external health probe returned 502 port not ready and /start failed.

## Changes
- Bound E2B ingress handles to 5 seconds.
- Refresh ingress tokens through one single-flight Sandbox.connect operation.
- Share the connect between session start and concurrent ingress resolution.
- Refuse ingress-driven connects when E2B reports the sandbox paused.
- Bypass the outer five-minute ingress cache for E2B only.
- Keep existing provider caches for all other providers.
- Add rotation, single-flight, start ordering, paused-state, and outer-cache regressions.

## Verification
- pnpm test: 378/378 flows passed; 0 failed; 0 skipped.
- E2B + sandbox backend: 42/42 tests passed.
- pnpm --filter kortix-api typecheck: passed.
- pnpm test -- --packages-only reached 8,173 passes and failed only on the pre-existing CLI self-host preview wording assertion; this diff touches no CLI files.