### PR TITLE
fix(sdk,web): one native model picker across sandbox states + hide dead gateway effort chip off-gateway

### DIFF
--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -25,6 +25,11 @@ Turning the flag off is a fully supported path. The project then runs
 - Model ids are OpenCode's native `provider/model` refs, like
   `anthropic/claude-opus-4-8`. Managed bare ids and `kortix/…` refs do not
   exist off-gateway.
+- The model picker shows one list before and after the sandbox boots: the
+  providers your keys connect, plus OpenCode Zen's free models (OpenCode
+  connects those without a key). Thinking effort is the model's **Thinking
+  mode** row in the picker; the gateway's reasoning-effort control does not
+  apply.
 - The gateway surfaces on this page — managed models, the model-defaults
   chain, budgets, logs — do not apply; OpenCode resolves the default model in
   the sandbox.

--- a/apps/web/src/features/session/reasoning-effort-selector.tsx
+++ b/apps/web/src/features/session/reasoning-effort-selector.tsx
@@ -139,7 +139,12 @@ export function useReasoningEffortControl(
     wireModel && routing.data
       ? (routing.data.project.modelGenerationConfig?.[wireModel]?.reasoningEffort ?? null)
       : null;
-  const canWrite = routing.data?.capabilities?.write ?? false;
+  // Gateway-only control. Off-gateway (native OpenCode) the box never reads
+  // the routing policy — the model's own THINKING MODE variants in the picker
+  // are the one real effort control there. `routing.data` alone is not
+  // enough: a disabled query still serves cache residue from before the flag
+  // flipped, which rendered a second, dead effort chip beside the variants.
+  const canWrite = routing.llmGatewayEnabled && (routing.data?.capabilities?.write ?? false);
 
   const setEffort = (next: string | null) => {
     if (!wireModel || !projectId || !routing.data) return;

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,35 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-25 — session `native-picker-unify` — ONE native picker across sandbox states + no dead effort chip — DONE
+
+**Files:** `react/provider-selection.ts` (NEW pure `mergeNativeProviderLists`;
+`nativeProviderListFromCatalog` now lists OpenCode Zen's free models keyless,
+ranked last) + tests · `react/use-opencode-sessions/providers.ts` (the
+`native-catalog` query stays enabled after boot; native mode returns the
+catalog ∪ runtime merge, never a source swap) ·
+`react/use-gateway-routing-policy.ts` (`llmGatewayEnabled` beside `data`) +
+test. **Public surface: no barrel changes** (additive field on the routing
+hook result; type-surface snapshot unchanged).
+
+**What.** Two field reports on the native path. (1) "the model pickers are
+different when the sandbox isn't started and when it is" — pre-boot the picker
+read the catalog synthesis, post-boot the runtime list; the two disagreed on
+provider order, on Zen (runtime auto-connects `opencode` free models keyless),
+and on the auto-picked default (runtime `default` is catalog-file-order). Now
+the catalog list is the skeleton (order + curated flagship default), the
+runtime provider object replaces each shared id (real variant settings, the
+box's exact models), runtime-only providers append, and a catalog default
+survives only while the runtime serves that model. (2) "2 thinking mode
+selections" — the composer's reasoning-effort chip is a gateway routing-policy
+control; the hook's query is disabled off-gateway, but a disabled query still
+serves cache residue, so `data.capabilities.write` kept the chip alive beside
+the model's real THINKING MODE variants. The hook now states the flag; the
+web chip requires it.
+
+**Gates:** `pnpm typecheck` clean · `pnpm test` 172 files 0 fail ·
+`public-type-surface.test.ts` pass · `pnpm smoke:install` pass.
+
 ### 2026-08-24 — session `fabricated-idle-veto` — a fabricated idle frame can no longer contradict the ledger — DONE (PR open, not merged)
 
 **Files:** `core/session/working.ts` (`WorkingStreamInput.origin?: 'wire' | 'local'`;

--- a/packages/sdk/src/react/provider-selection.test.ts
+++ b/packages/sdk/src/react/provider-selection.test.ts
@@ -7,6 +7,7 @@ import {
   connectedGatewayProviderIdsFromSecretNames,
   mergeProviderLists,
   mergeProjectSecretConnectedProviders,
+  mergeNativeProviderLists,
   nativeProviderListFromCatalog,
   projectLlmCatalogToProviderList,
 } from './provider-selection';
@@ -217,10 +218,45 @@ describe('nativeProviderListFromCatalog (pre-runtime native picker source)', () 
     ]);
   });
 
-  test('no connected key ⇒ an EMPTY list (the connect-provider call to action stays)', () => {
+  test('no connected key and no Zen entry ⇒ an EMPTY list (the connect-provider call to action stays)', () => {
     const list = nativeProviderListFromCatalog(catalog as never, new Set());
     expect(list.all).toEqual([]);
     expect(list.connected).toEqual([]);
+  });
+
+  // opencode auto-connects the OpenCode Zen provider (`opencode`) with its
+  // FREE models even when no key is present — the running sandbox always
+  // lists them. The pre-runtime source must too, or the picker's contents
+  // change the moment the box boots.
+  test('OpenCode Zen free models are always listed (keyless), paid Zen models are not', () => {
+    const withZen = {
+      ...catalog,
+      providers: [
+        ...catalog.providers,
+        {
+          id: 'opencode',
+          name: 'OpenCode Zen',
+          env: ['OPENCODE_API_KEY'],
+          models: [
+            { id: 'gpt-5.6-terra', name: 'GPT-5.6 Terra', released: '2026-07-09', cost: { input: 2.5, output: 15 } },
+            { id: 'hy3-free', name: 'Hy3 Free', released: '2026-05-01', cost: { input: 0, output: 0 } },
+            { id: 'big-pickle', name: 'Big Pickle', released: '2026-06-01', cost: { input: 0, output: 0 } },
+          ],
+        },
+      ],
+    };
+    const list = nativeProviderListFromCatalog(withZen as never, new Set());
+    expect(list.connected).toEqual(['opencode']);
+    const zen = (list.all ?? []).find((p) => p.id === 'opencode') as { models: Record<string, unknown> };
+    expect(Object.keys(zen.models)).toEqual(['big-pickle', 'hy3-free']);
+    // Zen ranks after every keyed provider, and never becomes the default pick
+    // when a keyed provider exists.
+    const keyed = nativeProviderListFromCatalog(withZen as never, new Set(['ANTHROPIC_API_KEY']));
+    expect((keyed.all ?? []).map((p) => p.id)).toEqual(['anthropic', 'opencode']);
+    expect((keyed as { default?: Record<string, string> }).default).toEqual({
+      anthropic: 'claude-sonnet-4-6',
+      opencode: 'big-pickle',
+    });
   });
 
   test('never synthesizes the synthetic kortix provider', () => {
@@ -391,5 +427,98 @@ describe('nativeProviderListFromCatalog — metadata parity with the runtime pic
     const flat = flattenModels(list, { providerMode: 'native' });
     const haiku = flat.find((m) => m.modelID === 'claude-3-haiku')!;
     expect(haiku.variants ?? {}).toEqual({});
+  });
+});
+
+// One picker across sandbox states: pre-boot the catalog synthesizes the
+// list, post-boot the runtime reports it. Swapping sources changed the
+// picker's contents on boot (different provider order, Zen appearing, the
+// auto-picked default flipping). The merge keeps ONE list: runtime truth per
+// provider, catalog order + curated defaults, runtime-only extras appended.
+describe('mergeNativeProviderLists (catalog ∪ runtime, one picker across boot)', () => {
+  const catalog = {
+    all: [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'env',
+        models: {
+          'claude-opus-4-8': { id: 'claude-opus-4-8', name: 'Opus', variants: { high: {}, max: {} } },
+          'claude-sonnet-4-6': { id: 'claude-sonnet-4-6', name: 'Sonnet' },
+        },
+      },
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        source: 'env',
+        models: { 'z-ai/glm-4.7-flash': { id: 'z-ai/glm-4.7-flash', name: 'GLM' } },
+      },
+    ],
+    connected: ['anthropic', 'openrouter'],
+    default: { anthropic: 'claude-opus-4-8', openrouter: 'z-ai/glm-4.7-flash' },
+  } as never;
+  const runtime = {
+    all: [
+      {
+        id: 'opencode',
+        name: 'OpenCode Zen',
+        source: 'api',
+        models: { 'big-pickle': { id: 'big-pickle', name: 'Big Pickle' } },
+      },
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'env',
+        models: {
+          'claude-opus-4-8': {
+            id: 'claude-opus-4-8',
+            name: 'Opus',
+            variants: { high: { thinking: { budgetTokens: 16000 } }, max: { thinking: { budgetTokens: 31999 } } },
+          },
+          'claude-sonnet-4-6': { id: 'claude-sonnet-4-6', name: 'Sonnet' },
+          'claude-haiku-4-5': { id: 'claude-haiku-4-5', name: 'Haiku' },
+        },
+      },
+    ],
+    connected: ['opencode', 'anthropic'],
+    default: { anthropic: 'claude-haiku-4-5', opencode: 'big-pickle' },
+  } as never;
+
+  test('runtime provider objects win for shared ids (real variant settings), catalog order is kept, extras append', () => {
+    const merged = mergeNativeProviderLists(catalog, runtime)!;
+    expect((merged.all ?? []).map((p) => p.id)).toEqual(['anthropic', 'openrouter', 'opencode']);
+    const anthropic = (merged.all ?? []).find((p) => p.id === 'anthropic') as {
+      models: Record<string, { variants?: Record<string, unknown> }>;
+    };
+    expect(Object.keys(anthropic.models)).toEqual(['claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5']);
+    expect(anthropic.models['claude-opus-4-8']!.variants).toEqual({
+      high: { thinking: { budgetTokens: 16000 } },
+      max: { thinking: { budgetTokens: 31999 } },
+    });
+    expect(merged.connected).toEqual(['anthropic', 'openrouter', 'opencode']);
+  });
+
+  test('the curated catalog default wins over the runtime default when the runtime serves that model', () => {
+    const merged = mergeNativeProviderLists(catalog, runtime)!;
+    expect((merged as { default?: Record<string, string> }).default).toEqual({
+      anthropic: 'claude-opus-4-8',
+      openrouter: 'z-ai/glm-4.7-flash',
+      opencode: 'big-pickle',
+    });
+  });
+
+  test('a catalog default the runtime does not serve falls back to the runtime default', () => {
+    const skewed = {
+      ...(catalog as { default: Record<string, string> }),
+      default: { anthropic: 'claude-opus-5', openrouter: 'z-ai/glm-4.7-flash' },
+    } as never;
+    const merged = mergeNativeProviderLists(skewed, runtime)!;
+    expect((merged as { default?: Record<string, string> }).default?.anthropic).toBe('claude-haiku-4-5');
+  });
+
+  test('either side missing returns the other unchanged', () => {
+    expect(mergeNativeProviderLists(catalog, undefined)).toBe(catalog);
+    expect(mergeNativeProviderLists(undefined, runtime)).toBe(runtime);
+    expect(mergeNativeProviderLists(undefined, undefined)).toBeUndefined();
   });
 });

--- a/packages/sdk/src/react/provider-selection.ts
+++ b/packages/sdk/src/react/provider-selection.ts
@@ -265,6 +265,29 @@ function nativeVariantIds(model: NativeCatalogModel): string[] {
   return [];
 }
 
+/**
+ * OpenCode Zen — opencode's own provider. The runtime auto-connects it with
+ * its FREE models even when no `OPENCODE_API_KEY` exists (opencode
+ * packages/opencode/src/provider/provider.ts: the `opencode` provider is
+ * always loaded, keyless it is trimmed to zero-cost models). The pre-runtime
+ * source mirrors that so a booting sandbox never adds a provider the
+ * pre-boot picker did not show.
+ */
+const ZEN_PROVIDER_ID = 'opencode';
+
+function isFreeModel(model: NativeCatalogModel): boolean {
+  return model.cost?.input === 0 && model.cost?.output === 0;
+}
+
+function providerRank(id: string): number {
+  // Keyed table providers first (table order), then every other keyed
+  // provider, Zen's keyless free tier last — "first connected provider" is
+  // what the composer auto-picks, and a free preview model must never beat a
+  // provider the user paid to connect.
+  if (id === ZEN_PROVIDER_ID) return Number.MAX_SAFE_INTEGER;
+  return NATIVE_PROVIDER_RANK.get(id) ?? Number.MAX_SAFE_INTEGER - 1;
+}
+
 export function nativeProviderListFromCatalog(
   catalog: {
     providers: Array<{
@@ -278,17 +301,18 @@ export function nativeProviderListFromCatalog(
   const connectedIds = connectedGatewayProviderIdsFromSecretNames(secretNames);
   const defaults: Record<string, string> = {};
   const all = (catalog.providers ?? [])
+    .map((provider) =>
+      provider.id === ZEN_PROVIDER_ID && !connectedIds.has(ZEN_PROVIDER_ID)
+        ? { ...provider, models: (provider.models ?? []).filter(isFreeModel), keyless: true }
+        : { ...provider, keyless: false },
+    )
     .filter(
       (provider) =>
-        connectedIds.has(provider.id) &&
+        (provider.keyless || connectedIds.has(provider.id)) &&
         !NATIVE_EXCLUDED_PROVIDER_IDS.has(provider.id) &&
         (provider.models?.length ?? 0) > 0,
     )
-    .sort(
-      (a, b) =>
-        (NATIVE_PROVIDER_RANK.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
-        (NATIVE_PROVIDER_RANK.get(b.id) ?? Number.MAX_SAFE_INTEGER),
-    )
+    .sort((a, b) => providerRank(a.id) - providerRank(b.id))
     .map((provider) => {
       // Newest first: the picker's visual order and the "first model" fallback
       // both read insertion order.
@@ -303,7 +327,7 @@ export function nativeProviderListFromCatalog(
       return {
         id: provider.id,
         name: provider.name,
-        source: 'env',
+        source: provider.keyless ? 'api' : 'env',
         models: Object.fromEntries(
           models.map((model) => {
             const variantIds = nativeVariantIds(model);
@@ -345,6 +369,66 @@ export function nativeProviderListFromCatalog(
     connected: all.map((provider) => provider.id),
     default: defaults,
   } as unknown as ProviderListResponse;
+}
+
+/**
+ * ONE native picker across sandbox states. Pre-boot the picker reads the
+ * catalog synthesis (`nativeProviderListFromCatalog`); once the runtime
+ * reports `/config/providers` it is the truth for what the box can actually
+ * serve. Swapping sources on boot changed the picker under the user (provider
+ * order, Zen appearing, the auto-picked default flipping). Merged instead:
+ *
+ * - shared provider ids take the RUNTIME object (real variant settings, the
+ *   box's exact model set), in CATALOG order (flagship rank);
+ * - runtime-only providers (Zen, auth.json logins) append after;
+ * - the curated catalog default wins per provider while the runtime serves
+ *   that model, else the runtime default — the auto-pick is stable across
+ *   boot and never names a model the box cannot run.
+ */
+export function mergeNativeProviderLists(
+  catalog: ProviderListResponse | undefined,
+  runtime: ProviderListResponse | undefined,
+): ProviderListResponse | undefined {
+  if (!catalog) return runtime;
+  if (!runtime) return catalog;
+  const first = normalizeProviderList(catalog);
+  const second = normalizeProviderList(runtime);
+  type Provider = NonNullable<ProviderListResponse['all']>[number];
+  const runtimeById = new Map<string, Provider>();
+  for (const provider of Array.isArray(second.all) ? second.all : []) {
+    runtimeById.set(provider.id, provider);
+  }
+  const all: Provider[] = [];
+  const seen = new Set<string>();
+  for (const provider of Array.isArray(first.all) ? first.all : []) {
+    all.push(runtimeById.get(provider.id) ?? provider);
+    seen.add(provider.id);
+  }
+  for (const provider of Array.isArray(second.all) ? second.all : []) {
+    if (!seen.has(provider.id)) {
+      all.push(provider);
+      seen.add(provider.id);
+    }
+  }
+  const connected: string[] = [];
+  const connectedSeen = new Set<string>();
+  for (const id of [
+    ...(Array.isArray(first.connected) ? first.connected : []),
+    ...(Array.isArray(second.connected) ? second.connected : []),
+  ]) {
+    if (!connectedSeen.has(id)) {
+      connected.push(id);
+      connectedSeen.add(id);
+    }
+  }
+  const defaults: Record<string, string> = { ...(second.default ?? {}) };
+  for (const [providerId, modelId] of Object.entries(first.default ?? {})) {
+    const runtimeProvider = runtimeById.get(providerId);
+    if (!runtimeProvider || (runtimeProvider.models && modelId in runtimeProvider.models)) {
+      defaults[providerId] = modelId;
+    }
+  }
+  return { ...second, all, connected, default: defaults };
 }
 
 export function connectedGatewayProviderIdsFromSecretNames(secretNames: Set<string>): Set<string> {

--- a/packages/sdk/src/react/use-gateway-routing-policy.test.ts
+++ b/packages/sdk/src/react/use-gateway-routing-policy.test.ts
@@ -46,6 +46,17 @@ describe("useGatewayRoutingPolicy", () => {
     expect((useGatewayRoutingPolicy("P1") as any).enabled).toBe(false);
   });
 
+  // A disabled query still serves whatever the cache holds from before the
+  // flag flipped. Consumers (the composer's reasoning-effort chip) must be
+  // able to ask "does this policy apply at all?" without reasoning about
+  // cache residue — so the hook states the flag alongside `data`.
+  test("exposes llmGatewayEnabled so consumers hide gateway-only controls off-gateway", () => {
+    expect((useGatewayRoutingPolicy("P1") as any).llmGatewayEnabled).toBe(true);
+    projectGatewayFlag = false;
+    expect((useGatewayRoutingPolicy("P1") as any).llmGatewayEnabled).toBe(false);
+    expect((useGatewayRoutingPolicy(null) as any).llmGatewayEnabled).toBe(false);
+  });
+
   test("set and reset invalidate the policy while preview remains a one-shot mutation", () => {
     const result = useGatewayRoutingPolicy("P1") as any;
     expect(result.set.mutationKey).toEqual(gatewayRoutingPolicyKey("P1"));

--- a/packages/sdk/src/react/use-gateway-routing-policy.ts
+++ b/packages/sdk/src/react/use-gateway-routing-policy.ts
@@ -33,6 +33,11 @@ export function useGatewayRoutingPolicy(projectId: string | null | undefined) {
     });
 
   return Object.assign(query, {
+    // Stated beside `data` on purpose: a disabled query still serves cache
+    // residue from before the flag flipped, and a consumer that only checks
+    // `data?.capabilities.write` would keep rendering a gateway-only control
+    // (the composer's reasoning-effort chip) for a native project.
+    llmGatewayEnabled: !!projectId && gateway.enabled,
     set: useMutation({
       mutationKey: gatewayRoutingPolicyKey(projectId),
       mutationFn: (policy: GatewayProjectRoutingPolicy) =>

--- a/packages/sdk/src/react/use-opencode-sessions/providers.ts
+++ b/packages/sdk/src/react/use-opencode-sessions/providers.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getClient } from '../../core/runtime/client';
 import { useKortixRouteProjectId } from '../route-project';
@@ -19,6 +20,7 @@ import {
   filterToNativeProviders,
   GATEWAY_PROVIDER_IDS,
   LLM_PROVIDER_CREDENTIALS,
+  mergeNativeProviderLists,
   mergeProjectSecretConnectedProviders,
   nativeProviderListFromCatalog,
   normalizeProviderList,
@@ -176,14 +178,27 @@ export function useOpenCodeProviders() {
         new Set(items.map((secret: { name: string }) => secret.name)),
       );
     },
-    enabled: !!projectId && projectModeKnown && !projectGatewayEnabled && !runtimeReady,
+    // Stays live after boot: the merged picker keeps catalog order + curated
+    // defaults under the runtime's provider objects (see
+    // `mergeNativeProviderLists`), so the list does not change under the user
+    // the moment the sandbox reports in.
+    enabled: !!projectId && projectModeKnown && !projectGatewayEnabled,
     ...contract('config'),
     retry: false,
   });
 
+  const mergedNative = useMemo(
+    () => mergeNativeProviderLists(nativeCatalogQuery.data, nativeProvidersQuery.data),
+    [nativeCatalogQuery.data, nativeProvidersQuery.data],
+  );
+
   if (projectId && projectGatewayEnabled) return gatewayProvidersQuery;
-  if (projectId && projectModeKnown && !runtimeReady && !nativeProvidersQuery.data) {
-    return nativeCatalogQuery;
+  if (projectId && projectModeKnown && !projectGatewayEnabled) {
+    // ONE native picker across sandbox states. `isLoading` follows whichever
+    // source is still the only one expected right now: pre-boot the catalog,
+    // post-boot the runtime.
+    const base = runtimeReady || nativeProvidersQuery.data ? nativeProvidersQuery : nativeCatalogQuery;
+    return Object.assign({}, base, { data: mergedNative }) as typeof nativeProvidersQuery;
   }
   return nativeProvidersQuery;
 }


### PR DESCRIPTION
## Problem
Native (\`llm_gateway\` off) projects, two field reports:
1. The model picker differs before vs after the sandbox boots. Pre-boot = catalog synthesis; post-boot = runtime \`/config/providers\`. They disagree on provider order, on OpenCode Zen (runtime auto-connects its free models keyless), and on the auto-picked default (runtime \`default\` is catalog-file order).
2. Two thinking-mode controls: the picker's THINKING MODE row (opencode variants — the real native control) and the toolbar reasoning-effort chip (gateway routing policy, which native never reads). The chip's query is disabled off-gateway but still serves cache residue, so \`data.capabilities.write\` kept it visible.

## Change
- \`packages/sdk/src/react/provider-selection.ts\`: new pure \`mergeNativeProviderLists(catalog, runtime)\` — catalog order + curated default as skeleton, runtime provider object per shared id, runtime-only providers appended, catalog default kept only while the runtime serves that model. \`nativeProviderListFromCatalog\` lists Zen's free (cost 0/0) models keyless, ranked last.
- \`packages/sdk/src/react/use-opencode-sessions/providers.ts\`: the \`native-catalog\` query stays enabled after boot; native mode returns the merge, never a source swap.
- \`packages/sdk/src/react/use-gateway-routing-policy.ts\`: exposes \`llmGatewayEnabled\` beside \`data\`.
- \`apps/web/src/features/session/reasoning-effort-selector.tsx\`: \`canWrite\` requires \`routing.llmGatewayEnabled\`.
- Docs: \`content/docs/project/models.mdx\`; \`packages/sdk/PROGRESS.md\`.

Gateway mode is unchanged (effort chip stays the gateway control).

## Verification
- \`packages/sdk\`: \`pnpm typecheck\` clean; \`pnpm test\` 172 files 0 fail (new: 4 merge cases, Zen keyless case, \`llmGatewayEnabled\` case); \`public-type-surface.test.ts\` pass; \`pnpm smoke:install\` pass.
- \`apps/web\`: \`bun test src/features/session/reasoning-effort-selector.test.ts\` 11 pass; \`tsc --noEmit\` — only pre-existing errors in untouched files.
- Dev browser check after merge: pre-boot vs post-boot picker on a native project + no effort chip; recorded in the session thread.

https://claude.ai/code/session_01XxEuty9EakLNG9VzkoQHaL