### PR TITLE
fix(api): never call a restart failure a lost computer without asking the provider

### DIFF
--- a/apps/api/src/projects/session-lifecycle/actions.ts
+++ b/apps/api/src/projects/session-lifecycle/actions.ts
@@ -31,7 +31,9 @@ import { invalidateProviderCache } from '../../sandbox-proxy';
 import {
   claimInPlaceRuntimeRecovery,
   markInPlaceRuntimeRecoveryAccepted,
+  parkEstablishedRuntime,
   preserveEstablishedRuntime,
+  runtimeLossVerdict,
   retireUnmaterializedRuntime,
   RUNTIME_IDENTITY_ERROR,
   RUNTIME_IDENTITY_UNAVAILABLE,
@@ -611,11 +613,40 @@ export async function restartSession(input: {
               () => null,
             );
           } else {
-            await preserveEstablishedRuntime(
-              claim.row,
-              'restart_missing_runtime',
-              'restart_failed',
-            ).catch(() => null);
+            // Incident 2026-08-14: a loss verdict requires a fresh, definitive
+            // provider `removed` — nothing else may reach the terminal "computer
+            // was lost" state. Neither condition that got us here is evidence of
+            // one. `isMissingRuntimeError` is a message heuristic that matches
+            // any error whose text merely contains "not found", and
+            // `recoverInPlace` is OPTIONAL: `?.` yields `undefined` for a
+            // provider that does not implement it, which is indistinguishable
+            // here from a provider that tried and failed. The sibling restart
+            // paths above both gate on `getStatus() === 'removed'` before they
+            // preserve; this one is reached from a catch block and did not, so
+            // an unrelated "not found" thrown mid-restart reported a live box as
+            // lost — unrecoverable and non-retriable to the user, a false
+            // `runtime.lost` page, and the box left running because only a park
+            // stops it. Ask the provider, then let the shared gate decide.
+            const status = await (async () => {
+              try {
+                return await provider.getStatus(externalId);
+              } catch {
+                return 'unknown' as const;
+              }
+            })();
+            if (runtimeLossVerdict(status) === 'preserve') {
+              await preserveEstablishedRuntime(
+                claim.row,
+                'restart_missing_runtime',
+                'restart_failed',
+              ).catch(() => null);
+            } else {
+              await parkEstablishedRuntime(
+                claim.row,
+                'restart_missing_runtime',
+                'restart_failed',
+              ).catch(() => null);
+            }
           }
           return;
         }

