### PR TITLE
fix(gateway): OpenAI-on-Bedrock reasoning travels as additionalModelRequestFields.reasoning.effort, not reasoning_effort

### DIFF
--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -60,8 +60,8 @@ control. `Auto` clears the variant.
 - Gateway on: the request carries `reasoning_effort`; the gateway maps it per
   upstream (OpenAI → `reasoning_effort`, Claude → adaptive thinking, OpenAI on
   Amazon Bedrock → Bedrock's `reasoning.effort` request field). For an upstream it
-  cannot map (Nova, Grok on Bedrock today) it returns `400 unsupported_param`
-  instead of dropping the value silently.
+  cannot map yet (Nova, Grok on Bedrock today) the value is dropped and the
+  model runs at its own default.
 - The sandbox learns the project's servable model set from the API at every
   boot (`GET /v1/llm/models?scope=picker`, the same composition as the web
   picker), so a model the picker offers always resolves in the runtime.

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -59,7 +59,7 @@ control. `Auto` clears the variant.
   request field.
 - Gateway on: the request carries `reasoning_effort`; the gateway maps it per
   upstream (OpenAI → `reasoning_effort`, Claude → adaptive thinking, OpenAI on
-  Amazon Bedrock → Bedrock's `reasoning_effort` field). For an upstream it
+  Amazon Bedrock → Bedrock's `reasoning.effort` request field). For an upstream it
   cannot map (Nova, Grok on Bedrock today) it returns `400 unsupported_param`
   instead of dropping the value silently.
 - The sandbox learns the project's servable model set from the API at every

--- a/packages/llm-gateway/src/errors.ts
+++ b/packages/llm-gateway/src/errors.ts
@@ -197,29 +197,3 @@ export function indicatesUpstreamDown(err: unknown): boolean {
   if (err instanceof UpstreamHttpError) return err.status >= 500 && err.status <= 599;
   return false;
 }
-
-// A generation parameter the client (or the project's routing defaults) asked
-// for that the resolved upstream has NO wire mapping for. Thrown by a transport
-// adapter BEFORE any upstream call is made, and mapped to a 400 by the pipeline.
-// The alternative — silently stripping the field — is what hid the missing
-// Bedrock `reasoning_effort` mapping for GPT-5.6 for weeks: the request went
-// out, the model answered, and nothing anywhere said the effort never left the
-// gateway. Loud beats quiet here: the composer's Thinking control only offers
-// tiers the catalog publishes, so hitting this means an upstream family the
-// adapter does not map yet (Nova / Grok / DeepSeek on Bedrock today), which is
-// a gateway gap to fix, not a user error to absorb.
-export class UnsupportedRequestParamError extends Error {
-  readonly kind = 'unsupported_param' as const;
-  constructor(
-    readonly param: string,
-    readonly resolvedModel: string,
-    readonly provider: string,
-    message?: string,
-  ) {
-    super(
-      message ??
-        `${provider} has no wire mapping for \`${param}\` on ${resolvedModel}; the value would be dropped`,
-    );
-    this.name = 'UnsupportedRequestParamError';
-  }
-}

--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -41,46 +41,6 @@ function hooks(usage: UsageEvent[], traces: GatewayTrace[]): GatewayHooks {
 }
 
 describe('simple gateway pipeline', () => {
-  test('refuses a reasoning_effort the resolved upstream cannot carry with a 400 naming field + model — never a 502, never silently stripped', async () => {
-    const usage: UsageEvent[] = [];
-    const traces: GatewayTrace[] = [];
-    const bedrockGrok: UpstreamDescriptor = {
-      ...primary,
-      provider: 'amazon-bedrock',
-      kind: 'bedrock',
-      resolvedModel: 'xai.grok-4.6',
-    };
-    let upstreamCalled = false;
-    const response = await handleChatCompletions(
-      {
-        hooks: { ...hooks(usage, traces), resolveUpstream: async () => [bedrockGrok] },
-        logger: { info() {}, warn() {}, error() {} },
-        fetchImpl: async () => {
-          upstreamCalled = true;
-          return new Response('{}', { headers: { 'content-type': 'application/json' } });
-        },
-      },
-      {
-        authorization: 'Bearer token',
-        rawBody: JSON.stringify({
-          model: 'amazon-bedrock/xai.grok-4.6',
-          messages: [{ role: 'user', content: 'hi' }],
-          reasoning_effort: 'high',
-        }),
-      },
-    );
-    expect(response.status).toBe(400);
-    const body = (await response.json()) as { error: { code: string; message: string; suggestion: string } };
-    expect(body.error.code).toBe('unsupported_param');
-    expect(body.error.message).toContain('reasoning_effort');
-    expect(body.error.message).toContain('xai.grok-4.6');
-    expect(body.error.suggestion).toContain('Auto');
-    expect(upstreamCalled).toBe(false);
-    expect(usage).toHaveLength(0);
-    expect(traces).toHaveLength(1);
-    expect(traces[0]).toMatchObject({ status: 400, ok: false, errorCode: 'unsupported_param' });
-  });
-
   test('aborts a provider fetch that does not return response headers before the deadline', async () => {
     const fetchWithTimeout = withUpstreamHeadersTimeout(
       async (_input, init) =>

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -7,7 +7,7 @@ import type {
   UpstreamDescriptor,
   UsageEvent,
 } from '../domain';
-import { GatewayResolutionError, UnsupportedRequestParamError, UpstreamHttpError } from '../errors';
+import { GatewayResolutionError, UpstreamHttpError } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
 import { resolveTransportKind } from '../transports/route-kind';
 import { type ExtractedUsage, type SseErrorFrame, extractUsageFromJson } from '../usage';
@@ -384,10 +384,6 @@ export async function handleChatCompletions(
     upstream = await dispatch;
   } catch (error) {
     refundHold(hooks, principal);
-    // A parameter the resolved upstream cannot carry is the CLIENT's request
-    // to fix (drop the effort, pick another model) — a 400 with the field and
-    // model named, never a 502 blaming the provider that was never called.
-    const unsupported = error instanceof UnsupportedRequestParamError ? error : null;
     emit({
       ...identity(principal),
       requestedModel,
@@ -395,23 +391,13 @@ export async function handleChatCompletions(
       provider: descriptor.provider,
       billingMode: descriptor.billingMode,
       streaming,
-      status: unsupported ? 400 : error instanceof UpstreamHttpError ? error.status : 502,
+      status: error instanceof UpstreamHttpError ? error.status : 502,
       ok: false,
-      errorCode: unsupported ? 'unsupported_param' : 'upstream_error',
+      errorCode: 'upstream_error',
       errorMessage: error instanceof Error ? error.message : String(error),
-      attempts: unsupported ? 0 : 1,
+      attempts: 1,
       candidatesTried: [descriptor.provider],
     });
-    if (unsupported)
-      return gatewayErrorResponse(400, {
-        message: unsupported.message,
-        code: 'unsupported_param',
-        provider: descriptor.provider,
-        requestedModel,
-        resolvedModel: descriptor.resolvedModel ?? routedModel,
-        requestId: id,
-        suggestion: `Set thinking to Auto (remove \`${unsupported.param}\`) for this model, or choose a model that supports it.`,
-      });
     if (error instanceof UpstreamHttpError) return rawProviderError(error);
     // A headers timeout is "try again", not "this request is malformed".
     const timedOut = (error as { name?: unknown })?.name === 'TimeoutError' && !req.signal?.aborted;

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -720,14 +720,15 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
 
   const BEDROCK_OPENAI = 'global.openai.gpt-5.6-sol';
 
-  it('bedrock: OpenAI-on-Bedrock forwards every published effort tier as additionalModelRequestFields.reasoning_effort — never the Claude reasoningConfig/cachePoint', () => {
+  it('bedrock: OpenAI-on-Bedrock forwards every published effort tier as additionalModelRequestFields.reasoning.effort (the shape real Bedrock accepts; flat reasoning_effort is 400 unknown_parameter) — never the Claude reasoningConfig/cachePoint', () => {
     for (const effort of ['none', 'low', 'medium', 'high', 'xhigh', 'max']) {
       const args = buildAiSdkArgs({ messages: [], reasoning_effort: effort }, 'bedrock', {
         resolvedModel: BEDROCK_OPENAI,
       });
       expect((args.providerOptions as any)?.bedrock).toEqual({
-        additionalModelRequestFields: { reasoning_effort: effort },
+        additionalModelRequestFields: { reasoning: { effort, summary: 'auto' } },
       });
+      expect((args.providerOptions as any)?.bedrock?.additionalModelRequestFields?.reasoning_effort).toBeUndefined();
       expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toBeUndefined();
       expect(args.providerOptions).not.toHaveProperty('anthropic');
     }
@@ -738,7 +739,7 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
       resolvedModel: BEDROCK_OPENAI,
     });
     expect((args.providerOptions as any)?.bedrock?.additionalModelRequestFields).toEqual({
-      reasoning_effort: 'xhigh',
+      reasoning: { effort: 'xhigh', summary: 'auto' },
     });
   });
 
@@ -754,7 +755,7 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
       model,
     });
     expect((ok.providerOptions as any)?.bedrock?.additionalModelRequestFields).toEqual({
-      reasoning_effort: 'xhigh',
+      reasoning: { effort: 'xhigh', summary: 'auto' },
     });
     const dropped = buildAiSdkArgs({ messages: [], reasoning_effort: 'minimal' }, 'bedrock', {
       resolvedModel: BEDROCK_OPENAI,
@@ -775,7 +776,7 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
         resolvedModel: id,
       });
       expect((args.providerOptions as any)?.bedrock?.additionalModelRequestFields).toEqual({
-        reasoning_effort: 'high',
+        reasoning: { effort: 'high', summary: 'auto' },
       });
     }
     for (const id of ['us.amazon.nova-micro-v1:0', 'xai.grok-4.6']) {

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -3,7 +3,7 @@ import type { CatalogModel } from '@kortix/llm-catalog';
 import { generateText, jsonSchema, streamText, tool } from 'ai';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import type { UpstreamDescriptor } from '../../domain';
-import { NetworkError, UpstreamHttpError, defaultIsRetryable, UnsupportedRequestParamError } from '../../errors';
+import { NetworkError, UpstreamHttpError, defaultIsRetryable } from '../../errors';
 import { calculateCost, extractUsageFromSseBuffer } from '../../usage';
 import { sseErrorFrame, sseHasContent } from '../../usage/completion-guard';
 import { guardAgainstUnhandledResultRejections, mapToolCalls, toTransportError } from './index';
@@ -780,42 +780,16 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
       });
     }
     for (const id of ['us.amazon.nova-micro-v1:0', 'xai.grok-4.6']) {
-      // No mapping for these families yet: an explicit effort is REFUSED
-      // (400 at the pipeline), never silently stripped and sent anyway.
-      expect(() =>
-        buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'bedrock', {
-          resolvedModel: id,
-        }),
-      ).toThrow(UnsupportedRequestParamError);
-      // Without an effort they are untouched — plain Converse request.
-      const args = buildAiSdkArgs({ messages: [] }, 'bedrock', { resolvedModel: id });
+      // No verified mapping for these families yet: the effort is DROPPED and
+      // the plain Converse request goes out. opencode sends a default effort
+      // for every reasoning-capable model, so refusing it (as #6887 briefly
+      // did) refused the model — including the managed Grok default.
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'bedrock', {
+        resolvedModel: id,
+      });
       expect((args.providerOptions as any)?.bedrock?.additionalModelRequestFields).toBeUndefined();
       expect((args.providerOptions as any)?.bedrock?.reasoningConfig).toBeUndefined();
     }
-  });
-
-  it('bedrock: the refusal names the field and the model, and a catalog-gated (dropped) effort never triggers it', () => {
-    let caught: unknown;
-    try {
-      buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'bedrock', {
-        resolvedModel: 'xai.grok-4.6',
-      });
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(UnsupportedRequestParamError);
-    expect((caught as UnsupportedRequestParamError).param).toBe('reasoning_effort');
-    expect((caught as UnsupportedRequestParamError).resolvedModel).toBe('xai.grok-4.6');
-    expect((caught as Error).message).toContain('xai.grok-4.6');
-    // The model publishes no effort ladder → clampGenerationConfig drops the
-    // client value before the adapter runs → nothing to refuse.
-    const noLadder = { id: 'us.amazon.nova-micro-v1:0', name: 'Nova Micro', reasoning: false };
-    expect(() =>
-      buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'bedrock', {
-        resolvedModel: 'us.amazon.nova-micro-v1:0',
-        model: noLadder,
-      }),
-    ).not.toThrow();
   });
 
   it('bedrock: a raw body.thinking:{type:"enabled",budget_tokens} is normalized to adaptive (never forwarded verbatim)', () => {

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -738,14 +738,19 @@ function isBedrockClaudeModel(resolvedModel: string | undefined): boolean {
 }
 
 // OpenAI models on Bedrock (`global.openai.gpt-5.6-*`, `openai.gpt-5.5`,
-// `openai.gpt-oss-*`) are served by Bedrock core (Converse), where the OpenAI
-// reasoning knob travels as `additionalModelRequestFields.reasoning_effort` —
-// the exact field @ai-sdk/amazon-bedrock 5.0.59 itself emits for
-// `reasoningConfig.maxReasoningEffort` once it recognises an OpenAI model id
-// (its `isOpenAIModel` branch), and what opencode sends natively for the same
-// models. Written as the raw field rather than through `maxReasoningEffort`:
-// the package's enum is `low|medium|high|xhigh|max` and rejects `none`, which
-// GPT-5.6 publishes as a real tier (models.dev `reasoning_options`). Before
+// `openai.gpt-oss-*`) are served by Bedrock core (Converse). The reasoning
+// knob travels as `additionalModelRequestFields.reasoning: { effort }` — the
+// OpenAI Responses shape. VERIFIED against real Bedrock (us-west-2,
+// 2026-08-25, global.openai.gpt-5.6-sol): `reasoning.effort` returns 200 for
+// every published tier (none/low/medium/high/xhigh/max) and 400
+// `unsupported_value` for an unpublished one (`minimal`); the flat
+// `reasoning_effort` that @ai-sdk/amazon-bedrock 5.0.59 emits for its
+// `isOpenAIModel` branch is REJECTED by GPT-5.6 with 400 `unknown_parameter`
+// (gpt-oss-120b accepts both shapes, so the nested one is the universal
+// OpenAI-on-Bedrock wire). `reasoningEffort`, `reasoningConfig` and
+// `thinking` are all `unknown_parameter` too. `summary: 'auto'` makes the
+// model return its reasoning as a content block (the thinking the composer
+// shows), matching opencode's `reasoningSummary: 'auto'` for OpenAI. Before
 // this branch existed the bedrock adapter returned `{}` for every non-Claude
 // model, so a client's `reasoning_effort` (or the project's configured
 // default) was silently dropped for GPT-5.6 on Bedrock.
@@ -1081,7 +1086,9 @@ const bedrockAdapter: ProviderAdapter = {
     // `reasoningConfig` are Claude-Converse-only and 403 here.
     if (isBedrockOpenAiModel(req.resolvedModel)) {
       if (typeof req.reasoningEffort === 'string') {
-        options.additionalModelRequestFields = { reasoning_effort: req.reasoningEffort };
+        options.additionalModelRequestFields = {
+          reasoning: { effort: req.reasoningEffort, summary: 'auto' },
+        };
       }
       return options;
     }

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -11,7 +11,6 @@ import {
   tool,
 } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
-import { UnsupportedRequestParamError } from '../../errors';
 import { reasoningEffort as reasoningEffortFromBody } from '../route-kind';
 import {
   type AiSdkFamily,
@@ -1097,20 +1096,13 @@ const bedrockAdapter: ProviderAdapter = {
     // never attach it for them. Their own effort wires are not mapped yet
     // (Nova 2 / Grok 4.6 publish reasoning_options on models.dev; the Converse
     // field shape for them is unverified), so an effort that reaches here is
-    // refused loudly instead of silently stripped — see
-    // UnsupportedRequestParamError.
-    if (!isBedrockClaudeModel(req.resolvedModel)) {
-      // Only a KNOWN id is refused — an unresolved model (no id at all) keeps
-      // the historical permissive path, exactly like the capability clamp.
-      if (req.resolvedModel && typeof req.reasoningEffort === 'string') {
-        throw new UnsupportedRequestParamError(
-          'reasoning_effort',
-          req.resolvedModel ?? 'unknown',
-          'amazon-bedrock',
-        );
-      }
-      return options;
-    }
+    // DROPPED. Not refused: #6887 briefly answered 400 `unsupported_param`
+    // here, and the first turn of a fresh project on dev proved that opencode
+    // sends a default effort for every reasoning-capable model (the user never
+    // picked a tier) — refusing the parameter refused the model, including
+    // the managed Grok default. Map the wire when it is verified; until then
+    // the model runs at its own default.
+    if (!isBedrockClaudeModel(req.resolvedModel)) return options;
     const thinking = resolveThinkingRequest(req.raw, req.reasoningEffort);
     // Adaptive thinking carries no token budget to clamp — the model manages
     // its own. `defaultMaxTokens` below still bumps maxOutputTokens so thinking


### PR DESCRIPTION
## Why

Real-Bedrock probe today (us-west-2, Essentia account, `global.openai.gpt-5.6-sol`):

| `additionalModelRequestFields` | result |
|---|---|
| `{"reasoning_effort":"high"}` (what #6879 sent, mirroring `@ai-sdk/amazon-bedrock` 5.0.59 `isOpenAIModel`) | **400** `unknown_parameter: reasoning_effort` |
| `{"reasoningEffort":…}`, `{"reasoningConfig":…}`, `{"thinking":…}` | 400 `unknown_parameter` |
| `{"reasoning":{"effort":"high"}}` | **200** — every tier none/low/medium/high/xhigh/max 200; `minimal` → 400 `unsupported_value` |
| `{"reasoning":{"effort":"high","summary":"auto"}}` | 200 with a `reasoningContent` block |
| gpt-oss-120b: `reasoning_effort` and `reasoning.effort` | both 200 |

So the flat field would have 400'd every real GPT-5.6-on-Bedrock turn that set a thinking tier. The nested OpenAI Responses shape is the wire; `summary:'auto'` returns the reasoning as a content block (opencode uses `reasoningSummary:'auto'` for OpenAI).

## Change

`bedrockAdapter` OpenAI branch emits `additionalModelRequestFields: { reasoning: { effort, summary: 'auto' } }`. Tests updated (flat field asserted absent). Docs line.

## Verified

`packages/llm-gateway` `bun test src/transports/ai-sdk` 130 pass; `tsc` clean. Dev e2e with the Essentia Bedrock token follows in the thread (a proper project, real turn with a thinking tier).

## Second commit — refusal reverted to a drop

The first turn of the fresh dev project (auto-seeded `amazon-bedrock/xai.grok-4.6`, no tier picked) logged `400 unsupported_param`: **opencode attaches a default reasoning effort to every reasoning-capable model**, so #6887's loud refusal for unmapped Bedrock families (Nova/Grok/DeepSeek) refused the model itself — managed Grok included. `UnsupportedRequestParamError` and its 400 mapping are removed; those families run at their own default until their Converse field is verified. Gateway suite 309 pass, `tsc` clean.