### PR TITLE
fix(cli): mint the Kortix connect link, not the provider's raw url

### DIFF
--- a/apps/cli/src/connector-gateway/gateway.ts
+++ b/apps/cli/src/connector-gateway/gateway.ts
@@ -110,7 +110,23 @@ export interface SecretLinkResult {
   expires_at: string;
 }
 
-/** Start the configured provider's authorization for a declared connector. */
+/**
+ * Mint the KORTIX connect link a human should open for a declared connector.
+ *
+ * It must be OUR `${FRONTEND_URL}/connect/<token>` url, not the provider's own
+ * page. The web transcript turns exactly that shape into the one-click Connect
+ * button (`parseSetupLinkHref` -> `SetupLinkButton`), and anything else renders
+ * as a bare underlined link — which is what a `connect.composio.dev/link/...`
+ * url did, next to a generic link preview, with no button and no popup.
+ *
+ * Despite its name this used to POST the provider-authorization route and hand
+ * back that raw url, quietly dropping `expiresInMinutes` because that route has
+ * no such parameter. The setup-link route is the one that takes it.
+ *
+ * Falls back to the provider url only when no setup link can be minted (a
+ * connector whose provider has no hosted page). A bare url is worse than a
+ * button, but far better than telling the human nothing.
+ */
 export async function mintConnectLink(opts: {
   slug: string;
   expiresInMinutes?: number;
@@ -118,6 +134,30 @@ export async function mintConnectLink(opts: {
 }): Promise<ConnectLinkResult> {
   if (!opts.slug) throw new CliError('connector slug is required', 'USAGE');
   const { client, projectId } = connectorProjectContext(opts.projectOverride);
+  try {
+    const link = await client.post<{ url?: string; app?: string | null; expires_at?: string }>(
+      `/projects/${projectId}/connect-requests`,
+      {
+        slug: opts.slug,
+        ...(opts.expiresInMinutes ? { expires_in_minutes: opts.expiresInMinutes } : {}),
+      },
+    );
+    if (link?.url) {
+      return {
+        provider: 'kortix',
+        url: link.url,
+        slug: opts.slug,
+        app: link.app ?? null,
+        connected: false,
+        is_no_auth: false,
+        session_id: null,
+        connection_id: null,
+        request_id: null,
+      };
+    }
+  } catch {
+    // Fall through to the provider url below.
+  }
   const result = await client.post<{
     provider?: string;
     app?: string | null;

--- a/apps/cli/src/connector-gateway/mint-connect-link.test.ts
+++ b/apps/cli/src/connector-gateway/mint-connect-link.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The url handed to the human must be OUR /connect/<token>, not the provider's.
+ *
+ * The web transcript turns exactly that shape into the one-click Connect button
+ * (parseSetupLinkHref -> SetupLinkButton). A `connect.composio.dev/link/...` url
+ * has no such handling, so it rendered as a bare underlined link beside a
+ * generic link preview — no button, no popup, and the human had to copy it into
+ * a tab and then type "done".
+ *
+ * Despite its name, mintConnectLink used to POST the provider-authorization
+ * route and return that raw url, silently dropping `expiresInMinutes` because
+ * that route has no such parameter.
+ */
+import { expect, mock, test } from 'bun:test';
+
+const posts: Array<{ path: string; body: Record<string, unknown> }> = [];
+let setupLinkResponse: unknown = { url: 'https://dev.kortix.com/connect/ksl_abc', app: 'gmail' };
+let setupLinkThrows = false;
+
+mock.module('./io.ts', () => ({ CliError: class extends Error {} }));
+mock.module('../api/auth.ts', () => ({ loadAuth: () => ({ token: 't' }) }));
+mock.module('../project-link.ts', () => ({ resolveProjectId: () => 'proj-1' }));
+mock.module('../api/sdk.ts', () => ({ kortixFromAuth: () => ({}) }));
+mock.module('../api/client.ts', () => ({
+  clientFromAuth: () => ({
+    post: async (path: string, body: Record<string, unknown>) => {
+      posts.push({ path, body });
+      if (path.includes('/connect-requests')) {
+        if (setupLinkThrows) throw new Error('409 provider unsupported');
+        return setupLinkResponse;
+      }
+      return { provider: 'composio', connectUrl: 'https://connect.composio.dev/link/lk_raw' };
+    },
+  }),
+}));
+
+const { mintConnectLink } = await import('./gateway.ts');
+
+test('mints the Kortix connect link the transcript renders as a button', async () => {
+  posts.length = 0;
+  const r = await mintConnectLink({ slug: 'gmail' });
+  expect(r.url).toBe('https://dev.kortix.com/connect/ksl_abc');
+  expect(r.url).not.toContain('composio.dev');
+  expect(posts[0].path).toBe('/projects/proj-1/connect-requests');
+  expect(posts[0].body).toMatchObject({ slug: 'gmail' });
+});
+
+test('forwards expires_in_minutes — the setup-link route is the one that takes it', async () => {
+  posts.length = 0;
+  await mintConnectLink({ slug: 'gmail', expiresInMinutes: 45 });
+  expect(posts[0].body).toMatchObject({ slug: 'gmail', expires_in_minutes: 45 });
+});
+
+test('falls back to the provider url when no setup link can be minted', async () => {
+  posts.length = 0;
+  setupLinkThrows = true;
+  const r = await mintConnectLink({ slug: 'weird' });
+  setupLinkThrows = false;
+  // A bare url is worse than a button, but better than telling the human nothing.
+  expect(r.url).toBe('https://connect.composio.dev/link/lk_raw');
+  expect(posts.at(-1)?.path).toContain('/connectors/weird/connect');
+});


### PR DESCRIPTION
## The symptom

The agent keeps posting a bare underlined `https://connect.composio.dev/link/...` into the transcript, beside a generic link preview — no button, no popup. Prod shows one black **Connect your Gmail account** button.

## Root cause

`mintConnectLink` mints nothing. Despite the name it POSTs the **provider-authorization** route and returns that provider url:

```ts
// apps/cli/src/connector-gateway/gateway.ts
export async function mintConnectLink(opts: { slug; expiresInMinutes?; ... }) {
  const result = await client.post(`/connectors/projects/${projectId}/connectors/${slug}/connect`, {});
  return { url: result.connectUrl ?? null, ... };
}
```

It also silently drops `expiresInMinutes` — that route has no such parameter. The **setup-link** route is the one that takes it, which is the tell that this was meant to mint a setup link all along.

Only our `${FRONTEND_URL}/connect/<token>` shape becomes a button: `parseSetupLinkHref` → `SetupLinkButton` → the "Connect an app" modal → the popup → the poll → the resume. A provider url has no handling anywhere, so every one of those was lost.

## Confirmed on the live session

The connection written for session `710d45a9` carries `requesting_session_id`, which **only** the provider-authorization path sets — the setup-link path passes `null`. So the agent was definitively on the raw-url route.

## The fix

POST `/projects/:id/connect-requests` first — the route #6890 made work for Composio — and fall back to the provider url only when no setup link can be minted (a provider with no hosted page). A bare url is worse than a button; it is much better than telling the human nothing.

Verified against **deployed dev** before writing the change:

```
POST /v1/projects/<id>/connect-requests {"slug":"gmail"}
→ 200 {"url":"https://dev.kortix.com/connect/ksl_…","slug":"gmail","app":"gmail"}
```

## Verification

```
apps/cli  connector-gateway suite   3 pass / 0 fail
apps/cli  tsc --noEmit              exit=0
```

New tests pin the three things that broke: the link is ours and not the provider's, `expires_in_minutes` is forwarded, and the fallback still returns something.

## Why this took another round

#6890 fixed the API so a Composio setup link *can* be minted. It never checked that the caller the agent uses actually asks for one — it doesn't. Two halves of one path; I fixed the far half first and reported it as done. This is the near half.