### PR TITLE
perf(session): untouched sends skip the no-op scope round-trip (~3.1s off send→live)

### DIFF
--- a/apps/web/src/features/session/scope/create-scoped-session.test.ts
+++ b/apps/web/src/features/session/scope/create-scoped-session.test.ts
@@ -126,7 +126,11 @@ describe('createScopedSession', () => {
   });
 
   test('does not replace untouched inherited connector defaults', async () => {
+    // Since the fresh-default skip, this draft — inherit secrets, inherited
+    // connector preview, nothing required — makes NO scope requests at all:
+    // its replacement only restates what a just-created session already is.
     let replacement: SessionScopeInput | undefined;
+    let read = false;
 
     await createScopedSession({
       create: async () => 'session-inherited',
@@ -139,17 +143,18 @@ describe('createScopedSession', () => {
         require_connectors: [],
       },
       availability: { secrets: true, connector_bindings: true },
-      readScope: async () => scope,
+      readScope: async () => {
+        read = true;
+        return scope;
+      },
       replaceScope: async (_id, input) => {
         replacement = input;
       },
       onReady: () => {},
     });
 
-    expect(replacement).toEqual({
-      secrets: null,
-      require_connectors: [],
-    });
+    expect(read).toBe(false);
+    expect(replacement).toBeUndefined();
   });
 
   test('an explicit zero-secrets draft still PUTs [] (deliberate deselect is preserved)', async () => {
@@ -176,5 +181,139 @@ describe('createScopedSession', () => {
       require_connectors: [],
     });
     expect(replacement?.secrets).toEqual([]);
+  });
+});
+
+describe('createScopedSession — the untouched draft skips the round-trip', () => {
+  test('the auto-initialized new-session draft makes no scope requests at all', async () => {
+    const calls: string[] = [];
+    await createScopedSession({
+      create: async () => {
+        calls.push('create');
+        return 'session-3';
+      },
+      // Exactly what createNewSessionScopeDraft produces for an untouched send:
+      // inherit secrets, inherited connector preview, nothing required.
+      draft: {
+        secrets: null,
+        connector_bindings: { mail: { connection_id: 'connection-mail-default' } },
+        connector_bindings_inherited: true,
+        require_connectors: [],
+      },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async (id) => {
+        calls.push(`read:${id}`);
+        return scope;
+      },
+      replaceScope: async (id) => {
+        calls.push(`replace:${id}`);
+      },
+      onReady: (id) => {
+        calls.push(`ready:${id}`);
+      },
+    });
+    expect(calls).toEqual(['create', 'ready:session-3']);
+  });
+
+  test('a real secrets selection still reads and replaces', async () => {
+    const calls: string[] = [];
+    await createScopedSession({
+      create: async () => {
+        calls.push('create');
+        return 'session-4';
+      },
+      draft: { secrets: ['ONLY_THIS'] },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async (id) => {
+        calls.push(`read:${id}`);
+        return scope;
+      },
+      replaceScope: async (id) => {
+        calls.push(`replace:${id}`);
+      },
+      onReady: (id) => {
+        calls.push(`ready:${id}`);
+      },
+    });
+    expect(calls).toEqual(['create', 'read:session-4', 'replace:session-4', 'ready:session-4']);
+  });
+
+  test('an explicit zero-secrets selection ([]) is NOT the default and still replaces', async () => {
+    const calls: string[] = [];
+    await createScopedSession({
+      create: async () => {
+        calls.push('create');
+        return 'session-5';
+      },
+      draft: { secrets: [] },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async (id) => {
+        calls.push(`read:${id}`);
+        return scope;
+      },
+      replaceScope: async (id) => {
+        calls.push(`replace:${id}`);
+      },
+      onReady: (id) => {
+        calls.push(`ready:${id}`);
+      },
+    });
+    expect(calls).toEqual(['create', 'read:session-5', 'replace:session-5', 'ready:session-5']);
+  });
+
+  test('a required connector still replaces', async () => {
+    const calls: string[] = [];
+    await createScopedSession({
+      create: async () => {
+        calls.push('create');
+        return 'session-6';
+      },
+      draft: {
+        secrets: null,
+        connector_bindings: {},
+        connector_bindings_inherited: true,
+        require_connectors: ['mail'],
+      },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async (id) => {
+        calls.push(`read:${id}`);
+        return scope;
+      },
+      replaceScope: async (id) => {
+        calls.push(`replace:${id}`);
+      },
+      onReady: (id) => {
+        calls.push(`ready:${id}`);
+      },
+    });
+    expect(calls).toEqual(['create', 'read:session-6', 'replace:session-6', 'ready:session-6']);
+  });
+
+  test('a user-chosen connector binding (not inherited) still replaces', async () => {
+    const calls: string[] = [];
+    await createScopedSession({
+      create: async () => {
+        calls.push('create');
+        return 'session-7';
+      },
+      draft: {
+        secrets: null,
+        connector_bindings: { mail: { connection_id: 'connection-mail-two' } },
+        connector_bindings_inherited: false,
+        require_connectors: [],
+      },
+      availability: { secrets: true, connector_bindings: true },
+      readScope: async (id) => {
+        calls.push(`read:${id}`);
+        return scope;
+      },
+      replaceScope: async (id) => {
+        calls.push(`replace:${id}`);
+      },
+      onReady: (id) => {
+        calls.push(`ready:${id}`);
+      },
+    });
+    expect(calls).toEqual(['create', 'read:session-7', 'replace:session-7', 'ready:session-7']);
   });
 });

