### PR TITLE
fix(connectors): serve catalogue sections the provider can filter

### DIFF
--- a/apps/api/src/connectors/composio.test.ts
+++ b/apps/api/src/connectors/composio.test.ts
@@ -501,8 +501,19 @@ test('composioCatalogPage uses a discovery-only identity and session.toolkits pa
     runtime: fakeRuntime({ created, calls }),
   });
 
+  // Enriched even with no metadata available: the fields are part of the page's
+  // contract now, so the client's category bucketing reads `[]` rather than
+  // `undefined` and cannot fork on which branch answered.
   expect(result).toEqual({
-    items: [{ slug: 'composio_search', name: 'Composio Search', isNoAuth: true }],
+    items: [
+      {
+        slug: 'composio_search',
+        name: 'Composio Search',
+        isNoAuth: true,
+        description: null,
+        categories: [],
+      },
+    ],
     cursor: 'next-page',
     totalPages: 2,
   });
@@ -661,4 +672,60 @@ test('gateway executes Composio with selected-row metadata and never exposes a s
     },
   });
   expect(JSON.stringify(executions)).not.toContain('COMPOSIO_API_KEY');
+});
+
+test('composioCatalogPage enriches the paged catalogue with the metadata that page omits', async () => {
+  // `session.toolkits()` returns no description and no categories, so every card
+  // fell into the client's synthetic "Other" bucket and opening it asked for
+  // `category=Other` — a category no provider has. The page then reported the
+  // catalogue as unavailable while showing it.
+  const calls: Array<Record<string, unknown>> = [];
+  const created = session({ toolkit: { slug: 'gmail', name: 'Gmail', isNoAuth: false } });
+  created.toolkits = async (options) => {
+    calls.push({ type: 'toolkits', options });
+    return {
+      items: [
+        { slug: 'gmail', name: 'Gmail', isNoAuth: false },
+        { slug: 'beyond_the_metadata_cap', name: 'Uncatalogued', isNoAuth: true },
+      ],
+      cursor: null,
+      totalPages: 1,
+    };
+  };
+
+  const result = await composioCatalogPage({
+    projectId: 'project-1',
+    runtime: fakeRuntime({
+      created,
+      calls,
+      catalogPage: [
+        {
+          slug: 'gmail',
+          name: 'Gmail',
+          noAuth: false,
+          meta: {
+            description: 'Google email',
+            categories: [
+              { slug: 'email', name: 'email' },
+              { slug: 'productivity', name: 'productivity' },
+            ],
+          },
+        },
+      ],
+    }),
+  });
+
+  const items = (result as { items: Array<Record<string, unknown>> }).items;
+  expect(items[0]).toMatchObject({
+    slug: 'gmail',
+    description: 'Google email',
+    categories: ['email', 'productivity'],
+  });
+  // Past the provider's 1000-toolkit metadata cap there is nothing to enrich
+  // with. The card still ships, uncategorized, rather than being dropped.
+  expect(items[1]).toMatchObject({
+    slug: 'beyond_the_metadata_cap',
+    description: null,
+    categories: [],
+  });
 });

--- a/apps/api/src/connectors/composio.test.ts
+++ b/apps/api/src/connectors/composio.test.ts
@@ -688,7 +688,6 @@ test('composioCatalogPage enriches the paged catalogue with the metadata that pa
         { slug: 'gmail', name: 'Gmail', isNoAuth: false },
         { slug: 'beyond_the_metadata_cap', name: 'Uncatalogued', isNoAuth: true },
       ],
-      cursor: null,
       totalPages: 1,
     };
   };
@@ -715,7 +714,8 @@ test('composioCatalogPage enriches the paged catalogue with the metadata that pa
     }),
   });
 