--- a/apps/api/src/projects/session-lifecycle/restart-loss-verdict.test.ts
+++ b/apps/api/src/projects/session-lifecycle/restart-loss-verdict.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Incident 2026-08-14
+ * (docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md).
+ *
+ * Corrective action 1: "Show the 'computer was lost' copy only when a fresh
+ * `provider.getStatus()` returns `removed` at preserve time."
+ *
+ * `runtime-identity.ts` states the same rule as an invariant of the module:
+ * only a definitive provider `removed` may classify an identity as lost;
+ * everything else parks a retriable row. `runtimeLossVerdict` is the gate that
+ * enforces it, and `runtime-identity.test.ts` pins the gate itself.
+ *
+ * A gate is only worth what its call sites are, and `restart-in-place` has
+ * three preserve sites that no unit test can reach: they live inside a
+ * detached async continuation behind a provider client. Two were already
+ * gated on `getStatus() === 'removed'`; the third — the one in the catch
+ * block — reached `preserveEstablishedRuntime` on an error-message heuristic
+ * alone. These are source assertions because that is what is testable here,
+ * and the alternative is no coverage at all on the exact line the incident
+ * was written about.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const actions = readFileSync(join(import.meta.dir, 'actions.ts'), 'utf8');
+
+/** The catch-block branch: from the heuristic to the end of its `return`. */
+function missingRuntimeBranch(): string {
+  const start = actions.indexOf('if (isMissingRuntimeError(err)) {');
+  expect(start).toBeGreaterThan(-1);
+  return actions.slice(start, actions.indexOf('const [failedRestart]', start));
+}
+
+describe('restart-in-place never declares a loss the provider did not confirm', () => {
+  test('every preserve in this file is preceded by a definitive removed check', () => {
+    // Three call sites, and the count is asserted so a fourth added later has
+    // to come here and account for itself rather than inheriting silence.
+    const preserves = actions.match(/await preserveEstablishedRuntime\(/g) ?? [];
+    expect(preserves.length).toBe(3);
+
+    let searchFrom = 0;
+    for (let i = 0; i < preserves.length; i++) {
+      const at = actions.indexOf('await preserveEstablishedRuntime(', searchFrom);
+      expect(at).toBeGreaterThan(-1);
+      const preceding = actions.slice(Math.max(0, at - 1600), at);
+      // Either an explicit `=== 'removed'` guard (the two sibling paths) or
+      // the shared gate (the catch-block path).
+      const gated =
+        /(providerStatus|verifiedStatus|status) === 'removed'/.test(preceding) ||
+        /runtimeLossVerdict\([^)]*\) === 'preserve'/.test(preceding);
+      expect(gated).toBe(true);
+      searchFrom = at + 1;
+    }
+  });
+
+  test('the catch-block branch asks the provider before it decides', () => {
+    const branch = missingRuntimeBranch();
+    // The heuristic that got us into this branch is not evidence: it matches
+    // any error whose message merely contains "not found".
+    expect(branch).toContain('provider.getStatus(externalId)');
+    expect(branch).toContain("runtimeLossVerdict(status) === 'preserve'");
+  });
+
+  test('anything short of removed parks — retriable, and the box is stopped', () => {
+    const branch = missingRuntimeBranch();
+    // parkEstablishedRuntime is the only one of the two that calls
+    // provider.stop(); preserving here left the box running (incident root
+    // cause 3, the compute leak).
+    expect(branch).toContain('await parkEstablishedRuntime(');
+
+    // The park must be the ELSE of the verdict, never the other way round.
+    const verdictAt = branch.indexOf("runtimeLossVerdict(status) === 'preserve'");
+    const preserveAt = branch.indexOf('await preserveEstablishedRuntime(');
+    const parkAt = branch.indexOf('await parkEstablishedRuntime(');
+    expect(verdictAt).toBeGreaterThan(-1);
+    expect(preserveAt).toBeGreaterThan(verdictAt);
+    expect(parkAt).toBeGreaterThan(preserveAt);
+  });
+
+  test('a provider that cannot answer parks rather than throwing out of the continuation', () => {
+    // This runs detached from the request, after the 202. An unhandled throw
+    // here is an unhandled rejection, not a 500 the caller could see.
+    const branch = missingRuntimeBranch();
+    expect(branch).toContain("return 'unknown' as const;");
+    // 'unknown' is a probe failure, not evidence — the gate parks on it.
+    expect(branch).toContain('} catch {');
+  });
+});


### PR DESCRIPTION
## Summary

`runtime-identity.ts` states the rule as an invariant of the module:

> Only a fresh, definitive provider `removed` may classify an identity as lost. Every other answer — a present state, a transitional state, or a probe the provider could not answer — parks the runtime as an ordinary stopped row that a later `/start` can wake.

`runtimeLossVerdict` is the gate that enforces it. It exists because of incident 2026-08-14 (`docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md`), where two **healthy** sandboxes were declared lost — a dead local tunnel kept them from booting and nothing asked the provider — while both control planes reported them running.

**`restart-in-place` has three `preserveEstablishedRuntime` call sites. Two are gated on a fresh `getStatus() === 'removed'`. The third is not.**

The ungated one is inside the restart catch block, and its only evidence is:

```ts
if (isMissingRuntimeError(err)) {
  ...
  const recovery = await provider.recoverInPlace?.(externalId)
    .catch(() => 'unavailable' as const);
  if (recovery === 'running' || recovery === 'recovering') { ... }
  else {
    await preserveEstablishedRuntime(claim.row, 'restart_missing_runtime', 'restart_failed')
  }
}
```

Neither condition is evidence that a box is gone:

- **`isMissingRuntimeError` is a message heuristic.** Its final clause is `message.includes('not found')`. Any error thrown anywhere in restart whose text contains that substring qualifies — a config lookup, a ref, a template, an unrelated 404 from a sub-call.
- **`recoverInPlace` is optional.** The `?.` yields `undefined` for a provider that does not implement it, and `undefined` is neither `'running'` nor `'recovering'`, so it falls straight through to the preserve. From this branch, "the provider has no in-place recovery" is indistinguishable from "the provider tried and failed". The `.catch(() => 'unavailable')` folds a transient error into the same path.

The provider is never asked.

### What that costs

`preserveEstablishedRuntime` is not a soft outcome. It is the terminal one, and it does three things:

