### PR TITLE
Reject production release tag collisions

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,15 @@ linked, not inlined.
 
 ## Register
 
+### Refuse a release version whose tag already names another commit (2026-08-24)
+
+**When:** resolving a production version before migrations or rollout. Check
+`refs/tags/vX.Y.Z` first. Permit no tag, or the current prod commit for a rerun.
+Do not trust a release action to move a tag: it can silently reuse the existing
+ref and publish correct images under a tag that names unrelated code. *Incident:*
+v0.13.5 served source `1eb51c95`, while its reused tag named `98843dc5` until
+corrected. *Enforcer:* `deploy-prod.yml` version preflight and workflow unit test.
+
 ### Provider traffic credentials need a cross-replica refresh bound (2026-08-24)
 
 **When:** caching a provider handle that carries a private ingress token. Bound

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -79,6 +79,15 @@ jobs:
           echo "tag=v$V" >> "$GITHUB_OUTPUT"
           echo "Publishing v$V"
 
+          # action-gh-release reuses an existing tag without moving it. Refuse
+          # a collision before migrations or image rollout can publish a release
+          # whose tag names unrelated code. A same-commit tag permits safe reruns.
+          EXISTING="$(git rev-parse -q --verify "refs/tags/v$V^{commit}" || true)"
+          if [ -n "$EXISTING" ] && [ "$EXISTING" != "$GITHUB_SHA" ]; then
+            echo "::error::Tag v$V already points at $EXISTING, not this prod commit $GITHUB_SHA. Refusing to reuse or move an immutable release tag."
+            exit 1
+          fi
+
           # promote.yml committed RELEASE_NOTES.md (line 1 = title, rest = notes)
           # onto the release branch; it merged into prod with this release. The
           # tag does NOT exist yet — the GitHub Release job creates it at this
@@ -715,6 +724,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.version.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           # Human title + notes from the tag annotation (set at promote time) lead
           # the release; the auto-generated PR list is appended below them.
           name: ${{ needs.version.outputs.title != '' && format('{0} — {1}', needs.version.outputs.tag, needs.version.outputs.title) || needs.version.outputs.tag }}

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -214,6 +214,14 @@ describe('web ECS migration', () => {
     );
   });
 
+  it('refuses to publish a release through a tag that points at another commit', () => {
+    const workflow = read('.github/workflows/deploy-prod.yml');
+    expect(workflow).toContain('refs/tags/v$V^{commit}');
+    expect(workflow).toContain('[ "$EXISTING" != "$GITHUB_SHA" ]');
+    expect(workflow).toContain('Refusing to reuse or move an immutable release tag.');
+    expect(workflow).toContain('target_commitish: ${{ github.sha }}');
+  });
+
   it('carries both Basic auth credentials and the Vercel SSO bypass in QA', () => {
     const config = read('tests/playwright.config.ts');
     expect(config).toContain('WEB_PROTECTION_PASSWORD');


### PR DESCRIPTION
## Problem\n\nThe v0.13.5 images and runtime served source `1eb51c95`, but a pre-existing `v0.13.5` tag pointed to unrelated commit `98843dc5`. `softprops/action-gh-release` reused that tag without moving it.\n\n## Changes\n\n- Fail the version job before migrations when `vX.Y.Z` exists on another commit.\n- Permit a same-commit tag for safe workflow reruns.\n- Pass the prod merge explicitly as `target_commitish`.\n- Record the incident rule in the append-only learnings register.\n\n## Verification\n\n- `bun test tests/unit/web-ecs-workflow.test.ts`: 12 passed, 0 failed.\n- `actionlint .github/workflows/deploy-prod.yml`: exit 0.