### PR TITLE
fix(runtime): prevent silent timeouts and wake races

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,27 @@ linked, not inlined.
 
 ## Register
 
+### A stale readiness observer must claim the runtime row before stopping its provider (2026-08-24)
+
+**When:** parking an established runtime after a failed readiness or wake probe.
+CAS the exact observed `active` row, including `updated_at`, before closing
+compute or calling `provider.stop()`. Never write a stale metadata object after
+an external stop. Persist stop intent so a parked-row sweep retries after a
+crash. *Incident:* overlapping Essentia `/start` requests paused each new E2B
+boot after about 8 seconds and erased its wake fence; OpenCode needed 11.574
+seconds. *Enforcer:* runtime-identity and parked-runtime verification tests pin
+the CAS and durable retry.
+
+### A response-header timeout must end when actual provider headers arrive (2026-08-24)
+
+**When:** wrapping an AI SDK streaming request with a response-header deadline.
+Apply the deadline to the provider `fetch`, then clear it when `fetch` resolves.
+Do not use that deadline as the full-stream abort signal; AI SDK returns
+synthetic gateway headers before Bedrock `/converse-stream` returns. Keep client
+cancellation attached for the full body. *Incident:* Essentia Fable produced 14
+zero-token turns at 89-91 seconds, recorded as `200 ok=true`. *Enforcer:* gateway
+header/body/cancellation and timeout-classification tests.
+
 ### Refuse a release version whose tag already names another commit (2026-08-24)
 
 **When:** resolving a production version before migrations or rollout. Check