1. **The user is told their work is gone.** It writes `runtimeIdentityState: 'unavailable'`, which the web renders as *"This session's computer was lost — its cloud sandbox disappeared on the provider side, so this session cannot be restarted or recovered"*, with `retriable: false`. For a box that is still running.
2. **A false alert fires.** Every preserve calls `reportLostRuntime`, unconditionally — `logger.error('Session runtime lost by the provider — user work is unrecoverable')` under the stable `event:"runtime.lost"` name Better Stack alerts on, plus a `captureException`. This is exactly the noise the incident flags: *"alert noise that will desensitize us to the genuine class."*
3. **The box keeps running.** Only `parkEstablishedRuntime` calls `provider.stop()`. Preserve closes the compute window and walks away, so the sandbox burns unmetered compute until a backstop fires (Daytona `autoStopInterval` 720 min, or the orphan sweep). That is the incident's root cause 3, on a path its fix did not reach.

## The fix

Ask the provider, then let the existing gate decide — the same shape the two sibling call sites already use:

```ts
const status = await (async () => {
  try { return await provider.getStatus(externalId); }
  catch { return 'unknown' as const; }
})();
if (runtimeLossVerdict(status) === 'preserve') {
  await preserveEstablishedRuntime(...)   // unchanged behaviour for a real removal
} else {
  await parkEstablishedRuntime(...)       // retriable, and the box is stopped
}
```

`removed` preserves exactly as before. Anything else parks: retriable row, honest "restart it" card, `provider.stop()` called, no `runtime.lost`.

`try/catch` rather than `.catch()`, and `unknown` on failure, are both deliberate. This runs **detached from the request** — the 202 has already gone out — so a throw here is an unhandled rejection with no caller to see it. And `unknown` is a probe failure, not evidence, so the gate parks on it: the conservative direction, since a park can always be escalated by a later verification sweep but a false loss cannot be walked back.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

**Full `apps/api` unit suite** (`bash scripts/test.sh`, the hermetic gate):

| | tests | pass | fail |
|---|---|---|---|
| `main` | 8256 | 8178 | 0 |
| this branch | 8260 | **8182** | 0 |

+4 new tests, nothing else moved. (78 skipped on both.)

**The new tests are not vacuous.** Reverting only the source change, with the tests left in place:

```
(fail) every preserve in this file is preceded by a definitive removed check
(fail) the catch-block branch asks the provider before it decides
(fail) anything short of removed parks — retriable, and the box is stopped
(fail) a provider that cannot answer parks rather than throwing out of the continuation
 0 pass
 4 fail
```

Restored, back to 4/4.

**On why they are source assertions:** these three call sites sit inside a detached async continuation behind a provider client, in a function that returns before they run. I could not reach them from a unit test without building a provider double and a fake DB, which would pin my scaffolding rather than the invariant. The assertion that matters is structural — *no preserve in this file is reachable without a removed check first* — and the count of preserve sites is asserted too, so a fourth added later has to come to this test and account for itself instead of inheriting silence. `runtimeLossVerdict` itself is already unit-tested in `runtime-identity.test.ts`; this covers its call sites.

**Other gates:**

- `pnpm --filter kortix-api typecheck` — clean
- `biome check` on both files — **identical findings before and after** (1 format, 2 `noExplicitAny`, 1 organizeImports, all pre-existing in `actions.ts`); the new test file adds none

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control) — no endpoint or authz path changed; this is inside an already-authorized restart continuation
- [x] User input is validated (e.g. Zod) and output is safe — no user input reaches this branch; the only new input is a provider status string consumed by an existing pure gate
- [x] No sensitive data (tokens, PII, secrets) is written to logs — strictly reduces logging: it stops a false `runtime.lost` payload being emitted for live boxes
- [x] DB schema / migration changes are reviewed and reversible — n/a
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner — **touches billing indirectly and should be reviewed as such**: `parkEstablishedRuntime` closes the compute window *and* stops the box, where preserve closed the window and left it running. Metering close happens on both paths, so this ends unmetered compute rather than starting any.

## Rollout / rollback

No migrations, flags, or env vars. Behaviour is unchanged whenever the provider genuinely answers `removed`; every other answer moves a session from a terminal, non-retriable state to a retriable one. Reverting the commit restores the previous classification.

Worth noting for the incident's ledger: rows written by this path before this change still carry `runtimeIdentityState: 'unavailable'`. This does not backfill them — the parked-runtime verification sweep already re-probes and heals such rows, which is how the daytona box in the incident recovered at 18:26:57.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied
