### PR TITLE
fix(web): drop the duplicate connect-requests audit label

### DIFF
--- a/apps/web/src/components/iam/audit-display-helpers.ts
+++ b/apps/web/src/components/iam/audit-display-helpers.ts
@@ -160,8 +160,6 @@ const ROUTE_LABEL_OVERRIDES: Record<string, string> = {
   'GET /v1/connectors/projects/:projectId/catalog': 'Viewed connector catalog',
   'GET /v1/connectors/projects/:projectId/sessions/:sessionId/connect-requests':
     'Viewed pending connector authorizations',
-  'GET /v1/connectors/projects/:projectId/sessions/:sessionId/connect-requests':
-    'Viewed pending connector authorizations',
   'PUT /v1/connectors/projects/:projectId/connectors/:slug/secret-binding':
     'Updated connector secret binding',
   'GET /v1/runtime-assets/manifest': 'Checked sandbox runtime-asset versions',


### PR DESCRIPTION
CodeQL js/duplicate-property at audit-display-helpers.ts:161/163 — #6881 and #6883 both added the key; the squash kept both. Keeps the first. `audit-display-helpers.test.ts` 44/44.