### PR TITLE
fix(api): a deleted session refuses /start and /restart with 404

### DIFF
--- a/apps/api/src/projects/lib/access.test.ts
+++ b/apps/api/src/projects/lib/access.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   callerHasManagerStanding,
   isAdminBypassEligible,
+  sessionIsTombstoned,
   shouldApplyAdminBypass,
   viewerManagerStanding,
 } from './access';
@@ -121,5 +122,30 @@ describe('isAdminBypassEligible', () => {
     expect(
       isAdminBypassEligible({ action: 'read', isServiceAccount: false, bypassHeaderPresent: false }),
     ).toBe(false);
+  });
+});
+
+describe('sessionIsTombstoned — a deleted session refuses every runtime verb', () => {
+  test('a string deletedAt tombstones the row', () => {
+    expect(
+      sessionIsTombstoned({ metadata: { deletedAt: '2026-08-24T14:18:56.979Z' } }),
+    ).toBe(true);
+  });
+
+  test('a live session is not tombstoned', () => {
+    expect(sessionIsTombstoned({ metadata: { warm: true } })).toBe(false);
+    expect(sessionIsTombstoned({ metadata: null })).toBe(false);
+    expect(sessionIsTombstoned({ metadata: undefined })).toBe(false);
+  });
+
+  test('a non-string deletedAt does not tombstone — only the server stamp counts', () => {
+    expect(sessionIsTombstoned({ metadata: { deletedAt: 1787580000000 } })).toBe(false);
+    expect(sessionIsTombstoned({ metadata: { deletedAt: null } })).toBe(false);
+  });
+
+  test('the /start and /restart handlers both ask it after loadVisibleSession', async () => {
+    const src = await Bun.file(new URL('../routes/r8.ts', import.meta.url)).text();
+    const occurrences = src.split('sessionIsTombstoned(visible.row)').length - 1;
+    expect(occurrences).toBe(2);
   });
 });

--- a/apps/api/src/projects/lib/access.ts
+++ b/apps/api/src/projects/lib/access.ts
@@ -211,6 +211,20 @@ export async function viewerManagerStanding(
   return probeManageCapability();
 }
 
