### PR TITLE
feat(sandbox): window inline images inside the sandbox — every gateway session routes through the daemon LLM proxy

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2564,3 +2564,24 @@ restarting it under the boot; and the PATH launcher on two boxes was the
    Conservative: anything unreadable is not a stub.
 
 *Automation:* `refresh-converge-guard.test.ts`, `opencode-binary.test.ts`.
+
+## Window inline images inside the sandbox; the edge is too late
+
+*Incident (2026-08-25, Essentia):* vision-heavy turns accumulated 118 inline
+screenshots (>128 MiB per request). The gateway's image window keeps 12, but
+only after the body has crossed the wire; the runtime's body ceiling refused it
+first and the turn died with an empty assistant message.
+
+**Rules.**
+1. Every gateway session routes OpenCode through the daemon's localhost LLM
+   proxy (`main.ts`, not only warm hot-swap forks). The proxy applies the same
+   window (`llm-image-window.ts`, default keep 12 of ≤20) to `chat/completions`,
+   `messages` and `responses` bodies BEFORE they leave the box, and lifts its
+   own body ceiling so a large body can be shrunk rather than refused.
+2. Kill switch `KORTIX_LLM_PROXY_DISABLE=1` (direct provider config);
+   `KORTIX_LLM_MAX_INLINE_IMAGES=0` disables the window only.
+3. A live gateway enable/disable (`/kortix/env`) keeps the proxy's upstream +
+   token in step (`applyLlmGatewayMode`).
+
+*Automation:* `llm-image-window.test.ts`, `llm-proxy.test.ts` ("in-sandbox
+inline image window").

--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-image-window.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-image-window.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+import { applyInlineImageWindow, imageWindowFromEnv, isChatRequestPath } from '../llm-image-window';
+
+const img = (n: number) => ({
+  type: 'image_url',
+  image_url: { url: `data:image/png;base64,${n}` },
+});
+const user = (...ids: number[]) => ({
+  role: 'user',
+  content: [{ type: 'text', text: 'shot' }, ...ids.map(img)],
+});
+
+describe('applyInlineImageWindow (in-sandbox)', () => {
+  test('a request under the cap is untouched', () => {
+    const body = { messages: [user(1, 2), user(3)] };
+    const before = JSON.stringify(body);
+    expect(applyInlineImageWindow(body, { maxImages: 3, keepOnOverflow: 2 })).toEqual({
+      total: 3,
+      dropped: 0,
+    });
+    expect(JSON.stringify(body)).toBe(before);
+  });
+  test('over the cap: keeps the newest, replaces older ones with a notice (OpenAI chat)', () => {
+    const body = { messages: [user(1, 2), { role: 'assistant', content: 'ok' }, user(3, 4, 5)] };
+    expect(applyInlineImageWindow(body, { maxImages: 4, keepOnOverflow: 2 })).toEqual({
+      total: 5,
+      dropped: 3,
+    });
+    const last = (body.messages[2]?.content ?? []) as Array<{ type: string }>;
+    expect(last.map((p) => p.type)).toEqual(['text', 'text', 'image_url', 'image_url']);
+  });
+  test('Anthropic and Responses API shapes are covered', () => {
+    const anthropic = {
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'image', source: {} },
+            { type: 'image', source: {} },
+          ],
+        },
+      ],
+    };
+    expect(applyInlineImageWindow(anthropic, { maxImages: 1, keepOnOverflow: 1 })).toEqual({
+      total: 2,
+      dropped: 1,
+    });
+    const responses = {
+      input: [
+        {
+          role: 'user',
+          content: [
+            { type: 'input_image', image_url: 'x' },
+            { type: 'input_image', image_url: 'y' },
+          ],
+        },
+      ],
+    };
+    expect(applyInlineImageWindow(responses, { maxImages: 1, keepOnOverflow: 1 })).toEqual({
+      total: 2,
+      dropped: 1,
+    });
+  });
+  test('env: default window, override, and 0 disables', () => {
+    expect(imageWindowFromEnv({})).toEqual({ maxImages: 20, keepOnOverflow: 12 });
+    expect(
+      imageWindowFromEnv({
+        KORTIX_LLM_MAX_INLINE_IMAGES: '6',
+        KORTIX_LLM_IMAGE_KEEP_ON_OVERFLOW: '9',
+      }),
+    ).toEqual({ maxImages: 6, keepOnOverflow: 6 });
+    expect(imageWindowFromEnv({ KORTIX_LLM_MAX_INLINE_IMAGES: '0' })).toBeNull();
+  });
+  test('only model request paths are candidates', () => {
+    expect(isChatRequestPath('/v1/llm/chat/completions')).toBe(true);
+    expect(isChatRequestPath('/v1/llm/messages')).toBe(true);
+    expect(isChatRequestPath('/v1/llm/responses')).toBe(true);
+    expect(isChatRequestPath('/v1/llm/models')).toBe(false);
+  });
+});

