### PR TITLE
fix(sdk): pre-runtime native picker defaults to a flagship, not catalog file order

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -66,8 +66,15 @@ this window; native mode now synthesizes its list from the ungated
 read 403s degrade to empty until boot). Runtime truth still wins the moment it
 exists.
 
-**Gates:** `typecheck` clean · `bun run test` 2509 pass / 0 fail ·
+**Gates:** `typecheck` clean · `bun run test` 2513 pass / 0 fail ·
 `smoke:install` passed. Shippable: YES.
+
+**Addendum (same session):** the first live dev run auto-picked
+`Hy-MT2-30B-A3B` (models.dev file order) and OpenRouter refused the first
+message with "No endpoints found that support tool use". The synthesized list
+now carries a per-provider `default` (flagship-candidate table mirroring the
+API picker's, else most-recent release), ranks flagship-table providers first,
+and orders models newest-first.
 
 ---
 

--- a/packages/sdk/src/react/provider-selection.test.ts
+++ b/packages/sdk/src/react/provider-selection.test.ts
@@ -235,3 +235,74 @@ describe('nativeProviderListFromCatalog (pre-runtime native picker source)', () 
     expect((list.all ?? []).some((p) => p.id === 'kortix')).toBe(false);
   });
 });
+
+// The first live dev run of the pre-runtime source auto-picked
+// `Hy-MT2-30B-A3B` (catalog file order) and OpenRouter answered "No endpoints
+// found that support tool use" on the user's very first message. The
+// synthesized list must therefore carry a per-provider `default` (the
+// composer's fallback reads `providers.default[id]` before "first model") and
+// order deterministically toward flagships.
+describe('nativeProviderListFromCatalog — default pick quality', () => {
+  const catalog = {
+    source: 'models.dev',
+    fetched_at: '2026-08-24T00:00:00Z',
+    provider_count: 2,
+    model_count: 5,
+    providers: [
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        env: ['OPENROUTER_API_KEY'],
+        models: [
+          { id: 'hy/hy-mt2-30b-a3b', name: 'Hy-MT2-30B-A3B', released: '2025-01-01' },
+          { id: 'z-ai/glm-4.7-flash', name: 'GLM-4.7-Flash', released: '2026-06-01' },
+          { id: 'old/thing', name: 'Old Thing', released: null },
+        ],
+      },
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        env: ['ANTHROPIC_API_KEY'],
+        models: [
+          { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', released: '2025-10-01' },
+          { id: 'claude-opus-4-8', name: 'Claude Opus 4.8', released: '2026-01-01' },
+        ],
+      },
+    ],
+  };
+
+  test('a known flagship becomes the provider default', () => {
+    const list = nativeProviderListFromCatalog(catalog as never, new Set(['ANTHROPIC_API_KEY']));
+    expect((list as { default?: Record<string, string> }).default).toEqual({
+      anthropic: 'claude-opus-4-8',
+    });
+  });
+
+  test('a provider with no flagship candidate defaults to its most recently released model', () => {
+    const list = nativeProviderListFromCatalog(catalog as never, new Set(['OPENROUTER_API_KEY']));
+    expect((list as { default?: Record<string, string> }).default).toEqual({
+      openrouter: 'z-ai/glm-4.7-flash',
+    });
+  });
+
+  test('flagship-table providers rank before the rest, so anthropic beats openrouter as first pick', () => {
+    const list = nativeProviderListFromCatalog(
+      catalog as never,
+      new Set(['ANTHROPIC_API_KEY', 'OPENROUTER_API_KEY']),
+    );
+    expect((list.all ?? []).map((p) => p.id)).toEqual(['anthropic', 'openrouter']);
+    expect(list.connected).toEqual(['anthropic', 'openrouter']);
+  });
+
+  test('models within a provider are ordered newest-first', () => {
+    const list = nativeProviderListFromCatalog(catalog as never, new Set(['OPENROUTER_API_KEY']));
+    const openrouter = (list.all ?? []).find((p) => p.id === 'openrouter') as {
+      models: Record<string, unknown>;
+    };
+    expect(Object.keys(openrouter.models)).toEqual([
+      'z-ai/glm-4.7-flash',
+      'hy/hy-mt2-30b-a3b',
+      'old/thing',
+    ]);
+  });
+});

