### PR TITLE
fix(iam): register the connect-requests route in the audit registry

### DIFF
--- a/apps/web/src/components/iam/audit-display-helpers.ts
+++ b/apps/web/src/components/iam/audit-display-helpers.ts
@@ -158,6 +158,10 @@ const ROUTE_LABEL_OVERRIDES: Record<string, string> = {
   'GET /v1/connectors/catalog': 'Viewed connector catalog',
   'POST /v1/connectors/projects/:projectId/call': 'Ran project connector action',
   'GET /v1/connectors/projects/:projectId/catalog': 'Viewed connector catalog',
+  'GET /v1/connectors/projects/:projectId/sessions/:sessionId/connect-requests':
+    'Viewed pending connector authorizations',
+  'GET /v1/connectors/projects/:projectId/sessions/:sessionId/connect-requests':
+    'Viewed pending connector authorizations',
   'PUT /v1/connectors/projects/:projectId/connectors/:slug/secret-binding':
     'Updated connector secret binding',
   'GET /v1/runtime-assets/manifest': 'Checked sandbox runtime-asset versions',

--- a/apps/web/src/components/iam/audit-http-routes.generated.ts
+++ b/apps/web/src/components/iam/audit-http-routes.generated.ts
@@ -235,6 +235,7 @@ const AUDIT_HTTP_ROUTE_KEYS = [
   "GET|v1|connectors|projects|:projectId|pipedream|sections",
   "GET|v1|connectors|projects|:projectId|policies",
   "PUT|v1|connectors|projects|:projectId|policies",
+  "GET|v1|connectors|projects|:projectId|sessions|:sessionId|connect-requests",
   "POST|v1|connectors|webhook|pipedream",
   "GET|v1|docs",
   "GET|v1|edge|tls-check",


### PR DESCRIPTION
## What broke

`main` is red on the packages lane:

```
apps/web test: (fail) audit HTTP route registry > contains every route in the authoritative API manifest
apps/web test: (fail) audit HTTP route registry > maps every API route to a readable label
error: GET /v1/connectors/projects/:projectId/sessions/:sessionId/connect-requests
```

#6878 added that route and regenerated `tests/spec/routes.generated.json`, but two artifacts derived from that manifest were left behind:

1. **`audit-http-routes.generated.ts`** — the registry test compares it against the manifest. It is generated (`node apps/web/scripts/generate-audit-http-routes.mjs`), not hand-edited; I regenerated it.
2. **The readable label** in `audit-display-helpers.ts`. Without it the audit log renders the bare method and path instead of a sentence. Added `'Viewed pending connector authorizations'`.

## Why it reached main

The first CI run of #6878 failed that lane on infrastructure:

```
failed to start daemon: error initializing graphdriver: driver not supported
[daytona-ci] exit=3
```

It died before running a single test, so the infra failure masked this real one. The re-run is what surfaced it — after the merge. Worth noting for its own sake: an infra failure and a test failure on the same lane are indistinguishable from the check name alone.

## Verification

```
apps/web  bun test src/components/iam/audit-display-helpers.test.ts   exit=0   44 pass / 0 fail
```

Branched from current `main`, so it applies cleanly regardless of what else has landed.