### PR TITLE
fix(web): preload inline and panel previews

### DIFF
--- a/apps/web/src/features/session/shared-preview.test.ts
+++ b/apps/web/src/features/session/shared-preview.test.ts
@@ -4,6 +4,7 @@ import {
   createSharedPreviewStore,
   publishSharedPreview,
   removeSharedPreview,
+  shouldRenderInlinePreviewClone,
 } from './shared-preview';
 
 const preview = (refreshKey: number, previewUrl = 'https://preview.test/authenticated') =>
@@ -40,5 +41,30 @@ describe('shared preview ownership', () => {
 
     expect(store.previews.get('https://preview.test')?.keys().next().value).toBe(first);
     expect(store.previews.get('https://preview.test')?.get(first)).toBe(refreshed);
+  });
+});
+
+describe('inline preview clone', () => {
+  const ready = {
+    shared: true,
+    isOwner: true,
+    hasPanelDestination: true,
+    hasPreviewUrl: true,
+    isLoading: false,
+    hasError: false,
+    linkOnlyPreview: false,
+  };
+
+  test('renders only while a panel owns the loaded primary preview', () => {
+    expect(shouldRenderInlinePreviewClone(ready)).toBe(true);
+    expect(shouldRenderInlinePreviewClone({ ...ready, hasPanelDestination: false })).toBe(false);
+    expect(shouldRenderInlinePreviewClone({ ...ready, isLoading: true })).toBe(false);
+    expect(shouldRenderInlinePreviewClone({ ...ready, hasError: true })).toBe(false);
+  });
+
+  test('does not clone non-owner, standalone, or link-only previews', () => {
+    expect(shouldRenderInlinePreviewClone({ ...ready, isOwner: false })).toBe(false);
+    expect(shouldRenderInlinePreviewClone({ ...ready, shared: false })).toBe(false);
+    expect(shouldRenderInlinePreviewClone({ ...ready, linkOnlyPreview: true })).toBe(false);
   });
 });

--- a/apps/web/src/features/session/shared-preview.test.ts
+++ b/apps/web/src/features/session/shared-preview.test.ts
@@ -1,10 +1,10 @@
 import type { ServicePreviewState } from '@/features/session/tool/shared/infrastructure';
 import { describe, expect, test } from 'bun:test';
 import {
+  SHARED_PREVIEW_FRAME_MODES,
   createSharedPreviewStore,
   publishSharedPreview,
   removeSharedPreview,
-  shouldRenderInlinePreviewClone,
 } from './shared-preview';
 
 const preview = (refreshKey: number, previewUrl = 'https://preview.test/authenticated') =>
@@ -44,27 +44,8 @@ describe('shared preview ownership', () => {
   });
 });
 
-describe('inline preview clone', () => {
-  const ready = {
-    shared: true,
-    isOwner: true,
-    hasPanelDestination: true,
-    hasPreviewUrl: true,
-    isLoading: false,
-    hasError: false,
-    linkOnlyPreview: false,
-  };
-
-  test('renders only while a panel owns the loaded primary preview', () => {
-    expect(shouldRenderInlinePreviewClone(ready)).toBe(true);
-    expect(shouldRenderInlinePreviewClone({ ...ready, hasPanelDestination: false })).toBe(false);
-    expect(shouldRenderInlinePreviewClone({ ...ready, isLoading: true })).toBe(false);
-    expect(shouldRenderInlinePreviewClone({ ...ready, hasError: true })).toBe(false);
-  });
-
-  test('does not clone non-owner, standalone, or link-only previews', () => {
-    expect(shouldRenderInlinePreviewClone({ ...ready, isOwner: false })).toBe(false);
-    expect(shouldRenderInlinePreviewClone({ ...ready, shared: false })).toBe(false);
-    expect(shouldRenderInlinePreviewClone({ ...ready, linkOnlyPreview: true })).toBe(false);
+describe('shared preview frames', () => {
+  test('preloads both inline and panel iframe documents', () => {
+    expect(SHARED_PREVIEW_FRAME_MODES).toEqual(['inline', 'panel']);
   });
 });

--- a/apps/web/src/features/session/shared-preview.tsx
+++ b/apps/web/src/features/session/shared-preview.tsx
@@ -39,25 +39,8 @@ type SharedPreviewContextValue = {
 
 const SharedPreviewContext = createContext<SharedPreviewContextValue | null>(null);
 
-export function shouldRenderInlinePreviewClone(input: {
-  shared: boolean;
-  isOwner: boolean;
-  hasPanelDestination: boolean;
-  hasPreviewUrl: boolean;
-  isLoading: boolean;
-  hasError: boolean;
-  linkOnlyPreview: boolean;
-}): boolean {
-  return (
-    input.shared &&
-    input.isOwner &&
-    input.hasPanelDestination &&
-    input.hasPreviewUrl &&
-    !input.isLoading &&
-    !input.hasError &&
-    !input.linkOnlyPreview
-  );
-}
+export const SHARED_PREVIEW_FRAME_MODES = ['inline', 'panel'] as const;
+type SharedPreviewFrameMode = (typeof SHARED_PREVIEW_FRAME_MODES)[number];
 
 function notify(store: SharedPreviewStore) {
   store.revision += 1;
@@ -223,7 +206,7 @@ export function useSharedPreviewDestination(key: string, element: HTMLElement | 
     context.setDestination(key, element, true);
     return () => context.setDestination(key, element, false);
   }, [context, element, key]);
-  return useCallback(() => context?.store.frames.get(key)?.focus(), [context, key]);
+  return useCallback(() => context?.store.frames.get(`${key}:panel`)?.focus(), [context, key]);
 }
 
 export function useSharedPreviewInlineDestination(
@@ -246,7 +229,10 @@ export function useSharedPreviewInlineDestination(
       notify(context.store);
     };
   }, [context, element, key, owner]);
-  return useCallback(() => context?.store.frames.get(key ?? '')?.focus(), [context, key]);
+  return useCallback(
+    () => context?.store.frames.get(`${key ?? ''}:inline`)?.focus(),
+    [context, key],
+  );
 }
 
 export function useSharedPreviewHasPanelDestination(key: string | null): boolean {
@@ -311,10 +297,11 @@ function SharedPreviewFrames({ context }: { context: SharedPreviewContextValue }
       const panelDestinations = context.store.destinations.get(key) ?? [];
       const inlineDestination = context.store.inlineDestinations.get(key)?.get(owner) ?? null;
       const src = context.store.frameUrls.get(key) ?? preview.previewUrl;
-      if ((panelDestinations.length === 0 && !inlineDestination) || !src) return null;
-      return (
+      if (!inlineDestination || !src) return null;
+      return SHARED_PREVIEW_FRAME_MODES.map((mode) => (
         <SharedPreviewFrame
-          key={key}
+          key={`${key}:${mode}`}
+          mode={mode}
           previewKey={key}
           preview={preview}
           panelDestinations={panelDestinations}
@@ -323,13 +310,14 @@ function SharedPreviewFrames({ context }: { context: SharedPreviewContextValue }
           refreshVersion={context.store.refreshVersions.get(key) ?? 0}
           store={context.store}
         />
-      );
+      ));
     }),
     document.body,
   );
 }
 
 function SharedPreviewFrame({
+  mode,
   previewKey,
   preview,
   panelDestinations,
@@ -338,10 +326,11 @@ function SharedPreviewFrame({
   refreshVersion,
   store,
 }: {
+  mode: SharedPreviewFrameMode;
   previewKey: string;
   preview: ServicePreviewState;
   panelDestinations: HTMLElement[];
-  inlineDestination: HTMLElement | null;
+  inlineDestination: HTMLElement;
   src: string;
   refreshVersion: number;
   store: SharedPreviewStore;
@@ -350,18 +339,20 @@ function SharedPreviewFrame({
 
   useEffect(() => {
     if (!iframeElement) return;
-    store.frames.set(previewKey, iframeElement);
+    const frameKey = `${previewKey}:${mode}`;
+    store.frames.set(frameKey, iframeElement);
     return () => {
-      if (store.frames.get(previewKey) === iframeElement) store.frames.delete(previewKey);
+      if (store.frames.get(frameKey) === iframeElement) store.frames.delete(frameKey);
     };
-  }, [iframeElement, previewKey, store]);
+  }, [iframeElement, mode, previewKey, store]);
 
   useEffect(() => {
     if (!iframeElement) return;
 
-    const allDestinations = [...panelDestinations, inlineDestination].filter(
-      (element): element is HTMLElement => !!element,
-    );
+    const allDestinations =
+      mode === 'inline'
+        ? [inlineDestination]
+        : panelDestinations.filter((element): element is HTMLElement => !!element);
     const allAncestors = new Set<HTMLElement>();
     for (const destination of allDestinations) {
       for (let ancestor = destination.parentElement; ancestor; ancestor = ancestor.parentElement) {
@@ -413,10 +404,20 @@ function SharedPreviewFrame({
     };
 
     const placeFrame = () => {
-      const destination = [...panelDestinations].reverse().find(isVisible) ?? inlineDestination;
+      const destination =
+        mode === 'inline'
+          ? inlineDestination
+          : ([...panelDestinations].reverse().find(isVisible) ?? null);
       if (!destination) {
-        iframeElement.style.visibility = 'hidden';
-        iframeElement.style.pointerEvents = 'none';
+        Object.assign(iframeElement.style, {
+          position: 'fixed',
+          top: '-10000px',
+          left: '-10000px',
+          width: '1px',
+          height: '1px',
+          visibility: 'hidden',
+          pointerEvents: 'none',
+        });
         return;
       }
       const rect = destination.getBoundingClientRect();
@@ -479,7 +480,7 @@ function SharedPreviewFrame({
         borderTopRightRadius: topRight,
         borderBottomRightRadius: bottomRight,
         borderBottomLeftRadius: bottomLeft,
-        zIndex: panelDestinations.includes(destination) ? '60' : '15',
+        zIndex: mode === 'panel' ? '60' : '15',
       });
     };
 
@@ -520,13 +521,24 @@ function SharedPreviewFrame({
       window.removeEventListener('resize', placeFrame);
       window.removeEventListener('scroll', placeFrame, true);
     };
-  }, [iframeElement, inlineDestination, panelDestinations, preview.hasError, preview.isLoading]);
+  }, [
+    iframeElement,
+    inlineDestination,
+    mode,
+    panelDestinations,
+    preview.hasError,
+    preview.isLoading,
+  ]);
 
   const handleLoad = () => {
-    store.previews.get(previewKey)?.forEach((record) => record.onLoad());
+    if (mode === 'inline') {
+      store.previews.get(previewKey)?.forEach((record) => record.onLoad());
+    }
   };
   const handleError = () => {
-    store.previews.get(previewKey)?.forEach((record) => record.onError());
+    if (mode === 'inline') {
+      store.previews.get(previewKey)?.forEach((record) => record.onError());
+    }
   };
 
   return (
@@ -534,9 +546,10 @@ function SharedPreviewFrame({
       ref={setIframeElement}
       key={refreshVersion}
       src={src}
-      title={preview.displayLabel}
+      title={`${preview.displayLabel}${mode === 'panel' ? ' panel preview' : ''}`}
       tabIndex={-1}
-      data-shared-preview={previewKey}
+      data-shared-preview={mode === 'inline' ? previewKey : undefined}
+      data-panel-preview={mode === 'panel' ? previewKey : undefined}
       style={{ visibility: 'hidden' }}
       className="bg-secondary border-0"
       sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}

--- a/apps/web/src/features/session/shared-preview.tsx
+++ b/apps/web/src/features/session/shared-preview.tsx
@@ -39,6 +39,26 @@ type SharedPreviewContextValue = {
 
 const SharedPreviewContext = createContext<SharedPreviewContextValue | null>(null);
 
+export function shouldRenderInlinePreviewClone(input: {
+  shared: boolean;
+  isOwner: boolean;
+  hasPanelDestination: boolean;
+  hasPreviewUrl: boolean;
+  isLoading: boolean;
+  hasError: boolean;
+  linkOnlyPreview: boolean;
+}): boolean {
+  return (
+    input.shared &&
+    input.isOwner &&
+    input.hasPanelDestination &&
+    input.hasPreviewUrl &&
+    !input.isLoading &&
+    !input.hasError &&
+    !input.linkOnlyPreview
+  );
+}
+
 function notify(store: SharedPreviewStore) {
   store.revision += 1;
   store.listeners.forEach((listener) => listener());

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -16,7 +16,6 @@ import { openSessionQuickView } from '@/features/session/open-session-quick-view
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import { isEmptyShowPart } from '@/features/session/session-activity-groups';
 import {
-  shouldRenderInlinePreviewClone,
   usePublishSharedPreview,
   useSharedPreview,
   useSharedPreviewHasPanelDestination,
@@ -339,40 +338,6 @@ export function ServicePreviewUrlFallback({ preview }: { preview: ServicePreview
   );
 }
 
-function InlinePreviewClone({ preview }: { preview: ServicePreviewState }) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
-
-  return (
-    <>
-      {isLoading && !hasError && (
-        <div className="bg-background/60 absolute inset-0 z-10 flex items-center justify-center">
-          <div className="text-muted-foreground flex items-center gap-2">
-            <Loading />
-            <span className="text-xs">
-              {tHardcodedUi.raw('componentsSessionToolRenderers.line380JsxTextLoadingPreview')}
-            </span>
-          </div>
-        </div>
-      )}
-      {hasError && <ServicePreviewUrlFallback preview={preview} />}
-      <iframe
-        src={preview.previewUrl!}
-        title={`${preview.displayLabel} inline preview`}
-        data-inline-preview-clone
-        className="bg-secondary absolute inset-0 h-full w-full border-0"
-        sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
-        onLoad={() => setIsLoading(false)}
-        onError={() => {
-          setIsLoading(false);
-          setHasError(true);
-        }}
-      />
-    </>
-  );
-}
-
 export function ServicePreviewViewport({ preview }: { preview: ServicePreviewState }) {
   const fill = useContext(ToolSurfaceContext) === 'panel';
   const { previewUrl, displayLabel, isLoading, hasError } = preview;
@@ -388,15 +353,6 @@ export function ServicePreviewViewport({ preview }: { preview: ServicePreviewSta
     inlineDestination,
   );
   const hasPanelDestination = useSharedPreviewHasPanelDestination(sharedPreviewKey);
-  const renderInlineClone = shouldRenderInlinePreviewClone({
-    shared,
-    isOwner,
-    hasPanelDestination,
-    hasPreviewUrl: !!previewUrl,
-    isLoading,
-    hasError,
-    linkOnlyPreview,
-  });
 
   return (
     <div
@@ -437,7 +393,6 @@ export function ServicePreviewViewport({ preview }: { preview: ServicePreviewSta
           onError={preview.onError}
         />
       )}
-      {renderInlineClone && <InlinePreviewClone key={preview.refreshKey} preview={preview} />}
     </div>
   );
 }

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -16,6 +16,7 @@ import { openSessionQuickView } from '@/features/session/open-session-quick-view
 import { prefersPreviewLink } from '@/features/session/preview-url-fallback';
 import { isEmptyShowPart } from '@/features/session/session-activity-groups';
 import {
+  shouldRenderInlinePreviewClone,
   usePublishSharedPreview,
   useSharedPreview,
   useSharedPreviewHasPanelDestination,
@@ -338,6 +339,40 @@ export function ServicePreviewUrlFallback({ preview }: { preview: ServicePreview
   );
 }
 
+function InlinePreviewClone({ preview }: { preview: ServicePreviewState }) {
+  const tHardcodedUi = useTranslations('hardcodedUi');
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  return (
+    <>
+      {isLoading && !hasError && (
+        <div className="bg-background/60 absolute inset-0 z-10 flex items-center justify-center">
+          <div className="text-muted-foreground flex items-center gap-2">
+            <Loading />
+            <span className="text-xs">
+              {tHardcodedUi.raw('componentsSessionToolRenderers.line380JsxTextLoadingPreview')}
+            </span>
+          </div>
+        </div>
+      )}
+      {hasError && <ServicePreviewUrlFallback preview={preview} />}
+      <iframe
+        src={preview.previewUrl!}
+        title={`${preview.displayLabel} inline preview`}
+        data-inline-preview-clone
+        className="bg-secondary absolute inset-0 h-full w-full border-0"
+        sandbox={INTERACTIVE_PREVIEW_IFRAME_SANDBOX}
+        onLoad={() => setIsLoading(false)}
+        onError={() => {
+          setIsLoading(false);
+          setHasError(true);
+        }}
+      />
+    </>
+  );
+}
+
 export function ServicePreviewViewport({ preview }: { preview: ServicePreviewState }) {
   const fill = useContext(ToolSurfaceContext) === 'panel';
   const { previewUrl, displayLabel, isLoading, hasError } = preview;
@@ -353,6 +388,15 @@ export function ServicePreviewViewport({ preview }: { preview: ServicePreviewSta
     inlineDestination,
   );
   const hasPanelDestination = useSharedPreviewHasPanelDestination(sharedPreviewKey);
+  const renderInlineClone = shouldRenderInlinePreviewClone({
+    shared,
+    isOwner,
+    hasPanelDestination,
+    hasPreviewUrl: !!previewUrl,
+    isLoading,
+    hasError,
+    linkOnlyPreview,
+  });
 
   return (
     <div
@@ -393,6 +437,7 @@ export function ServicePreviewViewport({ preview }: { preview: ServicePreviewSta
           onError={preview.onError}
         />
       )}
+      {renderInlineClone && <InlinePreviewClone key={preview.refreshKey} preview={preview} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- preload separate inline and panel iframe documents as soon as an inline preview appears
- keep the inline iframe visible while the panel iframe remains loaded off-screen
- reveal the already-loaded panel iframe with zero navigation on desktop and mobile
- keep iframe state independent and reload both from either shared refresh control

## Verification
- `pnpm test`: 378/378 API/CLI flows; SDK 2495 pass, 2 skip, 0 fail; all core lanes pass
- `pnpm --dir apps/web test`: 8356 pass, 0 fail
- `pnpm --dir apps/web build`: production build passed; 203/203 static pages generated
- focused frame tests: 3 pass, 0 fail
- TypeScript: only the documented baseline `test.each` errors; no changed-file errors
- desktop before open: one inline iframe and one panel iframe loaded; panel iframe was retained off-screen at `top: -10000px`
- desktop open: both DOM markers survived and HAR recorded 0 preview document requests
- mobile open: two loaded iframe nodes remained and HAR recorded 0 preview document requests
- shared refresh: two successful document loads reset both iframe states