+/**
+ * A soft-deleted session is gone for every runtime verb, exactly as it is for
+ * the read-by-id and the default list. `deleteSession` only stamps
+ * `metadata.deletedAt` (the row itself survives for `scope=project` tombstone
+ * inventory), so any route that loads a session by id and then acts on it must
+ * ask this first — `/start` and `/restart` used to skip it, answer
+ * `stage: "stopped"` / 202 on a deleted session, and leave the UI looping on a
+ * Restart button that could never work (essentia session b04a9911, 2026-08-24).
+ */
+export function sessionIsTombstoned(row: { metadata: unknown }): boolean {
+  const metadata = (row.metadata ?? {}) as Record<string, unknown>;
+  return typeof metadata.deletedAt === 'string';
+}
+
 export async function loadVisibleSession(
   loaded: {
     row: ProjectRow;

--- a/apps/api/src/projects/routes/project-sessions.ts
+++ b/apps/api/src/projects/routes/project-sessions.ts
@@ -21,7 +21,7 @@ import { db } from '../../shared/db';
 import { createRoute, z } from '@hono/zod-openapi';
 import { projectSessions, sessionSandboxes } from '@kortix/db';
 import { and, desc, eq, inArray, or } from 'drizzle-orm';
-import { callerHasManagerStanding, loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, assertProjectCapability, projectCapabilityAllowed, resolveSessionOwnerIdentities, viewerManagerStanding } from '../lib/access';
+import { callerHasManagerStanding, loadProjectForUser, loadVisibleSession, lookupEmailsByUserIds, assertProjectCapability, projectCapabilityAllowed, resolveSessionOwnerIdentities, viewerManagerStanding, sessionIsTombstoned } from '../lib/access';
 import { AnyObject, OkSchema, SessionCreateAcceptedSchema, SessionCreateInputSchema, SessionSchema, projectsApp } from '../lib/app';
 import {
   UUID_V4_REGEX,
@@ -380,8 +380,7 @@ projectsApp.openapi(
   // the same predicate the list uses (session-inventory.ts: a STRING deletedAt
   // hides the row). `scope=project` on the LIST deliberately keeps tombstones
   // for managers; that path is untouched.
-  const deletedAt = (visible.row.metadata ?? {}) as Record<string, unknown>;
-  if (typeof deletedAt.deletedAt === 'string') return c.json({ error: 'Not found' }, 404);
+  if (sessionIsTombstoned(visible.row)) return c.json({ error: 'Not found' }, 404);
   const ownerEmail = visible.row.createdBy && !visible.isOwner
     ? (await lookupEmailsByUserIds([visible.row.createdBy])).get(visible.row.createdBy) ?? null
     : null;

--- a/apps/api/src/projects/routes/r8.ts
+++ b/apps/api/src/projects/routes/r8.ts
@@ -30,6 +30,7 @@ import {
   assertProjectCapability,
   loadProjectForUser,
   loadVisibleSession,
+  sessionIsTombstoned,
 } from '../lib/access';
 import { resolveAndAuthorizeAgent } from '../lib/agent-access';
 import { assertAgentScope } from '../../iam/agent-scope';
@@ -107,6 +108,10 @@ projectsApp.openapi(
     const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null, callerKortixSessionId(c));
     stl.mark('session-loaded');
     if (!visible) return c.json({ error: 'Not found' }, 404);
+    // A deleted session must not answer `stage: "stopped"` — that reads as
+    // restartable and the UI offers a Restart that can never work. 404, the
+    // same answer the read-by-id gives (see sessionIsTombstoned).
+    if (sessionIsTombstoned(visible.row)) return c.json({ error: 'Not found' }, 404);
     // The agent this session will actually run has to still be one the caller
     // may run — grants change after a session is created, and `/start` is what
     // resumes a hibernated box days later. The session's stored `agent_name`
@@ -207,6 +212,9 @@ projectsApp.openapi(
     // Restart is reserved for the session owner or an account owner/admin.
     const visible = await loadVisibleSession(loaded, sessionId, c.get('sessionId') ?? null, callerKortixSessionId(c));
     if (!visible) return c.json({ error: 'Not found' }, 404);
+    // Same tombstone rule as /start: a deleted session's restart used to 202
+    // and silently do nothing the UI could see.
+    if (sessionIsTombstoned(visible.row)) return c.json({ error: 'Not found' }, 404);
     if (!visible.canManageLifecycle) {
       return c.json(
         {


### PR DESCRIPTION
## Problem

A soft-deleted session (`metadata.deletedAt`) 404s on read-by-id (#6832-era check), but:
- `POST …/start` answered **200** `{stage:"stopped", sandbox:null, retriable:false}`
- `POST …/restart` answered **202**

So the session page fell into `dormantWithoutRuntime` and rendered the ordinary **"This session is stopped" card with a Restart button that can never work** — restart 202s, start says stopped, the card re-renders, forever, with no error. Hit live on essentia session `b04a9911` (deleted 14:18Z, user stuck on "Waking the agent"/Restart loops).

## Fix

- `sessionIsTombstoned(row)` predicate in `projects/lib/access.ts` (one concept, one name).
- `/start` and `/restart` (`r8.ts`) return 404 for a tombstoned session right after `loadVisibleSession`.
- The session detail GET's inline check now uses the same predicate.

With `/start` 404ing, the page's existing `sessionMissing` branch (`session.startError?.status === 404 && !sandbox`) renders the honest "Couldn't start session — no longer available" card with **Back to project**. No FE change needed.

## Verified

- `bun test --isolate --env-file=scripts/test.env src/projects/lib/access.test.ts` → 21 pass (4 new).
- All 17 `src/projects/routes/*.test.ts` + security-invariant file → 187 pass.
- `tsc --noEmit` clean.
- Live repro pre-fix on essentia: `GET session` → 404, `POST start` → 200 `stage:stopped` (curl transcript in session log). Post-merge dev verification: open a deleted session by URL → expect the "no longer available" card.

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH