### PR TITLE
chore(runtime): bump OpenCode 1.18.19 → 1.18.23 everywhere (Bedrock redactedContent stream fix)

### DIFF
--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,24 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-25 — session `opencode-bump-11823` — OpenCode 1.18.19 → 1.18.23 lockstep — DONE
+
+**Files:** `package.json` (`@opencode-ai/sdk` 1.18.23) · `packages/shared/src/runtime-versions.json`
+(`opencode` + `opencodeSdk`) · shared Dockerfile goldens. **Public surface: no
+changes** — `@opencode-ai/sdk` 1.18.19→1.18.23 changes one line each in
+`v2/gen/types.gen.ts` / `sdk.gen.ts` (the `global.upgrade` payload); the
+type-surface snapshot is byte-identical.
+
+**Why.** Essentia (native mode) ran `amazon-bedrock/global.openai.gpt-5.6-sol`
+and every reasoning stream died on `contentBlockDelta.delta.reasoningContent.redactedContent`
+failing schema validation. Upstream anomalyco/opencode#43686 → #43909 bumped
+`@ai-sdk/amazon-bedrock` 4.0.112→4.0.158 (adds `redactedContent`); first
+release carrying it is v1.18.22. We pinned 1.18.19.
+
+**Gates:** `pnpm typecheck` clean · `pnpm test` 172 files 0 fail ·
+`public-type-surface.test.ts` pass · api `config-deps-version.test.ts` pass ·
+shared sandbox suite 72 pass (goldens regenerated).
+
 ### 2026-08-25 — session `native-catalog-status` — pre-boot picker hides deprecated models like the runtime — DONE
 
 **Files:** `react/provider-selection.ts` (`nativeProviderListFromCatalog` drops

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -14,7 +14,7 @@
   "sideEffects": false,
   "dependencies": {
     "@kortix/llm-catalog": "workspace:*",
-    "@opencode-ai/sdk": "1.18.19",
+    "@opencode-ai/sdk": "1.18.23",
     "zustand": "^5.0.3"
   },
   "peerDependencies": {

--- a/packages/shared/src/runtime-versions.json
+++ b/packages/shared/src/runtime-versions.json
@@ -29,8 +29,8 @@
   "bun": "1.3.14",
   "bunSha256Amd64": "951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f",
   "bunSha256Arm64": "a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b",
-  "opencode": "1.18.19",
-  "opencodeSdk": "1.18.19",
+  "opencode": "1.18.23",
+  "opencodeSdk": "1.18.23",
   "agentBrowser": "0.27.0",
   "playwright": "1.60.0",
   "anydoc": "0.1.6"

--- a/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
+++ b/packages/shared/src/sandbox/__tests__/__snapshots__/layer-render.test.ts.snap
@@ -105,16 +105,16 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
     && chromium --version \\
     && env -u AGENT_BROWSER_EXECUTABLE_PATH agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
-RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
+RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.23" \\
     && command -v opencode \\
     && opencode --version \\
     && opencode_native="$(sed -n 's/^# cmd-shim-target=//p' "$(command -v opencode)" | tail -n 1)" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
-    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && test "$("$opencode_native" --version)" = "1.18.23" \\
     && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
     && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
-    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.23"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
@@ -139,7 +139,7 @@ RUN pnpm add -g "@firecrawl/anydoc@0.1.6" \\
 
 RUN mkdir -p /opt/kortix/opencode-config-deps \\
     && cd /opt/kortix/opencode-config-deps \\
-    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.19","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.23","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
     && bun install
 
 RUN cd /opt/kortix/opencode-config-deps \\
@@ -289,16 +289,16 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
     && chromium --version \\
     && env -u AGENT_BROWSER_EXECUTABLE_PATH agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
-RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
+RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.23" \\
     && command -v opencode \\
     && opencode --version \\
     && opencode_native="$(sed -n 's/^# cmd-shim-target=//p' "$(command -v opencode)" | tail -n 1)" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
-    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && test "$("$opencode_native" --version)" = "1.18.23" \\
     && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
     && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
-    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.23"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
@@ -323,7 +323,7 @@ RUN pnpm add -g "@firecrawl/anydoc@0.1.6" \\
 
 RUN mkdir -p /opt/kortix/opencode-config-deps \\
     && cd /opt/kortix/opencode-config-deps \\
-    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.19","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.23","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
     && bun install
 
 RUN cd /opt/kortix/opencode-config-deps \\
@@ -474,16 +474,16 @@ RUN pnpm add -g --allow-build=agent-browser "agent-browser@0.27.0" \\
     && chromium --version \\
     && env -u AGENT_BROWSER_EXECUTABLE_PATH agent-browser doctor 2>&1 | grep -qE 'pass.+chrome-linux64/chrome'
 
-RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.19" \\
+RUN pnpm add -g --allow-build=opencode-ai "opencode-ai@1.18.23" \\
     && command -v opencode \\
     && opencode --version \\
     && opencode_native="$(sed -n 's/^# cmd-shim-target=//p' "$(command -v opencode)" | tail -n 1)" \\
     && test -x "$opencode_native" \\
     && test "$(wc -c < "$opencode_native")" -gt 50000000 \\
-    && test "$("$opencode_native" --version)" = "1.18.19" \\
+    && test "$("$opencode_native" --version)" = "1.18.23" \\
     && ln -sfn "$opencode_native" /opt/kortix/opencode.current \\
     && sudo ln -sfn /opt/kortix/opencode.current /usr/local/bin/opencode-kortix \\
-    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.19"
+    && test "$(/usr/local/bin/opencode-kortix --version)" = "1.18.23"
 
 COPY --chown=kortix:kortix kortix-opencode-warmup /tmp/kortix-opencode-warmup
 RUN bash /tmp/kortix-opencode-warmup migration && rm -f /tmp/kortix-opencode-warmup
@@ -508,7 +508,7 @@ RUN pnpm add -g "@firecrawl/anydoc@0.1.6" \\
 
 RUN mkdir -p /opt/kortix/opencode-config-deps \\
     && cd /opt/kortix/opencode-config-deps \\
-    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.19","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
+    && printf '{"name":"kortix-opencode-config","private":true,"dependencies":{"@mendable/firecrawl-js":"^4.25.1","@opencode-ai/plugin":"1.18.23","@tavily/core":"^0.7.3","replicate":"^1.4.0"},"overrides":{"axios":"1.18.0","form-data":"4.0.6"}}' > package.json \\
     && bun install
 
 RUN cd /opt/kortix/opencode-config-deps \\

--- a/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/fast-dockerfile.test.ts
@@ -23,7 +23,7 @@ describe('buildFastSandboxDockerfile', () => {
     const dockerfile = buildFastSandboxDockerfile(DEFAULT_OPTIONS);
 
 expect(dockerfile).toContain('FROM ubuntu:24.04');
-    expect(dockerfile).toContain('opencode-ai@1.18.19');
+    expect(dockerfile).toContain('opencode-ai@1.18.23');
     expect(dockerfile).toContain(
       "opencode_native=\"$(sed -n 's/^# cmd-shim-target=//p' \"$(command -v opencode)\" | tail -n 1)\"",
     );

--- a/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
+++ b/packages/shared/src/sandbox/__tests__/meta-dockerfile.test.ts
@@ -16,7 +16,7 @@ describe('buildMetaSandboxDockerfile', () => {
     expect(dockerfile).toContain('https://get.pnpm.io/install.sh');
     expect(dockerfile).toContain('PNPM_VERSION=11.15.1');
     expect(dockerfile).toContain('pnpm runtime set node 22.23.1 --global');
-    expect(dockerfile).toContain('opencode-ai@1.18.19');
+    expect(dockerfile).toContain('opencode-ai@1.18.23');
     expect(dockerfile).toContain(
       "opencode_native=\"$(sed -n 's/^# cmd-shim-target=//p' \"$(command -v opencode)\" | tail -n 1)\"",
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1538,8 +1538,8 @@ importers:
         specifier: workspace:*
         version: link:../llm-catalog
       '@opencode-ai/sdk':
-        specifier: 1.18.19
-        version: 1.18.19
+        specifier: 1.18.23
+        version: 1.18.23
       zustand:
         specifier: ^5.0.3
         version: 5.0.14(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0)
@@ -5989,8 +5989,8 @@ packages:
       rimraf: 3.0.2
     dev: true
 
-  /@opencode-ai/sdk@1.18.19:
-    resolution: {integrity: sha512-AnszRg7cJ3PA6/06mkqdTJDKn9NJuV26AJMWbKEgRsznbJvrhf3PT8UhQQOhyKQYCygx9ZOxyKMIPVOQdMSS1A==}
+  /@opencode-ai/sdk@1.18.23:
+    resolution: {integrity: sha512-VouYbL8O2ynLq0atr5fjzCv8YLtFi/zKLQ/uYkCvTJ4CmUdA01XwPn8om+u3TvxnGEfQsBfmThGU141vt3sg5w==}
     dependencies:
       cross-spawn: 7.0.6
     dev: false


### PR DESCRIPTION
## Problem
Essentia (native mode, \`llm_gateway\` off) on \`amazon-bedrock/global.openai.gpt-5.6-sol\`: every reasoning stream fails with \`Type validation failed\` on \`contentBlockDelta.delta.reasoningContent.redactedContent\`.

Root cause, verified from primary sources:
- opencode **1.18.19** (our pin) bundles \`@ai-sdk/amazon-bedrock\` **4.0.112** — its dist has 0 occurrences of \`redactedContent\`.
- Upstream anomalyco/opencode#43686 → PR #43909 (merged 2026-08-21T21:39Z) bumps it to **4.0.158** (12 occurrences: stream schema + round-trip).
- Per-tag \`packages/opencode/package.json\`: v1.18.19 = 4.0.112, v1.18.21 = 4.0.112, **v1.18.22 = 4.0.158**, v1.18.23 = 4.0.158.
- \`sst/opencode\` 301-redirects to \`anomalyco/opencode\`: it is upstream, not a fork. Nothing to patch on our side beyond the pin.

## Change (lockstep pins)
- \`packages/shared/src/runtime-versions.json\`: \`opencode\`, \`opencodeSdk\` → 1.18.23 (the sandbox Dockerfile, the manifest, and the plugin pin all read this).
- \`packages/sdk/package.json\`: \`@opencode-ai/sdk\` → 1.18.23 (+ \`pnpm-lock.yaml\`).
- \`packages/shared/src/sandbox/__tests__\`: fast/meta literals + \`layer-render\` goldens.
- \`packages/sdk/PROGRESS.md\` entry.

## Upstream audit v1.18.19…v1.18.23 (84 commits, 234 files; 12 under \`packages/opencode/src\`)
- \`session/prompt.ts\` + \`core/session/runner/llm.ts\` (#43892, #43900): a clean \`finish: "unknown"\` is now an incomplete stream → bounded transparent retry / continuation instead of "answered". Our \`runaway-turn-guard\` is per \`session.idle\`; a continuation inside one turn does not trip it.
- \`provider/error.ts\`: unrecognized \`{type:"error"}\` bodies now parse as retryable \`api_error\`. Our gateway emits that shape only for its 503 "Gateway unavailable", already retryable by status. 4xx bodies do not carry \`type:"error"\` → unchanged.
- \`provider/transform.ts\`: \`textVerbosity:"low"\` now only for \`@ai-sdk/openai\` / bedrock mantle. The kortix provider is \`@ai-sdk/openai-compatible\` and the gateway never read \`verbosity\` (0 hits in \`apps/llm-gateway/src\`) → no behavior change.
- \`session/llm/request.ts\`: \`x-parent-session-id\` now also sent to the opencode provider. Irrelevant to us.
- \`server/.../global.ts\`: \`POST /global/upgrade\` now requires a semver \`target\`. We never call it (0 hits).
- \`session/retry.ts\`: more retryable message patterns; \`tool/task.ts\`: subagent failures fail the task tool; new Cerebras plugin; Vertex endpoint + CF AI Gateway routing fixes.
- \`@opencode-ai/sdk\` types: one line each in \`v2/gen/{types,sdk}.gen.ts\`; our type-surface snapshot byte-identical.

## Propagation to existing sandboxes
No rebuild needed. \`GET /v1/runtime-assets/manifest\` states \`opencode.version\` from this pin; the daemon's \`reconcileRuntimeAssets\` (cold boot, \`POST /kortix/refresh\`, warm-fork adopt) compares the running version, and when the box is idle installs 1.18.23 from npm, refreshes the \`@opencode-ai/plugin\` pin, and restarts opencode. New snapshots bake 1.18.23 (identity includes \`OPENCODE_VERSION\`).

## Verification
- \`packages/sdk\`: \`pnpm typecheck\` clean; \`pnpm test\` 172 files 0 fail; \`public-type-surface.test.ts\` pass.
- \`packages/shared\`: \`bun test src/sandbox\` 72 pass (goldens regenerated).
- \`apps/api\`: \`config-deps-version.test.ts\` 2 pass.
- After merge: Deploy Dev → a fresh dev session reports \`opencode --version\` = 1.18.23; an OLD dev box converges via manifest; Essentia box updated with \`--version dev\` and the Bedrock model re-run.

https://claude.ai/code/session_01XxEuty9EakLNG9VzkoQHaL