### PR TITLE
fix(catalog,sdk): pass models.dev status through; pre-boot native picker hides deprecated models like the runtime

### DIFF
--- a/apps/api/src/llm-gateway/models/runtime-catalog.test.ts
+++ b/apps/api/src/llm-gateway/models/runtime-catalog.test.ts
@@ -134,6 +134,32 @@ describe('runtime model catalog', () => {
   // the live path's raw passthrough matches EXACTLY what the enrich script
   // would normalize the same input to for a budget_tokens entry — i.e. the
   // object survives verbatim on both paths, not just on live.
+  // models.dev marks retired entries `status: "deprecated"`; opencode hides
+  // those in the sandbox. The pre-runtime picker source reads this route, so
+  // the field must survive or the two pickers disagree (dev 2026-08-25: 29
+  // vs 7 free Zen models).
+  test('`status` passes through from models.dev', async () => {
+    const catalog = createRuntimeModelCatalog({
+      seed,
+      sourceUrl: 'https://catalog.test/api.json',
+      fetchImpl: async () => new Response(JSON.stringify({
+        opencode: {
+          id: 'opencode',
+          name: 'OpenCode Zen',
+          env: ['OPENCODE_API_KEY'],
+          models: {
+            'glm-5-free': { id: 'glm-5-free', name: 'GLM 5 Free', status: 'deprecated' },
+            'hy3-free': { id: 'hy3-free', name: 'Hy3 Free' },
+          },
+        },
+      }), { status: 200 }),
+    });
+    expect(await catalog.refresh()).toBe(true);
+    const models = catalog.snapshot().providers[0]?.models ?? [];
+    expect(models.find((m) => m.id === 'glm-5-free')?.status).toBe('deprecated');
+    expect(models.find((m) => m.id === 'hy3-free')?.status).toBeUndefined();
+  });
+
   test('a budget_tokens reasoning_options entry survives the live path in the SAME shape the baked enrich script normalizes it to', async () => {
     const rawBudgetTokensOption = { type: 'budget_tokens', min: 1024 };
     const catalog = createRuntimeModelCatalog({

--- a/apps/api/src/llm-gateway/models/runtime-catalog.ts
+++ b/apps/api/src/llm-gateway/models/runtime-catalog.ts
@@ -37,6 +37,7 @@ const PASSTHROUGH_MODEL_FIELDS = [
   'family',
   'modalities',
   'cost',
+  'status',
 ] as const;
 
 interface ModelsDevProvider {

--- a/apps/web/scripts/enrich-llm-catalog-capabilities.ts
+++ b/apps/web/scripts/enrich-llm-catalog-capabilities.ts
@@ -92,6 +92,7 @@ interface ModelsDevModel {
   knowledge?: string;
   last_updated?: string;
   family?: string;
+  status?: string;
   modalities?: { input?: string[]; output?: string[] };
   limit?: { context?: number; input?: number; output?: number };
   cost?: ModelsDevCost;
@@ -201,6 +202,7 @@ function normalizeModel(modelKey: string, model: ModelsDevModel) {
     ...(typeof model.knowledge === 'string' ? { knowledge: model.knowledge } : {}),
     ...(typeof model.last_updated === 'string' ? { last_updated: model.last_updated } : {}),
     ...(typeof model.family === 'string' ? { family: model.family } : {}),
+    ...(typeof model.status === 'string' ? { status: model.status } : {}),
     ...(modalities ? { modalities } : {}),
     ...(limit ? { limit } : {}),
     ...(cost ? { cost } : {}),

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -223,6 +223,11 @@ export interface CatalogModel {
   id: string;
   name: string;
   released?: string | null;
+  // models.dev lifecycle marker, mirrored verbatim ("active" | "deprecated"
+  // | ... — models.dev adds values; absent means active). opencode hides
+  // `deprecated` entries in the sandbox; every Kortix picker source that
+  // stands in for the runtime must apply the same rule.
+  status?: string;
   // Capabilities mirrored from models.dev by
   // apps/web/scripts/enrich-llm-catalog-capabilities.ts.
   // Single source of truth — consumers derive flags from these, never hardcode.

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,25 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-25 — session `native-catalog-status` — pre-boot picker hides deprecated models like the runtime — DONE
+
+**Files:** `react/provider-selection.ts` (`nativeProviderListFromCatalog` drops
+`status === 'deprecated'` for every provider) + test. Cross-package:
+`packages/llm-catalog` `CatalogModel.status?`, `apps/api`
+`runtime-catalog.ts` passthrough + test, `apps/web/scripts/enrich-llm-catalog-capabilities.ts`
+(baked path keeps the same field set). **Public surface: `CatalogModel` gains
+an optional field** (additive; type-surface snapshot unchanged).
+
+**What.** Dev verification of the merged picker (#6872) on a native project:
+pre-boot listed 16 OpenCode Zen free models, the running box served 7. The
+box's own `~/.cache/opencode/models.json` had all 29 — opencode hides the 22
+marked `status: "deprecated"` (core plugin: `enabled = status !== "deprecated"`).
+Our `/llm-catalog/providers` route whitelists model fields and dropped
+`status`, so the pre-boot source could not apply the rule. Now it can, for
+every provider, not only Zen.
+
+**Gates:** `pnpm typecheck` clean · `pnpm test` (see run) · type-surface pass.
+
 ### 2026-08-25 — session `native-picker-unify` — ONE native picker across sandbox states + no dead effort chip — DONE
 
 **Files:** `react/provider-selection.ts` (NEW pure `mergeNativeProviderLists`;

--- a/packages/sdk/src/react/provider-selection.test.ts
+++ b/packages/sdk/src/react/provider-selection.test.ts
@@ -259,6 +259,44 @@ describe('nativeProviderListFromCatalog (pre-runtime native picker source)', () 
     });
   });
 
+  // opencode drops every catalog model whose models.dev `status` is
+  // "deprecated" (core/src/plugin/provider/opencode.ts: `enabled = status !==
+  // "deprecated"`). Seen live on dev 2026-08-25: 29 free Zen models in the
+  // box's models.json, 7 served by the runtime — the other 22 were deprecated.
+  // The pre-boot source must apply the same rule for EVERY provider.
+  test('deprecated models are omitted, like the runtime does', () => {
+    const withDeprecated = {
+      ...catalog,
+      providers: [
+        {
+          id: 'anthropic',
+          name: 'Anthropic',
+          env: ['ANTHROPIC_API_KEY'],
+          models: [
+            { id: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', released: '2026-02-01', status: 'active' },
+            { id: 'claude-3-opus', name: 'Claude 3 Opus', released: '2024-02-29', status: 'deprecated' },
+            { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5', released: '2025-10-01' },
+          ],
+        },
+        {
+          id: 'opencode',
+          name: 'OpenCode Zen',
+          env: ['OPENCODE_API_KEY'],
+          models: [
+            { id: 'hy3-free', name: 'Hy3 Free', released: '2026-07-06', cost: { input: 0, output: 0 } },
+            { id: 'glm-5-free', name: 'GLM 5 Free', released: '2026-02-11', cost: { input: 0, output: 0 }, status: 'deprecated' },
+          ],
+        },
+      ],
+    };
+    const list = nativeProviderListFromCatalog(withDeprecated as never, new Set(['ANTHROPIC_API_KEY']));
+    const ids = (list.all ?? []).map((p) => [p.id, Object.keys((p as { models: Record<string, unknown> }).models)]);
+    expect(ids).toEqual([
+      ['anthropic', ['claude-sonnet-4-6', 'claude-haiku-4-5']],
+      ['opencode', ['hy3-free']],
+    ]);
+  });
+
   test('never synthesizes the synthetic kortix provider', () => {
     const withKortix = {
       ...catalog,

--- a/packages/sdk/src/react/provider-selection.ts
+++ b/packages/sdk/src/react/provider-selection.ts
@@ -224,6 +224,7 @@ interface NativeCatalogModel {
   id: string;
   name: string;
   released?: string | null;
+  status?: string;
   description?: string;
   family?: string;
   reasoning?: boolean;
@@ -301,11 +302,16 @@ export function nativeProviderListFromCatalog(
   const connectedIds = connectedGatewayProviderIdsFromSecretNames(secretNames);
   const defaults: Record<string, string> = {};
   const all = (catalog.providers ?? [])
-    .map((provider) =>
-      provider.id === ZEN_PROVIDER_ID && !connectedIds.has(ZEN_PROVIDER_ID)
-        ? { ...provider, models: (provider.models ?? []).filter(isFreeModel), keyless: true }
-        : { ...provider, keyless: false },
-    )
+    .map((provider) => {
+      // opencode hides every model models.dev marks `status: "deprecated"`
+      // (core/src/plugin/provider/opencode.ts: `enabled = status !==
+      // "deprecated"`), so the runtime never lists them. Dev 2026-08-25:
+      // 29 free Zen models in the box's models.json, 7 served.
+      const live = (provider.models ?? []).filter((model) => model.status !== 'deprecated');
+      return provider.id === ZEN_PROVIDER_ID && !connectedIds.has(ZEN_PROVIDER_ID)
+        ? { ...provider, models: live.filter(isFreeModel), keyless: true }
+        : { ...provider, models: live, keyless: false };
+    })
     .filter(
       (provider) =>
         (provider.keyless || connectedIds.has(provider.id)) &&


### PR DESCRIPTION
## Problem
Dev verification of #6872 on a native project (\`d563af5d\`): the pre-boot picker listed **16** OpenCode Zen free models, the running sandbox served **7**. Read from the box itself: \`~/.cache/opencode/models.json\` carries all 29 free Zen models; opencode's \`/config/providers\` lists 7. The 22 missing ones all have models.dev \`status: "deprecated"\` — opencode hides them (\`packages/core/src/plugin/provider/opencode.ts\`: \`model.enabled = config.status !== "deprecated"\`).

Our \`GET /v1/projects/:id/llm-catalog/providers\` whitelists model fields (\`PASSTHROUGH_MODEL_FIELDS\`) and dropped \`status\`, so the pre-boot source could not apply the rule.

## Change
- \`packages/llm-catalog/src/index.ts\`: \`CatalogModel.status?: string\` (additive).
- \`apps/api/src/llm-gateway/models/runtime-catalog.ts\`: \`status\` joins the passthrough set (+ test).
- \`apps/web/scripts/enrich-llm-catalog-capabilities.ts\`: baked path keeps the identical field set (the two paths must never diverge in shape).
- \`packages/sdk/src/react/provider-selection.ts\`: \`nativeProviderListFromCatalog\` drops \`status === 'deprecated'\` for every provider, keyed and keyless alike (+ test).

## Verification
- \`packages/sdk\`: \`pnpm typecheck\` clean; \`pnpm test\` 172 files 0 fail; \`public-type-surface.test.ts\` pass; \`pnpm smoke:install\` pass.
- \`apps/api\`: \`runtime-catalog.test.ts\` 5 pass (new: \`status\` passthrough). \`tsc --noEmit\` clean.
- \`packages/llm-catalog\`: 72 pass.
- After merge on dev: pre-boot Zen group on the native project must list the same 7 models the runtime serves.

https://claude.ai/code/session_01XxEuty9EakLNG9VzkoQHaL