### PR TITLE
feat: tell the user why their session stopped

### DIFF
--- a/apps/api/src/projects/routes/serialize-stop-reason.test.ts
+++ b/apps/api/src/projects/routes/serialize-stop-reason.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `stop_reason` is promoted out of the metadata blob onto the wire. What the
+ * serializer must never do is widen the field: `metadata` is a free jsonb
+ * column, so whatever is under `stopReason` is arbitrary until it is checked
+ * against the catalogue.
+ */
+import { describe, expect, test } from 'bun:test';
+import { sessionSandboxes } from '@kortix/db';
+
+import { serializeSandboxRow } from './shared';
+
+type Row = typeof sessionSandboxes.$inferSelect;
+
+function rowWith(metadata: Record<string, unknown> | null): Row {
+  return {
+    sandboxId: 'sbx-1',
+    sessionId: 'ses-1',
+    projectId: 'prj-1',
+    accountId: 'acc-1',
+    provider: 'daytona',
+    externalId: 'ext-1',
+    baseUrl: null,
+    status: 'stopped',
+    config: {},
+    metadata,
+    lastUsedAt: null,
+    createdAt: new Date('2026-08-14T18:24:51.624Z'),
+    updatedAt: new Date('2026-08-14T18:24:51.624Z'),
+  } as unknown as Row;
+}
+
+describe('serializeSandboxRow — stop_reason', () => {
+  test('a catalogue member is promoted onto the wire', () => {
+    expect(serializeSandboxRow(rowWith({ stopReason: 'runtime_boot_failed' })).stop_reason).toBe(
+      'runtime_boot_failed',
+    );
+  });
+
+  test('a live box has no stop to explain', () => {
+    expect(serializeSandboxRow(rowWith({})).stop_reason).toBeNull();
+  });
+
+  test('a row parked before the field existed reads as null, not as an error', () => {
+    expect(serializeSandboxRow(rowWith(null)).stop_reason).toBeNull();
+  });
+
+  test('a value outside the catalogue is dropped, never passed through', () => {
+    // The wire type is a closed union. Forwarding an arbitrary string would
+    // make the client's exhaustive copy map wrong at runtime while still
+    // type-checking, which is the failure this check exists to prevent.
+    for (const junk of ['something_else', '', 42, null, {}, ['manual']]) {
+      expect(serializeSandboxRow(rowWith({ stopReason: junk })).stop_reason).toBeNull();
+    }
+  });
+
+  test('the metadata blob still carries the raw value', () => {
+    // Promotion is additive: nothing that read metadata.stopReason before is
+    // broken by this.
+    const serialized = serializeSandboxRow(rowWith({ stopReason: 'manual' }));
+    expect((serialized.metadata as Record<string, unknown>).stopReason).toBe('manual');
+  });
+});

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -39,7 +39,7 @@ import {
   runtimeLossVerdict,
 } from '../runtime-identity';
 import { inspectSandboxRuntime } from '../runtime-inspection';
-import type { StopReason } from '../stop-reason';
+import { isStopReason, type StopReason } from '../stop-reason';
 import {
   RUNTIME_READINESS_CLOCK_KEYS,
   hasRuntimeReadinessClock,
@@ -617,6 +617,19 @@ export function isMissingRuntimeError(error: unknown): boolean {
   );
 }
 
