### PR TITLE
fix(gateway,daemon): survive a rejected reasoning parameter (one retry + per-model memory); egress-shim CA reuse; deterministic relay timing test

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2617,3 +2617,36 @@ pins the drop for Nova/Grok and the `reasoning.effort` shape for OpenAI ids.
 *Incident:* dev only; every Grok-on-Bedrock turn 400'd between the #6887
 deploy (`2635791cf1`) and the #6893 deploy (`77ec6b2307`), about 70 minutes.
 Prod was not promoted in that window. No data loss.
+
+## A 400 that names one parameter is never the turn's final answer
+
+*Incident (2026-08-25 19:40Z, Essentia session 58da74d4):* the gateway
+forwarded a reasoning field in a shape Bedrock's GPT-5.6 profile rejects
+(`400 unknown_parameter: reasoning_effort`); every turn on the model died with
+an empty assistant message until the wire shape was verified and corrected
+(#6893). The project's configured default was the trigger; the live mitigation
+was stripping it from `project_llm_routing_policies.model_generation_config`.
+
+**Rules.**
+1. `isUnknownParameterRejection(err, param)` (errors.ts) recognises an
+   upstream refusing ONE field. The chat handler re-dispatches a Bedrock
+   candidate once without `reasoning_effort` and remembers the model
+   (`noteBedrockOpenAiRejectsReasoningEffort`); the adapter never attaches the
+   field for a remembered model again. One retry, never the turn.
+2. The verified wire (#6893) stays the primary path; this is the backstop for
+   the next unverified claim, not a substitute for verifying.
+
+*Automation:* `errors.test.ts`, `simple-handler.test.ts`, `ai-sdk.test.ts`
+("never receives it again").
+
+## Regenerating a CA on every listener restart breaks trust and the CI clock
+
+*Incident (2026-08-25):* the daemon egress shim minted a fresh RSA CA on every
+rule change (`syncEgressShim` restart). Shells that had sourced the previous
+trust bundle would fail TLS until re-sourced, and node-forge's keygen (1-4 s)
+made the packages CI lane time out on the restart tests.
+
+**Rules.** One CA per daemon process (`sessionCa` in `egress-shim/index.ts`),
+reused across restarts; tests reset it via `__resetEgressShimForTests`.
+Timing tests keep at least a 5× margin between the paced event and the budget
+they assert (relay-transport "measures SILENCE").

--- a/apps/api/src/secrets/relay-transport.test.ts
+++ b/apps/api/src/secrets/relay-transport.test.ts
@@ -416,20 +416,23 @@ describe('the HEADERS deadline measures SILENCE, not the upload', () => {
         res.end(String(Buffer.concat(chunks).byteLength));
       });
     };
-    // 8 writes × 40 ms = ~320 ms of upload against a 120 ms headers budget.
+    // 12 writes × 50 ms = ~600 ms of upload against a 250 ms headers budget.
+    // The gap between writes (50 ms) sits 5× under the budget so a loaded CI
+    // worker stretching one timer cannot masquerade as upstream silence —
+    // the old 40 ms-vs-120 ms pairing flaked exactly that way (2026-08-25).
     const source = new Readable({ read() {} });
     void (async () => {
-      for (let i = 0; i < 8; i += 1) {
+      for (let i = 0; i < 12; i += 1) {
         source.push(Buffer.from('0123456789'));
-        await new Promise((r) => setTimeout(r, 40));
+        await new Promise((r) => setTimeout(r, 50));
       }
       source.push(null);
     })();
     const upstream = await openUpstream(head('/slow-upload'), source, {
       seam: seam(),
-      headersTimeoutMs: 120,
+      headersTimeoutMs: 250,
     });
-    expect((await drain(upstream.body)).toString()).toBe('80');
+    expect((await drain(upstream.body)).toString()).toBe('120');
   });
 
   test('the deadline still fires when the upstream goes silent AFTER the body', async () => {

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/index.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/index.ts
@@ -207,10 +207,21 @@ export function egressShimPort(env: NodeJS.ProcessEnv = process.env): number {
   return Number(env.KORTIX_EGRESS_SHIM_PORT) || DEFAULT_SHIM_PORT
 }
 
+// The session's CA, minted once per daemon process and REUSED across shim
+// restarts (a rule change restarts the listener — see syncEgressShim). Two
+// reasons: every agent shell that already sourced the trust bundle keeps
+// trusting the same root instead of failing TLS until it re-sources, and
+// node-forge's RSA keygen is the whole restart cost (1-4 s of pure JS — the
+// CI lane timed out at exactly that on 2026-08-25).
+let sessionCa: ReturnType<typeof createEphemeralCa> | null = null
+let sessionCaSeed: string | null = null
+
 /** Test seam: reset the module singletons. */
 export function __resetEgressShimForTests(): void {
   started = null
   armedSignature = null
+  sessionCa = null
+  sessionCaSeed = null
 }
 
 /** Stop the listener and drop the in-memory CA key. Safe to call with no shim. */
@@ -244,7 +255,12 @@ export async function startEgressShim(
 
   const port = egressShimPort(env)
   const hosts = [...new Set(config.rules.flatMap((rule) => rule.hosts))]
-  const ca = createEphemeralCa(env.KORTIX_PROJECT_ID?.slice(0, 8) ?? 'sandbox')
+  const caSeed = env.KORTIX_PROJECT_ID?.slice(0, 8) ?? 'sandbox'
+  if (!sessionCa || sessionCaSeed !== caSeed) {
+    sessionCa = createEphemeralCa(caSeed)
+    sessionCaSeed = caSeed
+  }
+  const ca = sessionCa
 
   writeTrustBundle(ca.certPem)
   const systemTrust = installSystemTrust(ca.certPem)

--- a/packages/llm-gateway/src/errors.test.ts
+++ b/packages/llm-gateway/src/errors.test.ts
@@ -8,6 +8,7 @@ import {
   defaultIsRetryable,
   indicatesUpstreamDown,
   looksLikeTerminalAuthFailure,
+  isUnknownParameterRejection,
 } from './errors';
 
 // Defect (2026-07-17, live-confirmed): an invalid upstream key retried 11+
@@ -118,5 +119,22 @@ describe('indicatesUpstreamDown — terminal auth errors never trip the shared b
     expect(indicatesUpstreamDown(new UpstreamHttpError(503, 'down'))).toBe(true);
     expect(indicatesUpstreamDown(new NetworkError('ECONNRESET'))).toBe(true);
     expect(indicatesUpstreamDown(new TimeoutError())).toBe(true);
+  });
+});
+
+describe('isUnknownParameterRejection — an upstream refusing ONE parameter, not the request', () => {
+  const bedrockBody =
+    'undefined: The model returned the following errors: {"error":{"code":"unknown_parameter","message":"Unknown parameter: \'reasoning_effort\'.","param":"reasoning_effort","type":"invalid_request_error"}}';
+
+  test("Bedrock's OpenAI-shaped unknown_parameter for reasoning_effort is recognised", () => {
+    const err = new UpstreamHttpError(400, bedrockBody, 'amazon-bedrock');
+    expect(isUnknownParameterRejection(err, 'reasoning_effort')).toBe(true);
+    expect(isUnknownParameterRejection(err, 'temperature')).toBe(false);
+  });
+
+  test('any other 400, a 5xx, or a non-HTTP error is not', () => {
+    expect(isUnknownParameterRejection(new UpstreamHttpError(400, 'context window exceeded', 'p'), 'reasoning_effort')).toBe(false);
+    expect(isUnknownParameterRejection(new UpstreamHttpError(500, bedrockBody, 'p'), 'reasoning_effort')).toBe(false);
+    expect(isUnknownParameterRejection(new Error(bedrockBody), 'reasoning_effort')).toBe(false);
   });
 });

--- a/packages/llm-gateway/src/errors.ts
+++ b/packages/llm-gateway/src/errors.ts
@@ -1,9 +1,4 @@
-export type UpstreamErrorKind =
-  | 'http'
-  | 'network'
-  | 'timeout'
-  | 'client_abort'
-  | 'misconfigured';
+export type UpstreamErrorKind = 'http' | 'network' | 'timeout' | 'client_abort' | 'misconfigured';
 
 export class TimeoutError extends Error {
   readonly kind: UpstreamErrorKind = 'timeout';
@@ -196,4 +191,25 @@ export function indicatesUpstreamDown(err: unknown): boolean {
   if (err instanceof NetworkError) return true;
   if (err instanceof UpstreamHttpError) return err.status >= 500 && err.status <= 599;
   return false;
+}
+
+/**
+ * Did the upstream refuse this exact request PARAMETER (an OpenAI-shaped
+ * `invalid_request_error` / `unknown_parameter` naming it)? Distinct from every
+ * other 400: the request is fine without that one field, so the caller can
+ * strip it and try once more instead of failing the turn.
+ *
+ * Essentia 2026-08-25: Bedrock's `global.openai.gpt-5.6-sol` profile answered
+ * `{"code":"unknown_parameter","param":"reasoning_effort"}` to a wire shape the
+ * gateway believed was right (#6879; corrected to the nested `reasoning.effort`
+ * by #6893). Whatever the next wrong claim is, it must cost one retry, never
+ * the turn.
+ */
+export function isUnknownParameterRejection(err: unknown, param: string): boolean {
+  if (!(err instanceof UpstreamHttpError) || err.status !== 400) return false;
+  const text = `${err.message} ${err.body}`;
+  if (!text.includes(param)) return false;
+  return /unknown_parameter|unknown parameter|unrecognized request argument|unsupported parameter/i.test(
+    text,
+  );
 }

--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -5,6 +5,7 @@ import {
   streamErrorTraceStatus,
   upstreamHeadersTimeoutMs,
   withUpstreamHeadersTimeout,
+  retryWithoutReasoningEffortPossible,
 } from './simple-handler';
 
 const principal = { userId: 'user', accountId: 'account', projectId: 'project' };
@@ -252,5 +253,15 @@ describe('simple gateway pipeline', () => {
     expect(sse.headers.get('content-length')).toBeNull();
     expect(sse.headers.get('content-type')).toBe('text/event-stream');
     expect(await sse.text()).toContain('[DONE]');
+  });
+});
+
+describe('retryWithoutReasoningEffortPossible', () => {
+  const bedrock: UpstreamDescriptor = { ...primary, provider: 'amazon-bedrock', kind: 'bedrock', resolvedModel: 'global.openai.gpt-5.6-sol' };
+  test('only a Bedrock candidate carrying reasoning_effort qualifies', () => {
+    expect(retryWithoutReasoningEffortPossible({ reasoning_effort: 'max' }, bedrock)).toBe(true);
+    expect(retryWithoutReasoningEffortPossible({}, bedrock)).toBe(false);
+    expect(retryWithoutReasoningEffortPossible({ reasoning_effort: 'max' }, primary)).toBe(false);
+    expect(retryWithoutReasoningEffortPossible(null, bedrock)).toBe(false);
   });
 });

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -7,8 +7,9 @@ import type {
   UpstreamDescriptor,
   UsageEvent,
 } from '../domain';