--- a/packages/sdk/src/react/provider-selection.ts
+++ b/packages/sdk/src/react/provider-selection.ts
@@ -188,6 +188,35 @@ export function mergeProjectSecretConnectedProviders(
  * Once the runtime is up, the live `/provider` list replaces this (it knows
  * auth.json, autoloaded providers like OpenCode Zen, and real capabilities).
  */
+/**
+ * Which model a provider should DEFAULT to when the user has picked nothing.
+ * Mirrors the API picker's table (apps/api/src/llm-gateway/models/
+ * picker-catalog.ts FLAGSHIP_CANDIDATES) — first candidate present in the
+ * catalog wins; a provider not listed (or whose candidates are absent) falls
+ * back to its most recently released model. Without this the very first
+ * message of a native project ran on whatever model happened to sort first in
+ * the models.dev file (observed live: `Hy-MT2-30B-A3B`, which OpenRouter
+ * refused with "No endpoints found that support tool use").
+ */
+const NATIVE_FLAGSHIP_CANDIDATES: Record<string, string[]> = {
+  anthropic: ['claude-opus-4-8', 'claude-sonnet-4-6'],
+  openai: ['gpt-5.5', 'gpt-5.1', 'gpt-5', 'gpt-4.1'],
+  google: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.0-flash'],
+  'x-ai': ['grok-4', 'grok-3'],
+  xai: ['grok-4', 'grok-3'],
+  deepseek: ['deepseek-chat', 'deepseek-reasoner'],
+  mistral: ['mistral-large-latest', 'mistral-large'],
+  groq: ['llama-3.3-70b-versatile'],
+  perplexity: ['sonar-pro', 'sonar'],
+  openrouter: ['anthropic/claude-sonnet-4.6', 'anthropic/claude-sonnet-4.5', 'openai/gpt-5.2'],
+};
+
+/** Table providers first, in table order — "first connected provider" then
+ *  favors a direct flagship provider over e.g. OpenRouter's 350-model sprawl. */
+const NATIVE_PROVIDER_RANK = new Map(
+  Object.keys(NATIVE_FLAGSHIP_CANDIDATES).map((id, index) => [id, index]),
+);
+
 export function nativeProviderListFromCatalog(
   catalog: {
     providers: Array<{
@@ -199,6 +228,7 @@ export function nativeProviderListFromCatalog(
   secretNames: Set<string>,
 ): ProviderListResponse {
   const connectedIds = connectedGatewayProviderIdsFromSecretNames(secretNames);
+  const defaults: Record<string, string> = {};
   const all = (catalog.providers ?? [])
     .filter(
       (provider) =>
@@ -206,24 +236,42 @@ export function nativeProviderListFromCatalog(
         !NATIVE_EXCLUDED_PROVIDER_IDS.has(provider.id) &&
         (provider.models?.length ?? 0) > 0,
     )
-    .map((provider) => ({
-      id: provider.id,
-      name: provider.name,
-      source: 'env',
-      models: Object.fromEntries(
-        provider.models.map((model) => [
-          model.id,
-          {
-            id: model.id,
-            name: model.name,
-            ...(model.released ? { release_date: model.released } : {}),
-          },
-        ]),
-      ),
-    }));
+    .sort(
+      (a, b) =>
+        (NATIVE_PROVIDER_RANK.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+        (NATIVE_PROVIDER_RANK.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+    )
+    .map((provider) => {
+      // Newest first: the picker's visual order and the "first model" fallback
+      // both read insertion order.
+      const models = [...provider.models].sort((a, b) =>
+        (b.released ?? '').localeCompare(a.released ?? ''),
+      );
+      const ids = new Set(models.map((model) => model.id));
+      const flagship =
+        (NATIVE_FLAGSHIP_CANDIDATES[provider.id] ?? []).find((candidate) => ids.has(candidate)) ??
+        models[0]?.id;
+      if (flagship) defaults[provider.id] = flagship;
+      return {
+        id: provider.id,
+        name: provider.name,
+        source: 'env',
+        models: Object.fromEntries(
+          models.map((model) => [
+            model.id,
+            {
+              id: model.id,
+              name: model.name,
+              ...(model.released ? { release_date: model.released } : {}),
+            },
+          ]),
+        ),
+      };
+    });
   return {
     all,
     connected: all.map((provider) => provider.id),
+    default: defaults,
   } as unknown as ProviderListResponse;
 }
 


### PR DESCRIPTION
## What

Follow-up to #6866, from its first live dev run: the pre-runtime native picker auto-picked **Hy-MT2-30B-A3B** (models.dev file order) and OpenRouter refused the user's first message with `No endpoints found that support tool use`.

`nativeProviderListFromCatalog` now:
- emits a per-provider **`default`** — flagship-candidate table mirroring the API picker's (`picker-catalog.ts FLAGSHIP_CANDIDATES`, plus openrouter candidates), else the provider's most recently released model. The composer's fallback reads `providers.default[id]` before 'first model'.
- ranks flagship-table providers ahead of catch-alls (anthropic beats openrouter as first pick),
- orders each provider's models newest-first (picker visual order + fallback both read insertion order).

## Verification
- TDD: 4 new pure tests (RED first).
- `packages/sdk` gates: typecheck clean · `bun run test` **2513 pass / 0 fail**.
- Dev after merge: fresh native project with only OPENROUTER_API_KEY should default to `anthropic/claude-sonnet-4.6`-via-openrouter (or the newest release), not Hy-MT2.

https://claude.ai/code/session_01VKuEu99XtQhctJ1SzYT2ox