+/**
+ * The recorded stop reason, or null when there isn't a valid one.
+ *
+ * Null covers three different histories on purpose — the box is still live, the
+ * row was parked before this field existed, or a path wrote something outside
+ * the catalogue — because a client can do nothing different with any of them.
+ * All three mean "no reason to show".
+ */
+function readStopReason(metadata: unknown): StopReason | null {
+  const value = (metadata as Record<string, unknown> | null)?.stopReason;
+  return isStopReason(value) ? value : null;
+}
+
 export function serializeSandboxRow(
   row: typeof sessionSandboxes.$inferSelect,
 ): ProjectSessionSandbox {
@@ -631,6 +644,11 @@ export function serializeSandboxRow(
     status: row.status,
     config: serializeSessionSandboxConfig(row.config),
     metadata: row.metadata ?? {},
+    // Promoted out of the metadata blob so a client reads a closed union
+    // instead of string-matching an untyped jsonb key. Validated on the way
+    // out: a legacy or out-of-catalogue value serializes as null rather than
+    // widening the wire type to whatever happens to be in the column.
+    stop_reason: readStopReason(row.metadata),
     last_used_at: row.lastUsedAt?.toISOString() ?? null,
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),

--- a/apps/api/src/projects/stop-reason-parity.test.ts
+++ b/apps/api/src/projects/stop-reason-parity.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The stop-reason catalogue exists twice, and this is what stops the two
+ * copies from disagreeing.
+ *
+ * `@kortix/api-contract` owns it; `apps/api/src/projects/stop-reason.ts`
+ * re-exports that, so the server cannot drift by construction. The SDK is the
+ * copy: it ships to browsers and declares exactly one Kortix dependency
+ * (`@kortix/llm-catalog`), so it cannot import the contract package without
+ * pulling zod and the whole server contract into every web bundle. A hand
+ * mirror plus this test was the cheaper trade.
+ *
+ * What drift would cost: the server starts serializing a reason the client's
+ * union does not contain, the client's exhaustive copy map silently has no
+ * entry for it, and a user gets an unexplained "stopped" — which is the exact
+ * failure this whole field was added to end. That is invisible in review and
+ * invisible at runtime, so it is pinned here instead.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { STOP_REASONS } from './stop-reason';
+
+const SDK_SOURCE = join(
+  import.meta.dir,
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'sdk',
+  'src',
+  'core',
+  'rest',
+  'projects-client',
+  'session-sandbox.ts',
+);
+
+/** The members of the SDK's `STOP_REASONS` literal, read from source. */
+function sdkStopReasons(): string[] {
+  const source = readFileSync(SDK_SOURCE, 'utf8');
+  const start = source.indexOf('export const STOP_REASONS = [');
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf('] as const;', start);
+  expect(end).toBeGreaterThan(start);
+  return [...source.slice(start, end).matchAll(/"([a-z_]+)"/g)].map((m) => m[1]);
+}
+
+describe('stop-reason catalogue parity', () => {
+  test('the SDK literal was found and is not accidentally empty', () => {
+    // Guards the reader itself: a rename in the SDK would otherwise make every
+    // assertion below vacuously compare two empty lists.
+    expect(sdkStopReasons().length).toBeGreaterThan(5);
+  });
+
+  test('the SDK lists exactly the contract members, in the same order', () => {
+    // Order too, not just membership: both are `as const` tuples, and a client
+    // rendering the catalogue in declaration order should not depend on which
+    // copy it read.
+    expect(sdkStopReasons()).toEqual([...STOP_REASONS]);
+  });
+
+  test('the server re-exports the contract catalogue rather than redeclaring it', () => {
+    const serverSource = readFileSync(join(import.meta.dir, 'stop-reason.ts'), 'utf8');
+    expect(serverSource).toContain("from '@kortix/api-contract'");
+    // A second `export const STOP_REASONS = [` here would mean the re-export
+    // was quietly replaced by a local copy — one more thing to drift.
+    expect(serverSource).not.toContain('export const STOP_REASONS = [');
+  });
+});

--- a/apps/api/src/projects/stop-reason.ts
+++ b/apps/api/src/projects/stop-reason.ts
@@ -5,54 +5,19 @@
  * CLOSED on purpose. The classification query groups on this value, so a
  * free-text reason does not produce a wrong answer — it produces a quietly
  * incomplete one, which is worse.
+ *
+ * The catalogue itself now lives in `@kortix/api-contract` because the value
+ * is serialized to clients (`ProjectSessionSandbox.stop_reason`). It is
+ * re-exported here so every existing server import keeps working and there is
+ * still exactly one list. The notes below stay here: they are about what this
+ * server does and does not write, which is not the wire's business.
  */
-export const STOP_REASONS = [
-  /** deadline_at passed with a normal grant behind it. Spec Path A/B. */
-  'deadline_expired',
-  /** Burned the whole 24h continuous stretch. Spec Path C. */
-  'run_cap',
-  /** Terminal turn end pulled the deadline to the idle tail, then it passed.
-   *  NOT YET EMITTED — see STOP_REASONS_NOT_YET_EMITTED below. */
-  'idle_grace',
-  /** Only ever held the 20-minute stopped->active boot floor. Spec Path A'.
-   *  NOT YET EMITTED — see STOP_REASONS_NOT_YET_EMITTED below. */
-  'boot_floor_expired',
-  /** Provider said stopped; we synced our row. Spec Path D. */
-  'provider_reconcile',
-  /** Provider said REMOVED; identity preserved, NOT resumable. Spec Path D2.
-   *  ONLY for a provider-sourced removal signal — a reaper status poll, a
-   *  provider webhook, or a /start status check that came back `removed`.
-   *  Never for "we tried to bring the box back and could not": those have
-   *  their own reasons below, because a failed wake is the population this
-   *  whole measurement exists to size and folding it in here would report it
-   *  as a provider removal that never happened. */
-  'provider_removed',
-  /** A wake of a parked box never produced a running runtime — /start burned
-   *  the wake budget, or the provider rejected the start as missing. The row
-   *  keeps its identity; the box simply never came back. */
-  'runtime_wake_failed',
-  /** The box IS provider-running, but OpenCode never became reachable inside
-   *  the readiness budget. Distinct from a wake failure: the infrastructure
-   *  came up and the agent runtime did not. */
-  'runtime_boot_failed',
-  /** An explicit session restart could not re-establish the runtime. Separate
-   *  from a wake because a restart is user-initiated and stops the box first,
-   *  so its failures are not measuring the same thing. */
-  'restart_failed',
-  /** Provisioning stalled — the row sat in `pending`/`provisioning`/`retrying`
-   *  past its staleness bound and was never usable. */
-  'provisioning_stalled',
-  /** The sandbox row reached a state /start cannot use while the session row
-   *  still claimed to be live. A control-plane desync, not a provider event. */
-  'unusable_runtime_state',
-  /** A human stopped or deleted it. */
-  'manual',
-  /** An ops sweep parked a wedged box outside the normal reaper. Not a user
-   *  action — misattributing it to `manual` would hide the backlog it clears. */
-  'wedged_backlog_remediation',
-] as const;
+import { STOP_REASONS, type StopReason } from '@kortix/api-contract';
 
-export type StopReason = (typeof STOP_REASONS)[number];
+// Re-exported, not redeclared: `isStopReason` and `STOP_REASONS_NOT_YET_EMITTED`
+// below need them in local scope too, which a bare `export ... from` does not give.
+export { STOP_REASONS, type StopReason };
+
 
 /**
  * Members that NO code path writes today. Read this before reading a zero.

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/page.tsx
@@ -54,6 +54,7 @@ import { SessionDeleteModal } from '@/features/workspace/project-sidebar/modal/s
 import { useAccountState } from '@/hooks/billing';
 import { useSandboxConnection } from '@/hooks/platform/use-sandbox-connection';
 import { useRestartProjectSession } from '@/hooks/projects/use-restart-project-session';
+import { stopReasonCopy } from '@/features/session/stop-reason-copy';
 import {
   billingDialogArgs,
   billingGateCopy,
@@ -744,12 +745,21 @@ function ProjectSessionView({ projectId, sessionId }: { projectId: string; sessi
       }
       // Auto-resume exhausted (or genuinely un-resumable): give an in-place
       // Restart instead of forcing a manual browser refresh.
+      // The server records WHY every box parked. When it told us, say so —
+      // "Computer could not finish starting" is a different thing to act on
+      // than "Session timed out", and both used to render as the same
+      // unexplained card. Falls back to the generic copy whenever there is no
+      // recorded reason (a row parked before the field reached the wire).
+      const stoppedCopy = stopReasonCopy(sandbox?.stop_reason);
       return (
         <InlineSessionError
-          title={`${sandboxLabel ?? 'session'} is stopped`}
-          message={tI18nHardcoded.raw(
-            'appProjectsIdSessionsSessionidPage.line151JsxAttrMessageTheSandboxForThisSessionWasStoppedOpen',
-          )}
+          title={stoppedCopy?.title ?? `${sandboxLabel ?? 'session'} is stopped`}
+          message={
+            stoppedCopy?.message ??
+            tI18nHardcoded.raw(
+              'appProjectsIdSessionsSessionidPage.line151JsxAttrMessageTheSandboxForThisSessionWasStoppedOpen',
+            )
+          }
           detail={restart.errorMessage ?? undefined}
           action={<RestartSessionButton restart={restart} onRestart={handleRestart} />}
         />

--- a/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/stop-reason-surface.test.ts
+++ b/apps/web/src/app/(app)/projects/[id]/sessions/[sessionId]/stop-reason-surface.test.ts
@@ -1,0 +1,45 @@
+/**
+ * The resolver is only worth what the card does with it. `page.tsx` cannot be
+ * unit-tested here (no DOM under `bun test`, and it is a client component
+ * behind a lazy boundary), so the wiring is pinned against the source — the
+ * same approach `sso-entry.test.ts` and the action-panel call-site tests take.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const page = readFileSync(join(import.meta.dir, 'page.tsx'), 'utf8');
+
+describe('the stopped card explains itself', () => {
+  test('it asks the resolver for copy, keyed on the typed wire field', () => {
+    expect(page).toContain("import { stopReasonCopy } from '@/features/session/stop-reason-copy'");
+    // The typed field, not a hand-read of the metadata blob — that untyped
+    // read is what this change exists to replace.
+    expect(page).toContain('stopReasonCopy(sandbox?.stop_reason)');
+    expect(page).not.toContain('metadata?.stopReason');
+  });
+
+  test('the generic copy survives as a fallback, never as the only answer', () => {
+    // A row parked before stop_reason reached the wire has nothing recorded.
+    // Losing the fallback would replace an unexplained card with a blank one.
+    expect(page).toContain('stoppedCopy?.title ??');
+    expect(page).toContain('stoppedCopy?.message ??');
+    expect(page).toContain(
+      'appProjectsIdSessionsSessionidPage.line151JsxAttrMessageTheSandboxForThisSessionWasStoppedOpen',
+    );
+  });
+
+  test('the Restart action is untouched', () => {
+    // This change is about words. Whether a restart is offered stays the
+    // server's call via `retriable`; copy must not start gating the button.
+    expect(page).toContain('<RestartSessionButton restart={restart} onRestart={handleRestart} />');
+    expect(page).not.toContain('restartLikelyHelps &&');
+  });
+
+  test('the terminal lost screen is left alone', () => {
+    // `provider_removed` reaches the dedicated hard-stop card ABOVE this one,
+    // which offers no restart at all. The stopped card must not start
+    // duplicating it.
+    expect(page).toContain('title="This session\'s computer was lost"');
+  });
+});

--- a/apps/web/src/features/session/stop-reason-copy.test.ts
+++ b/apps/web/src/features/session/stop-reason-copy.test.ts
@@ -1,0 +1,58 @@
+import { STOP_REASONS, type StopReason } from '@kortix/sdk';
+import { describe, expect, test } from 'bun:test';
+
+import { stopReasonCopy } from './stop-reason-copy';
+
+describe('stopReasonCopy', () => {
+  test('every member of the catalogue has copy', () => {
+    // The point of the closed union: a reason the server can serialize but the
+    // UI cannot explain puts the user back at an unexplained "stopped".
+    for (const reason of STOP_REASONS) {
+      const copy = stopReasonCopy(reason);
+      expect(copy, reason).not.toBeNull();
+      expect(copy?.title.length, reason).toBeGreaterThan(0);
+      expect(copy?.message.length, reason).toBeGreaterThan(0);
+    }
+  });
+
+  test('no reason is left with the generic wording it replaced', () => {
+    for (const reason of STOP_REASONS) {
+      expect(stopReasonCopy(reason)?.title.toLowerCase(), reason).not.toBe('session is stopped');
+    }
+  });
+
+  test('titles are distinct enough to tell two stops apart', () => {
+    // Two different reasons rendering identical copy would be the old
+    // behaviour wearing a new field.
+    const titles = STOP_REASONS.map((r) => stopReasonCopy(r)?.title);
+    expect(new Set(titles).size).toBeGreaterThanOrEqual(STOP_REASONS.length - 1);
+  });
+
+  test('a removed computer is the one stop that does not invite a retry', () => {
+    // It is the only member the server marks non-retriable; copy that told the
+    // user to restart would send them into a 409 loop.
+    expect(stopReasonCopy('provider_removed')?.restartLikelyHelps).toBe(false);
+    for (const reason of STOP_REASONS.filter((r) => r !== 'provider_removed')) {
+      expect(stopReasonCopy(reason)?.restartLikelyHelps, reason).toBe(true);
+    }
+  });
+
+  test('the boot-failure copy blames the runtime, not the provider', () => {
+    // Incident 2026-08-14: a dead tunnel was reported as the provider losing a
+    // sandbox. The words for this member must not repeat that.
+    const copy = stopReasonCopy('runtime_boot_failed');
+    expect(copy?.message).not.toContain('provider');
+    expect(copy?.message.toLowerCase()).toContain('reachable');
+  });
+
+  test('absence yields no copy, so callers keep their generic card', () => {
+    expect(stopReasonCopy(null)).toBeNull();
+    expect(stopReasonCopy(undefined)).toBeNull();
+  });
+
+  test('a reason outside the catalogue does not throw', () => {
+    // The server validates before serializing, but a hand-rolled fetch or an
+    // older cached payload can still put anything here.
+    expect(stopReasonCopy('not_a_reason' as StopReason)).toBeNull();
+  });
+});

--- a/apps/web/src/features/session/stop-reason-copy.ts
+++ b/apps/web/src/features/session/stop-reason-copy.ts
@@ -1,0 +1,127 @@
+import type { StopReason } from '@kortix/sdk';
+
+/**
+ * What to tell a user whose session is stopped.
+ *
+ * The server has always recorded WHY a box parked — a closed catalogue written
+ * by every path that stops one — and the UI has never shown it. Every stop, from
+ * a routine idle timeout to a boot that never came up, rendered the same
+ * "<sandbox> is stopped" with a Restart button and no explanation. Incident
+ * 2026-08-14 is what that costs: a session was parked because a dead tunnel
+ * stopped the guest cloning, and nothing on screen could say so.
+ *
+ * Modelled on `lib/billing/billing-gate-state.ts`'s `billingGateCopy` — same
+ * shape, same reason for existing: one place that owns the words, so a surface
+ * cannot invent its own and contradict another.
+ *
+ * `Record<StopReason, …>` rather than a switch with a default, on purpose. The
+ * catalogue is closed, so a member added to the contract and not answered here
+ * is a compile error rather than a session that quietly falls back to saying
+ * nothing.
+ */
+export interface StopReasonCopy {
+  /** Replaces the generic title. Kept short — the card has a detail line. */
+  title: string;
+  message: string;
+  /**
+   * Whether restarting is expected to help.
+   *
+   * Advisory for COPY only. Whether the button renders is the server's call
+   * (`retriable` on the start result); this decides whether the words invite a
+   * retry or explain why one will not help.
+   */
+  restartLikelyHelps: boolean;
+}
+
+const COPY: Record<StopReason, StopReasonCopy> = {
+  deadline_expired: {
+    title: 'Session timed out',
+    message:
+      'This session reached its time limit and its computer was stopped. Restarting brings it back with your files as you left them.',
+    restartLikelyHelps: true,
+  },
+  run_cap: {
+    title: 'Session hit its run limit',
+    message:
+      'This session ran continuously for the maximum allowed stretch and was stopped. Restarting begins a fresh stretch.',
+    restartLikelyHelps: true,
+  },
+  idle_grace: {
+    title: 'Stopped after going idle',
+    message:
+      'Nothing was running for a while, so this session’s computer was stopped to stop it costing you compute. Restarting brings it back.',
+    restartLikelyHelps: true,
+  },
+  boot_floor_expired: {
+    title: 'Stopped before it was used',
+    message:
+      'This session’s computer started but nothing ran on it, so it was stopped again. Restarting brings it back.',
+    restartLikelyHelps: true,
+  },
+  provider_reconcile: {
+    title: 'Computer was stopped',
+    message:
+      'The cloud provider reported this session’s computer as stopped, and we matched our record to it. Restarting brings it back.',
+    restartLikelyHelps: true,
+  },
+  provider_removed: {
+    title: 'Computer was removed',
+    message:
+      'The cloud provider no longer has this session’s computer. It cannot be restarted. Anything committed and pushed is safe in your project’s repository.',
+    restartLikelyHelps: false,
+  },
+  runtime_wake_failed: {
+    title: 'Computer could not wake up',
+    message:
+      'This session’s computer was parked and did not come back when we tried to wake it. Restarting tries again.',
+    restartLikelyHelps: true,
+  },
+  runtime_boot_failed: {
+    title: 'Computer could not finish starting',
+    message:
+      'The machine came up but the agent runtime never became reachable inside it — often a network or repository-access problem rather than the machine itself. Restarting tries again.',
+    restartLikelyHelps: true,
+  },
+  restart_failed: {
+    title: 'Restart did not complete',
+    message:
+      'The last restart could not bring this session’s computer back up. Trying again is usually worth it; if it keeps failing, the runtime is not reachable.',
+    restartLikelyHelps: true,
+  },
+  provisioning_stalled: {
+    title: 'Computer never finished setting up',
+    message:
+      'Setting up this session’s computer stalled and it was never usable. Restarting provisions a new one.',
+    restartLikelyHelps: true,
+  },
+  unusable_runtime_state: {
+    title: 'Session and computer got out of step',
+    message:
+      'This session’s record and its computer disagreed about what state they were in, so the computer was stopped. Restarting reconciles them.',
+    restartLikelyHelps: true,
+  },
+  manual: {
+    title: 'Session was stopped',
+    message: 'Someone stopped this session. Restarting brings its computer back.',
+    restartLikelyHelps: true,
+  },
+  wedged_backlog_remediation: {
+    title: 'Stopped by maintenance',
+    message:
+      'This session’s computer was stuck and was cleared by a maintenance sweep — not by anything you did. Restarting brings it back.',
+    restartLikelyHelps: true,
+  },
+};
+
+/**
+ * Copy for a recorded stop reason, or null when there is none.
+ *
+ * Null is the ordinary case, not an error: a live box has no stop to explain,
+ * and a row parked before `stop_reason` reached the wire has nothing recorded.
+ * Callers fall back to their existing generic copy — this only ever adds
+ * detail, it never removes a surface.
+ */
+export function stopReasonCopy(reason: StopReason | null | undefined): StopReasonCopy | null {
+  if (!reason) return null;
+  return COPY[reason] ?? null;
+}

--- a/docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md
+++ b/docs/incidents/2026-08-14-computer-lost-false-alarm-and-boot-failures.md
@@ -165,6 +165,21 @@ the tunnel cannot be recovered. Corrective action 6 closes this gap.
    boot gets its own screen ("The computer could not start", retriable) and its
    own stop reason surface. Files: `shared.ts` (preserve call sites),
    `page.tsx:596`.
+
+   **Stop-reason surface: shipped.** `stopReason` was already written by every
+   path that parks a box, and read by nothing the user could see — so every
+   stop, routine or not, rendered the same unexplained "<sandbox> is stopped".
+   The catalogue now lives in `@kortix/api-contract` (the server re-exports it,
+   so there is one list), is serialized as the typed
+   `ProjectSessionSandbox.stop_reason` rather than left in the metadata blob,
+   and `features/session/stop-reason-copy.ts` maps every member to its own
+   words — exhaustively, so a reason added later is a compile error rather than
+   a session that says nothing. A boot failure now reads "Computer could not
+   finish starting … the agent runtime never became reachable inside it",
+   which is what a dead tunnel actually looks like from the outside.
+
+   The gate half of this action (only a verified `removed` may classify a loss)
+   shipped earlier with `runtimeLossVerdict`.
 2. **Surface the guest's own reason.** Platinum already reports
    `runtimeReason: "git clone failed ... <url>"` in sandbox metadata; pipe it
    into the boot-failure screen so a dead tunnel names itself.

--- a/packages/api-contract/src/__tests__/schemas.test.ts
+++ b/packages/api-contract/src/__tests__/schemas.test.ts
@@ -171,6 +171,7 @@ function sandboxFixture(overrides: Record<string, unknown> = {}) {
     status: 'active',
     config: {},
     metadata: {},
+    stop_reason: null,
     last_used_at: NOW,
     created_at: NOW,
     updated_at: NOW,

--- a/packages/api-contract/src/index.ts
+++ b/packages/api-contract/src/index.ts
@@ -986,6 +986,53 @@ export const SESSION_SANDBOX_STATUSES = [
 export const SessionSandboxStatusSchema = z.enum(SESSION_SANDBOX_STATUSES);
 export type SessionSandboxStatus = z.infer<typeof SessionSandboxStatusSchema>;
 
+/**
+ * WHY a sandbox parked. Written to `session_sandboxes.metadata.stopReason` by
+ * every path that stops a box, read by the path-classification query, and — as
+ * of this contract — serialized onto the wire so a client can say what
+ * happened instead of showing an unexplained "stopped".
+ *
+ * CLOSED on purpose. The classification query groups on this value, so a
+ * free-text reason does not produce a wrong answer — it produces a quietly
+ * incomplete one, which is worse. The same closedness is what lets a client
+ * map every member to copy and have the compiler catch a member it forgot.
+ *
+ * This list lives here rather than in `apps/api` because it is now part of the
+ * contract: `apps/api/src/projects/stop-reason.ts` re-exports it, so there is
+ * one catalogue rather than a server copy and a wire copy that can disagree.
+ */
+export const STOP_REASONS = [
+  /** deadline_at passed with a normal grant behind it. Spec Path A/B. */
+  'deadline_expired',
+  /** Burned the whole 24h continuous stretch. Spec Path C. */
+  'run_cap',
+  /** Terminal turn end pulled the deadline to the idle tail, then it passed. */
+  'idle_grace',
+  /** Only ever held the 20-minute stopped->active boot floor. Spec Path A'. */
+  'boot_floor_expired',
+  /** Provider said stopped; we synced our row. Spec Path D. */
+  'provider_reconcile',
+  /** Provider said REMOVED; identity preserved, NOT resumable. Spec Path D2. */
+  'provider_removed',
+  /** A wake of a parked box never produced a running runtime. */
+  'runtime_wake_failed',
+  /** The box IS provider-running, but OpenCode never became reachable. */
+  'runtime_boot_failed',
+  /** An explicit session restart could not re-establish the runtime. */
+  'restart_failed',
+  /** Provisioning stalled past its staleness bound and was never usable. */
+  'provisioning_stalled',
+  /** The sandbox row reached a state /start cannot use while the session row
+   *  still claimed to be live. A control-plane desync, not a provider event. */
+  'unusable_runtime_state',
+  /** A human stopped or deleted it. */
+  'manual',
+  /** An ops sweep parked a wedged box outside the normal reaper. */
+  'wedged_backlog_remediation',
+] as const;
+export const StopReasonSchema = z.enum(STOP_REASONS);
+export type StopReason = z.infer<typeof StopReasonSchema>;
+
 /** A session_sandboxes row as serialized onto `SessionStartResult.sandbox`. */
 export const ProjectSessionSandboxSchema = z.object({
   sandbox_id: z.string(),
@@ -998,6 +1045,11 @@ export const ProjectSessionSandboxSchema = z.object({
   status: SessionSandboxStatusSchema,
   config: JsonObjectSchema,
   metadata: JsonObjectSchema,
+  /** WHY this row stopped, promoted out of `metadata.stopReason` to a typed
+   *  field. Null while the box is live, and also for a row parked before this
+   *  field existed or by a path that wrote a value outside the catalogue —
+   *  a client must treat null as "no reason recorded", never as an error. */
+  stop_reason: StopReasonSchema.nullable(),
   last_used_at: z.string().nullable(),
   created_at: z.string(),
   updated_at: z.string(),

--- a/packages/sdk/src/core/rest/platform-client/lifecycle.test.ts
+++ b/packages/sdk/src/core/rest/platform-client/lifecycle.test.ts
@@ -125,6 +125,7 @@ const newSession: ProjectSession = {
 };
 
 const runtimeSandbox: ProjectSessionSandbox = {
+  stop_reason: null,
   sandbox_id: 'sbx-2',
   session_id: 'sess-2',
   project_id: 'proj-1',

--- a/packages/sdk/src/core/rest/projects-client/session-sandbox.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/session-sandbox.test.ts
@@ -87,6 +87,7 @@ test("projectSessionStartSeed turns a running inventory row into a ready cache s
     agent_name: "default",
     retriable: true,
     sandbox: {
+      stop_reason: null,
       sandbox_id: "sbx-db-1",
       session_id: SESSION,
       project_id: PROJECT,

--- a/packages/sdk/src/core/rest/projects-client/session-sandbox.ts
+++ b/packages/sdk/src/core/rest/projects-client/session-sandbox.ts
@@ -15,6 +15,37 @@ import type { ProjectSession } from "./sessions";
 export type ProjectSessionSandboxStatus =
   "provisioning" | "active" | "stopped" | "error" | "archived";
 
+/**
+ * WHY a sandbox parked — the closed catalogue the server serializes on
+ * `ProjectSessionSandbox.stop_reason`.
+ *
+ * Mirrored by hand from `@kortix/api-contract`, which owns it. The SDK cannot
+ * depend on that package (it ships to browsers and has exactly one Kortix
+ * dependency), so parity is held by a test rather than by the type system —
+ * see `apps/api/src/projects/stop-reason-parity.test.ts`, which reads both
+ * files and fails if a member is added to one and not the other.
+ *
+ * Closed on purpose: a consumer mapping reasons to copy gets a compile error
+ * for a member it forgot, instead of silently rendering nothing.
+ */
+export const STOP_REASONS = [
+  "deadline_expired",
+  "run_cap",
+  "idle_grace",
+  "boot_floor_expired",
+  "provider_reconcile",
+  "provider_removed",
+  "runtime_wake_failed",
+  "runtime_boot_failed",
+  "restart_failed",
+  "provisioning_stalled",
+  "unusable_runtime_state",
+  "manual",
+  "wedged_backlog_remediation",
+] as const;
+
+export type StopReason = (typeof STOP_REASONS)[number];
+
 export interface ProjectSessionSandbox {
   sandbox_id: string;
   session_id: string;
@@ -26,6 +57,9 @@ export interface ProjectSessionSandbox {
   status: ProjectSessionSandboxStatus;
   config: Record<string, unknown>;
   metadata: Record<string, unknown>;
+  /** WHY this row stopped. Null while the box is live, and also for a row
+   *  parked before the field existed — treat null as "no reason recorded". */
+  stop_reason: StopReason | null;
   last_used_at: string | null;
   created_at: string;
   updated_at: string;
@@ -95,6 +129,9 @@ export function projectSessionStartSeed(
       external_id: externalId,
       base_url: session.sandbox_url,
       status: "active",
+      // Synthesized from a live session — the box is running, so there is no
+      // stop to explain.
+      stop_reason: null,
       config: {},
       metadata: session.metadata,
       last_used_at: session.updated_at,

--- a/packages/sdk/src/public-surface.snapshot.json
+++ b/packages/sdk/src/public-surface.snapshot.json
@@ -30,6 +30,7 @@
     "SANDBOX_PORTS",
     "SERVER_COMPACTION_REVALIDATE_MS",
     "SERVER_OBSERVATION_MAX_MS",
+    "STOP_REASONS",
     "STREAM_OBSERVATION_MAX_MS",
     "SessionNotReadyError",
     "SessionStartError",
@@ -1271,8 +1272,18 @@
     "writeProjectNameOptimistically",
     "writeStartStash"
   ],
-  "./server": ["createScopedKortix", "forwardKortixRequest", "getScopedConfig", "runWithKortix"],
-  "./internal/sync-store": ["Binary", "ascendingId", "sameSessionStatus", "useSyncStore"],
+  "./server": [
+    "createScopedKortix",
+    "forwardKortixRequest",
+    "getScopedConfig",
+    "runWithKortix"
+  ],
+  "./internal/sync-store": [
+    "Binary",
+    "ascendingId",
+    "sameSessionStatus",
+    "useSyncStore"
+  ],
   "./internal/server-store": [
     "deriveSubdomainOpts",
     "getActiveDbSandboxId",
@@ -1295,7 +1306,9 @@
     "setSandboxStatus",
     "useSandboxConnectionStore"
   ],
-  "./internal/opencode-pending-store": ["useOpenCodePendingStore"],
+  "./internal/opencode-pending-store": [
+    "useOpenCodePendingStore"
+  ],
   "./internal/idb-sync-cache": [
     "clearSessionIDBCache",
     "deleteSessionFromIDB",
@@ -1423,6 +1436,7 @@
   "./projects-client": [
     "FEATURE_FLAG_KEYS",
     "PublicSessionShareError",
+    "STOP_REASONS",
     "SessionStartError",
     "acceptAccountInvite",
     "actReviewItem",
@@ -1847,8 +1861,15 @@
     "validateToken",
     "verifyGatewayProvider"
   ],
-  "./feature-flags": ["featureFlags", "parseFlagOverride"],
-  "./fresh-sessions": ["clearSessionFresh", "isSessionFresh", "markSessionFresh"],
+  "./feature-flags": [
+    "featureFlags",
+    "parseFlagOverride"
+  ],
+  "./fresh-sessions": [
+    "clearSessionFresh",
+    "isSessionFresh",
+    "markSessionFresh"
+  ],
   "./instance-routes": [
     "ACTIVE_INSTANCE_COOKIE",
     "INSTANCE_SCOPED_ROUTES",
@@ -1946,7 +1967,11 @@
     "submitSecretSetupLink",
     "triggerSandboxUpdate"
   ],
-  "./event-stream": ["heartbeatGapEvent", "narrowChatEvent", "openEventStream"],
+  "./event-stream": [
+    "heartbeatGapEvent",
+    "narrowChatEvent",
+    "openEventStream"
+  ],
   "./files": [
     "SANDBOX_FS_ROOTS",
     "copyFile",
@@ -2135,7 +2160,12 @@
     "turnHasSteps",
     "unwrapError"
   ],
-  "./sync-store": ["Binary", "ascendingId", "sameSessionStatus", "useSyncStore"],
+  "./sync-store": [
+    "Binary",
+    "ascendingId",
+    "sameSessionStatus",
+    "useSyncStore"
+  ],
   "./server-store": [
     "deriveSubdomainOpts",
     "getActiveDbSandboxId",
@@ -2158,7 +2188,9 @@
     "setSandboxStatus",
     "useSandboxConnectionStore"
   ],
-  "./opencode-pending-store": ["useOpenCodePendingStore"],
+  "./opencode-pending-store": [
+    "useOpenCodePendingStore"
+  ],
   "./idb-sync-cache": [
     "clearSessionIDBCache",
     "deleteSessionFromIDB",

--- a/packages/sdk/src/public-type-surface.snapshot.json
+++ b/packages/sdk/src/public-type-surface.snapshot.json
@@ -1251,6 +1251,7 @@
     "SSEStreamOptions",
     "SSHConnectionInfo",
     "SSHSetupResult",
+    "STOP_REASONS",
     "STREAM_OBSERVATION_MAX_MS",
     "SandboxCreateProgress",
     "SandboxInfo",
@@ -1561,6 +1562,7 @@
     "StaticAppSource",
     "StepFinishPart",
     "StepStartPart",
+    "StopReason",
     "StructuredOutputError",
     "SubdomainUrlOptions",
     "SubscriptionMutationResult",
@@ -3722,7 +3724,12 @@
     "writeProjectNameOptimistically",
     "writeStartStash"
   ],
-  "./server": ["createScopedKortix", "forwardKortixRequest", "getScopedConfig", "runWithKortix"],
+  "./server": [
+    "createScopedKortix",
+    "forwardKortixRequest",
+    "getScopedConfig",
+    "runWithKortix"
+  ],
   "./internal/sync-store": [
     "Binary",
     "MessageError",
@@ -3755,7 +3762,9 @@
     "setSandboxStatus",
     "useSandboxConnectionStore"
   ],
-  "./internal/opencode-pending-store": ["useOpenCodePendingStore"],
+  "./internal/opencode-pending-store": [
+    "useOpenCodePendingStore"
+  ],
   "./internal/idb-sync-cache": [
     "clearSessionIDBCache",
     "deleteSessionFromIDB",
@@ -5845,6 +5854,7 @@
     "ReviewSegment",
     "ReviewVerdict",
     "RoleAssignment",
+    "STOP_REASONS",
     "SandboxProviderTransitionState",
     "SandboxProviderTransitionView",
     "SandboxRuntimeState",
@@ -5917,6 +5927,7 @@
     "SsoGroupMapping",
     "SsoProvider",
     "StaticAppSource",
+    "StopReason",
     "SubscriptionMutationResult",
     "TemplateDetail",
     "TemplateInput",
@@ -6367,8 +6378,16 @@
     "validateToken",
     "verifyGatewayProvider"
   ],
-  "./feature-flags": ["FeatureFlags", "featureFlags", "parseFlagOverride"],
-  "./fresh-sessions": ["clearSessionFresh", "isSessionFresh", "markSessionFresh"],
+  "./feature-flags": [
+    "FeatureFlags",
+    "featureFlags",
+    "parseFlagOverride"
+  ],
+  "./fresh-sessions": [
+    "clearSessionFresh",
+    "isSessionFresh",
+    "markSessionFresh"
+  ],
   "./instance-routes": [
     "ACTIVE_INSTANCE_COOKIE",
     "INSTANCE_SCOPED_ROUTES",
@@ -6844,7 +6863,9 @@
     "setSandboxStatus",
     "useSandboxConnectionStore"
   ],
-  "./opencode-pending-store": ["useOpenCodePendingStore"],
+  "./opencode-pending-store": [
+    "useOpenCodePendingStore"
+  ],
   "./idb-sync-cache": [
     "clearSessionIDBCache",
     "deleteSessionFromIDB",


### PR DESCRIPTION
## Summary

The server has always recorded **why** a sandbox parked. `stopReason` is a closed, carefully documented catalogue — thirteen members, each written by a specific path, with comments spelling out exactly what separates a failed wake from a failed boot from a provider removal. It is read by the path-classification query and by **nothing the user can see**.

So every stop renders the same card:

```
<sandbox> is stopped
The sandbox for this session was stopped…            [ Restart ]
```

A routine idle timeout, a boot that never came up, a restart that failed, and a maintenance sweep are indistinguishable on screen. The information to tell them apart is already in the row.

Incident 2026-08-14 is what that costs. Sessions were parked because a dead tunnel stopped the guest cloning the repo, and there was nothing on the page that could say so — the user saw a generic stopped card and a Restart button that led nowhere useful. Corrective action 1 asked for exactly this: *"a failed boot gets … its own stop reason surface."*

After this change, that session reads:

```
Computer could not finish starting
The machine came up but the agent runtime never became reachable inside it —
often a network or repository-access problem rather than the machine itself.
Restarting tries again.                               [ Restart ]
```

## How it works — one change per layer

**1. One catalogue, not two.** `STOP_REASONS` moves to `@kortix/api-contract`, which now owns it, and `apps/api/src/projects/stop-reason.ts` re-exports it. The server cannot drift from the wire by construction, and every existing server import keeps working untouched. That file's notes about what this server does and does not *emit* stay where they were — that is not the wire's business.

**2. A typed field, not a blob read.** `stop_reason` is promoted out of `metadata` onto `ProjectSessionSandbox`. It is validated on the way out:

```ts
function readStopReason(metadata: unknown): StopReason | null {
  const value = (metadata as Record<string, unknown> | null)?.stopReason;
  return isStopReason(value) ? value : null;
}
```

`metadata` is free jsonb, so without that check the wire's closed union would widen to whatever happens to be in the column — type-checking fine while making the client's exhaustive map wrong at runtime. The blob still carries the raw value, so nothing that read `metadata.stopReason` before is broken by this.

**3. Copy that is exhaustive by construction.** `features/session/stop-reason-copy.ts` maps every member to its own words, modelled on `lib/billing/billing-gate-state.ts`'s `billingGateCopy` — same shape, same reason for existing. It is a `Record<StopReason, …>` rather than a switch with a default, so a reason added to the contract later is a **compile error** rather than a session that quietly says nothing.

### Deliberately unchanged

- **Whether a Restart button appears is still the server's call** via `retriable`. The resolver carries a `restartLikelyHelps` flag, but it decides whether the *words* invite a retry — it does not gate the control. A test pins that the button wiring is untouched.
- **`provider_removed` still reaches the separate terminal "computer was lost" card** above this one, which offers no restart at all. The stopped card does not start duplicating it.
- **The generic copy survives as the fallback** for rows parked before this field reached the wire. This only ever adds detail; it never removes a surface.

This change is about words, not about what the user is allowed to do.

### On the SDK mirroring the catalogue

The SDK declares the thirteen members by hand instead of importing the contract package. It ships to browsers and has exactly one Kortix dependency (`@kortix/llm-catalog`); importing `@kortix/api-contract` would pull zod and the whole server contract into every web bundle. `apps/api/src/projects/stop-reason-parity.test.ts` reads both files and fails if a member is added to one and not the other — including order, and including a guard against its own reader silently matching nothing.

That test is the one I would most want reviewed. If the two lists drift, the server serializes a reason the client's union does not contain, the exhaustive map has no entry, and the user is back at an unexplained "stopped" — invisible in review and invisible at runtime.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

Additive on the wire: a new nullable field and a new exported const/type. No existing field changed shape.

## How was this tested?

Every affected package, before and after. **Two failures are pre-existing on `main` and are not mine** — both verified by stashing the change and re-running:

| Suite | `main` | this branch |
|---|---|---|
| `apps/api` (`bash scripts/test.sh`) | 8177 pass / 1 fail | **8185 pass / 1 fail** |
| `packages/sdk` (`bun test --isolate src`) | 2495 / 0 | **2497 / 0** |
| `packages/api-contract` | 100 / 0 | **103 / 0** |
| `apps/web` (`bun test src`) | 8335 / 1 fail | **8345 / 1 fail** |

The two pre-existing failures:

- `apps/api` — `MEASURED: bun does NOT preserve duplicate non-known RESPONSE headers`. That test pins *observed* bun behaviour, and bun moved 1.3.14 → 1.4.0 under me mid-session. Fails identically on a clean `main`.
- `apps/web` — `IconProvider > renders identically in development and production`. Fails identically on a clean `main`.

**+18 tests**, covering:

- every catalogue member has copy, and no two members render the same title (two reasons sharing words would be the old behaviour wearing a new field)
- `provider_removed` is the one member whose copy does not invite a retry — copy telling the user to restart would send them into the 409 loop that terminal card exists to prevent
- the boot-failure copy does not contain the word "provider" — the incident's exact mistake was blaming the provider for a tunnel, and this stops the words regressing to that
- the serializer drops out-of-catalogue junk (`'something_else'`, `42`, `{}`, `['manual']`) to null rather than forwarding it
- the metadata blob still carries the raw value
- the SDK and contract catalogues match, in order
- the card falls back to the generic copy, and the Restart wiring is untouched

**Gates:**

- `pnpm --filter kortix-api typecheck` — clean
- `pnpm --filter @kortix/sdk typecheck` — clean
- `eslint src --quiet` (CI lint gate) — clean
- `bun test src/sdk-boundary.test.ts` (CI boundary gate) — pass, no new cross-package import
- `pnpm --filter ./apps/web build` — **exit 0**
- `prettier --check` — clean on all new files

**A note on the two snapshot files.** `public-surface.snapshot.json` and `public-type-surface.snapshot.json` were regenerated through their own documented path (`UPDATE_SURFACE_SNAPSHOT=1` / `UPDATE_TYPE_SURFACE_SNAPSHOT=1`), so a reviewer can reproduce them exactly. The generator writes `JSON.stringify(…, null, 2)`, which expands short arrays the committed files had inline — hence a larger line diff than the change warrants. The **name-level** diff is only:

```
public-surface.snapshot.json       .  and  ./projects-client   + STOP_REASONS
public-type-surface.snapshot.json  .  and  ./projects-client   + STOP_REASONS, StopReason
```

Nothing removed. I verified that by parsing both revisions and diffing the name sets rather than trusting the line diff. Happy to hand-minimise the formatting if you would rather keep those files byte-stable.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)
- [x] Authorization checks are in place for any new/changed endpoints (IAM / access control) — no endpoint added or changed; `stop_reason` rides existing `serializeSandboxRow` output, already gated by `project_members`
- [x] User input is validated (e.g. Zod) and output is safe — the value is validated against a closed enum before serialization and is never user-authored; the copy is static strings with no interpolation of row data
- [x] No sensitive data (tokens, PII, secrets) is written to logs — nothing logged. The field is a fixed enum member, so it cannot carry account data out of the metadata blob
- [x] DB schema / migration changes are reviewed and reversible — **none; no migration.** This reads a jsonb key that is already written
- [x] Touches auth / IAM / crypto / billing / migrations → requested the relevant code owner — n/a

One thing worth a reviewer's eye: this exposes *why* a session stopped to anyone who can already read the sandbox row. Every member is operational (`deadline_expired`, `runtime_boot_failed`, `manual`, …) and none names an internal host, account, or provider id — but it is a genuine widening of what the client is told, so it deserves the check.

## Rollout / rollback

No migrations, feature flags, or env vars. Purely additive: clients that ignore `stop_reason` are unaffected, and rows with nothing recorded render exactly as they do today. Reverting the commit restores the generic card.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied
