### PR TITLE
feat(catalog): sandbox learns the project's servable model set at boot (scope=picker)

### DIFF
--- a/apps/api/src/llm-gateway/internal-routes.test.ts
+++ b/apps/api/src/llm-gateway/internal-routes.test.ts
@@ -29,6 +29,21 @@ mock.module('./hooks', () => ({
 mock.module('./models/catalog-models', () => ({
   gatewayModelCatalog: () => ({}),
 }));
+const servableCalls: unknown[] = [];
+mock.module('./models/servable-catalog', () => ({
+  servableProjectCatalog: async (input: unknown) => {
+    servableCalls.push(input);
+    return {
+      models: {
+        'amazon-bedrock/global.openai.gpt-5.6-sol': { name: 'GPT-5.6 Sol (Global)', enabled: true },
+        'grok-4.6': { name: 'Grok 4.6', enabled: false },
+      },
+      modelOverrides: {},
+      defaultModel: 'grok-4.6',
+      usingDefaults: true,
+    };
+  },
+}));
 mock.module('./routing', () => ({
   resolveGatewayRoute: async () => ({
     policyId: 'auto',
@@ -109,5 +124,34 @@ describe('POST /internal/gateway/resolve-upstream — GatewayResolutionError con
       authedRequest({ principal: { userId: 'u' }, model: 'auto' }),
     );
     expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /models scope=picker', () => {
+  test("serves the project's servable set (same composition as /model-picker) for a project principal", async () => {
+    servableCalls.length = 0;
+    const res = await app().request(
+      '/models',
+      authedRequest({
+        principal: { userId: 'u1', accountId: 'a1', projectId: 'p1' },
+        scope: 'picker',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { models: Record<string, { enabled?: boolean }> };
+    expect(Object.keys(body.models)).toEqual(['amazon-bedrock/global.openai.gpt-5.6-sol', 'grok-4.6']);
+    expect(body.models['grok-4.6']?.enabled).toBe(false);
+    expect(servableCalls).toEqual([{ projectId: 'p1', accountId: 'a1', principalUserId: 'u1' }]);
+  });
+
+  test('scope=picker without a project principal falls back to the plain catalog', async () => {
+    servableCalls.length = 0;
+    const res = await app().request(
+      '/models',
+      authedRequest({ principal: { userId: 'u1', accountId: 'a1' }, scope: 'picker' }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ models: {} });
+    expect(servableCalls).toEqual([]);
   });
 });

--- a/apps/api/src/llm-gateway/internal-routes.ts
+++ b/apps/api/src/llm-gateway/internal-routes.ts
@@ -17,6 +17,7 @@ import {
 } from './hooks';
 import { matchesInternalToken, weakInternalTokenWarnings } from './internal-auth';
 import { gatewayModelCatalog } from './models/catalog-models';
+import { servableProjectCatalog } from './models/servable-catalog';
 import { resolveCandidates } from './resolution/resolve-candidates';
 import { resolveGatewayRoute } from './routing';
 
@@ -107,8 +108,21 @@ export function createInternalGatewayRoutes() {
   });
 
   app.post('/models', async (c) => {
-    const { principal, managedOnly } = await c.req.json();
+    const { principal, managedOnly, scope } = await c.req.json();
     const p = principal as AuthedPrincipal;
+    // `scope:'picker'` backs the standalone gateway's `GET /models?scope=picker`:
+    // the project's SERVABLE set (managed the account may use + connected BYOK
+    // + routing-named ids, ~80KB) — what the web picker shows and what a
+    // sandbox registers on its `kortix` provider at boot. Same composition as
+    // `GET /projects/:id/model-picker` (servableProjectCatalog).
+    if (scope === 'picker' && p.projectId) {
+      const catalog = await servableProjectCatalog({
+        projectId: p.projectId,
+        accountId: p.accountId,
+        principalUserId: p.userId,
+      });
+      return c.json({ models: catalog.models });
+    }
     // `managedOnly` backs the standalone gateway's `GET /models?scope=managed`
     // — the compact managed lineup a sandbox fetches on boot. Dropping the
     // projectId is what selects MANAGED_ONLY; free-tier accounts still get an

--- a/apps/api/src/llm-gateway/models/servable-catalog.ts
+++ b/apps/api/src/llm-gateway/models/servable-catalog.ts
@@ -1,0 +1,83 @@
+import { accountMayUseManagedModels } from '../../billing/services/entitlements';
+import { listProjectSecretNamesForConsumer } from '../../projects/secrets';
+import { getAccountModelDefaults } from '../../repositories/model-preferences';
+import { getProjectRoutingPolicy } from '../../repositories/project-routing-policies';
+import { resolveEnablement } from '../model-enablement';
+import { toWireModel } from '../resolution/effective';
+import { gatewayModelCatalog } from './catalog-models';
+import { projectPickerCatalog } from './picker-catalog';
+import { platformDefaultModelId } from './served-managed-models';
+
+type GatewayModel = ReturnType<typeof gatewayModelCatalog>[string];
+
+export interface ServableProjectCatalog {
+  /** Wire model id → catalog record, stamped with the project's enablement. */
+  models: Record<string, GatewayModel & { enabled: boolean }>;
+  modelOverrides: Record<string, boolean>;
+  defaultModel: string | undefined;
+  usingDefaults: boolean;
+}
+
+/**
+ * The ONE composition of "which models can this project actually run right
+ * now": the runtime catalog reduced to managed models the account may use,
+ * the providers its secrets connect, and the ids its defaults/routing name —
+ * stamped with per-project enablement. Served to the web picker
+ * (`GET /projects/:id/model-picker`, r4.ts) AND to the sandbox at boot
+ * (`GET /v1/llm/models?scope=picker` → internal `/models` with
+ * `scope:'picker'`), so the list OpenCode registers on the `kortix` provider
+ * is exactly the list the composer offers. Before this the sandbox learned
+ * only the managed subset and kept the image-baked org catalog for the rest:
+ * a BYOK model added to models.dev after the image was built showed in the
+ * picker and answered `ModelNotFound` in the runtime.
+ *
+ * ~80KB / ~120 models for a typical project, versus ~3.9MB / ~6.6k for the
+ * full org catalog (`/llm-catalog`).
+ */
+export async function servableProjectCatalog(input: {
+  projectId: string;
+  accountId: string;
+  /** Whose secret-visibility applies for the BYOK connection check; the
+   *  gateway principal's user for a sandbox, the caller for the web picker. */
+  principalUserId: string | null | undefined;
+}): Promise<ServableProjectCatalog> {
+  const { projectId, accountId, principalUserId } = input;
+  const freeManagedOnly = !(await accountMayUseManagedModels(accountId));
+  const [secrets, defaults, routing] = await Promise.all([
+    listProjectSecretNamesForConsumer({
+      projectId,
+      principalUserId,
+      consumer: 'llm_gateway',
+    }).catch(() => [] as string[]),
+    getAccountModelDefaults(accountId, projectId),
+    getProjectRoutingPolicy(projectId),
+  ]);
+  const effectiveDefault = toWireModel(
+    defaults.projects[projectId] ?? defaults.account ?? platformDefaultModelId() ?? '',
+  );
+  const requiredModels = [
+    defaults.projects[projectId],
+    defaults.account,
+    platformDefaultModelId(),
+    routing?.visionModel,
+    ...(routing?.defaultFallback?.models ?? []),
+    ...(routing?.rules.flatMap((rule) => [rule.model, ...rule.fallbackModels]) ?? []),
+  ].filter((model): model is string => !!model);
+  const models = projectPickerCatalog(
+    gatewayModelCatalog(projectId, { freeManagedOnly }),
+    new Set(secrets),
+    requiredModels,
+  );
+  const enabled = resolveEnablement(models, routing?.modelOverrides ?? {}, requiredModels);
+  return {
+    models: Object.fromEntries(
+      Object.entries(models).map(([id, model]) => [
+        id,
+        { ...model, enabled: enabled.get(id) ?? true },
+      ]),
+    ),
+    modelOverrides: routing?.modelOverrides ?? {},
+    defaultModel: effectiveDefault || undefined,
+    usingDefaults: Object.keys(routing?.modelOverrides ?? {}).length === 0,
+  };
+}

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -343,9 +343,9 @@ function modelsRoute(path: string) {
     description: `Servable model catalog for the caller\'s account/project — a keyed object (NOT the OpenAI \`{object:"list",data:[...]}\` array shape) mapping model id → capabilities.\n\nAuth: ${AUTH_DESCRIPTION}\n\n\`\`\`\ncurl -sS $KORTIX_API_URL${fullPath} -H "Authorization: Bearer $KORTIX_GATEWAY_KEY"\n\`\`\``,
     request: {
       query: z.object({
-        scope: z.enum(['managed']).optional().openapi({
+        scope: z.enum(['managed', 'picker']).optional().openapi({
           description:
-            "Set to `managed` for the platform-managed lineup only (~3KB instead of ~3.3MB). Sandboxes call this on every boot to learn the current managed set. Omit for the caller's full catalog.",
+            "Set to `picker` for the caller's project SERVABLE set (~80KB: managed models the account may use, connected BYOK providers, routing-named ids — the same list the web model picker shows; sandboxes fetch it on every boot). `managed` is the platform-managed lineup only (~3KB). Omit for the caller's full catalog (~3.3MB).",
           example: 'managed',
         }),
       }),

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -81,9 +81,8 @@ import { PROJECT_ACTIONS } from '../../iam';
 import { setContextField } from '../../lib/request-context';
 import { isSessionSandboxCredential } from '../../middleware/session-sandbox-credential';
 import { projectLlmGatewayEnabled } from '../../llm-gateway/enablement';
-import { resolveEnablement } from '../../llm-gateway/model-enablement';
 import { gatewayModelCatalog } from '../../llm-gateway/models/catalog-models';
-import { projectPickerCatalog } from '../../llm-gateway/models/picker-catalog';
+import { servableProjectCatalog } from '../../llm-gateway/models/servable-catalog';
 import { runtimeModelCatalog } from '../../llm-gateway/models/runtime-catalog';
 import { platformDefaultModelId } from '../../llm-gateway/models/served-managed-models';
 import {
@@ -98,10 +97,7 @@ import {
   getAccountModelDefaults,
   upsertAccountModelPreference,
 } from '../../repositories/model-preferences';
-import {
-  getProjectRoutingPolicy,
-  setProjectModelOverrides,
-} from '../../repositories/project-routing-policies';
+import { setProjectModelOverrides } from '../../repositories/project-routing-policies';
 import { db } from '../../shared/db';
 import { isUniqueViolation } from '../../shared/postgres-errors';
 import { continueSession, drainSessionLifecycleQueue } from '../session-lifecycle';
@@ -153,7 +149,6 @@ import {
 import { validateWebhookSecretConfiguration } from '../lib/webhook-secret-policy';
 import { childIdleGraceMs } from '../sandbox-deadline';
 import { generateSessionTitleFromFirstPrompt } from '../session-title-generate';
-import { listProjectSecretNamesForConsumer } from '../secrets';
 import { reconcileProjectTriggerRuntime } from '../trigger-runtime-catalog';
 import {
   PRIVATE_TRIGGER_SESSION_ACCESS,
@@ -3023,61 +3018,14 @@ projectsApp.openapi(
     }
 
     const accountId = loaded.row.accountId as string;
-    const freeManagedOnly = !(await accountMayUseManagedModels(accountId));
-    const [secrets, defaults, routing] = await Promise.all([
-      listProjectSecretNamesForConsumer({
-        projectId,
-        principalUserId: loaded.userId,
-        consumer: 'llm_gateway',
-      }).catch(() => [] as string[]),
-      getAccountModelDefaults(accountId, projectId),
-      getProjectRoutingPolicy(projectId),
-    ]);
-    // What `auto` resolves to for this project. Served below so the client can
-    // LOCK its switch instead of offering a toggle that always 409s.
-    const effectiveDefault = toWireModel(
-      defaults.projects[projectId] ?? defaults.account ?? platformDefaultModelId() ?? '',
-    );
-    const requiredModels = [
-      defaults.projects[projectId],
-      defaults.account,
-      platformDefaultModelId(),
-      routing?.visionModel,
-      ...(routing?.defaultFallback?.models ?? []),
-      ...(routing?.rules.flatMap((rule) => [rule.model, ...rule.fallbackModels]) ?? []),
-    ].filter((model): model is string => !!model);
-    const models = projectPickerCatalog(
-      gatewayModelCatalog(projectId, { freeManagedOnly }),
-      new Set(secrets),
-      requiredModels,
-    );
-    // Server-owned per-project enablement, resolved HERE and stamped onto each
-    // model so every client renders the same answer. The session picker shows
-    // the enabled ones; "Manage models" shows them all and switches on this
-    // flag. Neither re-derives it. Display-only: the gateway never refuses a
-    // request over enablement (that 400'd in-use models — the #5932 revert).
-    const enabled = resolveEnablement(models, routing?.modelOverrides ?? {}, requiredModels);
-    return c.json({
-      models: Object.fromEntries(
-        Object.entries(models).map(([id, model]) => [
-          id,
-          { ...model, enabled: enabled.get(id) ?? true },
-        ]),
-      ),
-      // The stored EXCEPTIONS, so a client toggling one model can PUT the
-      // merged map back without having to reconstruct it by diffing the
-      // resolved flags against a default it would have to recompute.
-      modelOverrides: routing?.modelOverrides ?? {},
-      // The model `auto` resolves to. It cannot be turned off (that would break
-      // every default request — the PUT refuses it with 409), so the client
-      // renders its switch as locked rather than letting the user click into an
-      // error.
-      defaultModel: effectiveDefault || undefined,
-      // True while the project has made no exceptions at all — the only thing
-      // "reset to defaults" has left to act on, and not derivable from the
-      // `enabled` flags alone (they look identical either way).
-      usingDefaults: Object.keys(routing?.modelOverrides ?? {}).length === 0,
+    // One composition, shared with the sandbox's boot fetch
+    // (`/v1/llm/models?scope=picker`) — see servableProjectCatalog.
+    const catalog = await servableProjectCatalog({
+      projectId,
+      accountId,
+      principalUserId: loaded.userId,
     });
+    return c.json(catalog);
   },
 );
 

--- a/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/managed-model-overlay.test.ts
@@ -90,7 +90,7 @@ describe('managed listing fetch', () => {
 
     const models = await fetchManagedModels('https://gw.kortix.test/v1', 'k')
 
-    expect(urls).toEqual(['https://gw.kortix.test/v1/models?scope=managed'])
+    expect(urls).toEqual(['https://gw.kortix.test/v1/models?scope=picker'])
     expect(Object.keys(models ?? {}).sort()).toEqual([
       'deepseek-v4-flash',
       'grok-4.6',
@@ -124,7 +124,7 @@ describe('managed listing fetch', () => {
 describe('boot config composition', () => {
   test('a stale baked catalog is overlaid with the LIVE managed set once it is known', async () => {
     globalThis.fetch = (async (input: string) => {
-      expect(String(input)).toContain('scope=managed')
+      expect(String(input)).toContain('scope=picker')
       return new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
     }) as unknown as typeof fetch
 
@@ -220,7 +220,7 @@ describe('warm-fork adoption refresh', () => {
     const targetFile = join(dir, 'session.json')
     await writeFile(currentFile, JSON.stringify(current))
     globalThis.fetch = (async (input: string) =>
-      new Response(JSON.stringify(String(input).includes('scope=managed') ? managed : full), {
+      new Response(JSON.stringify(String(input).includes('scope=picker') ? managed : full), {
         status: 200,
       })) as unknown as typeof fetch
 
@@ -265,7 +265,7 @@ describe('warm-fork adoption refresh', () => {
     const targetFile = join(dir, 'session.json')
     await writeFile(currentFile, JSON.stringify(STALE_BAKED))
     globalThis.fetch = (async (input: string) =>
-      String(input).includes('scope=managed')
+      String(input).includes('scope=picker')
         ? new Response(JSON.stringify(LIVE_MANAGED), { status: 200 })
         : new Response('boom', { status: 500 })) as unknown as typeof fetch
 

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -910,17 +910,22 @@ export function withManagedOverlay(
 }
 
 /**
- * Fetch ONLY the managed lineup: `GET ${base}/models?scope=managed` (~3KB,
- * versus ~3.3MB for the full project catalog — which is why the full fetch
- * gets no place on the boot path). Returns null on failure or an empty set
- * (a free-tier account legitimately has no managed models; callers then keep
- * whatever the disk catalog holds).
+ * Fetch the project's SERVABLE set: `GET ${base}/models?scope=picker` (~80KB
+ * — managed models the account may use + the providers its secrets connect +
+ * routing-named ids, i.e. exactly the list the web picker shows; versus
+ * ~3.3MB for the full org catalog, which is why the full fetch gets no place
+ * on the boot path). Overlaid on the baked catalog, so a BYOK model added to
+ * models.dev after the image was built registers on the `kortix` provider
+ * instead of answering `ModelNotFound` (the same failure the managed-only
+ * fetch fixed for managed models on 2026-08-19). Returns null on failure or
+ * an empty set (a free-tier account with no connected provider legitimately
+ * has nothing; callers then keep whatever the disk catalog holds).
  */
 export async function fetchManagedModels(
   baseUrl: string,
   apiKey: string,
 ): Promise<Record<string, KortixGatewayModel> | null> {
-  const url = `${baseUrl.replace(/\/+$/, '')}/models?scope=managed`
+  const url = `${baseUrl.replace(/\/+$/, '')}/models?scope=picker`
   const deadline = Date.now() + MANAGED_MODELS_TOTAL_BUDGET_MS
   for (let attempt = 0; attempt < MANAGED_MODELS_ATTEMPTS; attempt++) {
     if (Date.now() >= deadline) break
@@ -935,14 +940,14 @@ export async function fetchManagedModels(
       const body = (await res.json()) as { models?: Record<string, KortixGatewayModel> }
       const models = body.models ?? {}
       if (Object.keys(models).length === 0) {
-        logger.info(`[opencode] managed listing is empty at ${url}; keeping the on-disk catalog`)
+        logger.info(`[opencode] servable listing is empty at ${url}; keeping the on-disk catalog`)
         return null
       }
       // Remote JSON becomes OpenCode's provider config — rebuild it to a known
       // shape before it can get anywhere near the config or the disk.
       const clean = sanitizeCatalogForDisk(models)
       if (!clean) return null
-      logger.info(`[opencode] fetched ${Object.keys(clean).length} managed models from ${url}`)
+      logger.info(`[opencode] fetched ${Object.keys(clean).length} servable models from ${url}`)
       return clean
     } catch (err) {
       logger.warn(
@@ -953,7 +958,7 @@ export async function fetchManagedModels(
       await new Promise((resolve) => setTimeout(resolve, 200))
     }
   }
-  logger.warn(`[opencode] managed models unavailable (${url}); using the bundled managed set`)
+  logger.warn(`[opencode] servable models unavailable (${url}); using the baked catalog + bundled managed set`)
   return null
 }
 

--- a/apps/llm-gateway/src/clients/api-client.ts
+++ b/apps/llm-gateway/src/clients/api-client.ts
@@ -177,6 +177,7 @@ export function createApiClient(opts: ApiClientOptions): ApiClient {
       const result = await post<{ models: ModelCatalog }>('/internal/gateway/models', {
         principal,
         managedOnly: !!opts?.managedOnly,
+        ...(opts?.scope ? { scope: opts.scope } : {}),
       });
       return result.models ?? {};
     },

--- a/apps/llm-gateway/src/server.ts
+++ b/apps/llm-gateway/src/server.ts
@@ -407,14 +407,16 @@ export function buildServer(options: { inflight?: InflightBudget } = {}): Gatewa
   app.post('/v1/llm/messages', messages);
   app.post('/v1/openai/messages', messages);
 
-  // `?scope=managed` → managed lineup only (~3KB). Sandboxes call it on every
-  // boot to learn the live managed set; see wire.ts for the full rationale.
+  // `?scope=managed` → managed lineup only (~3KB); `?scope=picker` → the
+  // project's servable set (~80KB), which sandboxes fetch on every boot so
+  // their `kortix` provider matches the web picker. See wire.ts.
   const models = (c: {
     req: { header: (k: string) => string | undefined; query: (k: string) => string | undefined };
   }) =>
     gateway
       .listModels(c.req.header('authorization'), {
         managedOnly: c.req.query('scope') === 'managed',
+        scope: c.req.query('scope') === 'picker' ? 'picker' : undefined,
       })
       .then(cloudflareSafe);
 

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -62,6 +62,9 @@ control. `Auto` clears the variant.
   Amazon Bedrock → Bedrock's `reasoning_effort` field). For an upstream it
   cannot map (Nova, Grok on Bedrock today) it returns `400 unsupported_param`
   instead of dropping the value silently.
+- The sandbox learns the project's servable model set from the API at every
+  boot (`GET /v1/llm/models?scope=picker`, the same composition as the web
+  picker), so a model the picker offers always resolves in the runtime.
 - A project default per model lives in Customize → Gateway → Routing →
   **Generation defaults** (`model_generation_config`). It fills only a field
   the request left unset, so a session's variant always wins.

--- a/packages/llm-gateway/src/create-gateway.ts
+++ b/packages/llm-gateway/src/create-gateway.ts
@@ -90,7 +90,7 @@ export function createGateway(hooks: GatewayHooks, deps: GatewayDeps = {}) {
       if (!hooks.listModels) return jsonResponse({ models: {} });
       const models = await hooks.listModels(principal, opts);
       logger.info(
-        `[gateway] models ${Object.keys(models).length}${opts?.managedOnly ? ' (managed only)' : ''} ` +
+        `[gateway] models ${Object.keys(models).length}${opts?.managedOnly ? ' (managed only)' : opts?.scope === 'picker' ? ' (picker)' : ''} ` +
           `for acct=${principal.accountId.slice(0, 8)}`,
       );
       return jsonResponse({ models });

--- a/packages/llm-gateway/src/domain/hooks.ts
+++ b/packages/llm-gateway/src/domain/hooks.ts
@@ -54,4 +54,13 @@ export interface GatewayHooks {
  * account with no managed access still gets an empty managed set. */
 export interface ListModelsOptions {
   managedOnly?: boolean;
+  /**
+   * `picker` serves the caller's project SERVABLE set (~80KB): managed models
+   * the account may use + the providers its secrets connect + routing-named
+   * ids, stamped with enablement — the same list the web model picker shows.
+   * A sandbox fetches it at boot so the `kortix` provider it registers is
+   * exactly what the composer offers (a BYOK model newer than the image used
+   * to answer `ModelNotFound`). `managed` is the legacy managed-only subset.
+   */
+  scope?: 'managed' | 'picker';
 }


### PR DESCRIPTION
## Why

After #6887 the web picker, the composer's thinking control and the gateway agree on one live catalog — but the **sandbox** still registered the image-baked org catalog plus a managed-only overlay on its `kortix` provider. A BYOK model added to models.dev after the image was built (`amazon-bedrock/global.openai.gpt-5.6-sol`, added 2026-08-16) shows in the picker and answers `ModelNotFound` in the runtime — the same class of failure the managed-only fetch fixed for managed models on 2026-08-19.

## What changed

- **API** `servableProjectCatalog()` (new, `llm-gateway/models/servable-catalog.ts`) is the one composition: managed models the account may use + providers its secrets connect + routing-named ids, enablement-stamped. `GET /projects/:id/model-picker` (r4) now calls it; the internal gateway `/models` route serves it for `scope:'picker'` (project principal required, else the plain catalog).
- **Gateway** `GET /v1/llm/models?scope=picker` (~80KB / ~120 models) alongside `managed` (~3KB) and the full org catalog (~3.3MB / ~6.6k). `ListModelsOptions.scope`; RPC forwards it.
- **Sandbox agent server** boot prefetch asks for `scope=picker`. The existing overlay (`withManagedOverlay`) and post-spawn reconcile (one controlled restart when the running OpenCode lacks an id, never across a live turn) now cover BYOK models. Combined with #6887, the provider also publishes the variant ids for each of them.
- Docs: models.mdx.

## Verified locally

- `apps/api` `bun tsc --noEmit` 0 errors; `internal-routes.test.ts` (canonical `scripts/test.env` runner) 40 pass, new: `scope:'picker'` serves the servable set with the exact `{projectId, accountId, principalUserId}` handed to the composer; no project principal → plain catalog. `src/llm-gateway` suite 278 pass.
- `apps/kortix-sandbox-agent-server` `bun test` 862 pass (overlay tests now pin `?scope=picker`), `tsc` clean.
- `packages/llm-gateway`, `apps/llm-gateway` `tsc` clean.

## Deploy order

API + gateway deploy in the same Deploy Dev run; the agent server ships through the sandbox runtime assets. An older gateway ignores the unknown scope and returns the full catalog, which the overlay merge tolerates (superset), so no ordering hazard.

## Dev verification (after deploy)

Synthetic project with a fake Bedrock BYOK secret: `GET /v1/llm/models?scope=picker` with a project gateway key returns ~120 models incl. `amazon-bedrock/global.openai.gpt-5.6-sol` with `reasoning_options`; a fresh session's `/config/providers` (via `/v1/p/<sbx>/8000`) lists that id on the `kortix` provider with six variants.