-import { GatewayResolutionError, UpstreamHttpError } from '../errors';
+import { GatewayResolutionError, UpstreamHttpError, isUnknownParameterRejection } from '../errors';
 import { type FetchImpl, callUpstream } from '../http';
+import { noteBedrockOpenAiRejectsReasoningEffort } from '../transports/ai-sdk/request';
 import { resolveTransportKind } from '../transports/route-kind';
 import { type ExtractedUsage, type SseErrorFrame, extractUsageFromJson } from '../usage';
 import { calculateCost } from '../usage/pricing';
@@ -371,6 +372,16 @@ export async function handleChatCompletions(
     upstreamHeadersTimeoutMs(body, descriptor, streaming),
   );
   let upstream: Response;
+  // The one retry this handler performs itself: an upstream that refuses the
+  // `reasoning_effort` PARAMETER (not the request) gets the same request once
+  // more without it. Kept only while such a retry is possible — the parsed
+  // graph is otherwise dropped before the provider wait, see below.
+  let retryWithoutEffort: Record<string, unknown> | null = retryWithoutReasoningEffortPossible(
+    body,
+    descriptor,
+  )
+    ? body
+    : null;
   try {
     const dispatch = callUpstream(body, descriptor, {
       fetchImpl: dispatchFetch,
@@ -381,7 +392,25 @@ export async function handleChatCompletions(
     // body synchronously up to its first await; this frame no longer needs
     // the parsed graph. Drop it before waiting on the provider.
     body = null;
-    upstream = await dispatch;
+    try {
+      upstream = await dispatch;
+    } catch (error) {
+      if (!retryWithoutEffort || !isUnknownParameterRejection(error, 'reasoning_effort'))
+        throw error;
+      const model = descriptor.resolvedModel ?? routedModel;
+      noteBedrockOpenAiRejectsReasoningEffort(model);
+      logger.warn(
+        `[gateway] ${id}: ${descriptor.provider} rejected reasoning_effort for ${model}; retrying once without it (the model is remembered)`,
+      );
+      const { reasoning_effort: _dropped, ...stripped } = retryWithoutEffort;
+      retryWithoutEffort = null;
+      upstream = await callUpstream(stripped, descriptor, {
+        fetchImpl: dispatchFetch,
+        signal: req.signal,
+        requestId: id,
+      });
+    }
+    retryWithoutEffort = null;
   } catch (error) {
     refundHold(hooks, principal);
     emit({
@@ -504,4 +533,20 @@ export async function handleChatCompletions(
     statusText: upstream.statusText,
     headers: passthroughHeaders(upstream.headers),
   });
+}
+
+/**
+ * Only a Bedrock-family candidate carrying a `reasoning_effort` can hit the
+ * `unknown_parameter` rejection this handler retries around; on every other
+ * wire the field is native.
+ */
+export function retryWithoutReasoningEffortPossible(
+  body: Record<string, unknown> | null,
+  descriptor: UpstreamDescriptor,
+): boolean {
+  return (
+    !!body &&
+    typeof body.reasoning_effort === 'string' &&
+    (descriptor.kind === 'bedrock' || descriptor.provider === 'amazon-bedrock')
+  );
 }

--- a/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/ai-sdk.test.ts
@@ -734,6 +734,28 @@ describe('ai-sdk anthropic/bedrock extended thinking (ported from native)', () =
     }
   });
 
+  it('bedrock: a model that once answered unknown_parameter for the reasoning field never receives it again', async () => {
+    const {
+      noteBedrockOpenAiRejectsReasoningEffort,
+      resetBedrockOpenAiReasoningEffortRejectionsForTests,
+    } = await import('./request');
+    try {
+      noteBedrockOpenAiRejectsReasoningEffort(BEDROCK_OPENAI);
+      const args = buildAiSdkArgs({ messages: [], reasoning_effort: 'max' }, 'bedrock', {
+        resolvedModel: BEDROCK_OPENAI,
+      });
+      expect((args.providerOptions as any)?.bedrock?.additionalModelRequestFields).toBeUndefined();
+      const other = buildAiSdkArgs({ messages: [], reasoning_effort: 'high' }, 'bedrock', {
+        resolvedModel: 'openai.gpt-oss-120b',
+      });
+      expect((other.providerOptions as any)?.bedrock?.additionalModelRequestFields).toEqual({
+        reasoning: { effort: 'high', summary: 'auto' },
+      });
+    } finally {
+      resetBedrockOpenAiReasoningEffortRejectionsForTests();
+    }
+  });
+
   it('bedrock: OpenAI-on-Bedrock accepts the Responses-style nested reasoning.effort too', () => {
     const args = buildAiSdkArgs({ messages: [], reasoning: { effort: 'xhigh' } }, 'bedrock', {
       resolvedModel: BEDROCK_OPENAI,

--- a/packages/llm-gateway/src/transports/ai-sdk/request.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/request.ts
@@ -757,6 +757,22 @@ function isBedrockOpenAiModel(resolvedModel: string | undefined): boolean {
   return /(^|\.)openai\./i.test(resolvedModel ?? '');
 }
 
+// Models that answered `unknown_parameter` for the reasoning field once. The
+// wire shape below is verified (#6893), but the next provider surface that
+// publishes an OpenAI ladder and rejects the field must cost one retry, never
+// the turn: the pipeline notes a rejection here and re-dispatches once without
+// it; every later request to that model skips the field.
+const bedrockOpenAiReasoningEffortRejected = new Set<string>();
+export function noteBedrockOpenAiRejectsReasoningEffort(resolvedModel: string): void {
+  bedrockOpenAiReasoningEffortRejected.add(resolvedModel);
+}
+export function bedrockOpenAiRejectsReasoningEffort(resolvedModel: string | undefined): boolean {
+  return !!resolvedModel && bedrockOpenAiReasoningEffortRejected.has(resolvedModel);
+}
+export function resetBedrockOpenAiReasoningEffortRejectionsForTests(): void {
+  bedrockOpenAiReasoningEffortRejected.clear();
+}
+
 const ANTHROPIC_CACHE_CONTROL = { type: 'ephemeral' } as const;
 const BEDROCK_CACHE_POINT = { type: 'default' } as const;
 
@@ -1084,7 +1100,10 @@ const bedrockAdapter: ProviderAdapter = {
     // effort as the OpenAI-native field. Nothing else — `cachePoint` and
     // `reasoningConfig` are Claude-Converse-only and 403 here.
     if (isBedrockOpenAiModel(req.resolvedModel)) {
-      if (typeof req.reasoningEffort === 'string') {
+      if (
+        typeof req.reasoningEffort === 'string' &&
+        !bedrockOpenAiRejectsReasoningEffort(req.resolvedModel)
+      ) {
         options.additionalModelRequestFields = {
           reasoning: { effort: req.reasoningEffort, summary: 'auto' },
         };


### PR DESCRIPTION
## Why
Essentia 2026-08-25 19:40Z, session 58da74d4: the gateway forwarded a reasoning field in a shape Bedrock's GPT-5.6 profile rejects (`400 unknown_parameter: reasoning_effort`); every turn on the model died with an empty assistant message. #6893 verified and corrected the wire (`additionalModelRequestFields.reasoning.effort`). This PR is the backstop so the *next* unverified claim costs one retry, never the turn — plus two CI-reliability fixes found while landing it.

## What
- `errors.ts`: `isUnknownParameterRejection(err, param)`.
- `pipeline/simple-handler.ts`: a Bedrock candidate carrying `reasoning_effort` that gets that rejection is re-dispatched once without the field (body retained only while such a retry is possible); the model is remembered and the adapter never attaches the field for it again (`request.ts`). A warn line names it.
- Daemon egress shim: the session CA is minted once per process and reused across listener restarts (trust continuity + no 1–4 s RSA keygen per rule change; the CI packages lane timed out on exactly that).
- `relay-transport.test.ts`: 12×50 ms vs 250 ms budget (5× margin) instead of 8×40 ms vs 120 ms (flaked twice in CI today).
- Learnings: two entries.

## Verification
`packages/llm-gateway` 313/0 (+ new tests), daemon egress-shim 78/0 (restart tests ≈1 s, were >5 s), `apps/api` relay-transport 19/0 ×2; `tsc` clean on gateway/daemon.