### PR TITLE
fix(web,api): approval card fills its parent, and Approve is never a dead button

### DIFF
--- a/apps/api/src/__tests__/integration-approvals.test.ts
+++ b/apps/api/src/__tests__/integration-approvals.test.ts
@@ -240,7 +240,10 @@ afterAll(async () => {
   if (ctx) await setDemoEnterprise(ctx.accountId, priorDemoEnterprise);
 }, 30_000);
 
-async function seedPending(argsPreviewComplete = true): Promise<string> {
+async function seedPending(
+  argsPreviewComplete = true,
+  argsPreview: Record<string, unknown> | null = { repo: 'kortix-ai/suna' },
+): Promise<string> {
   if (!ctx) throw new Error('approval integration test has no project context');
   const [row] = await db
     .insert(connectorCalls)
@@ -254,7 +257,7 @@ async function seedPending(argsPreviewComplete = true): Promise<string> {
       risk: null,
       resolvedAt: null, // genuinely awaiting a decision
       resultSummary: {
-        args_preview: { repo: 'kortix-ai/suna' },
+        ...(argsPreview ? { args_preview: argsPreview } : {}),
         args_preview_complete: argsPreviewComplete,
       },
     })
@@ -560,14 +563,29 @@ describe('approvals inbox + resolution', () => {
     expect(automatedItem?.detail).toMatchObject({ args_preview_authorized: false });
   });
 
-  test('an incomplete parameter preview blocks approve but still permits deny', async () => {
+  test('a TRUNCATED parameter preview is approvable — the elision is visible', async () => {
     if (!ctx) return;
-    const execId = await seedPending(false);
+    // What the builder writes for a call carrying an attachment: the fields are
+    // legible, one value is described rather than copied, `complete` is false.
+    // This used to 409, leaving Deny as the only possible answer.
+    const execId = await seedPending(false, {
+      repo: 'kortix-ai/suna',
+      attachment: '[400 chars omitted]',
+    });
+    const approve = await authPost(`/v1/projects/${ctx.projectId}/approvals/${execId}`, {
+      decision: 'approve',
+    });
+    expect(approve.status).toBe(200);
+  });
+
+  test('a call with NO recorded parameters blocks approve but still permits deny', async () => {
+    if (!ctx) return;
+    const execId = await seedPending(false, null);
     const approve = await authPost(`/v1/projects/${ctx.projectId}/approvals/${execId}`, {
       decision: 'approve',
     });
     expect(approve.status).toBe(409);
-    expect(await approve.json()).toMatchObject({ code: 'APPROVAL_PREVIEW_INCOMPLETE' });
+    expect(await approve.json()).toMatchObject({ code: 'APPROVAL_PREVIEW_UNAVAILABLE' });
 
     const deny = await authPost(`/v1/projects/${ctx.projectId}/approvals/${execId}`, {
       decision: 'deny',

--- a/apps/api/src/connectors/args-preview.test.ts
+++ b/apps/api/src/connectors/args-preview.test.ts
@@ -195,9 +195,9 @@ describe('approvalPreviewReviewable', () => {
     const details = buildArgsPreviewDetails(undefined);
 
     expect(details).toEqual({ preview: null, complete: true });
-    expect(
-      approvalPreviewReviewable({ args_preview: null, args_preview_complete: true }),
-    ).toBe(true);
+    expect(approvalPreviewReviewable({ args_preview: null, args_preview_complete: true })).toBe(
+      true,
+    );
   });
 
   test('an empty argument object is reviewable', () => {

--- a/apps/api/src/connectors/args-preview.test.ts
+++ b/apps/api/src/connectors/args-preview.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   REDACTED,
+  approvalPreviewReviewable,
   buildArgsPreview,
   buildArgsPreviewDetails,
   isSecretKey,
@@ -167,5 +168,54 @@ describe('summarizeArgsPreview', () => {
     expect(summarizeArgsPreview({ to: REDACTED })).toBeNull();
     expect(summarizeArgsPreview(null)).toBeNull();
     expect(summarizeArgsPreview({})).toBeNull();
+  });
+});
+
+describe('approvalPreviewReviewable', () => {
+  test('a truncated preview is still reviewable — the elision is shown in place', () => {
+    // The exact shape the builder writes for an email carrying an attachment:
+    // recipient and subject are legible, the blob is described, `complete` is
+    // false. This used to be un-approvable, so the run could only be killed.
+    const details = buildArgsPreviewDetails({
+      to: 'customer@example.com',
+      subject: 'Signed contract',
+      attachment: 'A'.repeat(400),
+    });
+
+    expect(details.complete).toBe(false);
+    expect(
+      approvalPreviewReviewable({
+        args_preview: details.preview,
+        args_preview_complete: details.complete,
+      }),
+    ).toBe(true);
+  });
+
+  test('an argument-less call is reviewable — there is nothing to withhold', () => {
+    const details = buildArgsPreviewDetails(undefined);
+
+    expect(details).toEqual({ preview: null, complete: true });
+    expect(
+      approvalPreviewReviewable({ args_preview: null, args_preview_complete: true }),
+    ).toBe(true);
+  });
+
+  test('an empty argument object is reviewable', () => {
+    const details = buildArgsPreviewDetails({});
+
+    expect(details).toEqual({ preview: null, complete: true });
+  });
+
+  test('a row with no preview at all is NOT reviewable', () => {
+    // Legacy rows written before previews existed, and callers not authorised
+    // to see connector arguments. Approving those is approving blind.
+    expect(approvalPreviewReviewable({ reason: 'policy_require_approval' })).toBe(false);
+    expect(approvalPreviewReviewable({ args_preview: null, args_preview_complete: false })).toBe(
+      false,
+    );
+    expect(approvalPreviewReviewable({ args_preview: {}, args_preview_complete: false })).toBe(
+      false,
+    );
+    expect(approvalPreviewReviewable(null)).toBe(false);
   });
 });

--- a/apps/api/src/connectors/args-preview.ts
+++ b/apps/api/src/connectors/args-preview.ts
@@ -243,6 +243,10 @@ export interface ArgsPreviewDetails {
 }
 
 export function buildArgsPreviewDetails(args: unknown): ArgsPreviewDetails {
+  // A call with NO arguments hides nothing, so it is complete by definition.
+  // Reporting it as incomplete used to mark every no-arg gated call as
+  // "parameters withheld", which is the one thing that blocks approval.
+  if (args === null || args === undefined) return { preview: null, complete: true };
   if (!isPlainRecord(args)) return { preview: null, complete: false };
   const state: PreviewState = { complete: true };
   let preview = previewRecord(args, 1, state);
@@ -269,6 +273,31 @@ export function buildArgsPreviewDetails(args: unknown): ArgsPreviewDetails {
 
 export function buildArgsPreview(args: unknown): Record<string, unknown> | null {
   return buildArgsPreviewDetails(args).preview;
+}
+
+/**
+ * Can a human actually judge this gated call from what the row recorded?
+ *
+ * NOT the same question as `args_preview_complete`. TRUNCATION IS NOT
+ * BLINDNESS: that flag goes false whenever the builder elided ANYTHING — an
+ * 11th array item, a 96-char URL, a fourth nesting level, an attachment body —
+ * and every elision is written into the preview the human reads (`[+3 more]`,
+ * `[204800 chars omitted]`). Gating approval on it made an ordinary "email this
+ * PDF" call permanently un-approvable: the prompt showed a disabled button and
+ * a warning, and the only move left was Deny, which kills the agent's run.
+ *
+ * The gate asks the question it was always meant to ask — is there anything to
+ * review? A row carrying parameters is decidable, elisions and all. A row
+ * carrying none is not: a pre-preview legacy row, or a caller not authorised to
+ * see the arguments. No approve path is offered for those.
+ */
+export function approvalPreviewReviewable(summary: unknown): boolean {
+  if (!isPlainRecord(summary)) return false;
+  const preview = summary.args_preview;
+  if (isPlainRecord(preview) && Object.keys(preview).length > 0) return true;
+  // No preview is still reviewable when the builder confirmed there was
+  // nothing to show — an argument-less call withholds nothing.
+  return summary.args_preview_complete === true;
 }
 
 function safeStringify(value: unknown): string {

--- a/apps/api/src/projects/routes/approvals.ts
+++ b/apps/api/src/projects/routes/approvals.ts
@@ -3,6 +3,7 @@
  * the per-session "needs input" summary, and the resolve endpoint.
  */
 
+import { approvalPreviewReviewable } from '../../connectors/args-preview';
 import { approvalResolvedAuditEvent } from '../../connectors/call-audit';
 import { PROJECT_ACTIONS } from '../../iam';
 import { auth, errors, json } from '../../openapi';
@@ -346,11 +347,16 @@ projectsApp.openapi(
 
     const existingDetail =
       typeof row.resultSummary === 'object' && row.resultSummary ? row.resultSummary : {};
-    if (decision === 'approve' && existingDetail.args_preview_complete !== true) {
+    // Blind approval stays impossible — but only when the row genuinely shows
+    // NOTHING. This used to test `args_preview_complete`, which the preview
+    // builder turns off for any elision at all (a long URL, an 11th recipient,
+    // an attachment body), so a fully legible call could be denied and never
+    // approved. See `approvalPreviewReviewable`.
+    if (decision === 'approve' && !approvalPreviewReviewable(existingDetail)) {
       return c.json(
         {
-          error: 'The complete connector parameters are not available for review',
-          code: 'APPROVAL_PREVIEW_INCOMPLETE',
+          error: 'This call recorded no parameters to review, so it cannot be approved',
+          code: 'APPROVAL_PREVIEW_UNAVAILABLE',
         },
         409,
       );

--- a/apps/web/src/app/(system)/debug/approvals/page.tsx
+++ b/apps/web/src/app/(system)/debug/approvals/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import {
+  COMPOSER_INPUT_SLOT_CLASS,
+  COMPOSER_SHELL_CLASS,
+} from '@/features/session/composer/composer';
+import { SessionApprovalNotice } from '@/features/session/session-approval-prompt';
+import { approvalNoticeRows } from '@/features/session/session-approval-review';
+import type { SessionAuditAction } from '@kortix/sdk';
+import { useState } from 'react';
+
+/**
+ * /debug/approvals
+ *
+ * Visual harness for the in-session connector approval card. Seeing it for
+ * real otherwise needs a live policy-gated connector call, which is why two
+ * defects sat in it unnoticed:
+ *
+ *  1. The card had no `w-full`, so the composer's `items-center` strip sized
+ *     it to its CONTENT — the width tracked whatever tool name was pending.
+ *  2. Any elided value (a long URL, an 11th recipient, an attachment body)
+ *     disabled Approve and printed a warning, leaving Deny as the only answer.
+ *
+ * The strip below is the REAL one — `COMPOSER_INPUT_SLOT_CLASS` and
+ * `COMPOSER_SHELL_CLASS` are imported from the composer, not copied — so a
+ * width measured here is the width the session renders. Not linked from
+ * anywhere; just hit /debug/approvals.
+ */
+
+const BASE: SessionAuditAction = {
+  execution_id: 'exec-1',
+  action: 'gmail.send_email',
+  connector_id: 'conn-1',
+  connector: 'gmail',
+  status: 'pending_approval',
+  risk: 'write',
+  acted_by: 'user-1',
+  acted_by_email: 'marko@kortix.ai',
+  resolved_by: null,
+  resolved_by_email: null,
+  result_summary: {
+    args_preview: { to: ['marko@kortix.ai'], subject: 'Weekly report' },
+    args_preview_complete: true,
+  },
+  at: new Date().toISOString(),
+  resolved_at: null,
+  approval_url: 'https://dev.kortix.com/approve/tok-1',
+};
+
+const row = (id: string, patch: Partial<SessionAuditAction>): SessionAuditAction => ({
+  ...BASE,
+  execution_id: id,
+  ...patch,
+});
+
+const SCENARIOS: Record<string, SessionAuditAction[]> = {
+  'Complete preview (approvable)': [BASE],
+  // The regression case: `args_preview_complete` is false, but every elision
+  // is written into the preview, so the call is still decidable.
+  'Shortened value — attachment (approvable)': [
+    row('exec-trunc', {
+      action: 'gmail.send_email',
+      result_summary: {
+        args_preview: {
+          to: ['ops@kortix.ai'],
+          subject: 'Signed contract',
+          body: 'Attached, please counter-sign.',
+          attachment: '[204800 chars omitted]',
+        },
+        args_preview_complete: false,
+      },
+    }),
+  ],
+  'Nothing recorded (deny only)': [
+    row('exec-blind', {
+      action: 'github.repos.delete',
+      risk: 'destructive',
+      result_summary: { args_preview_complete: false },
+    }),
+  ],
+  'Short tool name (the width regression)': [
+    row('exec-short', {
+      action: 'slack.ping',
+      risk: 'read',
+      result_summary: { args_preview: { channel: '#ops' }, args_preview_complete: true },
+    }),
+  ],
+  'Three pending at once': [
+    BASE,
+    row('exec-2', { action: 'github.repos.delete', risk: 'destructive' }),
+    row('exec-3', { action: 'slack.ping', risk: 'read' }),
+  ],
+};
+
+export default function DebugApprovalsPage() {
+  const [scenario, setScenario] = useState<keyof typeof SCENARIOS>(
+    'Shortened value — attachment (approvable)',
+  );
+  const [expanded, setExpanded] = useState<string | null>('exec-trunc');
+  const [decided, setDecided] = useState<Record<string, 'approve' | 'deny'>>({});
+
+  const actions = SCENARIOS[scenario];
+  const rows = approvalNoticeRows(actions, {}).map((r) => ({
+    ...r,
+    decision: decided[r.action.execution_id] ?? null,
+  }));
+
+  return (
+    <div className="bg-background min-h-screen py-10">
+      <div className="mx-auto mb-6 flex max-w-210 flex-wrap gap-2 px-4">
+        {Object.keys(SCENARIOS).map((key) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => {
+              setScenario(key);
+              setExpanded(SCENARIOS[key][0]?.execution_id ?? null);
+              setDecided({});
+            }}
+            className={`rounded-md border px-2.5 py-1 text-xs ${
+              scenario === key
+                ? 'border-foreground bg-foreground text-background'
+                : 'border-border text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {key}
+          </button>
+        ))}
+      </div>
+
+      {/* The composer's own shell + inset strip, imported not copied. */}
+      <div className={COMPOSER_SHELL_CLASS}>
+        <div className="relative isolate flex w-full flex-col items-center justify-center">
+          <div data-testid="composer-input-slot" className={COMPOSER_INPUT_SLOT_CLASS}>
+            <SessionApprovalNotice
+              rows={rows}
+              expanded={expanded}
+              busy={{}}
+              onToggle={(id) => setExpanded((current) => (current === id ? null : id))}
+              onDecide={(id, decision) => setDecided((current) => ({ ...current, [id]: decision }))}
+            />
+          </div>
+        </div>
+        <div className="bg-popover border-border rounded-b-xl border px-3 py-4">
+          <span className="text-muted-foreground text-sm">Ask anything…</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/approvals/approval-request.test.tsx
+++ b/apps/web/src/components/approvals/approval-request.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ApprovalDecisionActions, ApprovalParameters, ApprovalRequest } from './approval-request';
+import {
+  ApprovalDecisionActions,
+  ApprovalParameters,
+  ApprovalRequest,
+  approvalReviewable,
+} from './approval-request';
 
 const request = {
   action: 'gmail.send_email',
@@ -37,16 +42,54 @@ describe('ApprovalRequest', () => {
     expect(html).not.toContain('Always allow');
   });
 
-  test('blocks approval when the complete parameter preview is unavailable', () => {
+  test('a SHORTENED value still leaves the call approvable', () => {
+    // The shape the gateway writes for a mail carrying an attachment: every
+    // field is legible, the blob is described, `reviewComplete` is false. This
+    // used to render a disabled button beside an orange warning, so the only
+    // possible answer was Deny.
     const html = renderToStaticMarkup(
       <ApprovalRequest
-        request={{ ...request, reviewComplete: false }}
+        request={{
+          ...request,
+          reviewComplete: false,
+          argsPreview: { ...request.argsPreview, attachment: '[204800 chars omitted]' },
+        }}
         onDecision={() => undefined}
       />,
     );
 
-    expect(html).toContain('complete parameters are not available');
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>[\s\S]*Approve this call/);
+    expect(html).toContain('[204800 chars omitted]');
+    expect(html).toContain('marked in place');
+    expect(html).toContain('Approve this call');
+    expect(html).not.toContain('cannot be reviewed here');
+    expect(html).not.toMatch(/<button[^>]*disabled=""/);
+  });
+
+  test('a call with NOTHING to review offers no Approve button at all', () => {
+    const html = renderToStaticMarkup(
+      <ApprovalRequest
+        request={{ ...request, reviewComplete: false, argsPreview: null }}
+        onDecision={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('cannot be reviewed here');
+    expect(html).toContain('Deny');
+    // The point of the change: no dead control. Not disabled — absent.
+    expect(html).not.toContain('Approve this call');
+  });
+});
+
+describe('approvalReviewable', () => {
+  test('separates "shortened" from "shows nothing"', () => {
+    expect(approvalReviewable({ to: 'a@b.c' }, false)).toBe(true);
+    expect(approvalReviewable({ to: 'a@b.c' }, true)).toBe(true);
+    // No arguments at all: the server confirms nothing was withheld.
+    expect(approvalReviewable(null, true)).toBe(true);
+    expect(approvalReviewable({}, true)).toBe(true);
+    // No preview AND something was withheld — nothing to judge.
+    expect(approvalReviewable(null, false)).toBe(false);
+    expect(approvalReviewable({}, false)).toBe(false);
   });
 });
 
@@ -83,11 +126,12 @@ describe('ApprovalDecisionActions', () => {
     expect(html).not.toContain('Always allow');
   });
 
-  test('disables approval when the preview is incomplete', () => {
+  test('drops Approve entirely when the call cannot be reviewed', () => {
     const html = renderToStaticMarkup(
-      <ApprovalDecisionActions dense approveDisabled onDecision={() => undefined} />,
+      <ApprovalDecisionActions dense approvable={false} onDecision={() => undefined} />,
     );
 
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>[\s\S]*Approve this call/);
+    expect(html).toContain('Deny');
+    expect(html).not.toContain('Approve this call');
   });
 });

--- a/apps/web/src/components/approvals/approval-request.test.tsx
+++ b/apps/web/src/components/approvals/approval-request.test.tsx
@@ -106,10 +106,14 @@ describe('ApprovalParameters', () => {
     expect(html).toContain('Hidden credential');
   });
 
-  test('says so when the row carries no preview', () => {
+  test('says so when the row carries no preview — and does not tell you to approve it', () => {
     const html = renderToStaticMarkup(<ApprovalParameters dense argsPreview={null} />);
 
-    expect(html).toContain('no recorded parameter preview');
+    expect(html).toContain('No parameters were recorded for this call.');
+    // The old empty state said "Review the session context before you approve
+    // it", next to an Approve button that could not be clicked.
+    expect(html).not.toContain('before you approve');
+    expect(html).not.toContain('the redacted values the connector will receive');
   });
 });
 

--- a/apps/web/src/components/approvals/approval-request.test.tsx
+++ b/apps/web/src/components/approvals/approval-request.test.tsx
@@ -78,6 +78,24 @@ describe('ApprovalRequest', () => {
     // The point of the change: no dead control. Not disabled — absent.
     expect(html).not.toContain('Approve this call');
   });
+
+  test('an unauthorised viewer is told THAT, not that nothing was recorded', () => {
+    const html = renderToStaticMarkup(
+      <ApprovalRequest
+        request={{
+          ...request,
+          reviewComplete: false,
+          argsPreview: null,
+          previewAuthorized: false,
+        }}
+        onDecision={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('not allowed to see');
+    expect(html).not.toContain('Nothing was recorded');
+    expect(html).not.toContain('Approve this call');
+  });
 });
 
 describe('approvalReviewable', () => {

--- a/apps/web/src/components/approvals/approval-request.tsx
+++ b/apps/web/src/components/approvals/approval-request.tsx
@@ -142,18 +142,23 @@ export function ApprovalParameters({
     >
       <div
         className={cn(
-          'bg-primary/[0.03] border-border border-b',
+          'bg-primary/[0.03] border-border',
+          // No list under it means no divider — otherwise the empty case draws
+          // a rule along the bottom of the box for nothing.
+          entries.length > 0 && 'border-b',
           dense ? 'px-3 py-1.5' : 'px-4 py-2',
         )}
       >
         <p className="text-foreground text-xs font-medium">Parameters</p>
         <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
-          {reviewComplete
-            ? 'These are the redacted values the connector will receive.'
-            : 'These are the redacted values the connector will receive. Values too long to show are marked in place.'}
+          {entries.length === 0
+            ? 'No parameters were recorded for this call.'
+            : reviewComplete
+              ? 'These are the redacted values the connector will receive.'
+              : 'These are the redacted values the connector will receive. Values too long to show are marked in place.'}
         </p>
       </div>
-      {entries.length > 0 ? (
+      {entries.length > 0 && (
         <dl>
           {entries.map(([key, value]) => (
             <div
@@ -181,16 +186,6 @@ export function ApprovalParameters({
             </div>
           ))}
         </dl>
-      ) : (
-        <p
-          className={cn(
-            'text-muted-foreground text-xs text-pretty',
-            dense ? 'px-3 py-2' : 'px-4 py-4',
-          )}
-        >
-          This call has no recorded parameter preview. Review the session context before you approve
-          it.
-        </p>
       )}
     </div>
   );

--- a/apps/web/src/components/approvals/approval-request.tsx
+++ b/apps/web/src/components/approvals/approval-request.tsx
@@ -23,6 +23,10 @@ export interface ApprovalRequestData {
   requestedAt: string;
   argsPreview: Record<string, unknown> | null;
   reviewComplete?: boolean;
+  /** False when the VIEWER may not see connector arguments (Review Center
+   *  read-only members). Changes only the wording — the call is unreviewable
+   *  either way, but "nothing was recorded" would be a lie here. */
+  previewAuthorized?: boolean;
   resolution?: ApprovalDecisionValue | null;
   pending: boolean;
   status?: string | null;
@@ -199,9 +203,10 @@ export function ApprovalParameters({
  * next to a warning is not a decision, it is a dead end.
  */
 export function ApprovalUnreviewableNotice({
+  previewAuthorized = true,
   dense = false,
   className,
-}: DenseProp & { className?: string }) {
+}: DenseProp & { previewAuthorized?: boolean; className?: string }) {
   return (
     <p
       className={cn(
@@ -210,8 +215,9 @@ export function ApprovalUnreviewableNotice({
         className,
       )}
     >
-      Nothing was recorded about what this call would do, so it cannot be reviewed here — only
-      denied.
+      {previewAuthorized
+        ? 'Nothing was recorded about what this call would do, so it cannot be reviewed here — only denied.'
+        : 'You are not allowed to see this call’s parameters, so it cannot be approved here. Ask a project manager to review it.'}
     </p>
   );
 }
@@ -350,7 +356,9 @@ export function ApprovalRequest({
         <p className="text-destructive border-border border-t px-4 py-3 text-xs">{error}</p>
       ) : null}
 
-      {actionable && !reviewable ? <ApprovalUnreviewableNotice /> : null}
+      {actionable && !reviewable ? (
+        <ApprovalUnreviewableNotice previewAuthorized={request.previewAuthorized !== false} />
+      ) : null}
 
       {actionable ? (
         <ApprovalDecisionActions

--- a/apps/web/src/components/approvals/approval-request.tsx
+++ b/apps/web/src/components/approvals/approval-request.tsx
@@ -31,6 +31,34 @@ export interface ApprovalRequestData {
 
 export type ApprovalDecisionValue = 'approve' | 'deny';
 
+/**
+ * Can a human actually judge this call from what we recorded?
+ *
+ * TRUNCATION IS NOT BLINDNESS. `reviewComplete` (server:
+ * `args_preview_complete`) goes false whenever the preview builder elided
+ * ANYTHING — an 11th recipient, a 96-char URL, a fourth nesting level, an
+ * attachment body — and every elision is written into the preview the human
+ * reads (`[+3 more]`, `[204800 chars omitted]`). Gating the decision on it made
+ * an ordinary "email this PDF" call permanently un-approvable: a disabled
+ * button beside a warning, with Deny as the only possible answer.
+ *
+ * Reviewability is the narrower question: is there anything to look at? A call
+ * that shows its parameters is decidable, elisions and all. One that shows none
+ * is not — and no approve path is offered for it, rather than a dead control.
+ *
+ * Mirrors `approvalPreviewReviewable` in apps/api (connectors/args-preview.ts),
+ * which enforces the same rule on POST /approvals/:executionId.
+ */
+export function approvalReviewable(
+  argsPreview: Record<string, unknown> | null | undefined,
+  reviewComplete: boolean | undefined,
+): boolean {
+  if (argsPreview && Object.keys(argsPreview).length > 0) return true;
+  // No preview is still reviewable when the server confirms nothing was
+  // withheld — an argument-less call hides nothing.
+  return reviewComplete !== false;
+}
+
 interface ApprovalRequestProps {
   request: ApprovalRequestData;
   onDecision?: (decision: ApprovalDecisionValue) => void;
@@ -122,7 +150,7 @@ export function ApprovalParameters({
         <p className="text-muted-foreground mt-0.5 text-xs text-pretty">
           {reviewComplete
             ? 'These are the redacted values the connector will receive.'
-            : 'Some connector values could not be displayed in full.'}
+            : 'These are the redacted values the connector will receive. Values too long to show are marked in place.'}
         </p>
       </div>
       {entries.length > 0 ? (
@@ -168,8 +196,14 @@ export function ApprovalParameters({
   );
 }
 
-/** Why Approve is unavailable. Denying an unreviewable call is still allowed. */
-export function ApprovalIncompleteNotice({
+/**
+ * Shown ONLY when the row records no parameters at all — a call written before
+ * previews existed, or a viewer not authorised to see connector arguments.
+ * There is no Approve button beside it: approving what you cannot see is the
+ * one thing this gate exists to prevent, and a permanently disabled control
+ * next to a warning is not a decision, it is a dead end.
+ */
+export function ApprovalUnreviewableNotice({
   dense = false,
   className,
 }: DenseProp & { className?: string }) {
@@ -181,8 +215,8 @@ export function ApprovalIncompleteNotice({
         className,
       )}
     >
-      Kortix cannot approve this call because the complete parameters are not available. You can
-      deny it.
+      Nothing was recorded about what this call would do, so it cannot be reviewed here — only
+      denied.
     </p>
   );
 }
@@ -196,13 +230,15 @@ export function ApprovalIncompleteNotice({
 export function ApprovalDecisionActions({
   onDecision,
   busyDecision = null,
-  approveDisabled = false,
+  approvable = true,
   dense = false,
   className,
 }: DenseProp & {
   onDecision: (decision: ApprovalDecisionValue) => void;
   busyDecision?: ApprovalDecisionValue | null;
-  approveDisabled?: boolean;
+  /** False only when the call shows nothing to review — Approve is then not
+   *  offered at all, instead of rendered as a control that can never fire. */
+  approvable?: boolean;
   className?: string;
 }) {
   const size = dense ? 'sm' : 'default';
@@ -229,19 +265,21 @@ export function ApprovalDecisionActions({
         )}
         Deny
       </Button>
-      <Button
-        type="button"
-        size={size}
-        disabled={busyDecision !== null || approveDisabled}
-        onClick={() => onDecision('approve')}
-      >
-        {busyDecision === 'approve' ? (
-          <Loading className="size-4 shrink-0" />
-        ) : (
-          <CheckCircleIcon className="size-4 shrink-0" />
-        )}
-        Approve this call
-      </Button>
+      {approvable ? (
+        <Button
+          type="button"
+          size={size}
+          disabled={busyDecision !== null}
+          onClick={() => onDecision('approve')}
+        >
+          {busyDecision === 'approve' ? (
+            <Loading className="size-4 shrink-0" />
+          ) : (
+            <CheckCircleIcon className="size-4 shrink-0" />
+          )}
+          Approve this call
+        </Button>
+      ) : null}
     </div>
   );
 }
@@ -255,6 +293,7 @@ export function ApprovalRequest({
   className,
 }: ApprovalRequestProps) {
   const reviewComplete = request.reviewComplete !== false;
+  const reviewable = approvalReviewable(request.argsPreview, request.reviewComplete);
   const actionable = request.pending && onDecision;
   const resolved = !request.pending || outcome !== null;
   const resolutionLabel = resolvedLabel(request, outcome);
@@ -316,13 +355,13 @@ export function ApprovalRequest({
         <p className="text-destructive border-border border-t px-4 py-3 text-xs">{error}</p>
       ) : null}
 
-      {!reviewComplete ? <ApprovalIncompleteNotice /> : null}
+      {actionable && !reviewable ? <ApprovalUnreviewableNotice /> : null}
 
       {actionable ? (
         <ApprovalDecisionActions
           onDecision={actionable}
           busyDecision={busyDecision}
-          approveDisabled={!reviewComplete}
+          approvable={reviewable}
         />
       ) : null}
     </section>

--- a/apps/web/src/features/review-center/map.ts
+++ b/apps/web/src/features/review-center/map.ts
@@ -182,6 +182,9 @@ function approvalDetail(d: AnyRec, row: ApiReviewItem): ApprovalDetail {
         actionPath: path,
         rawArgsPreview: hasArgsPreview ? rawArgsPreview : undefined,
         reviewComplete: d.args_preview_complete === true,
+        // The API omits `args_preview` entirely for a viewer without argument
+        // visibility, which is indistinguishable from "the row recorded none".
+        previewAuthorized: d.args_preview_authorized !== false,
         connectorRisk: str(d.risk) ?? null,
         policySource: 'Requires approval',
       },

--- a/apps/web/src/features/review-center/review-detail-modal.tsx
+++ b/apps/web/src/features/review-center/review-detail-modal.tsx
@@ -460,6 +460,7 @@ function ApprovalBody({
           requestedAt: item.createdAt,
           argsPreview: adaptedAction.rawArgsPreview ?? null,
           reviewComplete: adaptedAction.reviewComplete === true,
+          previewAuthorized: adaptedAction.previewAuthorized !== false,
           pending: item.status === 'needs_you',
           resolution:
             item.status === 'approved' ? 'approve' : item.status === 'rejected' ? 'deny' : null,

--- a/apps/web/src/features/review-center/types.ts
+++ b/apps/web/src/features/review-center/types.ts
@@ -101,6 +101,8 @@ export interface ApprovalAction {
   actionPath?: string;
   rawArgsPreview?: Record<string, unknown>;
   reviewComplete?: boolean;
+  /** False when this viewer may not see connector arguments at all. */
+  previewAuthorized?: boolean;
   connectorRisk?: string | null;
   policySource: string;
   decided?: 'approved' | 'denied'; // prototype-local decision state

--- a/apps/web/src/features/session/composer/composer-input-slot.test.tsx
+++ b/apps/web/src/features/session/composer/composer-input-slot.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * The composer's inset strip centres its children, so every notice mounted
+ * into it must declare its own width.
+ *
+ * This is a real bug that shipped: the approval and permission notices had no
+ * `w-full`, so `items-center` sized them to their CONTENT — the card was as
+ * wide as whatever tool name happened to be pending, which is why it looked
+ * broken only sometimes. `QuestionPrompt` and the reply bar already carried
+ * `w-full`; nothing enforced it, so the next notice added forgot again.
+ *
+ * Renders the REAL component and reads its root class, so the guard cannot
+ * drift from what the session actually mounts. `SessionPermissionPrompt` needs
+ * an `AuthProvider` to render, so its width is measured in the browser harness
+ * at /debug/approvals instead.
+ */
+import type { SessionAuditAction } from '@kortix/sdk';
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { SessionApprovalNotice } from '@/features/session/session-approval-prompt';
+import { approvalNoticeRows } from '@/features/session/session-approval-review';
+import { COMPOSER_INPUT_SLOT_CLASS } from './composer';
+
+const pending: SessionAuditAction = {
+  execution_id: 'exec-1',
+  action: 'gmail.send_email',
+  connector_id: 'conn-1',
+  connector: 'gmail',
+  status: 'pending_approval',
+  risk: 'write',
+  acted_by: 'user-1',
+  acted_by_email: 'marko@kortix.ai',
+  resolved_by: null,
+  resolved_by_email: null,
+  result_summary: { args_preview: { to: 'a@b.c' }, args_preview_complete: true },
+  at: new Date().toISOString(),
+  resolved_at: null,
+  approval_url: null,
+};
+
+/** The class list of the outermost element a component renders. */
+function rootClass(html: string): string {
+  return /class="([^"]*)"/.exec(html.slice(0, html.indexOf('>') + 1))?.[1] ?? '';
+}
+
+const render = (node: React.ReactNode) =>
+  renderToStaticMarkup(<TooltipProvider>{node}</TooltipProvider>);
+
+describe('COMPOSER_INPUT_SLOT_CLASS', () => {
+  test('centres its children — which is why width is each notice’s job', () => {
+    expect(COMPOSER_INPUT_SLOT_CLASS).toContain('flex-col');
+    expect(COMPOSER_INPUT_SLOT_CLASS).toContain('items-center');
+  });
+
+  test('the approval notice sets its own width', () => {
+    const html = render(
+      <SessionApprovalNotice
+        rows={approvalNoticeRows([pending], {})}
+        expanded={null}
+        busy={{}}
+        onToggle={() => undefined}
+        onDecide={() => undefined}
+      />,
+    );
+
+    expect(rootClass(html).split(/\s+/)).toContain('w-full');
+  });
+});

--- a/apps/web/src/features/session/composer/composer.tsx
+++ b/apps/web/src/features/session/composer/composer.tsx
@@ -331,6 +331,20 @@ export interface SessionChatInputProps {
  */
 export const COMPOSER_SHELL_CLASS = 'relative z-10 mx-auto w-full max-w-210 shrink-0 px-4 md:pr-1';
 
+/**
+ * The inset strip above the card that hosts `inputSlot` — the approval notice,
+ * the permission notice, and `QuestionPrompt`.
+ *
+ * `items-center` is load-bearing and it BITES: a flex column sizes each child
+ * to its content unless the child says otherwise, so anything mounted here that
+ * omits `w-full` renders as a narrow box floating in the middle of the strip,
+ * with a width that tracks whatever text happens to be inside it. Exported so
+ * the invariant is pinned by a test (composer-input-slot.test.tsx) rather than
+ * rediscovered by the next notice that gets added.
+ */
+export const COMPOSER_INPUT_SLOT_CLASS =
+  'bg-sidebar border-border flex w-[96%] flex-col items-center gap-2 rounded-t-xl border border-b-0 p-1 empty:hidden';
+
 /** Stable empty defaults so a fresh `[]` per render never breaks memoization. */
 const EMPTY_AGENTS: Agent[] = [];
 const EMPTY_COMMANDS: Command[] = [];
@@ -1270,7 +1284,7 @@ function ComposerImpl({
             shell around it kept painting as an empty sliver.
           */}
           {showQueueStrip && (
-            <div className="bg-sidebar border-border flex w-[96%] flex-col items-center gap-2 rounded-t-xl border border-b-0 p-1 empty:hidden">
+            <div className={COMPOSER_INPUT_SLOT_CLASS}>
               {threadContext && (
                 <button
                   onClick={threadContext.onBackToParent}

--- a/apps/web/src/features/session/session-approval-prompt.test.tsx
+++ b/apps/web/src/features/session/session-approval-prompt.test.tsx
@@ -78,14 +78,20 @@ describe('SessionApprovalNotice', () => {
     expect(html).toContain('href="https://dev.kortix.com/approve/tok-1"');
   });
 
-  test('expanded: cannot approve a call whose preview is incomplete', () => {
-    const incomplete: SessionAuditAction = {
+  test('expanded: a SHORTENED value is still approvable in place', () => {
+    // A mail carrying an attachment: recipient legible, blob described,
+    // `args_preview_complete` false. This used to render a disabled Approve
+    // beside a warning, so the run could only ever be killed.
+    const truncated: SessionAuditAction = {
       ...pendingAction,
-      result_summary: { args_preview: { to: 'a@b.c' }, args_preview_complete: false },
+      result_summary: {
+        args_preview: { to: 'a@b.c', attachment: '[204800 chars omitted]' },
+        args_preview_complete: false,
+      },
     };
     const html = render(
       <SessionApprovalNotice
-        rows={approvalNoticeRows([incomplete], {})}
+        rows={approvalNoticeRows([truncated], {})}
         expanded="exec-1"
         busy={{}}
         onToggle={() => undefined}
@@ -93,8 +99,30 @@ describe('SessionApprovalNotice', () => {
       />,
     );
 
-    expect(html).toContain('complete parameters are not available');
-    expect(html).toMatch(/<button[^>]*disabled=""[^>]*>[\s\S]*Approve this call/);
+    expect(html).toContain('[204800 chars omitted]');
+    expect(html).toContain('Approve this call');
+    expect(html).not.toContain('cannot be reviewed here');
+    expect(html).not.toMatch(/<button[^>]*disabled=""/);
+  });
+
+  test('expanded: a call with nothing recorded offers Deny only', () => {
+    const blind: SessionAuditAction = {
+      ...pendingAction,
+      result_summary: { args_preview_complete: false },
+    };
+    const html = render(
+      <SessionApprovalNotice
+        rows={approvalNoticeRows([blind], {})}
+        expanded="exec-1"
+        busy={{}}
+        onToggle={() => undefined}
+        onDecide={() => undefined}
+      />,
+    );
+
+    expect(html).toContain('cannot be reviewed here');
+    expect(html).toContain('Deny');
+    expect(html).not.toContain('Approve this call');
   });
 
   test('a decision taken here is confirmed on the card, not navigated away from', () => {

--- a/apps/web/src/features/session/session-approval-prompt.tsx
+++ b/apps/web/src/features/session/session-approval-prompt.tsx
@@ -35,8 +35,9 @@
 import {
   ApprovalDecisionActions,
   type ApprovalDecisionValue,
-  ApprovalIncompleteNotice,
   ApprovalParameters,
+  ApprovalUnreviewableNotice,
+  approvalReviewable,
 } from '@/components/approvals/approval-request';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -204,6 +205,11 @@ export function SessionApprovalNotice({
           const request = approvalRequestFromAction(action, decision === null);
           const open = expanded === executionId;
           const reviewComplete = request.reviewComplete !== false;
+          // NOT the same test. A shortened value is still a reviewable one —
+          // see `approvalReviewable`. Only a call with nothing to show loses
+          // the Approve button, and it loses the button rather than wearing a
+          // disabled one.
+          const reviewable = approvalReviewable(request.argsPreview, request.reviewComplete);
 
           return (
             <li key={executionId}>
@@ -289,13 +295,13 @@ export function SessionApprovalNotice({
                       argsPreview={request.argsPreview}
                       reviewComplete={reviewComplete}
                     />
-                    {!reviewComplete ? <ApprovalIncompleteNotice dense /> : null}
+                    {decision === null && !reviewable ? <ApprovalUnreviewableNotice dense /> : null}
                     {decision === null ? (
                       <ApprovalDecisionActions
                         dense
                         onDecision={(next) => onDecide(executionId, next)}
                         busyDecision={busy[executionId] ?? null}
-                        approveDisabled={!reviewComplete}
+                        approvable={reviewable}
                       />
                     ) : null}
                   </div>

--- a/apps/web/src/features/session/session-approval-prompt.tsx
+++ b/apps/web/src/features/session/session-approval-prompt.tsx
@@ -172,7 +172,12 @@ export function SessionApprovalNotice({
   return (
     <div
       className={cn(
-        'bg-popover mb-2 overflow-hidden rounded-md border',
+        // `w-full`, or the composer's `items-center` strip shrinks this card to
+        // its CONTENT width — so the notice was as wide as whatever tool name
+        // happened to be pending, and looked broken at random. Same reason the
+        // reply bar and `QuestionPrompt` carry it (see composer.tsx). Vertical
+        // spacing belongs to that strip's `gap-2`, not to a margin here.
+        'bg-popover w-full overflow-hidden rounded-md border',
         pendingCount > 0 ? 'border-kortix-orange/25' : 'border-border',
       )}
     >

--- a/apps/web/src/features/session/session-approval-review.test.ts
+++ b/apps/web/src/features/session/session-approval-review.test.ts
@@ -1,3 +1,4 @@
+import { approvalReviewable } from '@/components/approvals/approval-request';
 import type { SessionAuditAction } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 import {
@@ -95,11 +96,23 @@ describe('approvalRequestFromAction', () => {
     });
   });
 
-  test('blocks review when the preview is incomplete', () => {
+  test('reports a shortened preview as incomplete — which no longer blocks it', () => {
     const request = approvalRequestFromAction(
       action({ result_summary: { args_preview: { to: 'a@b.c' }, args_preview_complete: false } }),
     );
     expect(request.reviewComplete).toBe(false);
+    // The decision gate is `approvalReviewable`, not this flag: the preview is
+    // there, so the call is still decidable.
+    expect(approvalReviewable(request.argsPreview, request.reviewComplete)).toBe(true);
+  });
+
+  test('a pending row with NO result_summary agrees with the server: unreviewable', () => {
+    // `!summary` used to read as "complete", so the card offered an Approve
+    // button that POST /approvals/:id answers with 409.
+    const request = approvalRequestFromAction(action({ result_summary: null }));
+    expect(request.pending).toBe(true);
+    expect(request.reviewComplete).toBe(false);
+    expect(approvalReviewable(request.argsPreview, request.reviewComplete)).toBe(false);
   });
 
   test('reads the recorded decision on a resolved row', () => {

--- a/apps/web/src/features/session/session-approval-review.ts
+++ b/apps/web/src/features/session/session-approval-review.ts
@@ -75,7 +75,11 @@ export function approvalRequestFromAction(
     risk: action.risk,
     requestedAt: action.at,
     argsPreview: approvalArgsPreview(action),
-    reviewComplete: !pending || !summary || summary.args_preview_complete === true,
+    // `!summary` used to count as complete, so a pending row that recorded
+    // NOTHING offered an Approve button the server answers with 409
+    // (`APPROVAL_PREVIEW_UNAVAILABLE`) — the client and the gate disagreed. A
+    // pending row is complete only when it says so.
+    reviewComplete: !pending || summary?.args_preview_complete === true,
     resolution: decision === 'approve' || decision === 'deny' ? decision : null,
     pending,
     status: action.status,

--- a/apps/web/src/features/session/session-permission-prompt.tsx
+++ b/apps/web/src/features/session/session-permission-prompt.tsx
@@ -251,7 +251,7 @@ export function SessionPermissionPrompt({
 
   if (autoApprove) {
     return (
-      <div className="border-border bg-popover mb-2 flex items-center gap-2 rounded-md border px-3 py-2">
+      <div className="border-border bg-popover flex w-full items-center gap-2 rounded-md border px-3 py-2">
         <ShieldCheck className="text-kortix-green size-4" />
         <span className="text-muted-foreground flex-1 text-xs">
           Auto-allowing all permission requests for this session
@@ -266,7 +266,9 @@ export function SessionPermissionPrompt({
   if (permissions.length === 0) return null;
 
   return (
-    <div className="bg-popover border-kortix-orange/25 mb-2 overflow-hidden rounded-md border">
+    // `w-full`: the composer strip is an `items-center` flex column, which
+    // sizes a child to its content unless it says otherwise (composer.tsx).
+    <div className="bg-popover border-kortix-orange/25 w-full overflow-hidden rounded-md border">
       <div className="border-kortix-orange/20 flex items-center gap-2 border-b px-3 py-2">
         <ShieldAlert className="text-kortix-orange size-4" />
         <span className="text-foreground text-xs font-medium">


### PR DESCRIPTION
Two defects in the in-session connector approval card, both reported from the chat: the card is not the width of its parent, and Approve is disabled with a warning that we cannot approve — leaving Deny as the only possible answer.

The founder's question was the right one: **if the button can never be pressed, why is it there?** The answer turned out to be that it should not be — and that in almost every case the block was wrong to begin with.

---

## 1. The width

`composer.tsx` mounts the approval notice, the permission notice, and `QuestionPrompt` into one inset strip:

```
flex w-[96%] flex-col items-center gap-2 …
```

`items-center` on a flex column sizes each child to its **content** unless the child says otherwise. `QuestionPrompt` and the reply bar carry `w-full` (the reply bar's comment says exactly why). The approval and permission notices did not — so the card's width tracked whatever tool name and argument summary happened to be pending. That is the "sometimes".

Measured in Chrome at 1280×800 on the new harness page:

| | strip inner | card |
|---|---|---|
| with the fix | 715px | **715px** (100%) |
| before, `gmail.send_email` + long summary | 715px | 651px (91%) |
| before, `slack.ping` | 715px | **394px (55%)** |

Mobile 375px: 322.375px card in a 322.374px strip, no horizontal page scroll.

Nothing enforced the rule, which is how two of the strip's four members ended up without it. The strip's class is now exported as `COMPOSER_INPUT_SLOT_CLASS`, documented as load-bearing, and `composer-input-slot.test.tsx` pins both halves: the strip centres its children, and the notice declares its own width.

Also dropped `mb-2` from both notices — the strip owns vertical rhythm through `gap-2`, so the margin only added 8px of asymmetric padding below the last one.

## 2. Why Approve was disabled — and why that was almost always wrong

The gate tested `args_preview_complete`. The preview builder sets that to **false for any elision at all**:

- a string ≥96 chars with no whitespace — **any long URL**
- an array with more than 10 items — an 11th recipient
- an object nested deeper than 3 — an ordinary structured payload
- a string over 20 000 chars — an attachment body
- more than 24 keys, or a preview over 64 000 chars
- and `args` being absent entirely — a call with **no arguments at all** reported as "parameters withheld"

**Truncation is not blindness.** Every elision is already written into the preview the human reads — `[+3 more]`, `[204800 chars omitted]`. An "email this signed PDF" call showed recipient, subject and body perfectly, and could still only ever be denied, which kills the agent's run.

The gate now asks the question it was always meant to ask — *is there anything to review?*

| row | before | now |
|---|---|---|
| preview with at least one field | blocked if anything was shortened | **approvable**, elisions and all |
| call with no arguments | blocked | **approvable** — nothing is withheld |
| no preview at all | blocked | **still blocked** — `409 APPROVAL_PREVIEW_UNAVAILABLE` |

The third case is the only real one: a row written before previews existed, or a caller not authorised to see connector arguments. Approving what you cannot see stays impossible — that is what this gate is for.

`approvalPreviewReviewable()` (apps/api) and `approvalReviewable()` (apps/web) are the same rule on both sides; the server still enforces it, so a client cannot talk its way past.

## 3. And when it genuinely cannot be reviewed, no dead button

A permanently disabled control beside an orange warning is not a decision, it is a dead end. Approve is now **absent**, not disabled — Deny is the only decision offered, and the line states the fact instead of blaming the product:

> Nothing was recorded about what this call would do, so it cannot be reviewed here — only denied.

The empty Parameters box also stopped contradicting itself. It used to claim *"These are the redacted values the connector will receive"* above no values, then advise *"Review the session context before you approve it"* next to a button that could not be clicked. It now reads **"No parameters were recorded for this call."**

One more message that did not match reality, found on the way: the Review Center omits `args_preview` entirely for a viewer without argument visibility, which on the wire is identical to a row that recorded none. Both landed on the same sentence, so a member who simply lacks permission was told the call had no parameters. `args_preview_authorized` was already on the payload and unread — it now picks the wording:

> You are not allowed to see this call's parameters, so it cannot be approved here. Ask a project manager to review it.

All four approval surfaces render through the same two components, so they are all fixed at once: the in-session card, the Audit side panel, the standalone `/approve/<token>` page, and the Review Center modal.

## 4. `/debug/approvals`

Seeing this card for real needs a live policy-gated connector call, which is why two defects sat in it unnoticed. The new harness mounts the **real** notice in the **real** strip — both classes imported from the composer, not copied — so a width measured there is the width a session renders. Mirrors the existing `/debug/permissions`. Not linked from anywhere.

| approvable, value shortened | nothing recorded |
|---|---|
| full-width card, all fields legible, `attachment: [204800 chars omitted]`, Approve enabled | Deny only, no dead control |

---

## Verification

**Real HTTP against a real database** — `integration-approvals.test.ts`, 4/4 on the preview-gate tests:

- truncated preview → `POST /v1/projects/:id/approvals/:executionId {"decision":"approve"}` → **200**
- no preview → **409** `APPROVAL_PREVIEW_UNAVAILABLE`, then `{"decision":"deny"}` → **200**

Note: `integration-*.test.ts` is excluded from the default `pnpm test` gate ([apps/api/scripts/test.sh:15](apps/api/scripts/test.sh#L15)), so this was run locally against a migrated database rather than in CI.

**Unit**
- `apps/api` full unit gate — 8228 pass / 0 fail
- `args-preview.test.ts` — 21 pass, covering all four reviewability cases
- `apps/web` approvals + session + review-center — 2654 pass / 0 fail

**Browser** — Chrome, light and dark, desktop 1280×800 and mobile 375px. Widths measured from the live DOM (table above); both button states confirmed visually.

**Gates** — `tsc --noEmit` and `eslint` clean on every touched file. `biome check` parity with the base commit on all four `apps/api` files.

### Known unrelated failure

`integration-approvals.test.ts` has one pre-existing failure, *"unentitled account: audit degrades to pending-only"*, on `audit_access`. Confirmed identical on the base commit (11 pass / 1 fail before, 12 pass / 1 fail after — one test replaced by two). Not touched here.

### What to test on dev

1. Trigger any policy-gated connector call from a session — the card should be the full width of the composer strip, whatever the tool is called.
2. Gate a call carrying an attachment or a long URL. Expand it: the elided value shows as `[N chars omitted]`, and **Approve is clickable**. Approve it and confirm the agent resumes.
3. `/debug/approvals` walks every state without needing a gated call.
