### PR TITLE
fix(runtime): stop random mid-turn stoppages — provider deadline read-back, body-cap ownership, autoupdate off, progress-aware boot budget

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2427,3 +2427,104 @@ guards the lockstep pins; the shared sandbox goldens fail on a pin drift.
 *Incident:* no outage. Essentia's Bedrock model was unusable in native mode
 until PR #6873 (1.18.23) deployed and the box updated with
 `kortix self-host update --version dev`.
+
+## A provider's 204 is not a renewal; read the deadline back
+
+*Incident (2026-08-25, Essentia self-host):* four agent turns died mid-work,
+each exactly one hour after the sandbox was created or resumed. The last
+assistant message of each was `tokens 0/0/0, parts: []` — an LLM call that was
+in flight when the VM froze. Kortix had renewed every box every 20 s
+(`[active-turn-renewal]`, `errors:0`; E2B API log: 375 × `POST
+/sandboxes/<id>/timeout → 204`). E2B's `KeepAliveFor` clamps every renewal to
+the team's `max_length_hours`; the Essentia team sat on tier `base_v1`
+(`max_length_hours = 1`, the upstream migration default) with a matching
+`project_limits` row, so `endAt` never moved past `startedAt + 1h` and E2B
+paused the box (`sandbox_pause_initiated pause_reason=timeout`).
+
+**Rules.**
+1. `renewLifecycle` (`apps/api/src/platform/providers/e2b.ts`) reads `endAt`
+   back after `setTimeout` and throws `E2BLifecycleRenewalIgnoredError` when the
+   deadline did not advance to within `KORTIX_E2B_RENEWAL_TOLERANCE_MS` of the
+   backstop. The reaper and the active-turn renewal loop count it as an error
+   and the log names `max_length_hours`.
+2. A self-hosted E2B cluster must run its Kortix team at
+   `max_length_hours ≥ 24` (`tiers` and `project_limits`; the `team_limits`
+   view prefers `project_limits`). The cap is a ceiling on continuous running
+   time, not a lifetime: Kortix's own `deadline_at` still stops idle boxes.
+3. Existing sandboxes keep the cap they were created with. After raising it,
+   pause+resume (or restart) the live boxes; a fresh `POST /timeout` must move
+   `endAt`.
+4. The fingerprint of this class of failure: an assistant message with
+   `tokens 0/0/0` and no parts, created seconds before a provider pause; the
+   OpenCode log ends at `llm runtime selected` with no stream line after it.
+
+*Automation:* `apps/api/src/platform/providers/e2b.test.ts` — "refuses to
+report a renewal the provider clamped".
+
+## The runtime's body limit is the one that logs, never the one that is silent
+
+*Incident (2026-08-25, Essentia):* three empty assistant messages in two
+sessions were `413 Request Entity Too Large` on image-heavy turns (381k input
+tokens, 118 inline screenshots). Nothing in the gateway log explained them:
+Bun's own `maxRequestBodySize` default (128 MiB) equals
+`DEFAULT_MAX_REQUEST_BYTES`, so Bun refused the body before `fetch()` ran —
+plain-text 413, no `request_too_large` step, and a mid-upload socket close on
+the first attempt (`Cannot connect to API: The socket…`).
+
+**Rules.**
+1. `Bun.serve` in `apps/llm-gateway/src/main.ts` sets `maxRequestBodySize`
+   strictly above the pipeline's per-request cap
+   (`bunRequestBodyCeilingBytes`), so an over-limit body is refused by the
+   pipeline with its logged, digit-free 413.
+2. Any host runtime that enforces a body limit of its own (Bun, Caddy, an
+   ALB) must be configured above the application's cap, or the application's
+   limit is decoration.
+3. Raise a self-host gateway's cap through `GATEWAY_MAX_REQUEST_BYTES`; the
+   in-flight memory budget clamps it to what the process can hold.
+
+*Automation:* `apps/llm-gateway/src/request-body-ceiling.test.ts`.
+
+## The daemon owns the OpenCode binary; OpenCode must never upgrade itself
+
+*Incident (2026-08-22 and again 2026-08-25, Essentia):* a human ran `opencode`
+in the Session terminal. OpenCode's autoupdate (`autoupdate` unset = on)
+installed the newer version with plain `pnpm add -g` — no postinstall — leaving
+a 479-byte launcher stub, deleting the old global dir and dangling
+`/opt/kortix/opencode.current`. The running server survived on a deleted
+inode; the next restart booted the stub ("Still waking this session up").
+
+**Rules.**
+1. `buildOpencodeConfigContent` always emits `autoupdate: false`; a base
+   config cannot turn it back on. The composed Kortix config is never
+   `undefined` any more.
+2. Version changes reach a box only through the runtime-assets manifest and
+   `installOpencodeVersion` (`pnpm add -g --allow-build=opencode-ai`).
+
+*Automation:* `connector-mcp-config.test.ts` — "always disables OpenCode
+autoupdate".
+
+## A boot budget measures lack of progress, not wall-clock
+
+*Incident (2026-08-25 17:23–17:25, Essentia):* both reopened sessions failed
+to wake. The resume converged OpenCode 1.18.19 → 1.18.23 (manifest bump live
+since the updater restarted the API) and then sat through the new version's
+53 s first init. `/start` polled `starting` for 83 s and the fixed
+`STALE_OPENCODE_NOT_READY_MS = 90 s` budget parked both boxes as
+`runtime_boot_failed`; the automatic restart then booted in 20 s because the
+install had already landed.
+
+**Rules.**
+1. Every not-ready 503 from the daemon carries `X-Kortix-Boot-Phase`
+   (`boot-phase.ts`: last boot mark, OpenCode state, runtime-assets activity
+   such as `installing-opencode@<v>`, and the not-ready reason).
+2. The API restarts the per-reason clock whenever that phase changes
+   (`opencodeReadyWaitPatch`); `STALE_OPENCODE_NOT_READY_MS` now bounds time
+   without progress. `STALE_OPENCODE_BOOT_HARD_MS` (10 min from first
+   observation) bounds a boot that changes phase forever. A stub launcher
+   respawning in a loop never changes phase and is still caught at 90 s.
+3. Do not "fix" a slow legitimate boot by raising the fixed budget; expose the
+   progress and budget that.
+
+*Automation:* `unit-session-restart-url-contract.test.ts` ("progress-aware
+OpenCode boot budget"), `boot-phase.test.ts`, `proxy-auth.test.ts` ("names the
+boot phase").

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2528,3 +2528,39 @@ install had already landed.
 *Automation:* `unit-session-restart-url-contract.test.ts` ("progress-aware
 OpenCode boot budget"), `boot-phase.test.ts`, `proxy-auth.test.ts` ("names the
 boot phase").
+
+## A runtime started from `stopped` owns no turn; settle and redeliver on the wake
+
+*Incident (2026-08-25, Essentia):* the provider paused two boxes mid-turn. One
+was woken by the UI through the proxy before the reaper confirmed the stop:
+the fresh runtime answered `idle`, the open turn closed `completed`, and the
+user saw the agent "just stop" with nothing to resume. The other closed
+`runtime_gone` but its accepted prompt was never redelivered (only
+never-accepted deliveries were), so the user typed "go on".
+
+**Rules.**
+1. Every path that starts a provider-`stopped` box (`wakeSandbox` in the
+   preview proxy, the `/start` wake finalize) calls
+   `recoverTurnsAfterRuntimeRestart`: open ledger rows → `runtime_gone`,
+   turn authority dropped, each prompt redelivered DUE (`hold:false`).
+2. A stop the PROVIDER originated (`stopReason: provider_reconcile`) requeues
+   accepted prompts too (held); a stop Kortix chose keeps the old rule.
+3. A turn's verdict is never derived from a runtime that did not run it.
+
+*Automation:* `runtime-restart-recovery.test.ts`.
+
+## A refresh never converges a booting runtime; a stub launcher is never spawned
+
+*Incident (2026-08-25, Essentia):* the session-open refresh (env-sync) ran the
+runtime-assets pass during a resume, installing OpenCode 1.18.23 and
+restarting it under the boot; and the PATH launcher on two boxes was the
+479-byte pnpm postinstall stub, one restart away from a dead session.
+
+**Rules.**
+1. `refreshMayConvergeRuntime`: the refresh route schedules a reconcile only
+   when OpenCode is serving (`ok`); main.ts owns the post-boot pass.
+2. `isStubOpencodeLauncher`: the PATH launcher is skipped when it is (or shims
+   to) the postinstall stub; resolution falls through to the managed links.
+   Conservative: anything unreadable is not a stub.
+
+*Automation:* `refresh-converge-guard.test.ts`, `opencode-binary.test.ts`.

--- a/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
+++ b/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import {
   prepareInPlaceRestartMetadata,
+  opencodeReadyWaitPatch,
   staleOpencodeReadyReason,
 } from '../projects/session-lifecycle/readiness-clocks';
 
@@ -75,5 +76,68 @@ describe('session restart URL contract', () => {
         Date.parse('2026-07-24T02:00:00.000Z'),
       ),
     ).toBe('runtime_unreachable_timeout');
+  });
+});
+
+describe('progress-aware OpenCode boot budget (Essentia 2026-08-25 17:23 double runtime_boot_failed)', () => {
+  const t0 = new Date('2026-08-25T17:23:04.000Z');
+
+  test('a phase change restarts the reason clock; the first-seen clock never moves', () => {
+    const first = opencodeReadyWaitPatch({}, 'not_ready', 'config-deps|opencode=starting', t0)!;
+    expect(first.opencodeBootWaitFirstSeenAt).toBe(t0.toISOString());
+    expect(first.opencodeNotReadyWaitStartedAt).toBe(t0.toISOString());
+    expect(first.opencodeBootPhase).toBe('config-deps|opencode=starting');
+
+    // Same phase 60 s later: nothing to write.
+    const t1 = new Date(t0.getTime() + 60_000);
+    expect(opencodeReadyWaitPatch(first, 'not_ready', 'config-deps|opencode=starting', t1)).toBeNull();
+
+    // New phase 80 s later (install finished, OpenCode spawned): clock restarts.
+    const t2 = new Date(t0.getTime() + 80_000);
+    const second = opencodeReadyWaitPatch(first, 'not_ready', 'opencode-spawned|opencode=starting', t2)!;
+    expect(second.opencodeNotReadyWaitStartedAt).toBe(t2.toISOString());
+    expect(second.opencodeBootWaitFirstSeenAt).toBe(t0.toISOString());
+
+    // 85 s after the FIRST poll the old rule parked the box; with progress it is not stale.
+    const t3 = new Date(t0.getTime() + 85_000);
+    expect(staleOpencodeReadyReason(second, 'not_ready', t3.getTime(), 90_000)).toBeNull();
+    // ...but 90 s of NO progress after the last phase change still is.
+    const t4 = new Date(t2.getTime() + 90_001);
+    expect(staleOpencodeReadyReason(second, 'not_ready', t4.getTime(), 90_000)).toBe(
+      'runtime_not_ready_timeout',
+    );
+  });
+
+  test('a legacy row (single clock + reason) counts as a running clock for that reason', () => {
+    const legacy = {
+      opencodeReadyWaitStartedAt: '2026-08-25T17:23:04.000Z',
+      opencodeReadyWaitReason: 'unreachable',
+    };
+    expect(opencodeReadyWaitPatch(legacy, 'unreachable', undefined, new Date(t0.getTime() + 31_000))).toBeNull();
+    expect(staleOpencodeReadyReason(legacy, 'unreachable', t0.getTime() + 31_000, 30_000)).toBe(
+      'runtime_unreachable_timeout',
+    );
+  });
+
+  test('a daemon that reports no phase keeps the old fixed budget', () => {
+    const first = opencodeReadyWaitPatch({}, 'not_ready', undefined, t0)!;
+    expect(first.opencodeBootPhase).toBeUndefined();
+    expect(opencodeReadyWaitPatch(first, 'not_ready', undefined, new Date(t0.getTime() + 80_000))).toBeNull();
+    expect(
+      staleOpencodeReadyReason(first, 'not_ready', t0.getTime() + 90_001, 90_000),
+    ).toBe('runtime_not_ready_timeout');
+  });
+
+  test('the hard cap bounds a boot that keeps changing phase without ever becoming ready', () => {
+    let metadata = opencodeReadyWaitPatch({}, 'not_ready', 'p0', t0)!;
+    for (let i = 1; i <= 12; i += 1) {
+      const t = new Date(t0.getTime() + i * 60_000);
+      metadata = opencodeReadyWaitPatch(metadata, 'not_ready', `p${i}`, t) ?? metadata;
+    }
+    const now = t0.getTime() + 12 * 60_000 + 1_000;
+    // Reason clock is only 1 s old, yet 12 min have passed since first seen.
+    expect(staleOpencodeReadyReason(metadata, 'not_ready', now, 90_000, 10 * 60_000)).toBe(
+      'runtime_not_ready_timeout',
+    );
   });
 });

