### PR TITLE
docs(learnings): sandbox model failure = check the OpenCode pin before the code

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2392,3 +2392,38 @@ above passed every unit test in the suite. Assert the process afterwards:
 leak); the 60x27 MiB overload that killed the container now peaks at 827 MiB
 and stays healthy. Enforcement: `read-bounded-body.test.ts` abort cases,
 `memory-envelope.test.ts` backpressure case.
+
+## A sandbox model failure is a version question before it is a code question
+
+Found 2026-08-25 on the Essentia box. Native-mode sessions on
+`amazon-bedrock/global.openai.gpt-5.6-sol` failed every reasoning stream:
+`Type validation failed` on `contentBlockDelta.delta.reasoningContent.redactedContent`.
+The first diagnosis blamed an "old SDK in the opencode fork" and planned a
+fork patch. `github.com/sst/opencode` redirects to `anomalyco/opencode`; it is
+upstream. Upstream had already fixed the crash (anomalyco/opencode#43686 →
+#43909, `@ai-sdk/amazon-bedrock` 4.0.112 → 4.0.158, first release v1.18.22).
+Our pin in `packages/shared/src/runtime-versions.json` was 1.18.19.
+
+**Rules.**
+1. For any failure inside the sandbox runtime, read the pinned OpenCode
+   version first, then the dependency pins of that exact tag
+   (`raw.githubusercontent.com/anomalyco/opencode/v<tag>/packages/opencode/package.json`)
+   and the upstream issue tracker. Diagnose code only after the pin is current.
+2. Bump OpenCode through the lockstep sites only: `runtime-versions.json`
+   (`opencode` + `opencodeSdk`), `packages/sdk/package.json`
+   (`@opencode-ai/sdk`), and the shared Dockerfile goldens. The Dockerfile,
+   the runtime-assets manifest, and the plugin pin read the JSON.
+3. Audit the upstream diff between the two tags for `packages/opencode/src`
+   before merging; record behavior changes that touch the daemon (turn
+   termination, retry classification, provider transforms).
+4. Do not rebuild sandboxes to propagate. The manifest states the version;
+   the daemon converges idle-only and restarts opencode. Verify on one old box:
+   `GET <sandbox_url>/global/health` reports the new version and
+   `/opt/kortix/runtime-assets-state.json` records it.
+
+*Automation:* `apps/api/src/snapshots/__tests__/config-deps-version.test.ts`
+guards the lockstep pins; the shared sandbox goldens fail on a pin drift.
+
+*Incident:* no outage. Essentia's Bedrock model was unusable in native mode
+until PR #6873 (1.18.23) deployed and the box updated with
+`kortix self-host update --version dev`.


### PR DESCRIPTION
Register entry for the 2026-08-25 Essentia Bedrock `redactedContent` incident (fixed by the 1.18.23 bump, #6873). Rules: check the pinned tag's dependency pins first; lockstep pin sites; audit the upstream diff; propagate through the manifest, not rebuilds.

https://claude.ai/code/session_01XxEuty9EakLNG9VzkoQHaL