### PR TITLE
fix(connectors): tell a stopped session its connector landed

### DIFF
--- a/apps/api/src/connectors/notify-session.test.ts
+++ b/apps/api/src/connectors/notify-session.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The notification must fire for a STOPPED session.
+ *
+ * It did not, and that made the feature a no-op in its own common case: the
+ * agent mints a connect link, posts it, and its turn ends — so the session is
+ * `stopped` long before the human finishes Google. Measured on dev, the connect
+ * landed at 18:15:32 against a session that stopped at 18:15:12, and the
+ * `running` check dropped the follow-up. Dev holds 3455 stopped sessions to 1
+ * running, so gating on `running` is gating on never.
+ */
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test';
+
+const enqueued: Array<Record<string, unknown>> = [];
+let sessionRow: Record<string, unknown> | undefined;
+
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => (sessionRow ? [sessionRow] : []) }) }),
+    }),
+  },
+}));
+
+mock.module('../projects/session-lifecycle', () => ({
+  enqueueContinueSessionCommand: async (input: Record<string, unknown>) => {
+    enqueued.push(input);
+    return { row: {}, deduped: false };
+  },
+  drainSessionLifecycleQueue: async () => ({}),
+}));
+
+const { notifyConnectorSession, connectorConnectedPrompt } = await import('./notify-session');
+
+beforeEach(() => {
+  enqueued.length = 0;
+  sessionRow = { status: 'stopped', accountId: 'acct-1', metadata: {} };
+});
+afterEach(() => { sessionRow = undefined; });
+
+test('a STOPPED session is still told its connector landed', async () => {
+  await notifyConnectorSession('session-1', 'project-1', 'user-1', 'gmail', 'gmail');
+  expect(enqueued).toHaveLength(1);
+  expect(enqueued[0]).toMatchObject({
+    source: 'system:connector-connected',
+    sessionId: 'session-1',
+    projectId: 'project-1',
+    accountId: 'acct-1',
+  });
+  expect(enqueued[0].text).toBe(connectorConnectedPrompt('gmail', 'gmail'));
+});
+
+test('a running session is told too', async () => {
+  sessionRow = { status: 'running', accountId: 'acct-1', metadata: {} };
+  await notifyConnectorSession('session-1', 'project-1', 'user-1', 'gmail', 'gmail');
+  expect(enqueued).toHaveLength(1);
+});
+
+test('a DELETED session is skipped — there is no agent left to tell', async () => {
+  sessionRow = { status: 'stopped', accountId: 'acct-1', metadata: { deletedAt: '2026-08-25T00:00:00Z' } };
+  await notifyConnectorSession('session-1', 'project-1', 'user-1', 'gmail', 'gmail');
+  expect(enqueued).toHaveLength(0);
+});
+
+test('an unknown session is skipped', async () => {
+  sessionRow = undefined;
+  await notifyConnectorSession('nope', 'project-1', 'user-1', 'gmail', 'gmail');
+  expect(enqueued).toHaveLength(0);
+});

--- a/apps/api/src/connectors/notify-session.ts
+++ b/apps/api/src/connectors/notify-session.ts
@@ -35,9 +35,20 @@ export function connectorConnectedPrompt(slug: string, app: string): string {
  * Hand the requesting agent a durable follow-up prompt through the
  * session-lifecycle queue — the same path approval-resume uses.
  *
- * Gated on `running`: a stopped or hibernated session reads the credential from
- * the store on its next run anyway, and finalizing a connect must never boot a
- * sandbox on its own.
+ * NOT gated on `running`, and that gate is why this never fired in practice.
+ * The ordinary sequence is: the agent mints a link, posts it, and its turn
+ * ends — so the session is `stopped` before the human has even opened Google.
+ * Measured on dev: the connect completed at 18:15:32 against a session that
+ * went `stopped` at 18:15:12, twenty seconds earlier, and the notification was
+ * skipped. The whole feature exists to spare someone typing "done", and a
+ * `running` check hands them that job back in its own common case. Dev carries
+ * 3455 stopped sessions against 1 running.
+ *
+ * Enqueuing is safe for a stopped session: this writes a durable
+ * `continue_session` row and the lifecycle engine owns waking the session to
+ * deliver it, exactly as approval-resume already relies on.
+ *
+ * A DELETED session is still skipped — there is no agent left to tell.
  */
 export async function notifyConnectorSession(
   sessionId: string,
@@ -56,7 +67,7 @@ export async function notifyConnectorSession(
       .from(projectSessions)
       .where(eq(projectSessions.sessionId, sessionId))
       .limit(1);
-    if (session?.status !== 'running') return;
+    if (!session) return;
     const meta = (session.metadata ?? {}) as Record<string, unknown>;
     if (typeof meta.deletedAt === 'string') return;
     const { enqueueContinueSessionCommand, drainSessionLifecycleQueue } = await import(


### PR DESCRIPTION
## What happened

The button and popup **worked**. What didn't happen is the message back to the agent, so the human still had to type something — the one thing this feature exists to remove.

Measured on dev, session `60e1dbfd-5554-4779-8116-4672b27b4f9d`:

```
18:15:12   session status → stopped        (agent posted the link, turn ended)
18:15:32   Google consent completes, finalize runs
           Composio: ca_Be1UCtOKyOVj ACTIVE, scope includes https://mail.google.com/
           Kortix DB: connected_account_id = ca_Be1UCtOKyOVj
           notifyConnectorSession → status is 'stopped' → returns silently
```

## Root cause

```ts
if (session?.status !== 'running') return;
```

That is not an edge case, it is the **ordinary sequence**: the agent mints a link, posts it, its turn ends, and only then does the human open Google. The session is stopped before the popup is even on screen.

How badly this misfires, on dev:

```
stopped    3455
failed      111
running        1
completed      1
```

Gating on `running` was gating on never. I copied the gate from the setup-link path without re-deriving whether it held here. It doesn't — that path is a human filling in a form while a session is live; this one is inherently post-turn.

## The fix

Drop the `running` check. Enqueuing for a stopped session is safe: `notifyConnectorSession` writes a durable `continue_session` row and the lifecycle engine owns waking the session to deliver it — exactly what approval-resume already relies on ("the durable face of *deliver this follow-up into the session*", `engine.ts:831`).

A **deleted** session is still skipped; there is no agent left to tell.

## Verification

New `notify-session.test.ts` asserts the stopped case directly, plus running, deleted, and unknown-session.

```
4 pass / 0 fail
pnpm --filter kortix-api typecheck   exit=0
```

I verified the test actually catches the regression rather than assuming it: restoring the old gate makes it fail —

```
(fail) a STOPPED session is still told its connector landed
 3 pass  1 fail
```

## Note on the surrounding feature

Two separate things were wrong and only this one remains. The card not rendering at all was a wrong session id (#6882, already merged and deployed). This is the second, independent defect underneath it — the connect completing without the agent being told.