-  const items = (result as { items: Array<Record<string, unknown>> }).items;
+  if (!('items' in result)) throw new Error('expected the paged browse shape');
+  const items = result.items;
   expect(items[0]).toMatchObject({
     slug: 'gmail',
     description: 'Google email',

--- a/apps/api/src/connectors/composio.ts
+++ b/apps/api/src/connectors/composio.ts
@@ -163,6 +163,65 @@ function activeConnectedAccountId(
   return state.connection?.isActive === true ? state.connection.connectedAccount?.id : undefined;
 }
 
+/**
+ * Description + categories for every toolkit, keyed by slug.
+ *
+ * The paged browse endpoint (`session.toolkits()`) returns only
+ * `{slug, name, logo, isNoAuth, connection}` — no description and no
+ * categories. The catalogue page grouped those items into sections by category,
+ * so every toolkit fell into the client's synthetic "Other" bucket, and opening
+ * it asked this route for `category=Other`, which is not a Composio category and
+ * answered zero. The page then said "Catalogue unavailable" over a catalogue
+ * that had just rendered.
+ *
+ * `toolkits.get()` carries both fields, so the page is enriched from it rather
+ * than served by it: that endpoint caps at 1000 toolkits while the catalogue is
+ * ~1400, and it publishes no cursor, so it cannot page.
+ *
+ * Cached per runtime because it is one 800ms request for data that changes when
+ * Composio adds an app, not per user. A failure resolves to an empty map and
+ * leaves the page unenriched — a card with no description beats no card.
+ */
+const TOOLKIT_META_TTL_MS = 6 * 60 * 60_000;
+
+interface ToolkitMeta {
+  description: string | null;
+  categories: string[];
+}
+
+const toolkitMetaCache = new WeakMap<
+  ComposioRuntime,
+  { at: number; bySlug: Promise<Map<string, ToolkitMeta>> }
+>();
+
+async function toolkitMetaBySlug(runtime: ComposioRuntime): Promise<Map<string, ToolkitMeta>> {
+  const cached = toolkitMetaCache.get(runtime);
+  if (cached && Date.now() - cached.at < TOOLKIT_META_TTL_MS) return cached.bySlug;
+  if (!runtime.toolkits) return new Map();
+
+  const bySlug = (async () => {
+    const page = await runtime.toolkits!.get({ limit: 1000 });
+    const map = new Map<string, ToolkitMeta>();
+    for (const toolkit of page) {
+      map.set(toolkit.slug.toLowerCase(), {
+        description: toolkit.meta?.description ?? null,
+        categories: (toolkit.meta?.categories ?? []).map((category) => category.slug),
+      });
+    }
+    return map;
+  })();
+  toolkitMetaCache.set(runtime, { at: Date.now(), bySlug });
+  try {
+    return await bySlug;
+  } catch (err) {
+    // Drop the poisoned entry so the next request retries instead of serving the
+    // rejection for the whole TTL.
+    toolkitMetaCache.delete(runtime);
+    console.warn('[composio] toolkit metadata unavailable, serving catalogue unenriched:', err);
+    return new Map();
+  }
+}
+
 export async function composioCatalogPage(input: {
   projectId: string;
   q?: string;
@@ -224,11 +283,28 @@ export async function composioCatalogPage(input: {
     manageConnections: false,
     sandbox: { enable: false },
   });
-  return session.toolkits({
-    ...(input.q?.trim() ? { search: input.q.trim() } : {}),
-    ...(input.cursor ? { cursor: input.cursor } : {}),
-    ...(input.limit != null ? { limit: input.limit } : {}),
-  });
+  const [page, meta] = await Promise.all([
+    session.toolkits({
+      ...(input.q?.trim() ? { search: input.q.trim() } : {}),
+      ...(input.cursor ? { cursor: input.cursor } : {}),
+      ...(input.limit != null ? { limit: input.limit } : {}),
+    }),
+    toolkitMetaBySlug(runtime),
+  ]);
+  // Enriched in place so the paged shape (`items` + `cursor`) is unchanged and
+  // the SDK's existing normalization still applies. A toolkit past the 1000-item
+  // metadata cap keeps the empty values it already had.
+  return {
+    ...page,
+    items: page.items.map((item) => {
+      const enrichment = meta.get(item.slug.toLowerCase());
+      return {
+        ...item,
+        description: enrichment?.description ?? null,
+        categories: enrichment?.categories ?? [],
+      };
+    }),
+  };
 }
 
 /** Fetch public tool schemas without creating a connection-scoped auth identity. */

--- a/apps/api/src/connectors/composio.ts
+++ b/apps/api/src/connectors/composio.ts
@@ -182,12 +182,21 @@ function activeConnectedAccountId(
  * Composio adds an app, not per user. A failure resolves to an empty map and
  * leaves the page unenriched — a card with no description beats no card.
  */
-const TOOLKIT_META_TTL_MS = 6 * 60 * 60_000;
-
 interface ToolkitMeta {
   description: string | null;
   categories: string[];
 }
+
+/**
+ * The paged browse response, plus the two fields the provider's paged endpoint
+ * omits. Declared rather than inferred so a caller that groups by `categories`
+ * cannot compile against a page that never carries them.
+ */
+export type EnrichedToolkitConnectionsPage = Omit<ToolkitConnectionsDetails, 'items'> & {
+  items: Array<ToolkitConnectionsDetails['items'][number] & ToolkitMeta>;
+};
+
+const TOOLKIT_META_TTL_MS = 6 * 60 * 60_000;
 
 const toolkitMetaCache = new WeakMap<
   ComposioRuntime,
@@ -230,7 +239,7 @@ export async function composioCatalogPage(input: {
   limit?: number;
   runtime?: ComposioRuntime;
 }): Promise<
-  | ToolkitConnectionsDetails
+  | EnrichedToolkitConnectionsPage
   | {
       provider: 'composio';
       toolkits: Array<{

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
@@ -171,7 +171,13 @@ export { POPULAR_SECTION };
  */
 export function catalogSections(
   entries: readonly CatalogEntry[],
-  opts: { popularCap: number },
+  opts: {
+    popularCap: number;
+    /** Key sections by the catalogue's own category slug rather than the curated
+     *  bucket. Set for any source whose sections are opened by asking the server
+     *  for that key — see `sectionKeysForEntry`. */
+    rawCategoryKeys?: boolean;
+  },
 ): Array<{ category: string; items: CatalogEntry[] }> {
   const ranked = entries
     .filter((entry) => entry.popularity !== null)
@@ -185,7 +191,9 @@ export function catalogSections(
   //
   // Popular is deliberately left alone. It is already ordered, by `popularity`,
   // and re-sorting it by picks would replace a real ranking with a guess.
-  const sections = groupIntoSections(entries, (entry) => entry.categories).map((section) => ({
+  const sections = groupIntoSections(entries, (entry) => entry.categories, {
+    raw: opts.rawCategoryKeys,
+  }).map((section) => ({
     category: section.category,
     items: sortByPicks(section.category, section.items),
   }));

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-browse.tsx
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-browse.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/lib/utils';
 import { isCatalogEntryConnected, type CatalogEntry } from './catalog-entry';
 import { catalogFootSummary } from './catalog-foot';
 import { CategoryIcon } from './category-icon';
-import { ALL_CATEGORIES } from './connector-categories';
+import { ALL_CATEGORIES, OTHER } from './connector-categories';
 import type { CatalogSection, CatalogState } from './use-catalog';
 import { useCatalogAutoload } from './use-catalog-autoload';
 
@@ -167,7 +167,11 @@ function CategorySection({
             {section.total.toLocaleString()}
           </span>
         </h2>
-        {section.total > section.items.length ? (
+        {/* `Other` is synthesised for entries the catalogue gave no category, so
+            no provider can serve it as a filter — opening it fetched zero and
+            painted "Catalogue unavailable" over a populated page. It stays a
+            readable section, without the control that would empty the grid. */}
+        {section.key !== OTHER && section.total > section.items.length ? (
           <Button
             variant="ghost"
             size="sm"

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-categories.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/connector-categories.ts
@@ -7,7 +7,7 @@
  */
 export const CATEGORY_ROW_CAP = 6;
 
-const OTHER = 'Other';
+export const OTHER = 'Other';
 
 /**
  * The synthetic first section. Not a catalogue category — see `catalogSections`
@@ -322,11 +322,19 @@ export function sectionTitle(key: string): string {
  * Productivity, and an app claiming both would otherwise render twice in that
  * grid under two identical React keys.
  */
-export function sectionKeysForEntry(categories: readonly string[]): Set<string> {
+export function sectionKeysForEntry(
+  categories: readonly string[],
+  opts: { raw?: boolean } = {},
+): Set<string> {
   const named: string[] = [];
   for (const category of categories) {
     const trimmed = category.trim();
-    if (trimmed.length > 0) named.push(sectionKeyForCategory(trimmed));
+    // `raw` keeps the catalogue's own slug as the section key instead of folding
+    // it into a curated bucket. Required wherever a section heading doubles as a
+    // server-side filter value: the curated keys are ours, and asking the
+    // provider for `sales-marketing` (which claims `crm` + `marketing`) returns
+    // zero, which the grid renders as "Catalogue unavailable".
+    if (trimmed.length > 0) named.push(opts.raw ? trimmed : sectionKeyForCategory(trimmed));
   }
   return named.length > 0 ? new Set(named) : new Set([OTHER]);
 }
@@ -367,10 +375,11 @@ export function countInSection<T>(
 export function groupIntoSections<T>(
   items: readonly T[],
   getCategories: (item: T) => readonly string[],
+  opts: { raw?: boolean } = {},
 ): Array<{ category: string; items: T[] }> {
   const buckets = new Map<string, T[]>();
   for (const item of items) {
-    for (const key of sectionKeysForEntry(getCategories(item))) {
+    for (const key of sectionKeysForEntry(getCategories(item), opts)) {
       const bucket = buckets.get(key);
       if (bucket) bucket.push(item);
       else buckets.set(key, [item]);

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/section-keys-servable.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/section-keys-servable.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The catalogue page opened a section by asking the server for that section's
+ * key. The keys were ours (curated buckets), the filter was the provider's
+ * (its own category slugs), and where the two disagreed the request answered
+ * zero — which the grid rendered as "Catalogue unavailable" over a catalogue
+ * that had just painted.
+ *
+ * Measured against the live Composio catalogue on dev:
+ *   category=email            -> 51     category=communication -> 30
+ *   category=crm              -> 80     category=sales-marketing -> 0
+ *   category=Other            -> 0
+ * So `crm` folded into `sales-marketing` emptied the grid outright, and `email`
+ * folded into `communication` quietly showed a different set than its heading
+ * counted.
+ */
+import { expect, test } from 'bun:test';
+import { OTHER, groupIntoSections, sectionKeysForEntry } from './connector-categories';
+
+const entry = (categories: string[]) => ({ categories });
+
+test('curated bucketing still folds provider categories together', () => {
+  expect([...sectionKeysForEntry(['crm'])]).toEqual(['sales-marketing']);
+  expect([...sectionKeysForEntry(['email'])]).toEqual(['communication']);
+});
+
+test('raw mode keeps the provider slug, which is the only key it can serve', () => {
+  expect([...sectionKeysForEntry(['crm'], { raw: true })]).toEqual(['crm']);
+  expect([...sectionKeysForEntry(['email'], { raw: true })]).toEqual(['email']);
+  expect([...sectionKeysForEntry(['scheduling-&-booking'], { raw: true })]).toEqual([
+    'scheduling-&-booking',
+  ]);
+});
+
+test('an uncategorized entry still lands in the synthetic section, raw or not', () => {
+  expect([...sectionKeysForEntry([], { raw: true })]).toEqual([OTHER]);
+  expect([...sectionKeysForEntry(['   '], { raw: true })]).toEqual([OTHER]);
+});
+
+test('raw grouping produces one section per provider category, not per curated bucket', () => {
+  const sections = groupIntoSections(
+    [entry(['crm']), entry(['marketing']), entry(['email'])],
+    (item) => item.categories,
+    { raw: true },
+  );
+  expect(sections.map((section) => section.category).sort()).toEqual(['crm', 'email', 'marketing']);
+});
+
+test('the same input collapses to two curated buckets without raw', () => {
+  const sections = groupIntoSections(
+    [entry(['crm']), entry(['marketing']), entry(['email'])],
+    (item) => item.categories,
+  );
+  expect(sections.map((section) => section.category).sort()).toEqual([
+    'communication',
+    'sales-marketing',
+  ]);
+});

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/use-catalog.ts
@@ -373,7 +373,15 @@ export function useCatalog(
         items: section.apps.map(catalogEntryFromEasyConnect),
       }));
     }
-    return catalogSections(entries, { popularCap: SECTION_CARD_COUNT }).map((section) => ({
+    // Composio serves each section's "View all" from its own catalogue, filtered
+    // by this key. Curated keys are ours and it does not have them — asking for
+    // `sales-marketing` answers zero, which the grid renders as an empty
+    // catalogue. Keying by the provider's slug keeps the heading and the grid
+    // behind it describing the same set.
+    return catalogSections(entries, {
+      popularCap: SECTION_CARD_COUNT,
+      rawCategoryKeys: easyConnectProvider === 'composio',
+    }).map((section) => ({
       key: section.category,
       label: sectionTitle(section.category),
       total: section.items.length,


### PR DESCRIPTION
## The bug

`https://dev.kortix.com/projects/<id>/connectors` renders the catalogue, then replaces it with **"Catalogue unavailable — The connector catalogue returned nothing"** a moment later.

## Root cause

Two defects compound.

**1. The browse endpoint omits the metadata the grid groups by.** `session.toolkits()` returns only `{slug, name, logo, isNoAuth, connection}` — measured on dev:

```
GET .../connect/toolkits?limit=48
  items: 48    with categories: 0    with description: 0
```

So all 48 cards reach the grid with `categories: []`, `sectionKeysForEntry` puts every one in the synthetic `Other` bucket, and the page renders a single section named "Other" holding the whole catalogue. Its "View all" asks the route for `category=Other`, which is not a Composio category:

```
category=Other  -> {"toolkits": [], "total": 0}     ← the empty state
category=productivity -> 59      category=developer-tools -> 375
```

The split-second flash is `placeholderData: keepPreviousData` holding the previous cards while that empty request is in flight.

**2. Section keys were ours, the filter behind them was the provider's.** `sectionKeyForCategory` folds provider slugs into curated buckets, and the server filters by the provider's slug. Measured on dev:

| section built from | folded key sent | provider result |
|---|---|---|
| `crm` (80) + `marketing` (32) | `sales-marketing` | **0** |
| `email` (51) | `communication` | 30 |

So the mismatch either emptied the grid outright or quietly showed a different set than the heading counted.

## The fix

- **API** — enrich each browse page with `description` + `categories` from `toolkits.get()`, cached per runtime for 6h. That endpoint carries both fields but caps at 1000 toolkits against a ~1400-toolkit catalogue (`totalPages: 29 × 48`) and publishes no cursor, so it enriches the page rather than serving it. A toolkit past the cap keeps the empty values it already had.
- **Web** — key Composio sections by the provider's own slug (`sectionKeysForEntry` gains `raw`), so a heading and the grid behind it always describe the same set.
- **Web** — drop "View all" from `Other`; it is synthesised for uncategorized entries and no provider can serve it as a filter.

## Verification

Against live Composio with the dev key, through the patched `composioCatalogPage`:

```
items: 48
with categories: 48        (was 0)
with description: 48       (was 0)
sample: {"slug":"gmail","categories":["email"],"description":"Gmail is Google's email service…"}

distinct section keys the grid will offer: 34
PASS: every offered section key returns results
```

Tests: `apps/api` composio suite 17 pass / 0 fail (1 updated for the new page contract, 1 added for enrichment + the past-the-cap case); `apps/web` connectors suite 275 pass / 0 fail, plus 5 new tests in `section-keys-servable.test.ts` pinning the curated-vs-raw distinction. `tsc --noEmit` clean on both, eslint clean on the changed files.

Still to do after merge: confirm on dev that the section opens with results instead of the empty state.