### PR TITLE
docs(learnings): a wedged snapshot build silently rolls every later resume back

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,28 @@ linked, not inlined.
 
 ## Register
 
+### A snapshot build stuck in progress silently rolls every later resume back (2026-08-24)
+
+**When:** operating pause/resume sandbox lifecycles where each pause appends a
+diff build and resume restores the newest build with a ready status. A build
+wedged in `snapshotting` is skipped by resume even when its rootfs upload
+completed; the sandbox silently boots the pre-wedge state, and every later
+pause then snapshots that stale branch as a new "success" build, burying the
+good lineage deeper on each cycle. User data vanishes with zero errors on any
+surface — the session opens fast and empty. Repair = finalize the wedged
+`env_builds` row (`status='success'`, `finished_at=created_at`), mark the
+stale-branch builds `failed`, resume. Verify the rootfs object exists in the
+`fc-templates` bucket before finalizing. *Incident:* essentia session
+`70f64114` resumed with an empty transcript on 2026-08-24; wedged build
+`4b583212` (03:34:23Z, during the wake-race window fixed by `b250949eb1`) had
+its full 660 MB rootfs in S3 but the status never flipped; 4 stale builds
+stacked on top; a cluster-wide sweep found 71 wedged builds and 11
+silent-rollback victim sandboxes. The transcript was recovered by the repair
+above. *Enforcer:* none yet — a wedged-build watchdog belongs in the
+self-hosted E2B ops (kortix-infra `e2b/ops`), and the sandbox daemon should
+detect a restore that is older than Kortix's last-known session activity and
+say so instead of serving an empty transcript.
+
 ### A stale readiness observer must claim the runtime row before stopping its provider (2026-08-24)
 
 **When:** parking an established runtime after a failed readiness or wake probe.


### PR DESCRIPTION
## What

One learnings-register entry. No code.

## The incident (2026-08-24, essentia)

- Session `70f64114` opened fast and EMPTY after a stop/resume cycle. No error on any surface.
- Root cause: pause-snapshot build `4b583212` wedged in `snapshotting` at 03:34:23Z (the wake-race window `b250949eb1` fixed). Its 660 MB rootfs was fully uploaded to S3; only the status row never flipped. Resume skips non-ready builds (`GetLastSnapshot`, upstream-intentional), so every later resume silently restored the pre-wedge state, and every later pause re-snapshotted the stale branch as "success".
- Cluster sweep: 71 wedged builds, 11 silent-rollback victim sandboxes.
- Recovery (verified end-to-end, transcript back in the UI): finalize the wedged `env_builds` row, mark the 4 stale-branch builds `failed`, resume through the normal Kortix path.

## Enforcement gap (follow-ups, not in this PR)

1. kortix-infra `e2b/ops`: watchdog that fails/finalizes `snapshotting` builds older than N minutes and alerts.
2. Sandbox daemon: detect a restore older than Kortix's last-known session activity and surface it instead of serving an empty transcript.

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH