### PR TITLE
fix(sdk): native model picker works before the sandbox runtime exists

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,28 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-24 — session `llm-gateway-off` (follow-up) — native picker source BEFORE the runtime exists — DONE
+
+**Files:** `react/provider-selection.ts` (NEW pure `nativeProviderListFromCatalog`)
++ tests · `react/use-opencode-sessions/providers.ts` (pre-runtime
+`['project-providers', :id, 'native-catalog']` query; returned while the native
+runtime query has no data). **Public surface: no barrel changes.**
+
+**What.** Reported from the field right after the native-mode ship: "no models
+shown after connecting api key". The native provider query is gated on
+`runtimeReady` — on the project home / a cold session there is no opencode to
+read, so the composer showed "No models available" and a key save changed
+nothing until a sandbox booted. Gateway mode always had `/model-picker` for
+this window; native mode now synthesizes its list from the ungated
+`/llm-catalog/providers` + the project's secret names (members whose secret
+read 403s degrade to empty until boot). Runtime truth still wins the moment it
+exists.
+
+**Gates:** `typecheck` clean · `bun run test` 2509 pass / 0 fail ·
+`smoke:install` passed. Shippable: YES.
+
+---
+
 ### 2026-08-24 — session `llm-gateway-off` — native-mode (flag off) model path — DONE
 
 **Files:** `react/model-flatten.ts` (`flattenModels` gains optional

--- a/packages/sdk/src/react/provider-selection.test.ts
+++ b/packages/sdk/src/react/provider-selection.test.ts
@@ -7,8 +7,10 @@ import {
   connectedGatewayProviderIdsFromSecretNames,
   mergeProviderLists,
   mergeProjectSecretConnectedProviders,
+  nativeProviderListFromCatalog,
   projectLlmCatalogToProviderList,
 } from './provider-selection';
+import { flattenModels } from './model-flatten';
 
 describe('LLM_PROVIDER_CREDENTIALS — Kortix auth requirements, not raw catalog env', () => {
   test('amazon-bedrock requires only the bearer token + region', () => {
@@ -147,5 +149,89 @@ describe('applyEnablementToProviderList', () => {
     applyEnablementToProviderList(providers, { 'glm-5.2': false });
     const models = (providers.all?.[0] as { models: Record<string, { enabled?: boolean }> }).models;
     expect(models['glm-5.2'].enabled).toBe(true);
+  });
+});
+
+// Native mode, BEFORE any sandbox runtime exists (project home, cold session):
+// there is no opencode /provider list to read, so the picker synthesizes a
+// ProviderListResponse from the ungated /llm-catalog/providers route plus the
+// project's secret NAMES. Without this the composer showed "No models
+// available" on every native project until a box booted — connecting a key
+// changed nothing.
+describe('nativeProviderListFromCatalog (pre-runtime native picker source)', () => {
+  const catalog = {
+    source: 'models.dev',
+    fetched_at: '2026-08-24T00:00:00Z',
+    provider_count: 3,
+    model_count: 5,
+    providers: [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        env: ['ANTHROPIC_API_KEY'],
+        models: [
+          { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', released: '2026-02-01' },
+          { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', released: '2025-10-01' },
+        ],
+      },
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        env: ['OPENROUTER_API_KEY'],
+        models: [{ id: 'z-ai/glm-4.7-flash', name: 'GLM-4.7-Flash', released: null }],
+      },
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        env: ['OPENAI_API_KEY'],
+        models: [{ id: 'gpt-5.2', name: 'GPT-5.2', released: null }],
+      },
+    ],
+  };
+
+  test('providers whose key is in the secrets connect, with catalog models flattened-compatible', () => {
+    const list = nativeProviderListFromCatalog(catalog as never, new Set(['ANTHROPIC_API_KEY']));
+    expect(list.connected).toEqual(['anthropic']);
+    const anthropic = (list.all ?? []).find((p) => p.id === 'anthropic') as {
+      models: Record<string, { name?: string; release_date?: string }>;
+    };
+    expect(Object.keys(anthropic.models)).toEqual(['claude-sonnet-4-6', 'claude-haiku-4-5']);
+    // `released` (catalog wire name) must land as `release_date` (the field
+    // flattenModels/the picker sort read).
+    expect(anthropic.models['claude-sonnet-4-6']!.release_date).toBe('2026-02-01');
+    // Disconnected providers are omitted entirely — 195 catalog providers per
+    // paint would be dead weight the flatten filters out anyway.
+    expect((list.all ?? []).some((p) => p.id === 'openai')).toBe(false);
+  });
+
+  test('the synthesized list flattens to native FlatModels', () => {
+    const list = nativeProviderListFromCatalog(
+      catalog as never,
+      new Set(['ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY']),
+    );
+    const flat = flattenModels(list, { providerMode: 'native' });
+    expect(flat.map((m) => `${m.providerID}/${m.modelID}`).sort()).toEqual([
+      'anthropic/claude-haiku-4-5',
+      'anthropic/claude-sonnet-4-6',
+      'openrouter/z-ai/glm-4.7-flash',
+    ]);
+  });
+
+  test('no connected key ⇒ an EMPTY list (the connect-provider call to action stays)', () => {
+    const list = nativeProviderListFromCatalog(catalog as never, new Set());
+    expect(list.all).toEqual([]);
+    expect(list.connected).toEqual([]);
+  });
+
+  test('never synthesizes the synthetic kortix provider', () => {
+    const withKortix = {
+      ...catalog,
+      providers: [
+        ...catalog.providers,
+        { id: 'kortix', name: 'Kortix', env: [], models: [{ id: 'glm-5.2', name: 'GLM', released: null }] },
+      ],
+    };
+    const list = nativeProviderListFromCatalog(withKortix as never, new Set(['ANTHROPIC_API_KEY']));
+    expect((list.all ?? []).some((p) => p.id === 'kortix')).toBe(false);
   });
 });

--- a/packages/sdk/src/react/provider-selection.ts
+++ b/packages/sdk/src/react/provider-selection.ts
@@ -165,6 +165,68 @@ export function mergeProjectSecretConnectedProviders(
   return { ...normalized, connected: [...connected] };
 }
 
+/**
+ * Native mode, BEFORE any sandbox runtime exists: synthesize the picker's
+ * provider list from the ungated `/llm-catalog/providers` route plus the
+ * project's secret NAMES.
+ *
+ * OpenCode in the box is the native catalog's source of truth — but on the
+ * project home and on a cold session there IS no box yet, and without a
+ * pre-runtime source the composer showed "No models available" on every
+ * native project until one booted (connecting a key changed nothing). This is
+ * the native twin of gateway mode's `/model-picker`, and it deliberately:
+ *
+ *  • includes ONLY providers whose auth the project's secrets satisfy — the
+ *    195-provider catalog would be dead weight `flattenModels` filters out,
+ *    and an unconnected provider's models must not be pickable;
+ *  • maps the catalog's `released` onto `release_date` (what the flatten and
+ *    the picker sort read);
+ *  • never emits the synthetic `kortix` provider;
+ *  • returns an EMPTY list with no keys, so the connect-provider call to
+ *    action stays honest.
+ *
+ * Once the runtime is up, the live `/provider` list replaces this (it knows
+ * auth.json, autoloaded providers like OpenCode Zen, and real capabilities).
+ */
+export function nativeProviderListFromCatalog(
+  catalog: {
+    providers: Array<{
+      id: string;
+      name: string;
+      models: Array<{ id: string; name: string; released: string | null }>;
+    }>;
+  },
+  secretNames: Set<string>,
+): ProviderListResponse {
+  const connectedIds = connectedGatewayProviderIdsFromSecretNames(secretNames);
+  const all = (catalog.providers ?? [])
+    .filter(
+      (provider) =>
+        connectedIds.has(provider.id) &&
+        !NATIVE_EXCLUDED_PROVIDER_IDS.has(provider.id) &&
+        (provider.models?.length ?? 0) > 0,
+    )
+    .map((provider) => ({
+      id: provider.id,
+      name: provider.name,
+      source: 'env',
+      models: Object.fromEntries(
+        provider.models.map((model) => [
+          model.id,
+          {
+            id: model.id,
+            name: model.name,
+            ...(model.released ? { release_date: model.released } : {}),
+          },
+        ]),
+      ),
+    }));
+  return {
+    all,
+    connected: all.map((provider) => provider.id),
+  } as unknown as ProviderListResponse;
+}
+
 export function connectedGatewayProviderIdsFromSecretNames(secretNames: Set<string>): Set<string> {
   const ids = new Set<string>();
   for (const provider of LLM_PROVIDER_CREDENTIALS) {

--- a/packages/sdk/src/react/use-opencode-sessions/providers.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/providers.ts
@@ -10,6 +10,7 @@ import type { ProviderListResponse } from './keys';
 import { unwrap, getLSCache, setLSCache, LS_PROVIDERS, CACHE_SCOPE_GLOBAL } from './shared';
 import {
   getProjectDetail,
+  getProjectLlmCatalogProviders,
   getProjectModelPicker,
   listProjectSecrets,
 } from '../../core/rest/projects-client';
@@ -19,6 +20,7 @@ import {
   GATEWAY_PROVIDER_IDS,
   LLM_PROVIDER_CREDENTIALS,
   mergeProjectSecretConnectedProviders,
+  nativeProviderListFromCatalog,
   normalizeProviderList,
   projectLlmCatalogToProviderList,
   providerListHasModels,
@@ -149,5 +151,39 @@ export function useOpenCodeProviders() {
     retry: (failureCount) => failureCount < 10,
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 8000),
   });
-  return projectId && projectGatewayEnabled ? gatewayProvidersQuery : nativeProvidersQuery;
+  // Native mode, BEFORE the session runtime exists (project home, cold
+  // session): opencode's /provider list — the native query's only source —
+  // cannot be read yet, so without a fallback the composer showed "No models
+  // available" until a sandbox booted, and connecting a key changed nothing.
+  // Synthesize the picker source from the ungated /llm-catalog/providers
+  // route + the project's secret names (nativeProviderListFromCatalog). The
+  // live runtime list takes over the moment it exists; a cached runtime
+  // answer (the native query's placeholderData) also wins, since it is
+  // runtime truth from a previous boot.
+  const nativeCatalogQuery = useQuery<ProviderListResponse>({
+    queryKey: ['project-providers', projectId, 'native-catalog'],
+    queryFn: async () => {
+      const [catalog, secrets] = await Promise.all([
+        getProjectLlmCatalogProviders(projectId!),
+        // `project.secret.read` is manager-tier: a member's read 403s. Treat
+        // that as "no keys visible" — the runtime list corrects it on boot —
+        // rather than erroring the whole picker source.
+        listProjectSecrets(projectId!).catch(() => ({ items: [] as Array<{ name: string }> })),
+      ]);
+      const items = Array.isArray(secrets) ? secrets : (secrets.items ?? []);
+      return nativeProviderListFromCatalog(
+        catalog,
+        new Set(items.map((secret: { name: string }) => secret.name)),
+      );
+    },
+    enabled: !!projectId && projectModeKnown && !projectGatewayEnabled && !runtimeReady,
+    ...contract('config'),
+    retry: false,
+  });
+
+  if (projectId && projectGatewayEnabled) return gatewayProvidersQuery;
+  if (projectId && projectModeKnown && !runtimeReady && !nativeProvidersQuery.data) {
+    return nativeCatalogQuery;
+  }
+  return nativeProvidersQuery;
 }


### PR DESCRIPTION
## What

Field report right after #6862 landed: **no models shown after connecting an API key** (screenshot: project-home composer, native project).

Root cause: the native provider query is gated on `runtimeReady` — with no booted sandbox there is no opencode `/provider` list to read, so the composer had zero models and a key save changed nothing until a box booted. Gateway mode always had `/model-picker` for this pre-runtime window; native mode had no source.

Fix: synthesize the pre-runtime picker source from the deliberately ungated `GET /llm-catalog/providers` + the project's secret names (`nativeProviderListFromCatalog`, pure + tested):
- only providers whose auth the project's secrets satisfy (195-provider catalog stays out),
- catalog `released` → `release_date` (what the flatten/sort read),
- never the synthetic `kortix` provider,
- empty with no keys — the connect-provider CTA stays honest,
- the live runtime list (and its cached placeholder) wins the moment it exists,
- a member whose `project.secret.read` 403s degrades to empty until boot.

## Verification
- TDD: 4 new pure tests (RED first) incl. flatten-compat of the synthesized list.
- `packages/sdk` gates: typecheck clean · `bun run test` **2509 pass / 0 fail** · `smoke:install` passed.
- `apps/web`: session-feature tests 2543 pass / 0 fail; `tsc --noEmit` clean apart from the known `test.each` noise and a pre-existing `use-connect-link.ts` `ConnectorConnectResult.connected` error from the Composio merge (untouched here).

Dev verification after merge: project-home picker on a native project with a connected key lists that provider's models pre-boot.

https://claude.ai/code/session_01VKuEu99XtQhctJ1SzYT2ox