### PR TITLE
fix(sdk): a running session no longer shows as stopped mid-turn

### DIFF
--- a/apps/web/src/features/session/model-connection-gate.tsx
+++ b/apps/web/src/features/session/model-connection-gate.tsx
@@ -116,9 +116,9 @@ export function ModelConnectionBar({ show }: { show: boolean }) {
               initial={reduceMotion ? false : { y: '-100%' }}
               animate={reduceMotion ? undefined : { y: '0%', transition: BAR_ENTER }}
               exit={reduceMotion ? undefined : { y: '-100%', transition: BAR_EXIT }}
-              className="border-border bg-muted mx-3 -mt-3 rounded-b-md border"
+              className="border-border bg-muted my-2 rounded-md border"
             >
-              <div className="flex items-center justify-between gap-3 pt-[18px] pr-2 pb-1.5 pl-4">
+              <div className="flex items-center justify-between gap-3  p-1 px-3">
                 <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-xs">
                   <KeyIcon className="size-3.5 shrink-0" />
                   <span className="truncate">
@@ -131,9 +131,8 @@ export function ModelConnectionBar({ show }: { show: boolean }) {
                     <Button
                       type="button"
                       variant="ghost"
-                      size="sm"
+                      size="xs"
                       onClick={openUpgrade}
-                      className="hit-area-1 gap-1.5 rounded-full text-xs"
                     >
                       <CreditCardIcon className="size-3.5 shrink-0" />
                       Upgrade
@@ -141,9 +140,8 @@ export function ModelConnectionBar({ show }: { show: boolean }) {
                   )}
                   <Button
                     type="button"
-                    size="sm"
+                    size="xs"
                     onClick={() => openConnectProvider('providers')}
-                    className="hit-area-1 rounded-full text-xs"
                   >
                     Connect model
                   </Button>

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,43 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `fabricated-idle-veto` — a fabricated idle frame can no longer contradict the ledger — DONE (PR open, not merged)
+
+**Files:** `core/session/working.ts` (`WorkingStreamInput.origin?: 'wire' | 'local'`;
+the idle-frame veto and the "fresher frame outranks the open row" ordering now apply
+to WIRE frames only) · `react/use-session-working.ts` (`buildWorkingInputs` threads
+`statusOrigin`; the hook reads `sessionStatusOrigin`) ·
+`browser/stores/sync-store.ts` (`sessionStatusOrigin` slice; `setStatus(id, status,
+origin='wire')`; same-value writes keep object identity but may flip origin;
+`clearSession` marks its fabricated idle `local`; `applyEvent` honors a
+`synthetic: true` event marker) · `react/use-opencode-events/use-event-stream-refs.ts`
+(`markSessionIdleLocally` / `markSessionAbortedLocally` mark their events synthetic) ·
+`react/use-opencode-events/index.ts` (hydrate snapshot writes are synthetic; the
+fill-gap guard now lets a snapshot overwrite a `local` frame, so a wrong sweep
+self-heals) + tests in all five areas.
+**Public surface: additive only** — the optional `origin` field on
+`WorkingStreamInput` and `statusOrigin` on `buildWorkingInputs`; snapshots unchanged.
+
+**Why.** Reported from dev (2026-08-24): mid-turn — long `run command` /
+tool calls — the busy indicator disappears, the composer swaps Stop for Send, the
+transcript freezes (the liveness poll gates on the projection), and the UI comes
+back for a couple of seconds right as the reply streams. Root cause: locally
+fabricated idle frames (`reconcileMissingBusySessions` sweeping the GLOBAL status
+map with a per-sandbox snapshot, `markSessionAbortedLocally` on
+`server.instance.disposed`, `clearSession`) were indistinguishable from the
+runtime's own frames, and the (deliberately unbounded, #6807) idle veto let one
+fabricated frame discard every fresh `/turn` read for the rest of a quiet turn —
+while the fill-gap guard blocked the snapshot from ever correcting the slot.
+
+**Gates:** `typecheck` clean (both projects) · `pnpm run test` (isolated runner)
+171 files / **2513 pass / 0 fail** · `smoke:install` passed.
+**Known follow-ups (not done here):** the sweep is still scope-blind
+(cross-sandbox absence fabricates local idles — now harmless to the projection but
+still wrong for child-session raw-slot readers); a session whose ledger row is
+lost server-side while its SSE is dead still freezes until visibility/remount.
+
+---
+
 ### 2026-08-24 — session `composio-connect-link-types` — generic connector authorization results — DONE
 
 **Files:** `core/rest/projects-client/connectors.ts` + test and both public-surface snapshots.

--- a/packages/sdk/src/browser/stores/sync-store.test.ts
+++ b/packages/sdk/src/browser/stores/sync-store.test.ts
@@ -2845,6 +2845,84 @@ describe("useSyncStore — setStatus writes an observation, never a heartbeat", 
 	});
 });
 