--- a/apps/api/src/projects/reaping/parked-runtime-verification.test.ts
+++ b/apps/api/src/projects/reaping/parked-runtime-verification.test.ts
@@ -15,7 +15,12 @@ import { decideParkedRuntime } from './parked-runtime-verification';
  * and 16 of them were already dead provider-side without Kortix knowing.
  */
 describe('decideParkedRuntime', () => {
-  const base = { providerStatus: 'stopped', identityState: null, wakeInProgress: false };
+  const base = {
+    providerStatus: 'stopped',
+    identityState: null,
+    wakeInProgress: false,
+    stopPending: false,
+  };
 
   test('a definitive `removed` on a healthy-looking parked row preserves the identity', () => {
     expect(decideParkedRuntime({ ...base, providerStatus: 'removed' })).toBe('preserve-lost');
@@ -68,6 +73,37 @@ describe('decideParkedRuntime', () => {
         wakeInProgress: true,
       }),
     ).toBe('skip');
+  });
+
+  test('a running provider with a durable stop intent is stopped again', () => {
+    expect(
+      decideParkedRuntime({
+        ...base,
+        providerStatus: 'running',
+        stopPending: true,
+      }),
+    ).toBe('stop-pending');
+  });
+
+  test('a stopped provider with durable stop intent still closes compute before cleanup', () => {
+    expect(decideParkedRuntime({ ...base, stopPending: true })).toBe('settle-stop-pending');
+  });
+
+  test('a wake fence outranks a stale stop intent', () => {
+    expect(
+      decideParkedRuntime({
+        ...base,
+        providerStatus: 'running',
+        stopPending: true,
+        wakeInProgress: true,
+      }),
+    ).toBe('skip');
+  });
+
+  test('an inconclusive provider status retains durable stop intent', () => {
+    for (const providerStatus of ['unknown', 'terminal', 'starting']) {
+      expect(decideParkedRuntime({ ...base, providerStatus, stopPending: true })).toBe('skip');
+    }
   });
 
   test('an ordinary healthy parked row is just stamped as verified', () => {

--- a/apps/api/src/projects/reaping/parked-runtime-verification.ts
+++ b/apps/api/src/projects/reaping/parked-runtime-verification.ts
@@ -36,6 +36,7 @@ import { sessionSandboxes } from '@kortix/db';
 import { and, eq, isNotNull, sql } from 'drizzle-orm';
 
 import { type SandboxProviderName, config } from '../../config';
+import { endComputeSession } from '../../billing/services/compute-metering';
 import { getProvider } from '../../platform/providers';
 import { db } from '../../shared/db';
 import { preserveEstablishedRuntime } from '../runtime-identity';
@@ -44,7 +45,8 @@ import { runtimeWakeInProgress } from '../session-lifecycle/runtime-wake-fence';
 /** How many parked rows one pass may examine. */
 const PARKED_VERIFY_BATCH = 60;
 
-export type ParkedRuntimeAction = 'preserve-lost' | 'heal-restored' | 'verified' | 'skip';
+export type ParkedRuntimeAction =
+  'preserve-lost' | 'heal-restored' | 'stop-pending' | 'settle-stop-pending' | 'verified' | 'skip';
 
 /**
  * Provider states that PROVE the sandbox object still exists and is settled.
@@ -61,6 +63,7 @@ export function decideParkedRuntime(input: {
   providerStatus: string;
   identityState: string | null;
   wakeInProgress: boolean;
+  stopPending: boolean;
 }): ParkedRuntimeAction {
   // A live wake owns this row. Two components acting on one sandbox is how a
   // wake gets cancelled underneath itself.
@@ -77,6 +80,12 @@ export function decideParkedRuntime(input: {
     // Only a settled, present state is proof the runtime came back. `unknown`
     // (a timeout or 5xx) is not — healing on it would resurrect a dead session.
     return PRESENT_AND_SETTLED.has(input.providerStatus) ? 'heal-restored' : 'skip';
+  }
+
+  if (input.stopPending) {
+    if (input.providerStatus === 'running') return 'stop-pending';
+    if (input.providerStatus === 'stopped') return 'settle-stop-pending';
+    return 'skip';
   }
 
   // Everything else — including `unknown` and a terminal-but-present box — is
@@ -138,6 +147,7 @@ export async function verifyParkedRuntimes(now = new Date()): Promise<{
         identityState:
           typeof metadata.runtimeIdentityState === 'string' ? metadata.runtimeIdentityState : null,
         wakeInProgress: runtimeWakeInProgress(metadata, now),
+        stopPending: typeof metadata.providerStopPendingAt === 'string',
       });
       examined += 1;
 
@@ -173,15 +183,54 @@ export async function verifyParkedRuntimes(now = new Date()): Promise<{
         continue;
       }
 
+      if (action === 'stop-pending' || action === 'settle-stop-pending') {
+        const stopPendingAt = metadata.providerStopPendingAt as string;
+        await db.transaction(async (tx) => {
+          const [owned] = await tx
+            .select({ sandboxId: sessionSandboxes.sandboxId })
+            .from(sessionSandboxes)
+            .where(
+              and(
+                eq(sessionSandboxes.sandboxId, row.sandboxId),
+                eq(sessionSandboxes.status, 'stopped'),
+                sql`${sessionSandboxes.metadata}->>'providerStopPendingAt' = ${stopPendingAt}`,
+                sql`${sessionSandboxes.metadata}->>'runtimeWakeId' IS NULL`,
+              ),
+            )
+            .for('update')
+            .limit(1);
+          if (!owned) return;
+
+          // Hold the row lock through the external stop. A concurrent wake
+          // cannot claim and start this runtime between our check and pause.
+          if (action === 'stop-pending') {
+            await getProvider(row.provider as SandboxProviderName).stop(externalId);
+          }
+          await endComputeSession(row.sandboxId);
+          await tx
+            .update(sessionSandboxes)
+            .set({
+              metadata: sql`(
+                coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
+                  - 'providerStopPendingAt'
+                ) || ${JSON.stringify({ parkedVerifiedAt: now.toISOString() })}::jsonb`,
+              updatedAt: now,
+            })
+            .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
+        });
+        continue;
+      }
+
       if (action === 'verified') {
         // Stamp only. Rotation depends on this, so it must happen even when
         // nothing interesting was found.
         await db
           .update(sessionSandboxes)
           .set({
-            metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb) || ${JSON.stringify(
-              { parkedVerifiedAt: now.toISOString() },
-            )}::jsonb`,
+            metadata: sql`(
+              coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
+                - 'providerStopPendingAt'
+              ) || ${JSON.stringify({ parkedVerifiedAt: now.toISOString() })}::jsonb`,
           })
           .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
       }

--- a/apps/api/src/projects/runtime-identity-park-ledger.test.ts
+++ b/apps/api/src/projects/runtime-identity-park-ledger.test.ts
@@ -22,6 +22,9 @@ let statements: Array<{ sql: string; inTransaction: boolean }> = [];
 let sandboxUpdates = 0;
 let inTransaction = false;
 let liveSession = true;
+let liveSandbox = true;
+let providerStops = 0;
+let computeEnds = 0;
 let savepoints = 0;
 /** When set, every `tx.execute` fails with this message. */
 let executeThrows: string | null = null;
@@ -47,6 +50,7 @@ const updater = (table: unknown) => ({
     where: () => ({
       returning: async () => {
         if (table === projectSessions) return liveSession ? [{ sessionId: 'sess-1' }] : [];
+        if (!liveSandbox) return [];
         sandboxUpdates += 1;
         return [{ sandboxId: 'sb-1', sessionId: 'sess-1' }];
       },
@@ -89,13 +93,19 @@ mock.module('../shared/db', () => ({
 // lists exports by hand deletes every export it omits.
 mock.module('../billing/services/compute-metering', () => ({
   ...realComputeMetering,
-  endComputeSession: async () => {},
+  endComputeSession: async () => {
+    computeEnds += 1;
+  },
   reopenComputeForSandbox: async () => undefined,
 }));
 
 mock.module('../platform/providers', () => ({
   ...realProviders,
-  getProvider: () => ({ stop: async () => {} }),
+  getProvider: () => ({
+    stop: async () => {
+      providerStops += 1;
+    },
+  }),
 }));
 
 const { parkEstablishedRuntime, preserveEstablishedRuntime } = await import('./runtime-identity');
@@ -110,6 +120,7 @@ const ROW = {
     },
   },
   provider: 'daytona',
+  updatedAt: new Date('2026-08-23T00:00:00.000Z'),
 };
 
 beforeEach(() => {
@@ -117,6 +128,9 @@ beforeEach(() => {
   sandboxUpdates = 0;
   inTransaction = false;
   liveSession = true;
+  liveSandbox = true;
+  providerStops = 0;
+  computeEnds = 0;
   savepoints = 0;
   executeThrows = null;
 });
@@ -158,12 +172,26 @@ describe('parks outside applyStoppedState settle the turn ledger', () => {
     expect(statements).toEqual([]);
   });
 
-  // Both parks stop the PROVIDER BOX before they open this transaction
-  // (parkEstablishedRuntime calls provider.stop(); preserveEstablishedRuntime
-  // runs because the provider already reports it gone). An abort here would
-  // leave the row 'active' and the session 'running' against a dead box, and
-  // every retry would fail the same way. The settle is savepoint-bounded so it
-  // cannot do that.
+  test('a stale readiness park that loses the sandbox CAS preserves the newer wake', async () => {
+    liveSandbox = false;
+
+    expect(
+      await parkEstablishedRuntime(
+        ROW as Parameters<typeof parkEstablishedRuntime>[0],
+        'runtime_wake_timeout',
+        'runtime_wake_failed',
+      ),
+    ).toBeNull();
+
+    expect(providerStops).toBe(0);
+    expect(computeEnds).toBe(0);
+    expect(sandboxUpdates).toBe(0);
+    expect(statements).toEqual([]);
+  });
+
+  // The settle is savepoint-bounded so an observation-table failure cannot
+  // abort the park transaction. parkEstablishedRuntime stops the provider only
+  // after this transaction's row CAS wins.
   test('a ledger settle that throws leaves the park committed', async () => {
     executeThrows = 'canceling statement due to statement timeout';
     const error = console.error;

--- a/apps/api/src/projects/runtime-identity.test.ts
+++ b/apps/api/src/projects/runtime-identity.test.ts
@@ -51,5 +51,6 @@ describe('parkMetadataPatch', () => {
     expect(patch.stopReason).toBe('runtime_boot_failed');
     expect(patch.stoppedAt).toBe('2026-08-14T18:24:51.624Z');
     expect(patch.runtimeParkReason).toBe('opencode_ready_wait_stale');
+    expect(patch.providerStopPendingAt).toBe('2026-08-14T18:24:51.624Z');
   });
 });

--- a/apps/api/src/projects/runtime-identity.ts
+++ b/apps/api/src/projects/runtime-identity.ts
@@ -295,12 +295,13 @@ export function parkMetadataPatch(
     stopReason,
     stoppedAt: now.toISOString(),
     runtimeParkReason: reason,
+    providerStopPendingAt: now.toISOString(),
   };
 }
 
 type ParkableRuntimeRow = Pick<
   typeof sessionSandboxes.$inferSelect,
-  'sandboxId' | 'sessionId' | 'externalId' | 'metadata' | 'provider'
+  'sandboxId' | 'sessionId' | 'externalId' | 'metadata' | 'provider' | 'updatedAt'
 >;
 
 /**
@@ -323,23 +324,6 @@ export async function parkEstablishedRuntime(
   }
   const externalId = row.externalId;
 
-  await endComputeSession(row.sandboxId).catch((err) =>
-    console.warn(
-      `[runtime-identity] failed to close compute for ${row.sandboxId} while parking ${externalId}:`,
-      err,
-    ),
-  );
-  // try/catch, not .catch(): getProvider() throws synchronously for a
-  // disabled provider, and a park must survive that too.
-  try {
-    await getProvider(row.provider as ProviderName).stop(externalId);
-  } catch (err) {
-    console.warn(
-      `[runtime-identity] provider stop failed while parking ${externalId}:`,
-      err instanceof Error ? err.message : err,
-    );
-  }
-
   const metadata = {
     ...((row.metadata as Record<string, unknown> | null) ?? {}),
   };
@@ -349,8 +333,9 @@ export async function parkEstablishedRuntime(
   delete metadata.runtimeRecoveryLeaseExpiresAtMs;
   Object.assign(metadata, parkMetadataPatch(reason, stopReason, now));
 
+  let parked: typeof sessionSandboxes.$inferSelect | null = null;
   try {
-    return await db.transaction(async (tx) => {
+    parked = await db.transaction(async (tx) => {
       const [liveSession] = await tx
         .update(projectSessions)
         .set({ status: 'stopped', error: null, updatedAt: now })
@@ -364,21 +349,48 @@ export async function parkEstablishedRuntime(
           and(
             eq(sessionSandboxes.sandboxId, row.sandboxId),
             eq(sessionSandboxes.externalId, externalId),
+            eq(sessionSandboxes.status, 'active'),
+            // A readiness request can outlive the wake it inspected. The wake
+            // rewrites this row before starting the provider. No provider or
+            // billing side effect is allowed unless this exact snapshot wins.
+            eq(sessionSandboxes.updatedAt, row.updatedAt),
           ),
         )
         .returning();
       if (!parkedRow) throw new RuntimeIdentityCasLostError();
-      // Same reason as the preserve path above: the provider box was stopped a
-      // few lines up, so a turn that was open ended with the runtime, and a
-      // `stopped` row can never be settled token by token again. The provider
-      // box being ALREADY off is also why this settle is savepoint-bounded.
+      // A turn that was open ended with this runtime. The settle remains
+      // savepoint-bounded so an observation-table failure cannot abort the
+      // lifecycle claim this transaction now owns.
       await settleOpenSandboxTurns(tx, row.sandboxId, 'runtime_gone');
+
+      // Keep the row lock through the provider pause. A concurrent restart
+      // cannot start the same runtime between our CAS and this stop.
+      let providerStopped = false;
+      try {
+        await getProvider(row.provider as ProviderName).stop(externalId);
+        providerStopped = true;
+      } catch (err) {
+        console.warn(
+          `[runtime-identity] provider stop failed while parking ${externalId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+      if (providerStopped) {
+        await endComputeSession(row.sandboxId).catch((err) =>
+          console.warn(
+            `[runtime-identity] failed to close compute for ${row.sandboxId} while parking ${externalId}:`,
+            err,
+          ),
+        );
+      }
       return parkedRow;
     });
   } catch (err) {
     if (err instanceof RuntimeIdentityCasLostError) return null;
     throw err;
   }
+
+  return parked;
 }
 
 /**

--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import type { GatewayHooks, GatewayTrace, UpstreamDescriptor, UsageEvent } from '../domain';
-import { handleChatCompletions } from './simple-handler';
+import {
+  handleChatCompletions,
+  streamErrorTraceStatus,
+  upstreamHeadersTimeoutMs,
+  withUpstreamHeadersTimeout,
+} from './simple-handler';
 
 const principal = { userId: 'user', accountId: 'account', projectId: 'project' };
 const primary: UpstreamDescriptor = {
@@ -36,6 +41,69 @@ function hooks(usage: UsageEvent[], traces: GatewayTrace[]): GatewayHooks {
 }
 
 describe('simple gateway pipeline', () => {
+  test('aborts a provider fetch that does not return response headers before the deadline', async () => {
+    const fetchWithTimeout = withUpstreamHeadersTimeout(
+      async (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+        }),
+      5,
+    );
+
+    await expect(fetchWithTimeout('https://provider.example', {})).rejects.toMatchObject({
+      name: 'TimeoutError',
+    });
+  });
+
+  test('clears the provider-headers deadline before consuming the response body', async () => {
+    const providerSignals: AbortSignal[] = [];
+    const fetchWithTimeout = withUpstreamHeadersTimeout(async (_input, init) => {
+      if (init.signal) providerSignals.push(init.signal);
+      return new Response(
+        new ReadableStream({
+          async start(controller) {
+            await Bun.sleep(15);
+            controller.enqueue(new TextEncoder().encode('late body'));
+            controller.close();
+          },
+        }),
+      );
+    }, 5);
+
+    const response = await fetchWithTimeout('https://provider.example', {});
+    expect(await response.text()).toBe('late body');
+    expect(providerSignals[0]?.aborted).toBe(false);
+  });
+
+  test('keeps client cancellation attached after provider headers arrive', async () => {
+    const client = new AbortController();
+    const providerSignals: AbortSignal[] = [];
+    const fetchWithTimeout = withUpstreamHeadersTimeout(async (_input, init) => {
+      if (init.signal) providerSignals.push(init.signal);
+      return new Response('stream');
+    }, 50);
+
+    await fetchWithTimeout('https://provider.example', {
+      signal: client.signal,
+    });
+    client.abort('client left');
+    expect(providerSignals[0]?.aborted).toBe(true);
+    expect(providerSignals[0]?.reason).toBe('client left');
+  });
+
+  test('preserves numeric stream failures and distinguishes client cancellation', () => {
+    expect(streamErrorTraceStatus({ message: 'limited', code: 429 })).toBe(429);
+    expect(streamErrorTraceStatus({ message: 'left', code: 'client_aborted' })).toBe(499);
+    expect(streamErrorTraceStatus({ message: 'timeout', code: 'upstream_timeout' })).toBe(502);
+  });
+
+  test('keeps a bounded but longer header budget for synthetic streaming responses', () => {
+    const limits = { direct: 90_000, syntheticStreaming: 300_000 };
+    expect(upstreamHeadersTimeoutMs({ stream: true }, { ...primary, kind: 'bedrock' }, true, limits)).toBe(300_000);
+    expect(upstreamHeadersTimeoutMs({ stream: true }, primary, true, limits)).toBe(90_000);
+    expect(upstreamHeadersTimeoutMs({ stream: false }, { ...primary, kind: 'bedrock' }, false, limits)).toBe(90_000);
+  });
+
   test('dispatches once and passes a provider 503 through without fallback or retry', async () => {
     const usage: UsageEvent[] = [];
     const traces: GatewayTrace[] = [];
@@ -93,6 +161,40 @@ describe('simple gateway pipeline', () => {
     expect(usage).toHaveLength(1);
     expect(usage[0]).toMatchObject({ promptTokens: 10, completionTokens: 4 });
     expect(traces).toHaveLength(1);
+  });
+
+  test('records an in-band streaming provider error as a failed gateway request', async () => {
+    const usage: UsageEvent[] = [];
+    const traces: GatewayTrace[] = [];
+    const response = await handleChatCompletions(
+      {
+        hooks: hooks(usage, traces),
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async () =>
+          new Response('data: {"error":{"message":"provider timed out","code":"upstream_timeout"}}\n\n', {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({
+          model: 'requested-model',
+          messages: [],
+          stream: true,
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('provider timed out');
+    expect(usage).toHaveLength(0);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]).toMatchObject({
+      status: 502,
+      ok: false,
+      errorCode: 'upstream_timeout',
+      errorMessage: 'provider timed out',
+    });
   });
 
   test('drops wire-framing headers the provider sent for a body fetch already decompressed', async () => {

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -9,7 +9,8 @@ import type {
 } from '../domain';
 import { GatewayResolutionError, UpstreamHttpError } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
-import { type ExtractedUsage, extractUsageFromJson } from '../usage';
+import { resolveTransportKind } from '../transports/route-kind';
+import { type ExtractedUsage, type SseErrorFrame, extractUsageFromJson } from '../usage';
 import { calculateCost } from '../usage/pricing';
 import { gatewayErrorResponse } from './error-response';
 import { applyGenerationDefaults } from './generation-defaults';
@@ -58,12 +59,63 @@ export interface HandlerRuntime {
  * an admission reservation forever while Cloudflare gave the caller a 524 at
  * 100s. This fires first, so the caller gets a typed 503 it can retry.
  *
- * Headers only: once the stream is flowing, `relayStream`'s heartbeat and its
- * 90-minute inactivity budget govern it — a long-thinking model is not a
- * timeout.
+ * Headers only: once the provider fetch resolves, the timer is cleared and
+ * `relayStream`'s heartbeat plus inactivity budget govern the response body.
+ * AI SDK streams get five minutes because their synthetic gateway headers keep
+ * the client alive while a large model prefill still waits on provider headers.
  */
 const UPSTREAM_HEADERS_TIMEOUT_MS =
   Number(process.env.GATEWAY_UPSTREAM_HEADERS_TIMEOUT_MS) || 90_000;
+const SYNTHETIC_STREAMING_HEADERS_TIMEOUT_MS =
+  Number(process.env.GATEWAY_STREAMING_UPSTREAM_HEADERS_TIMEOUT_MS) || 5 * 60_000;
+
+export function upstreamHeadersTimeoutMs(
+  body: Record<string, unknown>,
+  descriptor: UpstreamDescriptor,
+  streaming: boolean,
+  limits: { direct: number; syntheticStreaming: number } = {
+    direct: UPSTREAM_HEADERS_TIMEOUT_MS,
+    syntheticStreaming: SYNTHETIC_STREAMING_HEADERS_TIMEOUT_MS,
+  },
+): number {
+  const transportKind = resolveTransportKind(body, descriptor);
+  const hasSyntheticStreamingHeaders =
+    streaming && transportKind !== 'openai-compat' && transportKind !== 'custom';
+  return hasSyntheticStreamingHeaders ? limits.syntheticStreaming : limits.direct;
+}
+
+export function withUpstreamHeadersTimeout(
+  fetchImpl: FetchImpl,
+  timeoutMs: number = UPSTREAM_HEADERS_TIMEOUT_MS,
+): FetchImpl {
+  return async (input, init) => {
+    const deadline = new AbortController();
+    const timer = setTimeout(
+      () => deadline.abort(new DOMException('Provider response headers timed out', 'TimeoutError')),
+      timeoutMs,
+    );
+    const signal = init.signal ? AbortSignal.any([init.signal, deadline.signal]) : deadline.signal;
+
+    try {
+      return await fetchImpl(input, { ...init, signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
+export function streamErrorTraceStatus(error: SseErrorFrame): number {
+  if (error.code === 'client_aborted') return 499;
+  if (
+    typeof error.code === 'number' &&
+    Number.isInteger(error.code) &&
+    error.code >= 400 &&
+    error.code <= 599
+  ) {
+    return error.code;
+  }
+  return 502;
+}
 
 const EMPTY_USAGE: TokenCounts = {
   promptTokens: 0,
@@ -314,14 +366,15 @@ export async function handleChatCompletions(
 
   const streaming = body.stream === true;
   if (streaming) body.stream_options = { include_usage: true };
+  const dispatchFetch = withUpstreamHeadersTimeout(
+    fetchImpl ?? ((input, init) => globalThis.fetch(input, init)),
+    upstreamHeadersTimeoutMs(body, descriptor, streaming),
+  );
   let upstream: Response;
   try {
-    // Abort the dispatch if the provider has not produced response headers in
-    // time — combined with the client's own signal so a disconnect still wins.
-    const headersDeadline = AbortSignal.timeout(UPSTREAM_HEADERS_TIMEOUT_MS);
     const dispatch = callUpstream(body, descriptor, {
-      fetchImpl,
-      signal: req.signal ? AbortSignal.any([req.signal, headersDeadline]) : headersDeadline,
+      fetchImpl: dispatchFetch,
+      signal: req.signal,
       requestId: id,
     });
     // Dispatch has serialized (openai-compat) or translated (ai-sdk) the
@@ -369,7 +422,10 @@ export async function handleChatCompletions(
     });
   }
 
-  const settle = async (usage: ExtractedUsage | null): Promise<void> => {
+  const settle = async (
+    usage: ExtractedUsage | null,
+    streamError: SseErrorFrame | null = null,
+  ): Promise<void> => {
     const counts: TokenCounts = usage
       ? {
           promptTokens: usage.promptTokens,
@@ -409,8 +465,10 @@ export async function handleChatCompletions(
       provider: descriptor.provider,
       billingMode: descriptor.billingMode,
       streaming,
-      status: upstream.status,
-      ok: upstream.ok,
+      status: streamError ? streamErrorTraceStatus(streamError) : upstream.status,
+      ok: !streamError && upstream.ok,
+      errorCode: streamError ? String(streamError.code ?? 'upstream_stream_error') : undefined,
+      errorMessage: streamError?.message,
       attempts: 1,
       candidatesTried: [descriptor.provider],
       usage: counts,
@@ -426,7 +484,7 @@ export async function handleChatCompletions(
         requestId: id,
         logger,
         signal: req.signal,
-        settle: async (usage) => settle(usage),
+        settle,
       }),
       { status: upstream.status, headers: passthroughHeaders(upstream.headers) },
     );

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -177,6 +177,16 @@ describe('ai-sdk SSE adapter — /v1/llm contract fidelity', () => {
     expect(frame?.code).toBe(529);
   });
 
+  it('classifies a fetch headers TimeoutError with a stable gateway code', async () => {
+    const timeout = new DOMException('Provider response headers timed out', 'TimeoutError');
+    const sse = await readAll(openAiSseFromFullStream(parts({ type: 'error', error: timeout }), CTX));
+
+    expect(sseErrorFrame(sse)).toMatchObject({
+      message: 'Provider response headers timed out',
+      code: 'upstream_timeout',
+    });
+  });
+
   it('maps reasoning deltas to delta.reasoning (counts as content)', async () => {
     const sse = await readAll(
       openAiSseFromFullStream(

--- a/packages/llm-gateway/src/transports/ai-sdk/sse.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/sse.ts
@@ -331,11 +331,13 @@ export function openAiSseFromFullStream(
             // toTransportError (index.ts) does for the non-streaming path.
             const rawCode = errObj?.statusCode ?? errObj?.code;
             const code =
-              typeof rawCode === 'number' || typeof rawCode === 'string'
-                ? rawCode
-                : looksLikeTerminalAuthFailure(rawMessage)
-                  ? 401
-                  : undefined;
+              errObj?.name === 'TimeoutError'
+                ? 'upstream_timeout'
+                : typeof rawCode === 'number' || typeof rawCode === 'string'
+                  ? rawCode
+                  : looksLikeTerminalAuthFailure(rawMessage)
+                    ? 401
+                    : undefined;
             // `@ai-sdk/*` wraps an HTTP failure in an APICallError whose
             // `.message` is the upstream's real `error.message` ONLY when the
             // body parsed against the provider's error schema; if it didn't (a
@@ -411,8 +413,10 @@ export function openAiSseFromFullStream(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const code =
-        (err as { statusCode?: number })?.statusCode ??
-        (looksLikeTerminalAuthFailure(message) ? 401 : undefined);
+        (err as { name?: string })?.name === 'TimeoutError'
+          ? 'upstream_timeout'
+          : ((err as { statusCode?: number })?.statusCode ??
+            (looksLikeTerminalAuthFailure(message) ? 401 : undefined));
       emit(sse({ error: { message, ...(code != null ? { code } : {}) } }));
     }
 


### PR DESCRIPTION
## Problem\n\nEssentia session 3659940c-977a-4cbc-ab6c-929821a53b0c exposed two independent failures:\n\n- AI SDK streaming kept a 90-second response-header deadline attached to the full model stream. Bedrock Fable requests that crossed the deadline ended as empty successful turns.\n- A stale readiness observer could pause a newer E2B wake before OpenCode became ready.\n\n## Changes\n\n- Scope provider-header deadlines to the provider fetch and clear them when real headers arrive.\n- Keep direct and non-streaming headers at 90 seconds. Give synthetic AI SDK streams a bounded five-minute prefill budget.\n- Record in-band stream failures as failed traces and normalize TimeoutError to upstream_timeout.\n- CAS the exact active runtime row before any stop side effect.\n- Hold the lifecycle row lock through provider pause and compute close.\n- Persist providerStopPendingAt so the parked-runtime verifier retries interrupted stops safely.\n- Record both incident learnings.\n\n## Verification\n\n- @kortix/llm-gateway: 304 pass, 0 fail.\n- Focused API lifecycle suites: 27 pass, 0 fail.\n- API and gateway typechecks: pass.\n- Repository REST/CLI flows: 378/378 pass.\n- SDK isolated rerun: 2495 pass, 2 skip, 0 fail.\n- Adversarial reviews: no findings after fixes.