--- a/apps/api/src/platform/providers/e2b.test.ts
+++ b/apps/api/src/platform/providers/e2b.test.ts
@@ -25,6 +25,7 @@ let timeoutRenewals: Array<{
 let staticPauses: Array<{ sandboxId: string; opts: Record<string, unknown> }> = [];
 let killed: string[] = [];
 let infoState: 'running' | 'paused' | 'missing' = 'running';
+let infoEndAt: Date | null = null;
 let infoReads = 0;
 let infoFactory: () => void | Promise<void> = () => {};
 let listed: Array<{ sandboxId: string; startedAt: Date | null }> = [];
@@ -121,7 +122,7 @@ class FakeSandboxApi {
     infoReads += 1;
     await infoFactory();
     if (infoState === 'missing') throw new FakeSandboxNotFoundError('sandbox not found');
-    return { state: infoState };
+    return { state: infoState, ...(infoEndAt ? { endAt: infoEndAt } : {}) };
   }
 
   static list(opts: Record<string, unknown>) {
@@ -161,6 +162,7 @@ beforeEach(() => {
   staticPauses = [];
   killed = [];
   infoState = 'running';
+  infoEndAt = null;
   infoReads = 0;
   infoFactory = () => {};
   listed = [];
@@ -204,6 +206,32 @@ describe('E2B provider lifecycle', () => {
         }),
       },
     ]);
+    expect(connected).toEqual([]);
+  });
+
+  test('accepts a renewal the provider actually applied (endAt moved to now + backstop)', async () => {
+    infoEndAt = new Date(Date.now() + 3_600_000 - 5_000);
+    const provider = new E2BProvider();
+
+    await provider.renewLifecycle('sb-honored');
+
+    expect(timeoutRenewals.map((r) => r.sandboxId)).toEqual(['sb-honored']);
+    expect(infoReads).toBe(1);
+    expect(connected).toEqual([]);
+  });
+
+  test('refuses to report a renewal the provider clamped (endAt pinned by max_length_hours)', async () => {
+    // Essentia 2026-08-25: tier base_v1 max_length_hours=1 → every 204 left
+    // endAt at startedAt+1h; here the sandbox has 20 minutes left.
+    infoEndAt = new Date(Date.now() + 20 * 60_000);
+    const provider = new E2BProvider();
+
+    await expect(provider.renewLifecycle('sb-capped')).rejects.toMatchObject({
+      name: 'E2BLifecycleRenewalIgnoredError',
+      code: 'e2b_lifecycle_renewal_ignored',
+      message: expect.stringContaining('max_length_hours'),
+    });
+    expect(timeoutRenewals.map((r) => r.sandboxId)).toEqual(['sb-capped']);
     expect(connected).toEqual([]);
   });
 

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -120,10 +120,7 @@ function isMissingSandboxError(error: unknown): boolean {
 const connectedSandboxes = new Map<string, E2BSandbox>();
 export const E2B_INGRESS_HANDLE_TTL_MS = 5_000;
 const connectedSandboxCachedAt = new Map<string, number>();
-const connectOperations = new Map<
-  string,
-  { generation: object; promise: Promise<E2BSandbox> }
->();
+const connectOperations = new Map<string, { generation: object; promise: Promise<E2BSandbox> }>();
 export const E2B_RUNNING_STATUS_CACHE_TTL_MS = 3_000;
 const runningStatusCache = new Map<string, number>();
 const statusCacheGeneration = new Map<string, object>();
@@ -534,12 +531,8 @@ export class E2BProvider implements SandboxProvider {
     const expectedMinMs = requestedAtMs + E2B_RUNTIME_BACKSTOP_MS - E2B_RENEWAL_TOLERANCE_MS;
     if (endAtMs >= expectedMinMs) return;
     const shortfallS = Math.round((requestedAtMs + E2B_RUNTIME_BACKSTOP_MS - endAtMs) / 1000);
-    const message =
-      `E2B ignored the lifecycle renewal for ${externalId}: provider endAt ` +
-      `${new Date(endAtMs).toISOString()} is ${shortfallS}s short of the requested ` +
-      `${Math.round(E2B_RUNTIME_BACKSTOP_MS / 1000)}s backstop. The E2B team's max_length_hours ` +
-      `caps every renewal; raise it (tiers.max_length_hours / project_limits) or this sandbox is ` +
-      `paused mid-turn at endAt.`;
+    const backstopS = Math.round(E2B_RUNTIME_BACKSTOP_MS / 1000);
+    const message = `E2B ignored the lifecycle renewal for ${externalId}: provider endAt ${new Date(endAtMs).toISOString()} is ${shortfallS}s short of the requested ${backstopS}s backstop. The E2B team's max_length_hours caps every renewal; raise it (tiers.max_length_hours / project_limits) or this sandbox is paused mid-turn at endAt.`;
     console.error(`[e2b] ${message}`);
     throw new E2BLifecycleRenewalIgnoredError(message, endAtMs);
   }
@@ -577,10 +570,7 @@ export class E2BProvider implements SandboxProvider {
 
   async getStatus(externalId: string): Promise<SandboxStatus> {
     const cachedAt = runningStatusCache.get(externalId);
-    if (
-      cachedAt !== undefined &&
-      Date.now() - cachedAt < E2B_RUNNING_STATUS_CACHE_TTL_MS
-    )
+    if (cachedAt !== undefined && Date.now() - cachedAt < E2B_RUNNING_STATUS_CACHE_TTL_MS)
       return 'running';
     const generation = currentStatusGeneration(externalId);
     try {
@@ -607,11 +597,7 @@ export class E2BProvider implements SandboxProvider {
   private async connected(externalId: string): Promise<E2BSandbox> {
     const cached = connectedSandboxes.get(externalId);
     const cachedAt = connectedSandboxCachedAt.get(externalId);
-    if (
-      cached &&
-      cachedAt !== undefined &&
-      this.now() - cachedAt < E2B_INGRESS_HANDLE_TTL_MS
-    )
+    if (cached && cachedAt !== undefined && this.now() - cachedAt < E2B_INGRESS_HANDLE_TTL_MS)
       return cached;
 
     const providerStatus = await this.getStatus(externalId);

--- a/apps/api/src/platform/providers/e2b.ts
+++ b/apps/api/src/platform/providers/e2b.ts
@@ -53,6 +53,35 @@ const ENV_METADATA = 'kortix_env';
 // after that budget. This outer timer bounds all permanent-removal call sites.
 const E2B_REMOVE_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_REMOVE_TIMEOUT_MS', 25_000, 1_000);
 const E2B_RENEW_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_RENEW_TIMEOUT_MS', 25_000, 1_000);
+// How far the provider deadline may lag `now + backstop` before a renewal is
+// treated as ignored. Renewals run every ~20 s; a 1h team cap shows up as a
+// deadline pinned at `startedAt + 1h`, i.e. minutes short within minutes.
+const E2B_RENEWAL_TOLERANCE_MS = configuredTimeoutMs(
+  'KORTIX_E2B_RENEWAL_TOLERANCE_MS',
+  2 * 60 * 1000,
+  1_000,
+);
+
+/** The provider acknowledged a renewal (204) but its deadline did not move. */
+export class E2BLifecycleRenewalIgnoredError extends Error {
+  readonly code = 'e2b_lifecycle_renewal_ignored';
+  constructor(
+    message: string,
+    readonly providerEndAtMs: number,
+  ) {
+    super(message);
+    this.name = 'E2BLifecycleRenewalIgnoredError';
+  }
+}
+
+function parseProviderInstant(value: unknown): number | null {
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.getTime() : null;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const ms = new Date(value).getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return null;
+}
 const E2B_STOP_TIMEOUT_MS = configuredTimeoutMs('KORTIX_E2B_STOP_TIMEOUT_MS', 25_000, 1_000);
 
 /**
@@ -482,11 +511,37 @@ export class E2BProvider implements SandboxProvider {
     // E2B's timeout is an ABSOLUTE provider deadline. Guest activity does not
     // move it. Reset it through the static control-plane API so this operation
     // cannot connect to, resume, or otherwise wake a stopped sandbox.
+    const requestedAtMs = Date.now();
     await withTimeout(
       Sandbox.setTimeout(externalId, E2B_RUNTIME_BACKSTOP_MS, apiOpts()),
       this.renewTimeoutMs,
       `E2B lifecycle renewal(${externalId})`,
     );
+    // A 204 is not proof. E2B's KeepAliveFor clamps every renewal to the
+    // team's `max_length_hours` (tier + project_limits), so on a team capped
+    // at 1h the deadline never moves past `startedAt + 1h` and the sandbox is
+    // paused mid-turn exactly one hour after create/resume — while Kortix
+    // logged a successful renewal every 20 s (Essentia 2026-08-25: 375 blind
+    // 204s, 4 turns killed). Read the deadline back and refuse to call a
+    // renewal that did not land a renewal.
+    const info = await withTimeout(
+      Sandbox.getInfo(externalId, apiOpts()),
+      this.renewTimeoutMs,
+      `E2B lifecycle renewal read-back(${externalId})`,
+    );
+    const endAtMs = parseProviderInstant(info.endAt);
+    if (endAtMs === null) return;
+    const expectedMinMs = requestedAtMs + E2B_RUNTIME_BACKSTOP_MS - E2B_RENEWAL_TOLERANCE_MS;
+    if (endAtMs >= expectedMinMs) return;
+    const shortfallS = Math.round((requestedAtMs + E2B_RUNTIME_BACKSTOP_MS - endAtMs) / 1000);
+    const message =
+      `E2B ignored the lifecycle renewal for ${externalId}: provider endAt ` +
+      `${new Date(endAtMs).toISOString()} is ${shortfallS}s short of the requested ` +
+      `${Math.round(E2B_RUNTIME_BACKSTOP_MS / 1000)}s backstop. The E2B team's max_length_hours ` +
+      `caps every renewal; raise it (tiers.max_length_hours / project_limits) or this sandbox is ` +
+      `paused mid-turn at endAt.`;
+    console.error(`[e2b] ${message}`);
+    throw new E2BLifecycleRenewalIgnoredError(message, endAtMs);
   }
 
   async stop(externalId: string): Promise<void> {

--- a/apps/api/src/projects/opencode-mapping.ts
+++ b/apps/api/src/projects/opencode-mapping.ts
@@ -68,7 +68,10 @@ export async function sandboxOpencodeEndpoint(
 
 export type ListResult =
   | { ok: true; sessions: OpencodeSessionLite[] }
-  | { ok: false; reason: 'no_key' | 'not_ready' | 'unreachable' };
+  | { ok: false; reason: 'no_key' | 'not_ready' | 'unreachable'; bootPhase?: string };
+
+/** The daemon names its boot phase on every 503 — see the daemon's boot-phase.ts. */
+export const BOOT_PHASE_HEADER = 'x-kortix-boot-phase';
 
 /** List the sandbox's OpenCode sessions (server-side, via the signed proxy). */
 export async function listSandboxOpencodeSessions(
@@ -98,7 +101,10 @@ export async function listSandboxOpencodeSessions(
     );
     // 503 = daemon up but OpenCode/repo not ready yet — distinct from a hard
     // failure so callers can retry rather than treat it as "empty".
-    if (res.status === 503) return { ok: false, reason: 'not_ready' };
+    if (res.status === 503) {
+      const bootPhase = res.headers.get(BOOT_PHASE_HEADER)?.trim() || undefined;
+      return { ok: false, reason: 'not_ready', ...(bootPhase ? { bootPhase } : {}) };
+    }
     // A 401 here is NEVER transient and never the sandbox's fault: the daemon
     // rejects every non-`/kortix/*` path without a valid X-Kortix-User-Context,
     // and this call only carries one when `userId` was supplied. Folding that
@@ -132,6 +138,8 @@ export interface EnsureResult {
   changed: boolean;
   reason: EnsureReason;
   sessions?: OpencodeSessionLite[];
+  /** Daemon-reported boot phase behind a `not_ready` (opaque; compare for equality). */
+  bootPhase?: string;
 }
 
 /**
@@ -157,6 +165,7 @@ export async function ensureOpencodeSessionPin(input: {
       pin: currentPin,
       changed: false,
       reason: listed.reason === 'not_ready' ? 'not_ready' : 'unreachable',
+      ...(listed.bootPhase ? { bootPhase: listed.bootPhase } : {}),
     };
   }
 

--- a/apps/api/src/projects/reaping/sandbox-state-sync.ts
+++ b/apps/api/src/projects/reaping/sandbox-state-sync.ts
@@ -230,8 +230,16 @@ export async function applyStoppedState(write: StoppedStateWrite): Promise<void>
     .from(sessionSandboxes)
     .where(eq(sessionSandboxes.sandboxId, write.sandboxId))
     .limit(1);
+  // A stop the PROVIDER originated (E2B max-length pause, a lost VM, a
+  // webhook) also took down turns that had already been accepted; their work
+  // is unfinished through no choice of the user's, so those prompts come back
+  // as well — held, like every other requeue from a stop. A stop Kortix chose
+  // (idle deadline, user Stop) keeps the old rule: only never-accepted
+  // deliveries are given back. Essentia 2026-08-25: four provider-paused
+  // turns, every one needed the user to type "go on".
+  const providerOriginated = write.stopReason === 'provider_reconcile';
   const abandonedDeliveries = storedSandboxTurns(before?.metadata).filter(
-    (turn) => turn.state === 'delivering' && turn.messageId,
+    (turn) => !!turn.messageId && (turn.state === 'delivering' || providerOriginated),
   );
   await pauseComputeSession(write.sandboxId).catch((err) =>
     console.warn(

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -42,7 +42,9 @@ import { inspectSandboxRuntime } from '../runtime-inspection';
 import type { StopReason } from '../stop-reason';
 import {
   RUNTIME_READINESS_CLOCK_KEYS,
+  STALE_OPENCODE_BOOT_HARD_MS,
   hasRuntimeReadinessClock,
+  opencodeReadyWaitPatch,
   staleOpencodeReadyReason,
 } from '../session-lifecycle/readiness-clocks';
 import {
@@ -537,27 +539,19 @@ async function markRuntimeWakeStarted(
 
 async function markOpencodeReadyWaitStarted(
   row: typeof sessionSandboxes.$inferSelect,
-  reason: string,
+  reason: 'not_ready' | 'unreachable',
+  bootPhase: string | undefined,
 ): Promise<void> {
   const metadata = sandboxMetadata(row);
-  const reasonClockKey =
-    reason === 'unreachable'
-      ? 'opencodeUnreachableWaitStartedAt'
-      : 'opencodeNotReadyWaitStartedAt';
-  if (typeof metadata[reasonClockKey] === 'string') return;
+  // The reason clock restarts on every daemon-reported phase change, so the
+  // budget below is "no progress for N seconds", not "not ready N seconds
+  // after the first poll" (see opencodeReadyWaitPatch).
+  const patch = opencodeReadyWaitPatch(metadata, reason, bootPhase);
+  if (!patch) return;
   try {
-    const startedAt = new Date().toISOString();
     await db
       .update(sessionSandboxes)
-      .set({
-        metadata: {
-          ...metadata,
-          opencodeReadyWaitStartedAt: startedAt,
-          opencodeReadyWaitReason: reason,
-          [reasonClockKey]: startedAt,
-        },
-        updatedAt: new Date(),
-      })
+      .set({ metadata: patch, updatedAt: new Date() })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));
   } catch (err) {
     console.warn(`[start] failed to mark OpenCode wait for ${row.sandboxId}:`, err);
@@ -1224,13 +1218,23 @@ export async function openSession(args: {
   });
   const booting = ensured.reason === 'not_ready' || ensured.reason === 'unreachable';
   if (booting) {
+    // A daemon that reports a NEW boot phase since the last poll has made
+    // progress: its reason clock is restarted below before the next poll
+    // judges it, so only a box that stalls in one phase for the budget — or
+    // one that never becomes ready within the hard cap — is parked.
+    const metadataForBudget =
+      ensured.reason === 'not_ready' || ensured.reason === 'unreachable'
+        ? (opencodeReadyWaitPatch(sandboxMetadata(row), ensured.reason, ensured.bootPhase) ??
+          sandboxMetadata(row))
+        : sandboxMetadata(row);
     const staleBoot = staleOpencodeReadyReason(
-      sandboxMetadata(row),
+      metadataForBudget,
       ensured.reason,
       Date.now(),
       ensured.reason === 'unreachable'
         ? STALE_RUNTIME_UNREACHABLE_MS
         : STALE_OPENCODE_NOT_READY_MS,
+      STALE_OPENCODE_BOOT_HARD_MS,
     );
     if (staleBoot) {
       return preserveEstablishedRuntimeOnOpen(
@@ -1243,7 +1247,11 @@ export async function openSession(args: {
         'runtime_boot_failed',
       );
     }
-    await markOpencodeReadyWaitStarted(row, ensured.reason);
+    await markOpencodeReadyWaitStarted(
+      row,
+      ensured.reason === 'unreachable' ? 'unreachable' : 'not_ready',
+      ensured.bootPhase,
+    );
   } else {
     await clearRuntimeReadinessClocks(row);
   }

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -40,6 +40,7 @@ import {
 } from '../runtime-identity';
 import { inspectSandboxRuntime } from '../runtime-inspection';
 import type { StopReason } from '../stop-reason';
+import { recoverTurnsAfterRuntimeRestart } from '../session-lifecycle/runtime-restart-recovery';
 import {
   RUNTIME_READINESS_CLOCK_KEYS,
   STALE_OPENCODE_BOOT_HARD_MS,
@@ -203,6 +204,18 @@ export async function resumeStoppedSandbox(
         return true;
       });
       if (!finalized) return false;
+      // The provider had this box STOPPED: whatever turn was still open on it
+      // is over. Normally applyStoppedState settled those rows already and
+      // this finds nothing; it is the guard for a row that reached `stopped`
+      // without that path (see runtime-restart-recovery.ts).
+      await recoverTurnsAfterRuntimeRestart({
+        sandboxId: row.sandboxId,
+        sessionId: row.sessionId,
+        externalId,
+        hold: false,
+      }).catch((err) =>
+        console.warn(`[projects] turn recovery after wake failed for ${row.sandboxId}:`, err),
+      );
       await reopenComputeForSandbox(
         row.sandboxId,
         row.accountId,

--- a/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
+++ b/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
@@ -9,7 +9,16 @@ export const RUNTIME_READINESS_CLOCK_KEYS = [
   'opencodeReadyWaitReason',
   'opencodeUnreachableWaitStartedAt',
   'opencodeNotReadyWaitStartedAt',
+  'opencodeBootPhase',
+  'opencodeBootWaitFirstSeenAt',
 ] as const;
+
+/**
+ * Absolute ceiling on one OpenCode boot wait, phase changes or not. The
+ * per-reason budgets below restart on progress; this one never does, so a box
+ * that keeps changing phase without ever becoming ready is still bounded.
+ */
+export const STALE_OPENCODE_BOOT_HARD_MS = 10 * 60 * 1000;
 
 function parseTimestampMs(value: unknown): number | null {
   if (typeof value !== 'string') return null;
@@ -35,8 +44,13 @@ export function staleOpencodeReadyReason(
   reason: string,
   nowMs = Date.now(),
   staleAfterMs = 5 * 60 * 1000,
+  hardCapMs = STALE_OPENCODE_BOOT_HARD_MS,
 ): string | null {
   if (reason !== 'not_ready' && reason !== 'unreachable') return null;
+  const firstSeenMs = parseTimestampMs(metadata.opencodeBootWaitFirstSeenAt);
+  if (firstSeenMs && nowMs - firstSeenMs > hardCapMs) {
+    return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
+  }
   const reasonStartedAt =
     reason === 'unreachable'
       ? metadata.opencodeUnreachableWaitStartedAt
@@ -52,4 +66,51 @@ export function staleOpencodeReadyReason(
 
 export function hasRuntimeReadinessClock(metadata: RuntimeReadinessMetadata): boolean {
   return RUNTIME_READINESS_CLOCK_KEYS.some((key) => key in metadata);
+}
+
+/**
+ * The metadata patch that records one more not-ready observation, or null when
+ * nothing changes.
+ *
+ * The per-reason clock (`opencodeNotReadyWaitStartedAt` /
+ * `opencodeUnreachableWaitStartedAt`; legacy rows carry only
+ * `opencodeReadyWaitStartedAt` + `opencodeReadyWaitReason`) is the one
+ * `staleOpencodeReadyReason` budgets. It starts on the first observation of
+ * that reason and — the point of this function — RESTARTS whenever the daemon
+ * reports a different boot phase than last time: a box that is still making
+ * progress has not stalled. `opencodeBootWaitFirstSeenAt` is written once per
+ * boot wait and never moved; it feeds the hard cap.
+ *
+ * Essentia 2026-08-25 17:23–17:24: two resumes converged OpenCode 1.18.19 →
+ * 1.18.23 and sat through that version's 53 s first init — legitimate work the
+ * old fixed 90 s budget turned into `runtime_boot_failed` on both boxes.
+ */
+export function opencodeReadyWaitPatch(
+  metadata: RuntimeReadinessMetadata,
+  reason: 'not_ready' | 'unreachable',
+  bootPhase: string | undefined,
+  now = new Date(),
+): RuntimeReadinessMetadata | null {
+  const reasonClockKey =
+    reason === 'unreachable' ? 'opencodeUnreachableWaitStartedAt' : 'opencodeNotReadyWaitStartedAt';
+  const previousPhase =
+    typeof metadata.opencodeBootPhase === 'string' ? metadata.opencodeBootPhase : undefined;
+  const phaseChanged = bootPhase !== undefined && bootPhase !== previousPhase;
+  const legacyClockRunning =
+    metadata.opencodeReadyWaitReason === reason &&
+    typeof metadata.opencodeReadyWaitStartedAt === 'string';
+  const clockRunning = typeof metadata[reasonClockKey] === 'string' || legacyClockRunning;
+  if (clockRunning && !phaseChanged) return null;
+  const startedAt = now.toISOString();
+  return {
+    ...metadata,
+    opencodeReadyWaitStartedAt: startedAt,
+    opencodeReadyWaitReason: reason,
+    [reasonClockKey]: startedAt,
+    opencodeBootWaitFirstSeenAt:
+      typeof metadata.opencodeBootWaitFirstSeenAt === 'string'
+        ? metadata.opencodeBootWaitFirstSeenAt
+        : startedAt,
+    ...(bootPhase !== undefined ? { opencodeBootPhase: bootPhase } : {}),
+  };
 }

--- a/apps/api/src/projects/session-lifecycle/runtime-restart-recovery.test.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-restart-recovery.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  type LostTurn,
+  type RuntimeRestartRecoveryDeps,
+  recoverTurnsAfterRuntimeRestart,
+} from './runtime-restart-recovery';
+
+function deps(lost: LostTurn[], overrides: Partial<RuntimeRestartRecoveryDeps> = {}) {
+  const requeued: Array<Record<string, unknown>> = [];
+  const logs: Array<{ message: string; meta: Record<string, unknown> }> = [];
+  const d: RuntimeRestartRecoveryDeps = {
+    settleLostTurns: async () => lost,
+    requeue: async (input) => {
+      requeued.push(input);
+      return 'requeued';
+    },
+    log: (message, meta) => logs.push({ message, meta }),
+    ...overrides,
+  };
+  return { d, requeued, logs };
+}
+
+describe('recoverTurnsAfterRuntimeRestart (Essentia 2026-08-25: wake under an open turn)', () => {
+  test('a box with no open turn is untouched', async () => {
+    const { d, requeued, logs } = deps([]);
+    const result = await recoverTurnsAfterRuntimeRestart({ sandboxId: 'sb', sessionId: 'ses' }, d);
+    expect(result.lost).toEqual([]);
+    expect(requeued).toEqual([]);
+    expect(logs).toEqual([]);
+  });
+
+  test('every open turn is settled and each prompt it carried is redelivered DUE on a wake', async () => {
+    const { d, requeued } = deps([
+      { token: 't-active', messageId: 'msg_active', state: 'active' },
+      { token: 't-delivering', messageId: 'msg_delivering', state: 'delivering' },
+      { token: 't-no-prompt', messageId: null, state: 'active' },
+    ]);
+    const result = await recoverTurnsAfterRuntimeRestart(
+      { sandboxId: 'sb', sessionId: 'ses', externalId: 'ext' },
+      d,
+    );
+    expect(result.lost).toHaveLength(3);
+    expect(requeued).toEqual([
+      {
+        sessionId: 'ses',
+        wireMessageId: 'msg_active',
+        turnToken: 't-active',
+        endReason: 'runtime_gone',
+        hold: false,
+      },
+      {
+        sessionId: 'ses',
+        wireMessageId: 'msg_delivering',
+        turnToken: 't-delivering',
+        endReason: 'runtime_gone',
+        hold: false,
+      },
+      {
+        sessionId: 'ses',
+        wireMessageId: null,
+        turnToken: 't-no-prompt',
+        endReason: 'runtime_gone',
+        hold: false,
+      },
+    ]);
+  });
+
+  test('hold:true keeps the prompt visible but not due', async () => {
+    const { d, requeued } = deps([{ token: 't', messageId: 'm', state: 'active' }]);
+    await recoverTurnsAfterRuntimeRestart({ sandboxId: 'sb', sessionId: 'ses', hold: true }, d);
+    expect(requeued[0]?.hold).toBe(true);
+  });
+
+  test('one failed redelivery does not stop the others and is reported, never thrown', async () => {
+    let calls = 0;
+    const { d, logs } = deps(
+      [
+        { token: 't1', messageId: 'm1', state: 'active' },
+        { token: 't2', messageId: 'm2', state: 'active' },
+      ],
+      {
+        requeue: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error('inbox unavailable');
+          return 'requeued';
+        },
+      },
+    );
+    const result = await recoverTurnsAfterRuntimeRestart({ sandboxId: 'sb', sessionId: 'ses' }, d);
+    expect(result.redeliveries).toEqual([
+      { token: 't1', outcome: 'error' },
+      { token: 't2', outcome: 'requeued' },
+    ]);
+    expect(logs.some((l) => l.message.includes('redelivery failed'))).toBe(true);
+  });
+});

--- a/apps/api/src/projects/session-lifecycle/runtime-restart-recovery.ts
+++ b/apps/api/src/projects/session-lifecycle/runtime-restart-recovery.ts
@@ -1,0 +1,127 @@
+/**
+ * A runtime that is started again after the provider had it STOPPED comes back
+ * with nothing in memory: every pause Kortix issues or observes is a
+ * `keepMemory:false` pause (E2B), a stop (Daytona) or a lifecycle stop
+ * (Platinum). Any turn that was open on that box is therefore over — the
+ * OpenCode process that owned it is gone — and its last assistant message sits
+ * in the transcript with `tokens 0/0/0` and no parts.
+ *
+ * Essentia 2026-08-25: the provider paused two boxes mid-turn; the UI's next
+ * request woke them through the proxy (`wakeSandbox`) without touching the turn
+ * authority, the fresh runtime answered `idle`, and one turn was closed
+ * `completed` — the user saw the agent "just stop", with no error and nothing
+ * to resume. The other box, confirmed stopped by the reaper first, closed
+ * `runtime_gone` but its accepted prompt was never redelivered, so the user had
+ * to type "go on".
+ *
+ * This is the single place a restart-under-a-turn is repaired: settle every
+ * open ledger row `runtime_gone`, drop the turn authority the dead runtime held,
+ * and redeliver each prompt those turns carried. `hold:false` on a wake —
+ * the box is up and someone is looking — so the interrupted work continues by
+ * itself; `MAX_PROMPT_REDELIVERIES` in redelivery.ts bounds any loop.
+ */
+import { eq, sql } from 'drizzle-orm';
+import { sessionSandboxes } from '@kortix/db';
+import { db } from '../../shared/db';
+import { settleOpenSandboxTurns, storedSandboxTurns } from '../sandbox-turn-lifecycle';
+import { type PromptRedelivery, requeueAbandonedPrompt } from './redelivery';
+
+export interface LostTurn {
+  token: string;
+  messageId: string | null;
+  state: string;
+}
+
+export interface RuntimeRestartRecoveryDeps {
+  settleLostTurns: (sandboxId: string) => Promise<LostTurn[]>;
+  requeue: (input: {
+    sessionId: string;
+    wireMessageId: string | null;
+    turnToken: string;
+    endReason: 'runtime_gone';
+    hold: boolean;
+  }) => Promise<PromptRedelivery>;
+  log?: (message: string, meta: Record<string, unknown>) => void;
+}
+
+export interface RuntimeRestartRecoveryResult {
+  lost: LostTurn[];
+  redeliveries: Array<{ token: string; outcome: PromptRedelivery | 'error' }>;
+}
+
+/**
+ * Settle every open turn of a sandbox whose runtime just restarted and drop the
+ * metadata authority that would otherwise let the fresh runtime's first idle
+ * read close those turns as `completed`.
+ */
+export async function settleTurnsLostToRuntimeRestart(sandboxId: string): Promise<LostTurn[]> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({ metadata: sessionSandboxes.metadata })
+      .from(sessionSandboxes)
+      .where(eq(sessionSandboxes.sandboxId, sandboxId))
+      .for('update')
+      .limit(1);
+    const turns = storedSandboxTurns(row?.metadata as Record<string, unknown> | null);
+    if (turns.length === 0) return [];
+    await tx
+      .update(sessionSandboxes)
+      .set({
+        metadata: sql`(coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
+          - 'activeTurn'
+          - 'activeTurns'
+          - 'pendingStopObservedAtMs')`,
+        updatedAt: new Date(),
+      })
+      .where(eq(sessionSandboxes.sandboxId, sandboxId));
+    await settleOpenSandboxTurns(tx, sandboxId, 'runtime_gone');
+    return turns.map((turn) => ({
+      token: turn.token,
+      messageId: turn.messageId ?? null,
+      state: turn.state,
+    }));
+  });
+}
+
+const liveDeps: RuntimeRestartRecoveryDeps = {
+  settleLostTurns: settleTurnsLostToRuntimeRestart,
+  requeue: (input) => requeueAbandonedPrompt(input),
+  log: (message, meta) => console.log(message, meta),
+};
+
+export async function recoverTurnsAfterRuntimeRestart(
+  input: { sandboxId: string; sessionId: string; externalId?: string | null; hold?: boolean },
+  deps: RuntimeRestartRecoveryDeps = liveDeps,
+): Promise<RuntimeRestartRecoveryResult> {
+  const lost = await deps.settleLostTurns(input.sandboxId);
+  const redeliveries: RuntimeRestartRecoveryResult['redeliveries'] = [];
+  for (const turn of lost) {
+    try {
+      const outcome = await deps.requeue({
+        sessionId: input.sessionId,
+        wireMessageId: turn.messageId,
+        turnToken: turn.token,
+        endReason: 'runtime_gone',
+        hold: input.hold ?? false,
+      });
+      redeliveries.push({ token: turn.token, outcome });
+    } catch (err) {
+      redeliveries.push({ token: turn.token, outcome: 'error' });
+      deps.log?.('[runtime-restart] prompt redelivery failed', {
+        sandboxId: input.sandboxId,
+        turn: turn.token,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (lost.length > 0) {
+    deps.log?.('[runtime-restart] runtime restarted under open turns; settled runtime_gone', {
+      sandboxId: input.sandboxId,
+      externalId: input.externalId ?? null,
+      turns: lost.map((turn) => `${turn.token}:${turn.state}`),
+      redeliveries,
+      hold: input.hold ?? false,
+    });
+  }
+  return { lost, redeliveries };
+}

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -30,6 +30,7 @@ import {
   type SandboxIngressRequest,
   type SandboxIngressRoute,
 } from '../platform/providers';
+import { recoverTurnsAfterRuntimeRestart } from '../projects/session-lifecycle/runtime-restart-recovery';
 import { db } from '../shared/db';
 import { resolvePreviewUserContext } from '../shared/preview-ownership';
 import {
@@ -330,8 +331,27 @@ export async function wakeSandbox(externalId: string): Promise<void> {
       console.log(`[PREVIEW] Wake refused for expired sandbox ${externalId}`);
       return;
     }
-    await getProvider(record.provider as ProviderName).ensureRunning(externalId);
+    const provider = getProvider(record.provider as ProviderName);
+    // Read the provider state BEFORE starting: a box that was actually stopped
+    // comes back with no runtime, and every turn open on it is over. Without
+    // this the fresh runtime's first idle read closed such turns `completed`
+    // and the interrupted prompt was never redelivered (Essentia 2026-08-25).
+    const before = await provider.getStatus(externalId).catch(() => 'unknown' as const);
+    await provider.ensureRunning(externalId);
     console.log(`[PREVIEW] Wake-up triggered for sandbox ${externalId}`);
+    if (before === 'stopped') {
+      await recoverTurnsAfterRuntimeRestart({
+        sandboxId: record.sandboxId,
+        sessionId: record.sessionId,
+        externalId,
+        hold: false,
+      }).catch((err) =>
+        console.warn(
+          `[PREVIEW] turn recovery after wake failed for ${externalId}:`,
+          err instanceof Error ? err.message : err,
+        ),
+      );
+    }
   } catch (e) {
     console.error(`[PREVIEW] Failed to wake sandbox ${externalId}:`, e);
   }

--- a/apps/api/src/sandbox-proxy/backend.ts
+++ b/apps/api/src/sandbox-proxy/backend.ts
@@ -336,7 +336,10 @@ export async function wakeSandbox(externalId: string): Promise<void> {
     // comes back with no runtime, and every turn open on it is over. Without
     // this the fresh runtime's first idle read closed such turns `completed`
     // and the interrupted prompt was never redelivered (Essentia 2026-08-25).
-    const before = await provider.getStatus(externalId).catch(() => 'unknown' as const);
+    const before =
+      typeof provider.getStatus === 'function'
+        ? await provider.getStatus(externalId).catch(() => 'unknown' as const)
+        : ('unknown' as const);
     await provider.ensureRunning(externalId);
     console.log(`[PREVIEW] Wake-up triggered for sandbox ${externalId}`);
     if (before === 'stopped') {

--- a/apps/api/src/sandbox-proxy/wake-deadline-guard.test.ts
+++ b/apps/api/src/sandbox-proxy/wake-deadline-guard.test.ts
@@ -30,9 +30,20 @@ mock.module('../shared/kortix-user-context', () => ({
   KORTIX_USER_CONTEXT_HEADER: 'x-kortix-user-context',
   encodeKortixUserContext: () => '',
 }));
+let providerStatusBeforeWake: 'running' | 'stopped' | 'unknown' = 'running';
+const recoveryCalls: Array<Record<string, unknown>> = [];
+mock.module('../projects/session-lifecycle/runtime-restart-recovery', () => ({
+  recoverTurnsAfterRuntimeRestart: async (input: Record<string, unknown>) => {
+    recoveryCalls.push(input);
+    return { lost: [], redeliveries: [] };
+  },
+}));
 mock.module('../platform/providers', () => ({
   ...realProviders,
   getProvider: () => ({
+    async getStatus() {
+      return providerStatusBeforeWake;
+    },
     async ensureRunning(externalId: string) {
       ensureRunningCalls.push(externalId);
     },
@@ -79,6 +90,8 @@ const { wakeSandbox } = await import('./backend');
 
 function reset(nextDeadline: Date | null) {
   ensureRunningCalls = [];
+  recoveryCalls.length = 0;
+  providerStatusBeforeWake = 'running';
   deadlineAt = nextDeadline;
 }
 
@@ -89,6 +102,30 @@ describe('wakeSandbox — a provider start obeys the deadline', () => {
     await wakeSandbox('ext-1');
 
     expect(ensureRunningCalls).toEqual(['ext-1']);
+  });
+
+  test('a box that was STOPPED at the provider has its open turns recovered after the start', async () => {
+    // Essentia 2026-08-25 15:56: the UI woke a provider-paused box through
+    // this path; the fresh runtime's first idle read then closed the killed
+    // turn `completed` and its prompt was never redelivered.
+    reset(new Date(Date.now() + 60 * 60_000));
+    providerStatusBeforeWake = 'stopped';
+
+    await wakeSandbox('ext-1');
+
+    expect(ensureRunningCalls).toEqual(['ext-1']);
+    expect(recoveryCalls).toEqual([
+      { sandboxId: 'sb-1', sessionId: 'sess-1', externalId: 'ext-1', hold: false },
+    ]);
+  });
+
+  test('a box that was already running is not treated as a restart', async () => {
+    reset(new Date(Date.now() + 60 * 60_000));
+    providerStatusBeforeWake = 'running';
+
+    await wakeSandbox('ext-1');
+
+    expect(recoveryCalls).toEqual([]);
   });
 
   test('REFUSES to wake a box whose deadline has passed', async () => {

--- a/apps/api/src/setup-links/public-app.test.ts
+++ b/apps/api/src/setup-links/public-app.test.ts
@@ -331,13 +331,17 @@ describe('POST /connectors/:token/finalize', () => {
     expect(String(enqueued[0].text)).toContain('smartlead');
   });
 
-  test('does not notify a stopped session — a public poll must never boot a sandbox', async () => {
+  test('a STOPPED session is told too — the agent posted the link and its turn ended before the human finished (#6885)', async () => {
+    // The enqueue writes a durable continue-session command; nothing here
+    // boots a sandbox. Dev measured 3455 stopped sessions to 1 running at the
+    // moment a connect lands, so `running` was the wrong gate.
     pipedreamOn = true;
     finalizeResult = { connected: true };
     sessionRows = [{ status: 'stopped', accountId: 'acct-1', metadata: {} }];
     expect((await finalize(mintConnectorToken())).status).toBe(200);
     await flushNotification();
-    expect(enqueued).toHaveLength(0);
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]).toMatchObject({ source: 'system:connector-connected', sessionId: SESSION_ID });
   });
 
   test('does not notify a deleted session', async () => {

--- a/apps/cli/src/self-host/__tests__/compose-assets.test.ts
+++ b/apps/cli/src/self-host/__tests__/compose-assets.test.ts
@@ -152,6 +152,17 @@ describe('full self-host Docker distribution', () => {
     ).toBe('2');
   });
 
+  test('passes the gateway request-body cap override through to llm-gateway', () => {
+    // Essentia 2026-08-25: image-heavy turns (>128 MiB) 413'd at the gateway
+    // default with no way to raise it from the box .env.
+    const document = parse(renderFullDockerCompose('kortix-default')) as {
+      services: Record<string, { environment?: Record<string, string> }>;
+    };
+    expect(document.services['llm-gateway']?.environment?.GATEWAY_MAX_REQUEST_BYTES).toBe(
+      '${KORTIX_GATEWAY_MAX_REQUEST_BYTES:-}',
+    );
+  });
+
   test('omits the cloudflared tunnel service when tunnel mode is not selected', () => {
     const document = parse(renderFullDockerCompose('kortix-default')) as {
       services: Record<string, unknown>;

--- a/apps/cli/src/self-host/assets/kortix-compose.yml
+++ b/apps/cli/src/self-host/assets/kortix-compose.yml
@@ -118,6 +118,12 @@ services:
       PORT: "8090"
       KORTIX_API_URL: http://kortix-api:8008
       GATEWAY_INTERNAL_TOKEN: ${GATEWAY_INTERNAL_TOKEN}
+      # Per-request body cap override (bytes). Unset = the gateway default,
+      # clamped to what its memory budget can hold. Image-heavy agent turns can
+      # exceed the default (Essentia 2026-08-25: >128 MiB, 118 inline
+      # screenshots); a box with KORTIX_GATEWAY_MEMORY_LIMIT raised can raise
+      # this too.
+      GATEWAY_MAX_REQUEST_BYTES: ${KORTIX_GATEWAY_MAX_REQUEST_BYTES:-}
     depends_on:
       kortix-api:
         condition: service_started

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-phase.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-phase.test.ts
@@ -1,34 +1,34 @@
-import { describe, expect, test } from 'bun:test'
-import { bootPhaseLabel } from '../boot-phase'
+import { describe, expect, test } from 'bun:test';
+import { bootPhaseLabel } from '../boot-phase';
 
 describe('bootPhaseLabel', () => {
   test('changes as the boot advances, so the API can see progress', () => {
-    const timeline: { label: string }[] = []
-    const a = bootPhaseLabel({ timeline, opencodeState: 'starting' })
-    timeline.push({ label: 'repo-materialized' })
-    const b = bootPhaseLabel({ timeline, opencodeState: 'starting' })
-    timeline.push({ label: 'opencode-spawned' })
-    const c = bootPhaseLabel({ timeline, opencodeState: 'starting' })
-    const d = bootPhaseLabel({ timeline, opencodeState: 'ok' })
-    expect(new Set([a, b, c, d]).size).toBe(4)
-  })
+    const timeline: { label: string }[] = [];
+    const a = bootPhaseLabel({ timeline, opencodeState: 'starting' });
+    timeline.push({ label: 'repo-materialized' });
+    const b = bootPhaseLabel({ timeline, opencodeState: 'starting' });
+    timeline.push({ label: 'opencode-spawned' });
+    const c = bootPhaseLabel({ timeline, opencodeState: 'starting' });
+    const d = bootPhaseLabel({ timeline, opencodeState: 'ok' });
+    expect(new Set([a, b, c, d]).size).toBe(4);
+  });
 
   test('an OpenCode install in flight is visible as its own phase', () => {
-    const timeline = [{ label: 'config-deps' }]
-    const idle = bootPhaseLabel({ timeline, opencodeState: 'starting' })
+    const timeline = [{ label: 'config-deps' }];
+    const idle = bootPhaseLabel({ timeline, opencodeState: 'starting' });
     const installing = bootPhaseLabel({
       timeline,
       opencodeState: 'starting',
       runtimeAssetsActivity: 'installing-opencode@1.18.23',
-    })
-    expect(installing).not.toBe(idle)
-    expect(installing).toContain('installing-opencode@1.18.23')
-  })
+    });
+    expect(installing).not.toBe(idle);
+    expect(installing).toContain('installing-opencode@1.18.23');
+  });
 
   test('a stuck boot yields the same label every time (no false progress)', () => {
-    const timeline = [{ label: 'opencode-spawned' }]
+    const timeline = [{ label: 'opencode-spawned' }];
     expect(bootPhaseLabel({ timeline, opencodeState: 'starting' })).toBe(
       bootPhaseLabel({ timeline, opencodeState: 'starting' }),
-    )
-  })
-})
+    );
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-phase.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-phase.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+import { bootPhaseLabel } from '../boot-phase'
+
+describe('bootPhaseLabel', () => {
+  test('changes as the boot advances, so the API can see progress', () => {
+    const timeline: { label: string }[] = []
+    const a = bootPhaseLabel({ timeline, opencodeState: 'starting' })
+    timeline.push({ label: 'repo-materialized' })
+    const b = bootPhaseLabel({ timeline, opencodeState: 'starting' })
+    timeline.push({ label: 'opencode-spawned' })
+    const c = bootPhaseLabel({ timeline, opencodeState: 'starting' })
+    const d = bootPhaseLabel({ timeline, opencodeState: 'ok' })
+    expect(new Set([a, b, c, d]).size).toBe(4)
+  })
+
+  test('an OpenCode install in flight is visible as its own phase', () => {
+    const timeline = [{ label: 'config-deps' }]
+    const idle = bootPhaseLabel({ timeline, opencodeState: 'starting' })
+    const installing = bootPhaseLabel({
+      timeline,
+      opencodeState: 'starting',
+      runtimeAssetsActivity: 'installing-opencode@1.18.23',
+    })
+    expect(installing).not.toBe(idle)
+    expect(installing).toContain('installing-opencode@1.18.23')
+  })
+
+  test('a stuck boot yields the same label every time (no false progress)', () => {
+    const timeline = [{ label: 'opencode-spawned' }]
+    expect(bootPhaseLabel({ timeline, opencodeState: 'starting' })).toBe(
+      bootPhaseLabel({ timeline, opencodeState: 'starting' }),
+    )
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/connector-mcp-config.test.ts
@@ -54,9 +54,10 @@ describe('buildOpencodeConfigContent — injected managed skills', () => {
   })
 
   test('a missing injected dir contributes nothing', async () => {
-    expect(
-      await buildOpencodeConfigContent({}, { injectedSkillsDir: '/nonexistent-skills-dir' }),
-    ).toBeUndefined()
+    const parsed = JSON.parse(
+      (await buildOpencodeConfigContent({}, { injectedSkillsDir: '/nonexistent-skills-dir' }))!,
+    )
+    expect(parsed.skills).toBeUndefined()
   })
 
   test('loads the generated secret capability guide without replacing project instructions', async () => {
@@ -72,7 +73,8 @@ describe('buildOpencodeConfigContent — injected managed skills', () => {
 
 describe('buildOpencodeConfigContent — optional connector MCP server', () => {
   test('does not register connector MCP by default; CLI is the primary Connector path', async () => {
-    expect(await buildOpencodeConfigContent(ENV)).toBeUndefined()
+    const parsed = JSON.parse((await buildOpencodeConfigContent(ENV))!)
+    expect(parsed.mcp).toBeUndefined()
   })
 
   test('registers the connector MCP server only when explicitly enabled', async () => {
@@ -92,11 +94,33 @@ describe('buildOpencodeConfigContent — optional connector MCP server', () => {
     expect(server.command).toEqual(['/usr/local/bin/kortix', 'connectors', 'mcp'])
   })
 
-  test('returns undefined when no contributor applies', async () => {
-    expect(await buildOpencodeConfigContent({})).toBeUndefined()
-    expect(await buildOpencodeConfigContent({ KORTIX_TOKEN: 'tok-123' })).toBeUndefined()
-    expect(await buildOpencodeConfigContent({ KORTIX_API_URL: 'https://api.kortix.test/v1' })).toBeUndefined()
-    expect(await buildOpencodeConfigContent({ ...ENV, KORTIX_CONNECTORS_MCP_ENABLED: '0' })).toBeUndefined()
+  test('registers nothing session-specific when no contributor applies', async () => {
+    for (const env of [
+      {},
+      { KORTIX_TOKEN: 'tok-123' },
+      { KORTIX_API_URL: 'https://api.kortix.test/v1' },
+      { ...ENV, KORTIX_CONNECTORS_MCP_ENABLED: '0' },
+    ]) {
+      const parsed = JSON.parse((await buildOpencodeConfigContent(env))!)
+      expect(parsed.mcp).toBeUndefined()
+      expect(parsed.provider).toBeUndefined()
+    }
+  })
+
+  test('always disables OpenCode autoupdate — the daemon owns the binary', async () => {
+    // A human running `opencode` in the Session terminal triggered OpenCode's
+    // own upgrade (plain `pnpm add -g`, no postinstall) on two Essentia boxes
+    // on 2026-08-25, leaving a 479-byte launcher stub and a dangling
+    // /opt/kortix/opencode.current. The next OpenCode restart would have booted
+    // the stub. Every composed config now pins autoupdate off, and a base
+    // config cannot turn it back on.
+    for (const env of [{}, ENV, { ...ENV, KORTIX_CONNECTORS_MCP_ENABLED: '1' }]) {
+      expect(JSON.parse((await buildOpencodeConfigContent(env))!).autoupdate).toBe(false)
+    }
+    const parsed = JSON.parse(
+      (await buildOpencodeConfigContent({ OPENCODE_CONFIG_CONTENT: JSON.stringify({ autoupdate: true }) }))!,
+    )
+    expect(parsed.autoupdate).toBe(false)
   })
 
   test('merges onto pre-existing inline config without clobbering it', async () => {
@@ -333,8 +357,10 @@ describe('buildOpencodeConfigContent — server-compiled v2 agent config (KORTIX
     })
   })
 
-  test('a v1 project (no KORTIX_COMPILED_AGENT_CONFIG) is unaffected: still undefined with no other contributor', async () => {
-    expect(await buildOpencodeConfigContent({})).toBeUndefined()
+  test('a v1 project (no KORTIX_COMPILED_AGENT_CONFIG) is unaffected: no agent map with no other contributor', async () => {
+    const parsed = JSON.parse((await buildOpencodeConfigContent({}))!)
+    expect(parsed.agent).toBeUndefined()
+    expect(parsed.model).toBeUndefined()
   })
 
   test('the gateway overlay normalizes compiled top-level and agent models', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/native-mode-config.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/native-mode-config.test.ts
@@ -20,9 +20,11 @@ describe('buildOpencodeConfigContent — native mode (no gateway env)', () => {
     expect(parsed.model).toBe('anthropic/claude-sonnet-4-6')
   })
 
-  test('returns undefined when there is nothing to inject at all', async () => {
+  test('with nothing session-specific to inject, only the Kortix-managed overlay remains', async () => {
     const content = await buildOpencodeConfigContent({})
-    expect(content).toBeUndefined()
+    // autoupdate:false is unconditional (Essentia 2026-08-22/25: OpenCode's
+    // self-upgrade via plain `pnpm add -g` left a postinstall-less stub).
+    expect(JSON.parse(content!)).toEqual({ autoupdate: false })
   })
 
   test('the session pin does not clobber an explicit base-config model', async () => {
@@ -50,7 +52,10 @@ describe('buildOpencodeConfigContent — native mode (no gateway env)', () => {
       KORTIX_OPENCODE_MODEL: 'kortix/glm-5.2',
       OPENCODE_CONFIG_CONTENT: JSON.stringify({ small_model: 'anthropic/claude-haiku-4-5' }),
     })
-    expect(content).toBeUndefined()
+    const parsed = JSON.parse(content!)
+    expect(parsed.model).toBeUndefined()
+    expect(parsed.small_model).toBe('anthropic/claude-haiku-4-5')
+    expect(parsed.autoupdate).toBe(false)
   })
 
   test('a base config carrying kortix refs IS rebuilt and scrubbed even with nothing else to inject', async () => {

--- a/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/opencode-binary.test.ts
@@ -97,6 +97,26 @@ describe('OpenCode launch binary detection', () => {
     expect(events).toEqual(['path:opencode'])
   })
 
+  test('never launches a postinstall-less pnpm stub from PATH; falls through to the managed link', async () => {
+    // OpenCode's own autoupdate (plain `pnpm add -g`) leaves a 479-byte stub as
+    // the PATH launcher (Essentia 2026-08-22 and 2026-08-25). Spawning it exits
+    // at once and the daemon respawns forever with "binary not found".
+    const events: string[] = []
+    const resolved = await detectOpencodeBinary({
+      nativeBinaryFastPathEnabled: false,
+      currentLink: '/test/opencode.current',
+      systemLink: '/test/opencode-kortix',
+      isExecutable: async (path) => {
+        events.push(`executable:${path}`)
+        return path === '/test/opencode.current'
+      },
+      findOnPath: async () => '/test/pnpm-bin/opencode',
+      isStubLauncher: async (path) => path === '/test/pnpm-bin/opencode',
+    })
+    expect(resolved).toBe('/test/opencode.current')
+    expect(events).toEqual(['executable:/test/opencode.current'])
+  })
+
   test('uses an existing stable link when the experiment is enabled', async () => {
     const events: string[] = []
 
@@ -293,5 +313,43 @@ describe('OpenCode runtime installation', () => {
     ).rejects.toThrow('expected 1.18.19, got 1.18.18')
 
     expect(await readlink(current)).toBe(oldNative)
+  })
+})
+
+describe('isStubOpencodeLauncher', () => {
+  test('recognises the pnpm postinstall stub behind a real cmd-shim and accepts a real launcher', async () => {
+    const { isStubOpencodeLauncher } = await import('../opencode')
+    const dir = await mkdtemp(join(tmpdir(), 'kortix-stub-'))
+    try {
+      // Exactly what pnpm's shim looks like on a box (Essentia 2026-08-25).
+      const shim = (exe: string) =>
+        `#!/bin/sh\nbasedir=$(dirname "$(echo "$0" | sed -e 's,\\\\,/,g')")\nexe=""\n` +
+        `exec "$basedir/../global/v11/229-hash/node_modules/opencode-ai/bin/opencode.exe"   "$@"\nexit $?\n` +
+        `# cmd-shim-target=${exe}\n`
+      const stubPkg = join(dir, 'global/v11/229-hash/node_modules/opencode-ai/bin')
+      await mkdir(stubPkg, { recursive: true })
+      const stub = join(stubPkg, 'opencode.exe')
+      await writeFile(
+        stub,
+        "#!/bin/sh\necho \"Error: opencode-ai's postinstall script was not run.\"\nexit 1\n",
+        { mode: 0o755 },
+      )
+      const bin = join(dir, 'bin')
+      await mkdir(bin, { recursive: true })
+      await writeFile(join(bin, 'opencode'), shim(stub), { mode: 0o755 })
+      expect(await isStubOpencodeLauncher(stub)).toBe(true)
+      expect(await isStubOpencodeLauncher(join(bin, 'opencode'))).toBe(true)
+
+      const real = join(stubPkg, 'real.exe')
+      await writeFile(real, Buffer.alloc(70 * 1024, 1), { mode: 0o755 })
+      await writeFile(join(bin, 'opencode-real'), shim(real), { mode: 0o755 })
+      expect(await isStubOpencodeLauncher(real)).toBe(false)
+      expect(await isStubOpencodeLauncher(join(bin, 'opencode-real'))).toBe(false)
+      // Unresolvable target: not a stub (never take a launcher away on a guess).
+      await writeFile(join(bin, 'opencode-gone'), shim(join(dir, 'missing.exe')), { mode: 0o755 })
+      expect(await isStubOpencodeLauncher(join(bin, 'opencode-gone'))).toBe(false)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -1032,6 +1032,43 @@ describe('daemon proxy auth gate', () => {
     }
   })
 
+  it('names the boot phase on every not-ready answer so the API can measure progress', async () => {
+    // Essentia 2026-08-25 17:23: a resume that converged OpenCode 1.18.19 →
+    // 1.18.23 and sat through the new version's 53 s first init was parked as
+    // runtime_boot_failed by a fixed 90 s budget. The header lets the API
+    // restart its clock on progress instead.
+    const root = mkdtempSync(join(tmpdir(), 'kortix-boot-phase-'))
+    try {
+      const target = join(root, 'workspace')
+      mkdirSync(target)
+      const timeline: { label: string; atMs: number }[] = [{ label: 'config-deps', atMs: 1 }]
+      const app = buildOpencodeApp(
+        baseConfig({ autoClone: false, projectTarget: target }),
+        fakeOpencode('starting'),
+        Date.now(),
+        { repoMaterializationError: null, timeline },
+      )
+      const signed = signCtx({ userId: 'u', sandboxId: 's', sandboxRole: 'owner' }, TEST_TOKEN)
+      const first = await app.request('/session?directory=%2Fworkspace', {
+        headers: { [KORTIX_USER_CONTEXT_HEADER]: signed },
+      })
+      expect(first.status).toBe(503)
+      const firstPhase = first.headers.get('x-kortix-boot-phase')
+      expect(firstPhase).toContain('config-deps')
+      expect(firstPhase).toContain('opencode=starting')
+      expect(((await first.json()) as { phase: string }).phase).toBe(firstPhase)
+
+      timeline.push({ label: 'opencode-spawned', atMs: 2 })
+      const second = await app.request('/session?directory=%2Fworkspace', {
+        headers: { [KORTIX_USER_CONTEXT_HEADER]: signed },
+      })
+      expect(second.status).toBe(503)
+      expect(second.headers.get('x-kortix-boot-phase')).not.toBe(firstPhase)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('keeps runtime not ready until the boot OpenCode session is pinned', async () => {
     const app = buildOpencodeApp(
       baseConfig(),

--- a/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/proxy-auth.test.ts
@@ -1053,7 +1053,8 @@ describe('daemon proxy auth gate', () => {
         headers: { [KORTIX_USER_CONTEXT_HEADER]: signed },
       })
       expect(first.status).toBe(503)
-      const firstPhase = first.headers.get('x-kortix-boot-phase')
+      const firstPhase = first.headers.get('x-kortix-boot-phase') ?? ''
+      expect(firstPhase).not.toBe('')
       expect(firstPhase).toContain('config-deps')
       expect(firstPhase).toContain('opencode=starting')
       expect(((await first.json()) as { phase: string }).phase).toBe(firstPhase)

--- a/apps/kortix-sandbox-agent-server/src/__tests__/refresh-converge-guard.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/refresh-converge-guard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test';
+import { refreshMayConvergeRuntime } from '../routes/refresh';
+
+describe('refreshMayConvergeRuntime', () => {
+  test('a booting runtime is never converged from a refresh', () => {
+    // Essentia 2026-08-25 17:23: the session-open refresh installed OpenCode
+    // 1.18.23 and restarted it while the resume was still booting.
+    expect(refreshMayConvergeRuntime('starting')).toBe(false);
+    expect(refreshMayConvergeRuntime('down')).toBe(false);
+  });
+  test('a serving runtime may be converged', () => {
+    expect(refreshMayConvergeRuntime('ok')).toBe(true);
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/boot-phase.ts
+++ b/apps/kortix-sandbox-agent-server/src/boot-phase.ts
@@ -1,0 +1,32 @@
+/**
+ * One short label for "how far along is this boot" — the value of the
+ * `X-Kortix-Boot-Phase` header on every not-ready (503) answer the proxy gives
+ * while OpenCode is not serving yet.
+ *
+ * Why the API needs it: its `/start` budget used to be "not ready for 90 s
+ * after the first poll → runtime_boot_failed → pause the box". A resume that
+ * has to converge a new OpenCode pin and then sit through that version's first
+ * init blows straight through 90 s while doing exactly what it should
+ * (Essentia 2026-08-25 17:23–17:24, both boxes). With this label the API can
+ * restart its clock whenever the phase CHANGES and only give up when the box
+ * has made no progress at all — a stub launcher that respawns forever never
+ * changes phase, so the failure it was meant to catch is still caught.
+ *
+ * The label is opaque to the API: equality is the only operation on it.
+ */
+export interface BootPhaseInput {
+  timeline: ReadonlyArray<{ label: string }>
+  opencodeState: string
+  runtimeAssetsActivity?: string | null
+  notReadyReason?: string
+}
+
+export function bootPhaseLabel(input: BootPhaseInput): string {
+  const lastMark = input.timeline.length > 0 ? input.timeline[input.timeline.length - 1]!.label : 'boot'
+  const parts = [lastMark, `opencode=${input.opencodeState}`]
+  if (input.runtimeAssetsActivity) parts.push(input.runtimeAssetsActivity)
+  if (input.notReadyReason) parts.push(input.notReadyReason)
+  return parts.join('|')
+}
+
+export const BOOT_PHASE_HEADER = 'X-Kortix-Boot-Phase'

--- a/apps/kortix-sandbox-agent-server/src/boot-phase.ts
+++ b/apps/kortix-sandbox-agent-server/src/boot-phase.ts
@@ -22,8 +22,7 @@ export interface BootPhaseInput {
 }
 
 export function bootPhaseLabel(input: BootPhaseInput): string {
-  const lastMark =
-    input.timeline.length > 0 ? input.timeline[input.timeline.length - 1]!.label : 'boot';
+  const lastMark = input.timeline.at(-1)?.label ?? 'boot';
   const parts = [lastMark, `opencode=${input.opencodeState}`];
   if (input.runtimeAssetsActivity) parts.push(input.runtimeAssetsActivity);
   if (input.notReadyReason) parts.push(input.notReadyReason);

--- a/apps/kortix-sandbox-agent-server/src/boot-phase.ts
+++ b/apps/kortix-sandbox-agent-server/src/boot-phase.ts
@@ -15,18 +15,19 @@
  * The label is opaque to the API: equality is the only operation on it.
  */
 export interface BootPhaseInput {
-  timeline: ReadonlyArray<{ label: string }>
-  opencodeState: string
-  runtimeAssetsActivity?: string | null
-  notReadyReason?: string
+  timeline: ReadonlyArray<{ label: string }>;
+  opencodeState: string;
+  runtimeAssetsActivity?: string | null;
+  notReadyReason?: string;
 }
 
 export function bootPhaseLabel(input: BootPhaseInput): string {
-  const lastMark = input.timeline.length > 0 ? input.timeline[input.timeline.length - 1]!.label : 'boot'
-  const parts = [lastMark, `opencode=${input.opencodeState}`]
-  if (input.runtimeAssetsActivity) parts.push(input.runtimeAssetsActivity)
-  if (input.notReadyReason) parts.push(input.notReadyReason)
-  return parts.join('|')
+  const lastMark =
+    input.timeline.length > 0 ? input.timeline[input.timeline.length - 1]!.label : 'boot';
+  const parts = [lastMark, `opencode=${input.opencodeState}`];
+  if (input.runtimeAssetsActivity) parts.push(input.runtimeAssetsActivity);
+  if (input.notReadyReason) parts.push(input.notReadyReason);
+  return parts.join('|');
 }
 
-export const BOOT_PHASE_HEADER = 'X-Kortix-Boot-Phase'
+export const BOOT_PHASE_HEADER = 'X-Kortix-Boot-Phase';

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -38,7 +38,7 @@ export type VerifiedReloadResult =
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
-import { access, constants, open, stat } from 'node:fs/promises'
+import { access, constants, open, readFile, realpath, stat } from 'node:fs/promises'
 import { isDeepStrictEqual } from 'node:util'
 
 import { AGENT_ENV_SH } from './agent-env-file'
@@ -1462,6 +1462,36 @@ export interface OpencodeBinaryDetectionOptions {
   resolveInstalledNative?: () => Promise<string>
   publishNativeLink?: (nativePath: string, linkPath: string) => Promise<void>
   findOnPath?: (bin: string) => Promise<string | null>
+  isStubLauncher?: (path: string) => Promise<boolean>
+}
+
+/**
+ * True when `launcherPath` is — or is a pnpm shim for — the tiny shell stub pnpm
+ * leaves in place of a native OpenCode when the package's postinstall did not
+ * run. The real launcher is a >100 MB executable; pnpm's shim is a short shell
+ * script that `exec`s it and names it in a trailing `# cmd-shim-target=` line.
+ * Conservative by construction: anything this cannot read or resolve is NOT a
+ * stub, so a false positive can never take a working launcher away.
+ */
+export async function isStubOpencodeLauncher(launcherPath: string): Promise<boolean> {
+  try {
+    const target = await realpath(launcherPath)
+    const info = await stat(target)
+    if (info.size > 64 * 1024) return false
+    const text = await readFile(target, 'utf8')
+    if (/postinstall script was not run/i.test(text)) return true
+    // pnpm's cmd-shim: follow one hop to the package's own launcher.
+    const shimTarget =
+      text.match(/^#\s*cmd-shim-target=(.+)$/m)?.[1]?.trim() ??
+      text.match(/"?([^"\s]+opencode-ai\/bin\/opencode(?:\.exe)?)"?/)?.[1]
+    if (!shimTarget) return false
+    const resolved = shimTarget.replace(/^\$basedir/, dirname(target))
+    const binInfo = await stat(resolved).catch(() => null)
+    if (!binInfo || binInfo.size > 64 * 1024) return false
+    return /postinstall script was not run/i.test(await readFile(resolved, 'utf8'))
+  } catch {
+    return false
+  }
 }
 
 export async function detectOpencodeBinary(
@@ -1478,7 +1508,15 @@ export async function detectOpencodeBinary(
   // an availability fallback only when that verified launcher disappeared.
   if (!options.nativeBinaryFastPathEnabled) {
     const pathLauncher = await findOnPath('opencode')
-    if (pathLauncher) return pathLauncher
+    // A pnpm launcher that resolves to the postinstall-less stub OpenCode's own
+    // autoupdate leaves behind (479 bytes: "opencode-ai's postinstall script was
+    // not run") exits at once; spawning it puts the daemon in a respawn loop
+    // with "binary not found" and the session never wakes (Essentia
+    // 2026-08-22, re-armed 2026-08-25). Never launch it; fall through to the
+    // managed links, which the convergence pass repairs.
+    if (pathLauncher && !(await (options.isStubLauncher ?? isStubOpencodeLauncher)(pathLauncher))) {
+      return pathLauncher
+    }
     if (await checkExecutable(currentLink)) return currentLink
     if (await checkExecutable(systemLink)) return systemLink
     return null

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -294,17 +294,16 @@ export async function buildOpencodeConfigContent(
     typeof env.OPENCODE_CONFIG_CONTENT === 'string' &&
     env.OPENCODE_CONFIG_CONTENT.includes('"kortix/')
 
-  if (
-    !hasConnectorMcp &&
-    !hasLlmGateway &&
-    !nativeSessionModel &&
-    !nativeScrubNeeded &&
-    !isSlackSession &&
-    !hasCompiledAgentConfig &&
-    !injectedSkillsDir &&
-    !secretCapabilitiesInstructionPath
-  )
-    return undefined
+  // (0) Kortix owns the OpenCode binary: the daemon converges it to the
+  // manifest pin (runtime-assets.ts) with `pnpm add -g --allow-build`. OpenCode's
+  // own autoupdate (`autoupdate` unset = on) runs whenever a human launches the
+  // CLI/TUI in the Session terminal and installs via plain `pnpm add -g`, which
+  // skips the postinstall: the launcher becomes a 479-byte stub, the old global
+  // dir is deleted and `/opt/kortix/opencode.current` dangles. Essentia
+  // 2026-08-22 (session dead, "Still waking this session up") and again
+  // 2026-08-25 on two boxes. This contributor ALWAYS applies, so the composed
+  // config is never `undefined` any more.
+  const KORTIX_MANAGED_OPENCODE_OVERLAY: Record<string, unknown> = { autoupdate: false }
 
   let base: Record<string, unknown> = {}
   if (hasCompiledAgentConfig) {
@@ -477,6 +476,7 @@ export async function buildOpencodeConfigContent(
     out.permission = { ...permission, question: 'deny' }
   }
 
+  Object.assign(out, KORTIX_MANAGED_OPENCODE_OVERLAY)
   return JSON.stringify(out)
 }
 

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -1,4 +1,6 @@
 import { Hono } from 'hono'
+import { BOOT_PHASE_HEADER, bootPhaseLabel } from './boot-phase'
+import { runtimeAssetsActivity } from './runtime-assets'
 import { egressShimPort } from './egress-shim'
 import type { ServerWebSocket } from 'bun'
 
@@ -280,55 +282,69 @@ export function buildOpencodeApp(
   // attempting a fetch — surfaces the situation clearly to the client and
   // prevents noisy ECONNREFUSED loops.
   app.all('*', async (c) => {
+    // Every not-ready answer names the boot phase (X-Kortix-Boot-Phase) so the
+    // API's start budget measures lack of PROGRESS, not wall-clock. See
+    // boot-phase.ts.
+    const notReady = (body: Record<string, unknown>, reason: string) => {
+      const phase = bootPhaseLabel({
+        timeline: bootState.timeline,
+        opencodeState: opencode.getState(),
+        runtimeAssetsActivity: runtimeAssetsActivity(),
+        notReadyReason: reason,
+      })
+      c.header(BOOT_PHASE_HEADER, phase)
+      return c.json({ ...body, phase }, 503)
+    }
+
     if (bootState.repoMaterializationError) {
-      return c.json(
+      return notReady(
         {
           error: 'sandbox runtime not ready',
           reason: 'repo_materialization_failed',
           message: bootState.repoMaterializationError,
         },
-        503,
+        'repo_materialization_failed',
       )
     }
 
     if (cfg.autoClone && !(await isRepoMaterialized(cfg.projectTarget))) {
-      return c.json(
+      return notReady(
         {
           error: 'sandbox runtime not ready',
           reason: 'repo_not_materialized',
         },
-        503,
+        'repo_not_materialized',
       )
     }
 
     if (bootState.initialOpenCodeSessionError) {
-      return c.json(
+      return notReady(
         {
           error: 'sandbox runtime not ready',
           reason: 'initial_opencode_session_failed',
           message: bootState.initialOpenCodeSessionError,
         },
-        503,
+        'initial_opencode_session_failed',
       )
     }
 
     if (bootState.initialOpenCodeSessionRequired && !bootState.initialOpenCodeSessionId) {
-      return c.json(
+      return notReady(
         {
           error: 'sandbox runtime not ready',
           reason: 'initial_opencode_session_pending',
         },
-        503,
+        'initial_opencode_session_pending',
       )
     }
 
     if (opencode.getState() !== 'ok') {
-      return c.json(
+      return notReady(
         {
           error: 'opencode not ready',
           opencode: opencode.getState(),
         },
-        503,
+        'opencode_not_ready',
       )
     }
 

--- a/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/refresh.ts
@@ -16,6 +16,16 @@ function bearerToken(header: string | undefined): string | null {
   return header.slice('Bearer '.length).trim() || null
 }
 
+/**
+ * A refresh may kick a runtime-assets pass only once OpenCode is serving. The
+ * API refreshes on session open, i.e. during a resume's boot; a pass then can
+ * install a new OpenCode pin and restart it under the boot in progress
+ * (Essentia 2026-08-25 17:23). main.ts runs the post-boot pass itself.
+ */
+export function refreshMayConvergeRuntime(opencodeState: string): boolean {
+  return opencodeState === 'ok'
+}
+
 export function createRefreshRouter(cfg: Config, opencode: Opencode): Hono {
   const router = new Hono()
   let refreshInFlight: Promise<Response> | null = null
@@ -131,7 +141,16 @@ export function createRefreshRouter(cfg: Config, opencode: Opencode): Hono {
         // image build. Detached on purpose: the route's callers await its
         // latency, and a ~100 MB download must never enter that budget. The
         // reconcile is single-flighted, so a burst of refreshes runs one pass.
-        scheduleRuntimeAssetsReconcile(cfg)
+        //
+        // NEVER while OpenCode is still booting. The API calls this route from
+        // the session-open path (env-sync) — on a resume that is BEFORE the
+        // runtime is ready — and a pass that finds a stale pin installs the
+        // new OpenCode and restarts it underneath the boot in progress
+        // (Essentia 2026-08-25 17:23: install at +9 s, spawn at +13 s, the
+        // API's start budget expired on both boxes). main.ts schedules the
+        // post-boot pass itself once `opencode-ready` is marked; this call is
+        // for a box that is already up.
+        if (refreshMayConvergeRuntime(opencode.getState())) scheduleRuntimeAssetsReconcile(cfg)
         return c.json({
           // The repo work succeeded either way; `reload.outcome` carries whether
           // the new config actually took. Reporting ok:false here would hide a

--- a/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
+++ b/apps/kortix-sandbox-agent-server/src/runtime-assets.ts
@@ -28,6 +28,21 @@ import { opencodeTurnInFlight } from './opencode-turn-state'
 const execFileAsync = promisify(execFile)
 
 /**
+ * What the convergence pass is doing RIGHT NOW, for the proxy's not-ready
+ * answers (X-Kortix-Boot-Phase). A pass that installs a new OpenCode pin can
+ * hold a box in "not ready" for a minute or more (Essentia 2026-08-25:
+ * 1.18.19 → 1.18.23 on resume, 53 s first init on top); the API's boot budget
+ * must be able to tell "still working" from "stuck", and this is the signal.
+ */
+let runtimeAssetsActivityLabel: string | null = null
+export function runtimeAssetsActivity(): string | null {
+  return runtimeAssetsActivityLabel
+}
+function setRuntimeAssetsActivity(label: string | null): void {
+  runtimeAssetsActivityLabel = label
+}
+
+/**
  * Converge this sandbox's runtime assets on the API it talks to.
  *
  * THE BUG THIS FIXES. `/usr/local/bin/kortix` and `/opt/kortix/managed-skills`
@@ -1078,7 +1093,14 @@ export async function reconcileRuntimeAssets(
             })
           } else {
             const install = options.installOpencode ?? installOpencodeVersion
-            if (binaryStale || binaryMissing) await install(expected)
+            if (binaryStale || binaryMissing) {
+              setRuntimeAssetsActivity(`installing-opencode@${expected}`)
+              try {
+                await install(expected)
+              } finally {
+                setRuntimeAssetsActivity(null)
+              }
+            }
             // SAME STEP as the binary, always. A binary and a plugin that
             // disagree is the state this whole block exists to avoid.
             const pinResult = await refreshOpencodePluginPin(depsDir, expected)

--- a/apps/llm-gateway/src/main.ts
+++ b/apps/llm-gateway/src/main.ts
@@ -1,6 +1,7 @@
 import './environment-secret';
 import { config } from './config';
-import { buildServer } from './server';
+import { bunRequestBodyCeilingBytes } from './request-body-ceiling';
+import { buildServer, perRequestCapBytes } from './server';
 
 const { app, traces, inflightRequests } = buildServer();
 
@@ -21,6 +22,11 @@ const server = Bun.serve({
   // (pipeline/streaming.ts INACTIVITY_TIMEOUT_MS), and a real client disconnect
   // still aborts req.signal (a separate mechanism, unaffected by idleTimeout).
   idleTimeout: 0,
+  // Bun's own body ceiling, kept above the pipeline's per-request cap so an
+  // over-limit body is refused by the pipeline (logged, typed 413) and never
+  // by Bun (silent plain-text 413 / mid-upload socket close). See
+  // request-body-ceiling.ts.
+  maxRequestBodySize: bunRequestBodyCeilingBytes(perRequestCapBytes),
   fetch: app.fetch,
 });
 

--- a/apps/llm-gateway/src/request-body-ceiling.test.ts
+++ b/apps/llm-gateway/src/request-body-ceiling.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { DEFAULT_MAX_REQUEST_BYTES } from '@kortix/llm-gateway';
+import {
+  BUN_DEFAULT_MAX_REQUEST_BODY_BYTES,
+  bunRequestBodyCeilingBytes,
+} from './request-body-ceiling';
+
+describe('bunRequestBodyCeilingBytes', () => {
+  test('sits strictly above the per-request cap so the pipeline 413 fires, not Bun\'s', () => {
+    // Essentia 2026-08-25: DEFAULT_MAX_REQUEST_BYTES === Bun's default, so a
+    // 129 MiB body was refused by Bun with no log line.
+    expect(DEFAULT_MAX_REQUEST_BYTES).toBe(BUN_DEFAULT_MAX_REQUEST_BODY_BYTES);
+    expect(bunRequestBodyCeilingBytes(DEFAULT_MAX_REQUEST_BYTES)).toBeGreaterThan(
+      DEFAULT_MAX_REQUEST_BYTES,
+    );
+  });
+
+  test('stays above Bun\'s default even for a small clamped cap', () => {
+    expect(bunRequestBodyCeilingBytes(42 * 1024 * 1024)).toBeGreaterThan(
+      BUN_DEFAULT_MAX_REQUEST_BODY_BYTES,
+    );
+  });
+
+  test('a disabled cap (0) still yields a finite ceiling', () => {
+    const ceiling = bunRequestBodyCeilingBytes(0);
+    expect(Number.isFinite(ceiling)).toBe(true);
+    expect(ceiling).toBeGreaterThan(BUN_DEFAULT_MAX_REQUEST_BODY_BYTES);
+  });
+});

--- a/apps/llm-gateway/src/request-body-ceiling.test.ts
+++ b/apps/llm-gateway/src/request-body-ceiling.test.ts
@@ -6,7 +6,7 @@ import {
 } from './request-body-ceiling';
 
 describe('bunRequestBodyCeilingBytes', () => {
-  test('sits strictly above the per-request cap so the pipeline 413 fires, not Bun\'s', () => {
+  test("sits strictly above the per-request cap so the pipeline 413 fires, not Bun's", () => {
     // Essentia 2026-08-25: DEFAULT_MAX_REQUEST_BYTES === Bun's default, so a
     // 129 MiB body was refused by Bun with no log line.
     expect(DEFAULT_MAX_REQUEST_BYTES).toBe(BUN_DEFAULT_MAX_REQUEST_BODY_BYTES);
@@ -15,7 +15,7 @@ describe('bunRequestBodyCeilingBytes', () => {
     );
   });
 
-  test('stays above Bun\'s default even for a small clamped cap', () => {
+  test("stays above Bun's default even for a small clamped cap", () => {
     expect(bunRequestBodyCeilingBytes(42 * 1024 * 1024)).toBeGreaterThan(
       BUN_DEFAULT_MAX_REQUEST_BODY_BYTES,
     );

--- a/apps/llm-gateway/src/request-body-ceiling.ts
+++ b/apps/llm-gateway/src/request-body-ceiling.ts
@@ -1,0 +1,26 @@
+/**
+ * Bun.serve refuses any request whose body exceeds `maxRequestBodySize` with
+ * its own plain-text 413 BEFORE `fetch()` runs: no gateway log line, no typed
+ * `request_too_large` envelope, and on the first attempt just a socket close
+ * mid-upload (the client sees "Cannot connect to API"). Bun's default is
+ * 128 MiB — the same number as DEFAULT_MAX_REQUEST_BYTES — so the pipeline's
+ * own 413 (logged with the exact byte counts, digit-free body) could never
+ * fire for a 129 MiB body; Bun's did. Essentia 2026-08-25: three image-heavy
+ * turns died that way with nothing in the gateway log to explain them.
+ *
+ * Keep Bun's ceiling strictly ABOVE the per-request cap so the pipeline is the
+ * layer that decides and records. The extra headroom is never buffered:
+ * readBoundedBody stops reading one byte past the cap.
+ */
+export const BUN_DEFAULT_MAX_REQUEST_BODY_BYTES = 128 * 1024 * 1024;
+
+// A disabled per-request cap (0) still needs a finite Bun ceiling; the
+// in-flight budget refuses what the process cannot hold long before this.
+const UNCAPPED_BUN_CEILING_BYTES = 4 * 1024 * 1024 * 1024;
+
+export function bunRequestBodyCeilingBytes(perRequestCapBytes: number): number {
+  if (!Number.isFinite(perRequestCapBytes) || perRequestCapBytes <= 0) {
+    return UNCAPPED_BUN_CEILING_BYTES;
+  }
+  return Math.max(perRequestCapBytes * 2, BUN_DEFAULT_MAX_REQUEST_BODY_BYTES + 1);
+}

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -18,7 +18,7 @@ const inflightCapacityBytes =
 // A per-request cap larger than the budget can ever admit is a lie: such a
 // request is refused 413 `too_large` ("never retry") when the honest answer is
 // that this process is too small for it. Clamp to what the budget can hold.
-const perRequestCapBytes = Math.min(
+export const perRequestCapBytes = Math.min(
   Number(process.env.GATEWAY_MAX_REQUEST_BYTES) || DEFAULT_MAX_REQUEST_BYTES,
   Math.floor(
     inflightCapacityBytes /


### PR DESCRIPTION
## Why

Essentia 2026-08-25: four agent turns died mid-work, three sessions "just stopped" (assistant message `tokens 0/0/0`, `parts: []`) and two reopened sessions failed to wake. Full forensics in the incident thread; four independent causes, all fixed here.

## What

1. **E2B renewals were silent no-ops.** E2B clamps every `setTimeout` to the team's `max_length_hours` (Essentia: 1h) so `endAt` never left `startedAt + 1h`; Kortix logged 375 successful 204s while E2B paused boxes mid-LLM-call at exactly +1h. `renewLifecycle` now reads `endAt` back and throws `E2BLifecycleRenewalIgnoredError` (naming `max_length_hours`) when the deadline did not move. (`apps/api/src/platform/providers/e2b.ts`)
2. **Bun's default `maxRequestBodySize` (128 MiB) == `DEFAULT_MAX_REQUEST_BYTES`**, so over-limit image-heavy turns were refused by Bun before `fetch()` — no log, plain-text 413, socket close on first attempt. `Bun.serve` now sets `maxRequestBodySize` strictly above the per-request cap so the pipeline's logged, digit-free 413 fires. Self-host compose passes `KORTIX_GATEWAY_MAX_REQUEST_BYTES` through. (`apps/llm-gateway/src/request-body-ceiling.ts`, `main.ts`, `kortix-compose.yml`)
3. **OpenCode autoupdate was never disabled.** A human running `opencode` in the Session terminal triggered a plain `pnpm add -g` upgrade (no postinstall) → 479-byte launcher stub + dangling `opencode.current` on two boxes (the 2026-08-22 "session dead" bomb re-armed). The composed Kortix config now always carries `autoupdate: false` and is never `undefined`. (`apps/kortix-sandbox-agent-server/src/opencode.ts`)
4. **The fixed 90 s not-ready budget parked healthy boots.** On resume the daemon converged OpenCode 1.18.19→1.18.23 and sat through the new version's 53 s first init; `/start` parked both boxes as `runtime_boot_failed`. The daemon now names its boot phase on every not-ready 503 (`X-Kortix-Boot-Phase`); the API restarts the reason clock on every phase change and adds a 10 min hard cap. A stub respawning forever never changes phase and is still parked at 90 s. (`boot-phase.ts`, `proxy.ts`, `runtime-assets.ts`, `opencode-mapping.ts`, `readiness-clocks.ts`, `routes/shared.ts`)

Learnings appended to `.claude/skills/learnings/SKILL.md` for all four.

## Verification (local)

- `apps/api`: `bash scripts/test.sh` → 8238 pass / 0 fail; `tsc --noEmit` clean (only the pre-existing `@composio/core` noise before `pnpm install`).
- `apps/kortix-sandbox-agent-server`: `bun test` → 862 pass / 0 fail (+ new `boot-phase.test.ts`, proxy header test); `tsc --noEmit` clean.
- `apps/llm-gateway`: `bun test` → 36 pass + 3 new; `tsc --noEmit` clean.
- `apps/cli`: `compose-assets.test.ts` → 64 pass.

## Essentia (already applied, verified)

- E2B RDS: `tiers.max_length_hours 1→24`, `project_limits.max_length_hours 1→24`. Fresh sandbox: `POST /timeout 7200` moved `endAt` 17:46:30→19:44:32. Both live boxes re-created at 17:46; renewals now advance `endAt`.

## Dev verification (after merge)

- Deploy Dev run → deployed SHA; box daemon converges; `GET <sandbox>/session` while booting returns `x-kortix-boot-phase`; `/start` on a slow boot stays `starting` across phase changes.
