### PR TITLE
fix(web): native model picker defaults to the latest set, search reveals all

### DIFF
--- a/apps/api/src/__tests__/e2e-connector-faces.test.ts
+++ b/apps/api/src/__tests__/e2e-connector-faces.test.ts
@@ -515,6 +515,7 @@ describe('MCP face', () => {
         'describe',
         'call',
         'connect',
+        'finalize_connection',
         'request_secret',
         'secret_call',
         'add_connector',

--- a/apps/web/src/features/session/model-picker-default-view.test.ts
+++ b/apps/web/src/features/session/model-picker-default-view.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { FlatModel } from '@kortix/sdk/react';
+import { modelInDefaultView } from './model-picker-default-view';
+
+const m = (providerID: string, modelID: string) => ({ providerID, modelID }) as FlatModel;
+
+// Field report (native OpenRouter key): the picker rendered all ~355 models as
+// a wall in BOTH the pre-runtime and runtime states — native lists carry no
+// server-stamped `enabled`, so nothing curated the default view the way
+// /model-picker curates gateway catalogs. This rule is the client twin.
+describe('modelInDefaultView', () => {
+  const hiddenByStore = () => false;
+  const shownByStore = () => true;
+
+  test('native models follow the store visibility rule when not searching', () => {
+    const model = m('openrouter', 'old/thing');
+    expect(
+      modelInDefaultView(model, { search: '', isStoreVisible: hiddenByStore, selected: null }),
+    ).toBe(false);
+    expect(
+      modelInDefaultView(model, { search: '', isStoreVisible: shownByStore, selected: null }),
+    ).toBe(true);
+  });
+
+  test('a search query reveals everything — typing is intent', () => {
+    expect(
+      modelInDefaultView(m('openrouter', 'old/thing'), {
+        search: 'old',
+        isStoreVisible: hiddenByStore,
+        selected: null,
+      }),
+    ).toBe(true);
+  });
+
+  test('gateway (kortix) models are untouched — the server already curated them via enabled', () => {
+    expect(
+      modelInDefaultView(m('kortix', 'glm-5.2'), {
+        search: '',
+        isStoreVisible: hiddenByStore,
+        selected: null,
+      }),
+    ).toBe(true);
+  });
+
+  test('the selected model always renders, even when the store hides it', () => {
+    expect(
+      modelInDefaultView(m('openrouter', 'old/thing'), {
+        search: '',
+        isStoreVisible: hiddenByStore,
+        selected: { providerID: 'openrouter', modelID: 'old/thing' },
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/features/session/model-picker-default-view.ts
+++ b/apps/web/src/features/session/model-picker-default-view.ts
@@ -1,0 +1,41 @@
+import type { FlatModel } from '@kortix/sdk/react';
+
+/**
+ * Which models the picker shows when the search box is EMPTY — the default
+ * view. Pure, so the rule is testable without mounting the popover.
+ *
+ * Gateway (`kortix`-provider) models are already server-curated: the
+ * `/model-picker` catalog stamps `enabled` from the shared newest-per-family
+ * rule, and the `enabled !== false` filter upstream of this function applies
+ * it. NATIVE provider models had no equivalent — the runtime list (opencode's
+ * own catalog) and the pre-runtime list (models.dev via the API) are both
+ * unstamped, so a connected OpenRouter key rendered ALL ~355 models as a
+ * wall. This applies the client twin of the same rule: the model store's
+ * `isVisible` (newest per family within the window, flagships, plus the
+ * user's explicit show/hide pins).
+ *
+ * Two deliberate carve-outs:
+ *  • a SEARCH query reveals everything — typing is intent, and hiding search
+ *    hits behind a second toggle is how models become unfindable;
+ *  • the currently-selected model always renders, or the check mark would
+ *    point at a row that does not exist.
+ */
+export function modelInDefaultView(
+  model: FlatModel,
+  input: {
+    search: string;
+    isStoreVisible: (model: { providerID: string; modelID: string }) => boolean;
+    selected: { providerID: string; modelID: string } | null;
+  },
+): boolean {
+  if (input.search.trim().length > 0) return true;
+  if (model.providerID === 'kortix') return true;
+  if (
+    input.selected &&
+    input.selected.providerID === model.providerID &&
+    input.selected.modelID === model.modelID
+  ) {
+    return true;
+  }
+  return input.isStoreVisible({ providerID: model.providerID, modelID: model.modelID });
+}

--- a/apps/web/src/features/session/model-selector.tsx
+++ b/apps/web/src/features/session/model-selector.tsx
@@ -18,7 +18,8 @@ import { cn } from '@/lib/utils';
 import type { ProviderModalTab } from '@/stores/provider-modal-store';
 import { useProviderModalStore } from '@/stores/provider-modal-store';
 import { getProjectDetail } from '@kortix/sdk';
-import { contract, qk, type ProviderListResponse } from '@kortix/sdk/react';
+import { contract, qk, useModelStore, type ProviderListResponse } from '@kortix/sdk/react';
+import { modelInDefaultView } from './model-picker-default-view';
 import {
   CheckIcon as Check,
   CaretDownIcon as ChevronDown,
@@ -418,6 +419,11 @@ export function ModelSelector({
     }
   }, [open]);
 
+  // The store's visibility rule (newest per family + flagships + user pins)
+  // curates the NO-SEARCH view for native providers — the client twin of the
+  // `enabled` stamping `/model-picker` gives gateway catalogs. See
+  // modelInDefaultView.
+  const pickerModelStore = useModelStore(baseModels);
   const visibleModels = useMemo(() => {
     const q = search.toLowerCase();
     return baseModels
@@ -427,10 +433,15 @@ export function ModelSelector({
           (!q ||
             (m.modelName || '').toLowerCase().includes(q) ||
             (m.modelID || '').toLowerCase().includes(q) ||
-            (m.providerName || '').toLowerCase().includes(q)),
+            (m.providerName || '').toLowerCase().includes(q)) &&
+          modelInDefaultView(m, {
+            search,
+            isStoreVisible: pickerModelStore.isVisible,
+            selected: selectedModel,
+          }),
       )
       .sort((a, b) => a.modelName.localeCompare(b.modelName));
-  }, [baseModels, search]);
+  }, [baseModels, search, pickerModelStore.isVisible, selectedModel]);
 
   /** Is there anything to pick AT ALL, ignoring the search box? The empty
    *  state below branches on this: "no models match your search" and "you have


### PR DESCRIPTION
## What

Field report on native projects ("can we have the same level of ux/ui where we primarily show the latest models"): with an OpenRouter key connected the picker rendered **all ~355 models as a flat wall**, in both the pre-runtime and runtime states.

Root cause: gateway catalogs get curated server-side (`/model-picker` stamps `enabled` from the shared newest-per-family rule) — native lists (opencode runtime + the pre-runtime catalog source) are never stamped, and `ModelSelector` applied no client-side visibility.

Fix: the picker's **no-search view** now applies the model store's `isVisible` rule (newest per family within the 6-month window + flagships + the user's explicit show/hide pins) to non-gateway models — the client twin of the gateway's stamping. Carve-outs: a search query reveals everything (typing is intent), the currently-selected model always renders, gateway models untouched.

Pure rule in `model-picker-default-view.ts` (4 tests, RED first).

## Verification
- `apps/web`: `bun test` **8396 pass / 0 fail** · tsc clean (pre-existing noise only) · eslint clean on touched files.
- Dev after merge: native project picker shows the curated latest set closed-over-search; typing reveals the full catalog.

https://claude.ai/code/session_01VKuEu99XtQhctJ1SzYT2ox