### PR TITLE
fix(session): give the Connect card the durable project session id

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -4871,7 +4871,15 @@ export function SessionChat({
                       finalizing tells the agent directly. */}
                   <SessionConnectCard
                     projectId={projectId}
-                    sessionId={sessionId}
+                    // `projectSessionId`, NOT `sessionId`. This component carries
+                    // both: `sessionId` is the runtime/sandbox session, and
+                    // `projectSessionId` is the durable Kortix project session
+                    // every project-session API is keyed on — including the
+                    // connect route, which stores whichever id the agent's
+                    // scoped token carried. Passing the runtime id asked for a
+                    // session the API has no rows for, so the answer was always
+                    // an empty list and the card never rendered.
+                    sessionId={projectSessionId}
                     className="mb-2"
                   />
                   <ConnectorRequiredNotice


### PR DESCRIPTION
## The bug

The Connect card never rendered. The user's session showed only the agent's raw markdown link — `👉 Connect your Gmail account` — with no button and no popup, which is exactly the flow #6878 set out to replace.

## Root cause

`SessionChat` carries two different session ids:

```ts
sessionId: string;
/** Durable Kortix project session id used by project-session APIs. */
projectSessionId?: string;
```

`sessionId` is the runtime/sandbox session. `projectSessionId` is the durable Kortix project session that every project-session API is keyed on — including `GET /connectors/projects/:id/sessions/:sessionId/connect-requests`, which stores whichever id the agent's scoped token carried.

I passed `sessionId`. The query therefore asked for a session the API has no rows for, always received `{"connectors": []}`, and the card correctly rendered nothing.

## Evidence from dev

The backend half was working the whole time. On project `41168a95`:

```
connection_id | 79e0f3aa-8ea2-4d8e-85a9-e0d524357ade
metadata      | requesting_session_id: "60e1dbfd-5554-4779-8116-4672b27b4f9d"
                connected_account_id: null          ← genuinely pending
updated_at    | 17:58:38Z                           ← after the deploy
```

`60e1dbfd-…` is the id in the session URL — the **project** session id. The UI was asking about the runtime id.

## The fix

Pass `projectSessionId`. The two sibling project-session components in the same file (lines 4350 and 4564) already do exactly this; this call now matches them.

## Verification

```
apps/web  npx tsc --noEmit   20 errors — all pre-existing, none in the changed file
apps/web  npx eslint src/features/session/session-chat.tsx   exit=0
```

## Test gap, stated plainly

Nothing caught this, and something should have. Every test on this feature covers pure functions (`sessionConnectPrompt`) or the API contract (`CONN-24`); none asserts which id actually reaches the component. Prop wiring between two same-typed `string` ids is precisely the seam that survives both. Worth a follow-up that renders the card and asserts the id it queries with — I did not want to hold this fix behind it.