--- a/apps/web/src/features/session/scope/create-scoped-session.ts
+++ b/apps/web/src/features/session/scope/create-scoped-session.ts
@@ -2,6 +2,7 @@ import type { SessionScope, SessionScopeInput } from '@kortix/sdk';
 
 import {
   buildSessionScopeReplacement,
+  scopeReplacementIsFreshDefault,
   type SessionScopeAvailability,
   type SessionScopeDraft,
 } from './session-scope-model';
@@ -26,10 +27,23 @@ function hasDraftReplacement(draft: SessionScopeDraft | undefined): draft is Ses
 export async function createScopedSession(input: CreateScopedSessionInput): Promise<string> {
   const sessionId = await input.create();
   if (hasDraftReplacement(input.draft)) {
-    const currentScope = await input.readScope(sessionId);
-    const replacement = buildSessionScopeReplacement(input.draft, currentScope, input.availability);
-    if (Object.keys(replacement).length > 0) {
-      await input.replaceScope(sessionId, replacement);
+    // The session was just created, so its scope IS the fresh default. A
+    // replacement that only restates that default replaces nothing — skip the
+    // read + write instead of spending two serial round trips between the
+    // warm-claim and /start on every untouched send. Built without a previous
+    // scope on purpose: at creation there is no previous scope beyond the
+    // default, and the draft carries every axis it intends to set.
+    const provisional = buildSessionScopeReplacement(input.draft, undefined, input.availability);
+    if (!scopeReplacementIsFreshDefault(provisional)) {
+      const currentScope = await input.readScope(sessionId);
+      const replacement = buildSessionScopeReplacement(
+        input.draft,
+        currentScope,
+        input.availability,
+      );
+      if (Object.keys(replacement).length > 0) {
+        await input.replaceScope(sessionId, replacement);
+      }
     }
   }
   await input.onReady(sessionId);

--- a/apps/web/src/features/session/scope/session-scope-model.ts
+++ b/apps/web/src/features/session/scope/session-scope-model.ts
@@ -253,6 +253,28 @@ export function createNewSessionScopeDraft(
   return draft;
 }
 
+/**
+ * Is this replacement exactly the state a FRESH session is born with?
+ *
+ * A just-created (or warm, never-prompted) session starts as: secrets
+ * `null` (inherit the grant), no connector-binding override, no required
+ * connectors. The overrides toolbar auto-initializes a draft in that same
+ * shape for every new-session composer — untouched or not — so every send
+ * used to pay a scope read + write whose only effect was re-writing the
+ * defaults. Measured on dev 2026-08-24: GET 0.8s + PUT 2.3s, serial, between
+ * warm-claim and /start, on every untouched send.
+ *
+ * `createScopedSession` asks this with a replacement built WITHOUT a previous
+ * scope, which is exactly the session-creation situation: the previous scope
+ * IS the fresh default, so a replacement that matches it replaces nothing.
+ */
+export function scopeReplacementIsFreshDefault(replacement: SessionScopeInput): boolean {
+  if (Object.hasOwn(replacement, 'connector_bindings')) return false;
+  if (Object.hasOwn(replacement, 'secrets') && replacement.secrets !== null) return false;
+  if ((replacement.require_connectors ?? []).length > 0) return false;
+  return true;
+}
+
 export function buildSessionScopeReplacement(
   draft: SessionScopeDraft,
   previousScope?: SessionScope,

--- a/apps/web/src/features/session/session-audit-shared.tsx
+++ b/apps/web/src/features/session/session-audit-shared.tsx
@@ -99,9 +99,12 @@ interface UseSessionAuditOptions {
   /** Suppress the global error toast (for the always-mounted header nudge). */
   silent?: boolean;
   /**
-   * Rows to ask for. The panel reads the timeline and wants the full 1000; the
-   * badge only counts pending approvals, which the server returns most-recent
-   * first, so 100 is plenty and ten times less to serialise every 15 s.
+   * Rows to ask for. Every consumer of THIS hook reads pending approvals, which
+   * the server returns most-recent first, so 100 is plenty — the deep timeline
+   * moved to `useSessionAuditTimeline`. The query key ignores the limit (all
+   * consumers share one cache entry), so the first fetch's limit is the one
+   * that runs: a 1000 default here re-imposed the heavy read on every session
+   * open even after callers asked for 100.
    */
   limit?: number;
 }
@@ -120,7 +123,7 @@ export function useSessionAudit(
     queryKey: sessionAuditKey(projectId, sessionId),
     // `enabled` guards presence, so the `?? ''` fallbacks are never exercised.
     queryFn: () =>
-      getSessionAudit(projectId ?? '', sessionId ?? '', options?.limit ?? 1000, {
+      getSessionAudit(projectId ?? '', sessionId ?? '', options?.limit ?? 100, {
         showErrors: !options?.silent,
         includeEvents: false,
       }),


### PR DESCRIPTION
## Evidence (dev HAR, 2026-08-24)

Home-composer send critical path:
```
t=0.00  POST warm/claim   1145ms
t=1.34  GET  scope         763ms   <- pure no-op
t=2.30  PUT  scope        2344ms   <- pure no-op
t=4.65  POST start        2181ms
```
The untouched draft the overrides toolbar auto-initializes (`{secrets: null, connector_bindings_inherited: true, require_connectors: []}`) builds the replacement `{secrets: null, require_connectors: []}` — exactly the state a fresh session is born with. Every untouched send paid ~3.1s to rewrite defaults.

## Fix

1. `scopeReplacementIsFreshDefault()` — a replacement with no `connector_bindings` key, `secrets` absent-or-null, and no required connectors is the fresh default.
2. `createScopedSession` skips the read+write for it. Every REAL selection still replaces — pinned by tests: explicit `secrets: []` (deliberate deselect), a user-chosen binding, a required connector, explicit `connector_bindings: {}` override.
3. `useSessionAudit` default limit 1000→100: the query key ignores the limit so the first consumer's fetch wins — chat/approval-prompt's 1000 default re-imposed the heavy read #6832 capped at one call site (the same send's HAR still showed `audit?limit=1000`). The deep timeline lives in `useSessionAuditTimeline`; no consumer of this hook needs 1000.

## Verified

- `bun test src/features/session/scope/` → 72 pass (5 new cases; 1 pre-existing test strengthened from "PUTs the defaults" to "makes no requests", matching its own name).
- `bun test src/features/session/session-audit` → 5 pass.
- `tsc --noEmit`: only the known pre-existing `test.each`/`@/.source` noise, none in touched files.
- Post-merge dev check: HAR the home-composer send again → expect no scope GET/PUT between warm/claim and start, and `audit?limit=100`.

https://claude.ai/code/session_01AYJQQyUY7koHfWsXbSeeBH