### PR TITLE
fix(gateway): remove all gateway-imposed upstream timeouts (#6473-class regression)

### DIFF
--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -151,4 +151,76 @@ describe('simple gateway pipeline', () => {
     expect(sse.headers.get('content-type')).toBe('text/event-stream');
     expect(await sse.text()).toContain('[DONE]');
   });
+
+  test('the acceptance deadline NEVER aborts a stream that outlives it (#6473 regression)', async () => {
+    // A long-running turn: headers arrive instantly, tokens keep flowing far
+    // past the acceptance budget. The old implementation handed
+    // AbortSignal.timeout to the fetch, which governs the whole response —
+    // killing every turn longer than the budget with "timeout of 90000ms".
+    const enc = new TextEncoder();
+    const response = await handleChatCompletions(
+      {
+        hooks: hooks([], []),
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async (_input, init) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              async start(c) {
+                for (let i = 0; i < 6; i += 1) {
+                  if (init.signal?.aborted) {
+                    c.error(new Error('aborted by gateway'));
+                    return;
+                  }
+                  c.enqueue(enc.encode(`data: {"choices":[{"delta":{"content":"t${i}"}}]}\n\n`));
+                  await new Promise((resolve) => setTimeout(resolve, 25));
+                }
+                c.enqueue(enc.encode('data: [DONE]\n\n'));
+                c.close();
+              },
+            }),
+            { headers: { 'content-type': 'text/event-stream' } },
+          ),
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({ model: 'm', messages: [], stream: true }),
+      },
+    );
+    expect(response.status).toBe(200);
+    const text = await response.text(); // total stream time ~150ms >> 30ms budget
+    expect(text).toContain('t5');
+    expect(text).toContain('[DONE]');
+  });
+
+  test('no gateway deadline exists: a dead provider ends only when the client aborts', async () => {
+    // Removed 2026-08-24, the same day it was added — every gateway-side
+    // timer here has eventually killed a legitimate long turn. The contract
+    // is abort-forwarding instead: the client's abort must reach the
+    // in-flight upstream call and end the dispatch (freeing the admission
+    // lease), and a hang here would mean it does not.
+    const client = new AbortController();
+    const pending = handleChatCompletions(
+      {
+        hooks: hooks([], []),
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: (_input, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+          }),
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({ model: 'm', messages: [], stream: true }),
+        signal: client.signal,
+      },
+    );
+    setTimeout(() => client.abort(new DOMException('client gave up', 'AbortError')), 30);
+    const response = await Promise.race([
+      pending,
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('dispatch did not end after client abort')), 2_000),
+      ),
+    ]);
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
 });

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -49,22 +49,6 @@ export interface HandlerRuntime {
   imageWindow?: ImageWindowOptions;
 }
 
-/**
- * Deadline for the provider's response HEADERS (time to first byte).
- *
- * There was no upstream timeout at all: `callUpstream` passed only the client's
- * signal, Bun's `idleTimeout` is 0, and no load balancer bounds that leg. A
- * provider that accepts the TCP connection and never answers therefore pinned
- * an admission reservation forever while Cloudflare gave the caller a 524 at
- * 100s. This fires first, so the caller gets a typed 503 it can retry.
- *
- * Headers only: once the stream is flowing, `relayStream`'s heartbeat and its
- * 90-minute inactivity budget govern it — a long-thinking model is not a
- * timeout.
- */
-const UPSTREAM_HEADERS_TIMEOUT_MS =
-  Number(process.env.GATEWAY_UPSTREAM_HEADERS_TIMEOUT_MS) || 90_000;
-
 const EMPTY_USAGE: TokenCounts = {
   promptTokens: 0,
   completionTokens: 0,
@@ -316,12 +300,24 @@ export async function handleChatCompletions(
   if (streaming) body.stream_options = { include_usage: true };
   let upstream: Response;
   try {
-    // Abort the dispatch if the provider has not produced response headers in
-    // time — combined with the client's own signal so a disconnect still wins.
-    const headersDeadline = AbortSignal.timeout(UPSTREAM_HEADERS_TIMEOUT_MS);
+    // The gateway imposes NO deadline of its own on the provider — not on
+    // acceptance and not on the completion. Deliberate: every gateway-side
+    // timer tried here has eventually killed a legitimate long turn (#6473's
+    // 90s probe in July; a 90s AbortSignal.timeout added and removed the same
+    // day, 2026-08-24 — a signal handed to fetch/streamText governs the WHOLE
+    // response, not just headers). Pacing belongs to the caller: its abort
+    // forwards into this controller for the response's whole lifetime, so a
+    // hung provider costs exactly as long as the caller keeps waiting, and
+    // the admission lease frees the moment the caller gives up. A stream that
+    // goes silent AFTER it started is still reaped by relayStream's
+    // 90-minute inactivity budget.
+    const upstreamAbort = new AbortController();
+    const forwardClientAbort = () => upstreamAbort.abort(req.signal?.reason);
+    if (req.signal?.aborted) forwardClientAbort();
+    else req.signal?.addEventListener('abort', forwardClientAbort, { once: true });
     const dispatch = callUpstream(body, descriptor, {
       fetchImpl,
-      signal: req.signal ? AbortSignal.any([req.signal, headersDeadline]) : headersDeadline,
+      signal: upstreamAbort.signal,
       requestId: id,
     });
     // Dispatch has serialized (openai-compat) or translated (ai-sdk) the
@@ -346,18 +342,6 @@ export async function handleChatCompletions(
       candidatesTried: [descriptor.provider],
     });
     if (error instanceof UpstreamHttpError) return rawProviderError(error);
-    // A headers timeout is "try again", not "this request is malformed".
-    const timedOut = (error as { name?: unknown })?.name === 'TimeoutError' && !req.signal?.aborted;
-    if (timedOut)
-      return gatewayErrorResponse(503, {
-        message: `Provider ${descriptor.provider} sent no response headers within ${UPSTREAM_HEADERS_TIMEOUT_MS}ms`,
-        code: 'upstream_timeout',
-        provider: descriptor.provider,
-        requestedModel,
-        resolvedModel: descriptor.resolvedModel ?? routedModel,
-        requestId: id,
-        suggestion: 'Retry the request, or choose another model.',
-      });
     return gatewayErrorResponse(502, {
       message: error instanceof Error ? error.message : 'Provider request failed',
       code: 'upstream_error',


### PR DESCRIPTION
The 90s upstream deadline added this morning in #6835 was an `AbortSignal.timeout` passed into the upstream call. That signal governs the **whole response** — fetch body reads and `streamText` generation alike — so any turn longer than 90s died mid-stream with `timeout of 90000ms`: the #6473 symptom, reintroduced. Caught on dev the same day; never reached staging or prod.

**Per Marko's call, the timeout is removed entirely rather than re-scoped.** Every gateway-side timer tried on this path has eventually killed a legitimate long turn. The contract is now:

- **No gateway deadline** on provider acceptance or completion.
- **Abort forwarding**: the client's abort propagates into the in-flight upstream call for the response's whole lifetime — a hung provider costs exactly as long as the caller keeps waiting, and the admission lease frees the moment the caller gives up (proven by test: a hang fails it).
- **Kept**: `relayStream`'s 90-*minute* mid-stream inactivity reaper — fires only on total silence of an already-started stream; cannot kill a producing turn.

**Tests** (299/0): a stream outliving any plausible deadline completes with `[DONE]` — verified failing against the pre-fix handler; a never-answering provider ends the instant the client aborts.

https://claude.ai/code/session_018pdwWaQKfKpG1rX5L4bsHH