--- a/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/llm-proxy.test.ts
@@ -230,3 +230,86 @@ describe('refreshGatewayCatalogFile — warm snapshot catalog recovery', () => {
     }
   })
 })
+
+describe('in-sandbox inline image window (Essentia 2026-08-25: >128 MiB vision bodies 413d at the edge)', () => {
+  afterEach(() => {
+    stopLlmProxy()
+    delete process.env.KORTIX_LLM_MAX_INLINE_IMAGES
+  })
+
+  function countingUpstream() {
+    let seen: { images: number; bytes: number; contentLength: string | null; auth: string | null } | null = null
+    const server = Bun.serve({
+      port: 0,
+      maxRequestBodySize: 512 * 1024 * 1024,
+      async fetch(req) {
+        const text = await req.text()
+        const body = JSON.parse(text) as { messages: Array<{ content: Array<{ type: string }> }> }
+        const images = body.messages.flatMap((m) => m.content).filter((p) => p.type === 'image_url').length
+        seen = { images, bytes: text.length, contentLength: req.headers.get('content-length'), auth: req.headers.get('authorization') }
+        return new Response('{"ok":true}', { headers: { 'content-type': 'application/json' } })
+      },
+    })
+    return { url: `http://127.0.0.1:${server.port}`, stop: () => server.stop(true), seen: () => seen }
+  }
+
+  const img = (n: number) => ({ type: 'image_url', image_url: { url: `data:image/png;base64,${'A'.repeat(64 * 1024)}${n}` } })
+
+  test('a model request over the window leaves the sandbox with only the most recent images', async () => {
+    const up = countingUpstream()
+    try {
+      startLlmProxy(14321, up.url, 'real-token')
+      const messages = [
+        { role: 'user', content: [{ type: 'text', text: 'a' }, ...Array.from({ length: 15 }, (_, i) => img(i))] },
+        { role: 'user', content: [{ type: 'text', text: 'b' }, ...Array.from({ length: 15 }, (_, i) => img(15 + i))] },
+      ]
+      const res = await fetch(`${llmProxyBaseUrl()}/v1/llm/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: `Bearer ${LLM_PROXY_PLACEHOLDER_KEY}` },
+        body: JSON.stringify({ model: 'x', messages }),
+      })
+      expect(res.status).toBe(200)
+      const seen = up.seen()!
+      expect(seen.images).toBe(12) // DEFAULT_IMAGE_WINDOW.keepOnOverflow
+      expect(seen.auth).toBe('Bearer real-token')
+      expect(Number(seen.contentLength)).toBe(seen.bytes)
+      expect(seen.bytes).toBeLessThan(15 * 64 * 1024)
+    } finally {
+      up.stop()
+    }
+  })
+
+  test('a request under the window and a non-model path stream through untouched', async () => {
+    const up = countingUpstream()
+    try {
+      startLlmProxy(14322, up.url, 'real-token')
+      const messages = [{ role: 'user', content: [{ type: 'text', text: 'a' }, img(1), img(2)] }]
+      const res = await fetch(`${llmProxyBaseUrl()}/v1/llm/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'x', messages }),
+      })
+      expect(res.status).toBe(200)
+      expect(up.seen()!.images).toBe(2)
+    } finally {
+      up.stop()
+    }
+  })
+
+  test('KORTIX_LLM_MAX_INLINE_IMAGES=0 disables the window', async () => {
+    process.env.KORTIX_LLM_MAX_INLINE_IMAGES = '0'
+    const up = countingUpstream()
+    try {
+      startLlmProxy(14323, up.url, 'real-token')
+      const messages = [{ role: 'user', content: Array.from({ length: 25 }, (_, i) => img(i)) }]
+      await fetch(`${llmProxyBaseUrl()}/v1/llm/chat/completions`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model: 'x', messages }),
+      })
+      expect(up.seen()!.images).toBe(25)
+    } finally {
+      up.stop()
+    }
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/llm-image-window.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-image-window.ts
@@ -1,0 +1,91 @@
+/**
+ * Inline-image window applied INSIDE the sandbox, before a chat request leaves
+ * the box.
+ *
+ * The gateway already keeps only the most recent images of a request
+ * (@kortix/llm-gateway image-window.ts) — but it can only do so after the whole
+ * body has crossed the wire. A vision-heavy agent turn accumulates every
+ * screenshot it ever read as base64 in the OpenCode transcript; on Essentia
+ * 2026-08-25 that reached 118 inline images and >128 MiB per request, which
+ * the gateway's runtime refused with 413 before the pipeline (and its window)
+ * ran. The daemon's localhost LLM proxy applies the same window here so the
+ * body that leaves the sandbox is already small. Same defaults as the gateway;
+ * the gateway's own pass is then a no-op.
+ *
+ * Shapes covered: OpenAI chat (`messages[].content[]` with `image_url` /
+ * `input_image`), Anthropic (`messages[].content[]` with `image`) and the
+ * OpenAI Responses API (`input[].content[]` with `input_image`).
+ */
+export interface ImageWindowOptions {
+  /** Requests carrying at most this many inline images pass untouched. */
+  maxImages: number;
+  /** On overflow, the most recent this-many images survive. */
+  keepOnOverflow: number;
+}
+
+export const DEFAULT_IMAGE_WINDOW: ImageWindowOptions = { maxImages: 20, keepOnOverflow: 12 };
+
+export interface ImageWindowResult {
+  total: number;
+  dropped: number;
+}
+
+const IMAGE_PART_TYPES = new Set(['image_url', 'input_image', 'image']);
+
+function isImagePart(part: unknown): boolean {
+  return (
+    !!part &&
+    typeof part === 'object' &&
+    IMAGE_PART_TYPES.has(String((part as { type?: unknown }).type))
+  );
+}
+
+function itemsOf(body: Record<string, unknown>): unknown[] {
+  if (Array.isArray(body.messages)) return body.messages;
+  if (Array.isArray(body.input)) return body.input;
+  return [];
+}
+
+/** Mutates the request body in place. Returns what it counted and dropped. */
+export function applyInlineImageWindow(
+  body: Record<string, unknown>,
+  options: ImageWindowOptions = DEFAULT_IMAGE_WINDOW,
+): ImageWindowResult {
+  const slots: Array<{ content: unknown[]; index: number }> = [];
+  for (const item of itemsOf(body)) {
+    if (!item || typeof item !== 'object') continue;
+    const content = (item as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (let i = 0; i < content.length; i += 1) {
+      if (isImagePart(content[i])) slots.push({ content, index: i });
+    }
+  }
+  const total = slots.length;
+  const max = Math.max(0, Math.trunc(options.maxImages));
+  if (max === 0 || total <= max) return { total, dropped: 0 };
+  const keep = Math.min(max, Math.max(0, Math.trunc(options.keepOnOverflow)));
+  const dropped = total - keep;
+  const notice = `[image omitted by sandbox: ${dropped} older image${dropped === 1 ? '' : 's'} removed; the ${keep} most recent are kept]`;
+  for (let i = 0; i < dropped; i += 1) {
+    const slot = slots[i];
+    if (slot) slot.content[slot.index] = { type: 'text', text: notice };
+  }
+  return { total, dropped };
+}
+
+export function imageWindowFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ImageWindowOptions | null {
+  const raw = env.KORTIX_LLM_MAX_INLINE_IMAGES?.trim();
+  if (raw === '0') return null;
+  const maxImages = raw && /^\d+$/.test(raw) ? Number(raw) : DEFAULT_IMAGE_WINDOW.maxImages;
+  const keepRaw = env.KORTIX_LLM_IMAGE_KEEP_ON_OVERFLOW?.trim();
+  const keepOnOverflow =
+    keepRaw && /^\d+$/.test(keepRaw) ? Number(keepRaw) : DEFAULT_IMAGE_WINDOW.keepOnOverflow;
+  return { maxImages, keepOnOverflow: Math.min(keepOnOverflow, maxImages) };
+}
+
+/** Paths whose JSON body carries a model request with inline images. */
+export function isChatRequestPath(pathname: string): boolean {
+  return /\/(chat\/completions|messages|responses)$/.test(pathname);
+}

--- a/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
@@ -1,3 +1,4 @@
+import { applyInlineImageWindow, imageWindowFromEnv, isChatRequestPath } from './llm-image-window'
 import { logger } from './logger'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -21,6 +22,41 @@ import { logger } from './logger'
 // SCOPE: stateful warm-fork only (the caller gates it). Cold templates + Daytona
 // never start these proxies and keep their direct config unchanged.
 // ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * For a POST to a model endpoint with a JSON body: read it, apply the inline
+ * image window, and return the re-serialized body — or null to stream the
+ * request through untouched (not a model request, no window configured, not
+ * JSON, or a body this cannot parse: the upstream then answers as it would
+ * have anyway).
+ */
+async function windowModelRequestBody(req: Request, pathname: string, name: string): Promise<string | null> {
+  if (req.method !== 'POST' || !isChatRequestPath(pathname)) return null
+  const window = imageWindowFromEnv()
+  if (!window) return null
+  if (!(req.headers.get('content-type') ?? '').includes('application/json')) return null
+  let text: string
+  try {
+    text = await req.text()
+  } catch {
+    return null
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    return text
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return text
+  const result = applyInlineImageWindow(parsed as Record<string, unknown>, window)
+  if (result.dropped === 0) return text
+  const out = JSON.stringify(parsed)
+  logger.info(`[${name}-proxy] image window: kept ${result.total - result.dropped} of ${result.total} inline images`, {
+    bytesBefore: Buffer.byteLength(text),
+    bytesAfter: Buffer.byteLength(out),
+  })
+  return out
+}
 
 type ProxyState = {
   /** The real upstream base, e.g. https://gateway-dev.kortix.com/v1/llm (LLM) or
@@ -91,6 +127,11 @@ function createCredentialProxy(name: string, placeholderKey: string): Credential
         hostname: '127.0.0.1',
         // Model streams can run minutes. 0 = no idle timeout.
         idleTimeout: 0,
+        // Bun's default body ceiling is 128 MiB. A vision-heavy turn can be
+        // larger than that BEFORE the window below shrinks it (Essentia
+        // 2026-08-25: 118 inline screenshots); the whole point of windowing
+        // here is that such a body never reaches the network, so accept it.
+        maxRequestBodySize: 2 * 1024 * 1024 * 1024,
         async fetch(req) {
           const upstream = state.upstreamBase
           const tok = state.token
@@ -111,16 +152,24 @@ function createCredentialProxy(name: string, placeholderKey: string): Credential
           headers.set('authorization', `Bearer ${tok}`)
 
           try {
+            // Model requests are windowed HERE, before they leave the sandbox
+            // (see llm-image-window.ts). Everything else streams through.
+            let body: RequestInit['body'] = req.body ?? undefined
+            const windowed = await windowModelRequestBody(req, inUrl.pathname, name)
+            if (windowed !== null) {
+              body = windowed
+              headers.set('content-length', String(Buffer.byteLength(windowed)))
+            }
             // duplex:'half' is required by Bun/undici when a request carries a
             // streaming body; valid at runtime even where the RequestInit type
             // omits it, so build + cast rather than inline.
             const init: RequestInit & { duplex?: 'half' } = {
               method: req.method,
               headers,
-              body: req.body ?? undefined,
+              body,
               redirect: 'manual',
             }
-            if (req.body) init.duplex = 'half'
+            if (windowed === null && req.body) init.duplex = 'half'
             const upstreamRes = await fetch(target, init)
             const outHeaders = new Headers()
             upstreamRes.headers.forEach((v, k) => {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -308,6 +308,25 @@ async function main() {
         err: err instanceof Error ? err.message : String(err),
       })
     })
+    // Every gateway session routes OpenCode through the localhost LLM proxy,
+    // not only warm hot-swap forks: the proxy is where inline images are
+    // windowed BEFORE a request leaves the sandbox (llm-image-window.ts).
+    // Essentia 2026-08-25: >128 MiB vision bodies were refused at the gateway
+    // edge with a silent 413 and the turn died. Kill switch:
+    // KORTIX_LLM_PROXY_DISABLE=1 restores the direct provider config.
+    if (
+      hasKortixLlmGateway(process.env) &&
+      !process.env.KORTIX_LLM_PROXY_URL &&
+      process.env.KORTIX_LLM_PROXY_DISABLE !== '1'
+    ) {
+      const llmPort = Number(process.env.KORTIX_LLM_PROXY_PORT) || 4319
+      const llmUrl = startLlmProxy(llmPort, process.env.KORTIX_LLM_BASE_URL, process.env.KORTIX_TOKEN)
+      if (llmUrl) {
+        process.env.KORTIX_LLM_PROXY_URL = llmUrl
+        bootMark('llm-proxy-started')
+        logger.info('[boot] llm proxy up; opencode provider routes through it', { llmUrl })
+      }
+    }
     opencode.reconfigure(cfg, opencodeConfigDir, projectEnv)
     await opencode.start().catch((err) => {
       logger.warn('[boot] opencode.start() rejected', {

--- a/apps/kortix-sandbox-agent-server/src/routes/env.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env.ts
@@ -4,6 +4,7 @@ import { writeAgentEnvFile } from '../agent-env-file'
 import type { Config } from '../config'
 import { syncEgressShim } from '../egress-shim'
 import { KORTIX_USER_CONTEXT_HEADER } from '../kortix-user-context'
+import { llmProxyBaseUrl, setLlmProxyToken } from '../llm-proxy'
 import { logger } from '../logger'
 import { requiresRespawn, type Opencode } from '../opencode'
 import { reconcileProjectEnv, type ProjectEnvStore } from '../project-env'
@@ -107,6 +108,17 @@ function applyLlmGatewayMode(enabled: unknown, baseUrl: unknown): { changed: boo
   const token = process.env.KORTIX_TOKEN
   if (!token) {
     throw new Error('KORTIX_TOKEN is unavailable; cannot enable LLM gateway in this running sandbox')
+  }
+  // A running localhost LLM proxy (every gateway session since the in-sandbox
+  // image window) learns the new upstream + token and stays the provider
+  // base URL; a box that never started one keeps the direct config.
+  const proxyUrl = llmProxyBaseUrl()
+  if (proxyUrl && process.env.KORTIX_LLM_PROXY_DISABLE !== '1') {
+    setLlmProxyToken(token, baseUrl)
+    return setOpencodeRuntimeEnv({
+      KORTIX_LLM_BASE_URL: baseUrl,
+      KORTIX_LLM_PROXY_URL: proxyUrl,
+    })
   }
   return setOpencodeRuntimeEnv({
     KORTIX_LLM_BASE_URL: baseUrl,


### PR DESCRIPTION
## Why

Essentia 2026-08-25: vision-heavy turns reached 118 inline screenshots and >128 MiB per request. The gateway's image window (keep 12) can only run after the body crossed the wire; the runtime body ceiling refused it first — silent 413, empty assistant message, turn dead. #6883 made that 413 visible; this PR makes it impossible by shrinking the body **before it leaves the box**.

## What

- `apps/kortix-sandbox-agent-server/src/llm-image-window.ts`: the gateway's window (default keep 12 of ≤20; OpenAI chat / Anthropic / Responses shapes), applied in the daemon's localhost LLM proxy to `chat/completions`, `messages`, `responses` POST bodies. `KORTIX_LLM_MAX_INLINE_IMAGES` / `KORTIX_LLM_IMAGE_KEEP_ON_OVERFLOW` override; `=0` disables.
- `llm-proxy.ts`: buffers only model-request JSON bodies (everything else streams), rewrites `content-length`, lifts its Bun body ceiling to 2 GiB so a large body is shrunk, not refused.
- `main.ts`: the proxy starts for **every** gateway session (cold path), not only `KORTIX_LLM_HOTSWAP` warm forks; `KORTIX_LLM_PROXY_DISABLE=1` restores the direct provider config.
- `routes/env.ts`: a live gateway enable keeps the proxy's upstream + token in step and keeps the provider base URL on the proxy.
- learnings entry.

## Verification

**Unit:** daemon `bun test` → 875 pass / 0 fail (+ `llm-image-window.test.ts` 5, `llm-proxy.test.ts` +3: a 30-image body reaches the upstream with 12 images, real token, correct content-length; under-window and `=0` pass through untouched); `tsc --noEmit` clean; biome clean on new files.

**Real sandbox (local stack, worktree API :20008, Platinum box `sbx_01M0X45Q1SKK7MGQ0Z3QRRD2PX`, daemon built from this branch and served via runtime-assets manifest sha `82b6a2b6…`):**
- `/kortix/health` boot timeline: `… config-deps → llm-proxy-started → runtime-binary-resolved → … → opencode-ready`.
- `~/.config/kortix-opencode.json`: `provider.kortix.options.baseURL = http://127.0.0.1:4319`, `apiKey = kortix-llm-proxy-injected`, `autoupdate = false`.
- In-box `curl` of a 5,001,792-byte / 25-image chat body to `127.0.0.1:4319/chat/completions` → daemon log `[llm-proxy] image window: kept 12 of 25 inline images, bytesBefore 5001792, bytesAfter 2402296`; the gateway answered through the proxy with the real token (`model_not_found` for the deliberately bogus model id).
- Real turn: `POST /session/<id>/prompt_async` "Reply with exactly the single word: pong" → assistant completed, output tokens 4, text `pong` (proxy → gateway → model).