+/**
+ * WHO minted a frame travels with it. A tab-fabricated idle (the missing-busy
+ * sweep, a synthetic abort, `clearSession`) is `'local'`; `projectWorking`
+ * lets it answer for a silent session but never lets it contradict the
+ * server's open `/turn` row. Unmarked, one fabricated frame vetoed the
+ * lifecycle authority for the rest of a quiet turn (dev, 2026-08-24: busy
+ * indicator gone, Send instead of Stop, transcript poll off — mid-run).
+ */
+describe("useSyncStore — sessionStatusOrigin: who minted the frame", () => {
+	test("a plain write is wire by default", () => {
+		useSyncStore.getState().setStatus("ses_1", { type: "busy" });
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("wire");
+	});
+
+	test("an explicit local write records local", () => {
+		useSyncStore.getState().setStatus("ses_1", { type: "idle" }, "local");
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("local");
+	});
+
+	test("an equal value with a NEW origin updates origin but keeps identity", () => {
+		// The identity rule above must hold — re-stamping an unchanged value
+		// restarts the staleness clock — but who said it is still news: a wire
+		// frame landing over a fabricated one restores its right to veto.
+		const store = useSyncStore.getState();
+		store.setStatus("ses_1", { type: "idle" }, "local");
+		const first = useSyncStore.getState().sessionStatus.ses_1;
+
+		store.setStatus("ses_1", { type: "idle" }, "wire");
+
+		expect(useSyncStore.getState().sessionStatus.ses_1).toBe(first);
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("wire");
+	});
+
+	test("a synthetic session.idle event lands with local origin", () => {
+		// `markSessionIdleLocally` routes through `applyEvent` with
+		// `synthetic: true` — a field no wire `Event` carries.
+		useSyncStore.getState().applyEvent({
+			type: "session.idle",
+			synthetic: true,
+			properties: { sessionID: "ses_1" },
+		} as never);
+		expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: "idle" });
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("local");
+	});
+
+	test("a wire session.idle event lands with wire origin", () => {
+		useSyncStore.getState().applyEvent({
+			type: "session.idle",
+			properties: { sessionID: "ses_1" },
+		} as never);
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("wire");
+	});
+
+	test("a synthetic session.error marks its idle write local", () => {
+		// `markSessionAbortedLocally` fires on `server.instance.disposed` for
+		// EVERY non-idle session in the tab — an inference about the runtime,
+		// never the runtime speaking.
+		useSyncStore.getState().setStatus("ses_1", { type: "busy" });
+		useSyncStore.getState().applyEvent({
+			type: "session.error",
+			synthetic: true,
+			properties: {
+				sessionID: "ses_1",
+				error: { name: "AbortError", data: { message: "disposed" } },
+			},
+		} as never);
+		expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: "idle" });
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("local");
+	});
+
+	test("clearSession's fabricated idle is local", () => {
+		useSyncStore.getState().setStatus("ses_1", { type: "busy" });
+		useSyncStore.getState().clearSession("ses_1");
+		expect(useSyncStore.getState().sessionStatus.ses_1).toEqual({ type: "idle" });
+		expect(useSyncStore.getState().sessionStatusOrigin.ses_1).toBe("local");
+	});
+});
+
 describe("sameSessionStatus", () => {
 	test("compares exactly the fields the retry readers read", () => {
 		expect(sameSessionStatus({ type: "busy" }, { type: "busy" })).toBe(true);

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -56,6 +56,20 @@ export function sameSessionStatus(
 	return a.attempt === b.attempt && a.message === b.message && a.next === b.next;
 }
 
+/**
+ * WHO minted a status-bearing event handed to `applyEvent`. A tab-synthesized
+ * event (`markSessionIdleLocally`, `markSessionAbortedLocally`, the hydrate
+ * snapshot fill) carries `synthetic: true` — a field no wire `Event` has — and
+ * its status write lands with `'local'` origin so it can never contradict the
+ * control plane's turn authority (`WorkingStreamInput.origin`). Everything off
+ * the wire stays `'wire'`.
+ */
+function syntheticEventOrigin(event: unknown): "wire" | "local" {
+	return (event as { synthetic?: boolean } | null | undefined)?.synthetic === true
+		? "local"
+		: "wire";
+}
+
 /** The two `Part` variants that carry streaming `.text` (vs. tool/file/etc.
  *  parts, which don't). Narrows a `Part` down so `.text` is safe to read
  *  without a cast — every `Part` member shares `id`/`sessionID`/`messageID`/
@@ -147,6 +161,19 @@ interface SyncState {
 	messages: Record<string, Message[]>;
 	parts: Record<string, Part[]>;
 	sessionStatus: Record<string, SessionStatus>;
+	/**
+	 * WHO minted each session's current `sessionStatus` value: `'wire'` for the
+	 * runtime's own SSE frame, `'local'` for a tab-synthesized one (the
+	 * missing-busy sweep, a synthetic abort, `clearSession`). Absent means
+	 * `'wire'` — the field is additive.
+	 *
+	 * `useSessionWorking` threads this into `projectWorking`
+	 * (`WorkingStreamInput.origin`): only the runtime's own idle frame may
+	 * contradict the control plane's open `/turn` row. Without the bit, one
+	 * fabricated idle vetoed the lifecycle authority for the rest of a quiet
+	 * turn (dev, 2026-08-24).
+	 */
+	sessionStatusOrigin: Record<string, "wire" | "local">;
 	/**
 	 * When the RUNTIME'S OWN OUTPUT last reached this tab, per session.
 	 *
@@ -246,7 +273,7 @@ interface SyncState {
 		delta: string,
 		eventID?: string,
 	) => void;
-	setStatus: (sessionID: string, status: SessionStatus) => void;
+	setStatus: (sessionID: string, status: SessionStatus, origin?: "wire" | "local") => void;
 	setDiff: (sessionID: string, diffs: FileDiff[]) => void;
 	setTodo: (sessionID: string, todos: Todo[]) => void;
 	/**
@@ -1053,6 +1080,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 	messages: {},
 	parts: {},
 	sessionStatus: {},
+	sessionStatusOrigin: {},
 	sessionActivityAt: {},
 	diffs: {},
 	todos: {},
@@ -1263,7 +1291,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 		});
 	},
 
-	setStatus: (sessionID, status) =>
+	setStatus: (sessionID, status, origin = "wire") =>
 		set((s) => {
 			// A value that did not change is not news. `useSessionWorking` stamps
 			// its stream observation from this object's IDENTITY, so an
@@ -1271,8 +1299,18 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			// `STREAM_OBSERVATION_MAX_MS` from zero on every write — the bound
 			// that stops a dead stream from deciding was never reached. See
 			// `sameSessionStatus`.
-			if (sameSessionStatus(s.sessionStatus[sessionID], status)) return s;
-			return { sessionStatus: { ...s.sessionStatus, [sessionID]: status } };
+			if (sameSessionStatus(s.sessionStatus[sessionID], status)) {
+				// The VALUE is not news, but who said it can be: a wire frame
+				// landing over a fabricated one (or the reverse) changes what the
+				// frame is allowed to decide. Update only the origin — the status
+				// object keeps its identity so nothing re-stamps a stale value.
+				if ((s.sessionStatusOrigin[sessionID] ?? "wire") === origin) return s;
+				return { sessionStatusOrigin: { ...s.sessionStatusOrigin, [sessionID]: origin } };
+			}
+			return {
+				sessionStatus: { ...s.sessionStatus, [sessionID]: status },
+				sessionStatusOrigin: { ...s.sessionStatusOrigin, [sessionID]: origin },
+			};
 		}),
 
 	setDiff: (sessionID, diffs) =>
@@ -1533,6 +1571,10 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				parts: nextParts,
 				sessionActivityAt: nextActivity,
 				sessionStatus: { ...s.sessionStatus, [sessionID]: { type: "idle" } as SessionStatus },
+				// Fabricated, not observed — a cache handoff says nothing about
+				// whether the runtime is running. Marked local so it can never
+				// veto the control plane's open turn (`WorkingStreamInput.origin`).
+				sessionStatusOrigin: { ...s.sessionStatusOrigin, [sessionID]: "local" as const },
 				diffs: { ...s.diffs, [sessionID]: [] },
 				todos: { ...s.todos, [sessionID]: [] },
 				sessionRevert: { ...s.sessionRevert, [sessionID]: null },
@@ -2049,6 +2091,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			messages: {},
 			parts: {},
 			sessionStatus: {},
+			sessionStatusOrigin: {},
 			diffs: {},
 			todos: {},
 			sessionRevert: {},
@@ -2404,12 +2447,12 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 					status: SessionStatus;
 				};
 				if (props.sessionID && props.status)
-					store.setStatus(props.sessionID, props.status);
+					store.setStatus(props.sessionID, props.status, syntheticEventOrigin(event));
 				return;
 			}
 		case "session.idle": {
 			const sessionID = (event.properties as { sessionID: string }).sessionID;
-			if (sessionID) store.setStatus(sessionID, { type: "idle" });
+			if (sessionID) store.setStatus(sessionID, { type: "idle" }, syntheticEventOrigin(event));
 			// Streaming finished for THIS session — clear only its own delta
 			// tracking so future message.part.updated snapshots for it are
 			// accepted normally. Never the whole map: another session may
@@ -2427,7 +2470,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			const sid = props.sessionID;
 			const error = props.error;
 			// Mark session idle — errors terminate the response.
-			store.setStatus(sid, { type: "idle" });
+			store.setStatus(sid, { type: "idle" }, syntheticEventOrigin(event));
 			// Clear only this session's delta tracking — see the idle handler
 			// above and the comment above deltaActiveParts.
 			deltaActiveParts.delete(sid);

--- a/packages/sdk/src/core/session/working.test.ts
+++ b/packages/sdk/src/core/session/working.test.ts
@@ -913,6 +913,117 @@ describe('projectWorking — a runtime idle frame ends the turn it names', () =>
 });
 
 /**
+ * Only the RUNTIME'S OWN idle frame may end a turn. The tab also fabricates
+ * idle frames locally — `reconcileMissingBusySessions` when a status snapshot
+ * omits a session, `markSessionAbortedLocally` on `server.instance.disposed`,
+ * `clearSession` on a cache-ownership handoff — and every one of them is an
+ * INFERENCE, not the runtime speaking.
+ *
+ * Reported from dev 2026-08-24: mid-turn — usually a long `run
+ * command` or tool call — the busy indicator disappears and the composer swaps
+ * Stop for the send arrow while the agent is still running; the UI comes back
+ * "for a brief couple seconds" right as the reply streams, then ends. That is
+ * a fabricated idle frame vetoing the ledger's open row: the veto is
+ * deliberately unbounded (a dropped `kind:"end"` relay must stay ended — see
+ * the block above), so one wrong local frame discards every fresh `/turn`
+ * read for the rest of the turn, and a quiet tool call emits no new wire
+ * frame to lift it.
+ *
+ * `origin` is the discriminator: absent or `'wire'` keeps today's full veto;
+ * `'local'` may still ANSWER (rule 4 — a repair for a missed terminal frame is
+ * still the honest fallback when nothing fresher exists) but may never
+ * CONTRADICT the lifecycle authority or the runtime's own output.
+ */
+describe('projectWorking — a fabricated idle frame cannot contradict the ledger', () => {
+  test('a local idle frame never vetoes an open turn the server re-affirms', () => {
+    // The sweep fabricated idle at T0+60s; the poll keeps reporting the turn
+    // open on reads issued after it. The server is the authority here.
+    const projection = projectWorking({
+      optimistic: null,
+      server: { turns: [turn()], atMs: T0 + 65_000 },
+      stream: { type: 'idle', origin: 'local', atMs: T0 + 60_000 },
+      nowMs: T0 + 65_100,
+    });
+
+    expect(projection).toMatchObject({ state: 'working', source: 'server', turnId: 'msg_01' });
+  });
+
+  test('a local idle frame NEWER than the read still loses to the open row', () => {
+    // The fabricated frame lands between polls, so it is the newest
+    // observation in the tab. Newest is not truest: a local frame never
+    // outranks the lifecycle authority, not even for one poll interval.
+    const projection = projectWorking({
+      optimistic: null,
+      server: { turns: [turn()], atMs: T0 + 60_000 },
+      stream: { type: 'idle', origin: 'local', atMs: T0 + 62_000 },
+      nowMs: T0 + 62_100,
+    });
+
+    expect(projection).toMatchObject({ state: 'working', source: 'server' });
+  });
+
+  test('streaming content outranks a NEWER local idle frame', () => {
+    // Content is the runtime working; a fabricated frame is a guess about it.
+    // The wire-idle rule ("content older than the idle frame does not
+    // resurrect the turn") must not apply to a frame the runtime never sent.
+    const projection = projectWorking({
+      optimistic: null,
+      server: null,
+      stream: { type: 'idle', origin: 'local', atMs: T0 + 60_500 },
+      activity: { atMs: T0 + 60_000 },
+      nowMs: T0 + 61_000,
+    });
+
+    expect(projection).toMatchObject({ state: 'working', source: 'stream' });
+  });
+
+  test('a local idle frame still answers when nothing fresher exists', () => {
+    // The repair for a missed terminal frame keeps its value: with no server
+    // read, no content, and no receipt, the fabricated frame is the only
+    // observation there is, and idle is the honest default it feeds.
+    const projection = projectWorking({
+      optimistic: null,
+      server: null,
+      stream: { type: 'idle', origin: 'local', atMs: T0 },
+      nowMs: T0 + 1_000,
+    });
+
+    expect(projection).toMatchObject({ state: 'idle', source: 'stream' });
+  });
+
+  test("an explicit 'wire' origin behaves exactly like an unmarked frame", () => {
+    // `origin` is additive: absent means wire, and wire keeps the full veto.
+    for (const stream of [
+      { type: 'idle' as const, atMs: T0 + 60_000 },
+      { type: 'idle' as const, origin: 'wire' as const, atMs: T0 + 60_000 },
+    ]) {
+      expect(
+        projectWorking({
+          optimistic: null,
+          server: { turns: [turn()], atMs: T0 + 60_044 },
+          stream,
+          nowMs: T0 + 60_200,
+        }).state,
+      ).toBe('idle');
+    }
+  });
+
+  test('a local BUSY frame still reports working off the stream', () => {
+    // The status snapshot fill writes busy/retry values through the same local
+    // path. False-working self-heals through `/turn` and the wire idle; only
+    // the idle direction ever masked a live turn, so busy keeps answering.
+    const projection = projectWorking({
+      optimistic: null,
+      server: null,
+      stream: { type: 'busy', origin: 'local', atMs: T0 },
+      nowMs: T0 + 1_000,
+    });
+
+    expect(projection).toMatchObject({ state: 'working', source: 'stream' });
+  });
+});
+
+/**
  * A prompt queued BEHIND a running turn is not ended by that turn's idle frame.
  *
  * This block exists because the opposite was implemented first and measured

--- a/packages/sdk/src/core/session/working.ts
+++ b/packages/sdk/src/core/session/working.ts
@@ -202,6 +202,25 @@ export interface WorkingServerInput {
 /** One observed runtime status frame, stamped when this tab observed it. */
 export interface WorkingStreamInput {
   type: 'busy' | 'retry' | 'idle';
+  /**
+   * WHO minted the frame. `'wire'` (or absent — the field is additive) means
+   * the runtime's own SSE frame reached this tab. `'local'` means the tab
+   * synthesized it: `reconcileMissingBusySessions` reading absence out of a
+   * status snapshot, `markSessionAbortedLocally` on `server.instance.disposed`,
+   * `clearSession` on a cache-ownership handoff.
+   *
+   * The distinction exists for exactly one rule: only the runtime's own idle
+   * frame may CONTRADICT the lifecycle authority (`endedByRuntime`, and the
+   * "fresher frame knows more" ordering over an open row). A local frame is an
+   * inference, and the veto it inherited is unbounded on purpose — so one
+   * fabricated idle discarded every fresh `/turn` read for the rest of a quiet
+   * turn: the busy indicator left, the composer swapped Stop for Send, and
+   * both came back only when the reply finally streamed (dev, 2026-08-24). A
+   * local frame may still ANSWER when nothing fresher exists — the repair for
+   * a missed terminal frame stays a repair — it just cannot overrule a source
+   * that can actually know.
+   */
+  origin?: 'wire' | 'local';
   atMs: number;
 }
 
@@ -351,7 +370,13 @@ export function projectWorking(inputs: WorkingInputs): WorkingProjection {
   // and permanently — at `stream.atMs + STREAM_OBSERVATION_MAX_MS` the veto
   // vanished with no new input, and a row the relay never closed put the
   // composer back on Stop until its deadline (240 MINUTES for an accepted turn).
-  const idleFrame = stream && stream.type === 'idle' ? stream : null;
+  // WIRE frames only. A fabricated local idle (`origin: 'local'`) is the tab
+  // inferring, not the runtime speaking, and this veto is unbounded — one wrong
+  // local frame silenced every fresh `/turn` read for the rest of a quiet turn
+  // (dev, 2026-08-24: busy indicator gone, composer on Send, transcript poll
+  // switched off, all mid-run). See `WorkingStreamInput.origin`.
+  const idleFrame =
+    stream && stream.type === 'idle' && stream.origin !== 'local' ? stream : null;
 
   // CONTENT FIRST. Bounded by the stream's own freshness rule, because it
   // arrives on the same transport and goes stale for the same reasons — but
@@ -446,7 +471,15 @@ export function projectWorking(inputs: WorkingInputs): WorkingProjection {
   // session went idle. The stream frame is newer BY OBSERVATION, and the daemon
   // relays `turn_end` to the control plane at the same moment the frame is
   // emitted — so a fresher idle frame means this read is simply out of date.
-  if (openTurn && server!.atMs >= abortFloor && (!stream || server!.atMs >= stream.atMs)) {
+  //
+  // A LOCAL idle frame is exempt from that ordering: it is not the runtime
+  // speaking, so "newer" buys it nothing against the lifecycle authority. It
+  // lands between polls by construction (the sweep runs on connect), and
+  // waiting one poll interval for the row to outrank it again is exactly the
+  // flicker being fixed.
+  const streamContradicts =
+    !!stream && !(stream.type === 'idle' && stream.origin === 'local');
+  if (openTurn && server!.atMs >= abortFloor && (!streamContradicts || server!.atMs >= stream!.atMs)) {
     return {
       state: 'working',
       source: 'server',

--- a/packages/sdk/src/react/use-opencode-events/hydrate-status-guard.test.ts
+++ b/packages/sdk/src/react/use-opencode-events/hydrate-status-guard.test.ts
@@ -23,17 +23,31 @@ function hydrateStatusBlock(): string {
 }
 
 describe('hydrateCore session-status snapshot', () => {
-  test('skips any session the live stream has already answered for', () => {
+  test('skips any session a WIRE frame has already answered for', () => {
+    // Only the runtime's own frame owns the slot. A `'local'` value is the
+    // tab's fabrication (the missing-busy sweep, a synthetic abort), and
+    // letting it block this fill made a wrong fabrication self-sustaining: a
+    // sweep that idled a running session could never be corrected by the very
+    // snapshot that now says `busy`.
     const block = hydrateStatusBlock();
-    expect(block).toContain('if (useSyncStore.getState().sessionStatus[sessionID]) continue;');
+    expect(block).toContain('slotState.sessionStatus[sessionID] &&');
+    expect(block).toContain("slotState.sessionStatusOrigin[sessionID] !== 'local'");
   });
 
   test('the skip precedes the write, so a stale reading cannot land first', () => {
     const block = hydrateStatusBlock();
-    const guard = block.indexOf('sessionStatus[sessionID]) continue');
+    const guard = block.indexOf("sessionStatusOrigin[sessionID] !== 'local'");
     const write = block.indexOf('applySyncEvent(');
     expect(guard).toBeGreaterThan(-1);
     expect(write).toBeGreaterThan(guard);
+  });
+
+  test('the snapshot write is marked synthetic, so it lands with local origin', () => {
+    // A snapshot is a reading ABOUT the runtime taken at issue time, not the
+    // runtime speaking on the wire. Unmarked, its write would mint a
+    // wire-origin frame that `projectWorking` lets contradict an open turn.
+    const block = hydrateStatusBlock();
+    expect(block).toContain('synthetic: true');
   });
 
   test('the enumeration repair still runs — absence is not a per-session reading', () => {

--- a/packages/sdk/src/react/use-opencode-events/index.ts
+++ b/packages/sdk/src/react/use-opencode-events/index.ts
@@ -246,12 +246,26 @@ export function useOpenCodeEventStream(options: { enabled?: boolean } = {}) {
             // value; the correction for a session that went idle unseen is
             // `reconcileMissingBusySessions` below, which reads ABSENCE from the
             // complete list rather than a per-session reading.
-            if (useSyncStore.getState().sessionStatus[sessionID]) continue;
+            //
+            // Only a WIRE frame owns the slot. A `'local'` value is the tab's
+            // own fabrication (the missing-busy sweep, a synthetic abort), and
+            // letting it block this fill made the fabrication self-sustaining:
+            // a sweep that wrongly idled a running session could never be
+            // corrected by the very snapshot that now says `busy`.
+            const slotState = useSyncStore.getState();
+            if (
+              slotState.sessionStatus[sessionID] &&
+              slotState.sessionStatusOrigin[sessionID] !== 'local'
+            )
+              continue;
             // Locally-synthesized event (this is a REST poll, not an SSE
             // frame) — omits the `id` field every real `Event` union member
-            // carries, hence the assertion.
+            // carries, hence the assertion. `synthetic: true` marks its write
+            // `'local'`: a snapshot is a reading ABOUT the runtime taken at
+            // issue time, not the runtime speaking on the wire.
             applySyncEvent({
               type: 'session.status',
+              synthetic: true,
               properties: { sessionID, status },
             } as unknown as OpenCodeSdkEvent);
           }

--- a/packages/sdk/src/react/use-opencode-events/use-event-stream-refs.ts
+++ b/packages/sdk/src/react/use-opencode-events/use-event-stream-refs.ts
@@ -160,8 +160,12 @@ export function useEventStreamRefs(deps: {
       // the SDK's `session.error` error union). The sync store's `applyEvent`
       // handles both structurally (see `MessageError`); the assertion just
       // documents that this event is fabricated, not wire data.
+      // `synthetic: true` is what that fabrication COSTS: the idle status this
+      // writes lands with `'local'` origin, so it may fill a gap but can never
+      // veto the control plane's open turn (`WorkingStreamInput.origin`).
       applySyncEvent({
         type: 'session.error',
+        synthetic: true,
         properties: { sessionID, error },
       } as unknown as OpenCodeSdkEvent);
       // A brand-new session whose first prompt has not been echoed yet is the
@@ -187,12 +191,20 @@ export function useEventStreamRefs(deps: {
   const markSessionIdleLocally = useRef((sessionID: string) => {
     if (!sessionID) return;
     stopCompaction(sessionID);
-    // Same locally-synthesized-event caveat as above: no real `id`.
+    // Same locally-synthesized-event caveat as above: no real `id`, and
+    // `synthetic: true` so the idle it writes is `'local'`-origin — an
+    // INFERENCE from a snapshot's absence, which may answer for a session
+    // nothing else speaks for but may never contradict an open `/turn` row.
+    // Unmarked, one sweep un-busied a session mid-turn and the unbounded idle
+    // veto then discarded every fresh `/turn` read for the rest of the turn
+    // (dev, 2026-08-24: no busy indicator, Send instead of Stop, transcript
+    // liveness poll off — all while the agent was running).
     applySyncEvent({
       type: 'session.idle',
+      synthetic: true,
       properties: { sessionID },
     } as unknown as OpenCodeSdkEvent);
-    useSyncStore.getState().setStatus(sessionID, { type: 'idle' });
+    useSyncStore.getState().setStatus(sessionID, { type: 'idle' }, 'local');
     useSyncStore.getState().clearOptimisticMessages(sessionID);
   });
 

--- a/packages/sdk/src/react/use-session-working.test.ts
+++ b/packages/sdk/src/react/use-session-working.test.ts
@@ -147,12 +147,34 @@ describe('buildWorkingInputs', () => {
         nowMs: T0,
       }).stream;
 
-    expect(at({ type: 'busy' })).toEqual({ type: 'busy', atMs: T0 });
-    expect(at({ type: 'retry' })).toEqual({ type: 'retry', atMs: T0 });
-    expect(at({ type: 'idle' })).toEqual({ type: 'idle', atMs: T0 });
+    // `origin: 'wire'` is the default: an unmarked frame is the runtime's own,
+    // and only `sessionStatusOrigin` (threaded via `statusOrigin`) demotes one
+    // to `'local'`.
+    expect(at({ type: 'busy' })).toEqual({ type: 'busy', origin: 'wire', atMs: T0 });
+    expect(at({ type: 'retry' })).toEqual({ type: 'retry', origin: 'wire', atMs: T0 });
+    expect(at({ type: 'idle' })).toEqual({ type: 'idle', origin: 'wire', atMs: T0 });
     // No status frame observed at all is NOT an idle frame — silence is not
     // an observation, and treating it as one is how a live turn got unmasked.
     expect(at(undefined)).toBeNull();
+  });
+
+  test('a local origin is threaded through to the stream input', () => {
+    // The fabricators (`markSessionIdleLocally`, `clearSession`, the hydrate
+    // snapshot) write `'local'` into `sessionStatusOrigin`; the hook passes it
+    // here, and `projectWorking` then refuses to let the frame contradict the
+    // server's open turn. Dropping the field on this seam would silently
+    // restore the fabricated-idle veto.
+    const inputs = buildWorkingInputs({
+      turn: undefined,
+      inbox: undefined,
+      status: { type: 'idle' } as never,
+      statusAtMs: T0,
+      statusOrigin: 'local',
+      optimistic: null,
+      nowMs: T0,
+    });
+
+    expect(inputs.stream).toEqual({ type: 'idle', origin: 'local', atMs: T0 });
   });
 
   test('the stop receipt is passed through, so a doomed turn stops deciding', () => {

--- a/packages/sdk/src/react/use-session-working.ts
+++ b/packages/sdk/src/react/use-session-working.ts
@@ -80,6 +80,13 @@ export function buildWorkingInputs(input: {
   inbox: WorkingInboxInput | undefined;
   status: SessionStatus | undefined;
   statusAtMs: number;
+  /**
+   * Who minted the status frame (`useSyncStore.sessionStatusOrigin`). `'local'`
+   * marks a tab fabrication — the missing-busy sweep, a synthetic abort, a
+   * cache handoff — which may answer for a silent session but may never veto
+   * the server's open turn. Absent means `'wire'`.
+   */
+  statusOrigin?: 'wire' | 'local';
   /** When the runtime's own output last reached this tab for this session
    *  (`useSyncStore.sessionActivityAt`). 0/undefined when it never has. */
   activityAtMs?: number;
@@ -109,6 +116,7 @@ export function buildWorkingInputs(input: {
             input.status.type === 'busy' || input.status.type === 'retry'
               ? input.status.type
               : 'idle',
+          origin: input.statusOrigin ?? 'wire',
           atMs: input.statusAtMs,
         }
       : null,
@@ -142,6 +150,11 @@ export function useSessionWorking(
   const streamKey = runtimeSessionId ?? '';
   const status = useSyncStore((state) =>
     streamKey ? (state.sessionStatus[streamKey] as SessionStatus | undefined) : undefined,
+  );
+  // Who minted that frame — `'local'` for a tab fabrication, which the
+  // projection lets answer but never lets contradict the server's open turn.
+  const statusOrigin = useSyncStore((state) =>
+    streamKey ? state.sessionStatusOrigin[streamKey] : undefined,
   );
   // Both LOCAL inputs come from one per-session store rather than from props.
   // More than one place mounts this hook for the same session and they share
@@ -177,6 +190,7 @@ export function useSessionWorking(
   const [observed, setObserved] = useState<{
     key: string;
     status: SessionStatus;
+    origin: 'wire' | 'local';
     atMs: number;
   } | null>(null);
   useEffect(() => {
@@ -184,8 +198,11 @@ export function useSessionWorking(
       setObserved((previous) => (previous && previous.key === streamKey ? previous : null));
       return;
     }
-    setObserved({ key: streamKey, status, atMs: Date.now() });
-  }, [status, streamKey]);
+    // An origin flip over an unchanged value re-stamps too: the store kept the
+    // object's identity on purpose (`setStatus`), but a wire frame landing
+    // over a fabricated one — or the reverse — is a new observation.
+    setObserved({ key: streamKey, status, origin: statusOrigin ?? 'wire', atMs: Date.now() });
+  }, [status, statusOrigin, streamKey]);
   const stream = observed && observed.key === streamKey ? observed : null;
 
   // The runtime's own output for THIS session's wire id. Quantized to a second
@@ -202,6 +219,7 @@ export function useSessionWorking(
       inbox,
       status: stream?.status,
       statusAtMs: stream?.atMs ?? 0,
+      statusOrigin: stream?.origin,
       activityAtMs,
       optimistic,
       abort,


### PR DESCRIPTION
## Summary

Reported from dev (2026-08-24): mid-turn — usually a long `run command` or tool call — the session UI drops to idle while the agent is still running. The busy indicator disappears, the composer swaps Stop for the send arrow, the transcript freezes, and the UI comes back for a couple of seconds right as the reply streams, then ends. A second capture showed the inverse tail: the runtime finished a 20-minute turn while the tab's transcript stayed frozen at minute 8.

**Root cause — three compounding defects:**

1. The tab fabricates idle status frames: `reconcileMissingBusySessions` sweeps the **global** `sessionStatus` map with a **per-sandbox** `client.session.status()` snapshot; `markSessionAbortedLocally` fires for every non-idle session on one `server.instance.disposed` frame; `clearSession` writes `{type:'idle'}` on a cache handoff.
2. The `sessionStatus` slot kept no provenance, so a fabricated frame was indistinguishable from the runtime's own SSE frame, and `useSessionWorking` stamped it as a fresh observation.
3. The idle-frame veto over the open `/turn` row is unbounded on purpose (#6807 — a dropped `kind:"end"` relay must stay ended). One fabricated frame therefore discarded every fresh 5s `/turn` read for the rest of a quiet turn, and the hydrate fill-gap guard (`if (sessionStatus[sessionID]) continue`) blocked the snapshot from ever correcting the slot — self-sustaining. The same wrong `idle` also switched off the transcript liveness poll (`livenessBusy` gates on the projection), which is why the transcript froze mid-turn and the turn-end tail read fired too early, never again.

**Fix — status frames carry provenance:**

- `WorkingStreamInput` gains an additive `origin?: 'wire' | 'local'`. Only the runtime's own (wire) idle frame may veto the ledger's open turn or outrank it by freshness. A local frame may still answer when nothing fresher exists (the missed-terminal-frame repair keeps its value) and never suppresses streaming content.
- The sync store records `sessionStatusOrigin`; `setStatus` grows an `origin` param (default `'wire'`); same-value writes keep object identity (the staleness clock is stamped from identity) but may flip origin.
- Every fabricator marks its synthesized event `synthetic: true`; `applyEvent` maps that to `'local'`.
- The hydrate fill-gap guard now lets a wire snapshot overwrite a `local` frame, so a wrong sweep self-heals on the next connect.

Public surface is additive only; both surface snapshots are unchanged.

**Known follow-ups (out of scope here):** the sweep is still scope-blind for child-session raw-slot readers; a ledger row lost server-side mid-turn with a dead SSE still freezes the tab until visibility/remount.

## Test plan

- [x] TDD: the three veto tests were written first and observed failing (`idle` where `working` is expected) before the fix.
- [x] `pnpm --filter @kortix/sdk typecheck` — clean (both projects).
- [x] `pnpm --filter @kortix/sdk test` (per-file `--isolate` runner) — 171 files, 2513 pass, 0 fail.
- [x] `pnpm --filter @kortix/sdk run smoke:install` — pack → install → import passed.
- [x] Public-surface and public-type-surface snapshot tests pass without re-record.
- [ ] Dev smoke after merge: start a long quiet command in session A, navigate to another session and back — the composer must keep Stop and the busy indicator must stay while the command runs; the transcript must keep catching up with the stream dropped.