### PR TITLE
fix(bedrock): prefer inference-profile ids in the picker + flagship seed; gateway retries a refused bare id with global./us.

### DIFF
--- a/apps/api/src/llm-gateway/models/picker-catalog.ts
+++ b/apps/api/src/llm-gateway/models/picker-catalog.ts
@@ -1,4 +1,4 @@
-import { type Catalog, type CatalogModel } from '@kortix/llm-catalog';
+import { type Catalog, type CatalogModel, bedrockInferenceProfileRank } from '@kortix/llm-catalog';
 import { toWireModel } from '../resolution/effective';
 import { resolveCatalogUpstream } from './provider-registry';
 import { runtimeModelCatalog } from './runtime-catalog';
@@ -77,8 +77,14 @@ export function providerFlagship(providerId: string): string | null {
   // provider (deterministic, real). Released dates sort lexically (YYYY-MM-DD).
   const provider = state.catalog.providers.find((p) => p.id === providerId);
   if (!provider || provider.models.length === 0) return null;
-  const sorted = [...provider.models].sort((a, b) =>
-    (b.released ?? '').localeCompare(a.released ?? ''),
+  // Newest first; on a release-date tie prefer the Bedrock inference profile
+  // (`global.` > regional > bare) — the bare id is what Bedrock refuses with
+  // "on-demand throughput isn't supported", and it used to be what a fresh
+  // BYOK Bedrock project was seeded with (`amazon-bedrock/xai.grok-4.6`).
+  const sorted = [...provider.models].sort(
+    (a, b) =>
+      (b.released ?? '').localeCompare(a.released ?? '') ||
+      bedrockInferenceProfileRank(b.id) - bedrockInferenceProfileRank(a.id),
   );
   return sorted[0]?.id ?? null;
 }

--- a/apps/web/content/docs/project/models.mdx
+++ b/apps/web/content/docs/project/models.mdx
@@ -62,6 +62,10 @@ control. `Auto` clears the variant.
   Amazon Bedrock → Bedrock's `reasoning.effort` request field). For an upstream it
   cannot map yet (Nova, Grok on Bedrock today) the value is dropped and the
   model runs at its own default.
+- Amazon Bedrock refuses the bare in-region id of most current models
+  ("on-demand throughput isn't supported"). The picker prefers the `global.` /
+  regional inference-profile id when the catalog carries one, and the gateway
+  retries a refused bare id once per profile prefix (`global.`, `us.`).
 - The sandbox learns the project's servable model set from the API at every
   boot (`GET /v1/llm/models?scope=picker`, the same composition as the web
   picker), so a model the picker offers always resolves in the runtime.

--- a/packages/llm-catalog/src/enablement.test.ts
+++ b/packages/llm-catalog/src/enablement.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 
-import { type EnablementCandidate, defaultEnabledModelIds } from './enablement';
+import {
+  type EnablementCandidate,
+  bedrockInferenceProfileRank,
+  defaultEnabledModelIds,
+} from './enablement';
 
 const NOW = new Date('2026-07-29T00:00:00Z');
 
@@ -65,5 +69,49 @@ describe('defaultEnabledModelIds', () => {
 
   test('is empty for an empty catalog', () => {
     expect(ids([])).toEqual([]);
+  });
+});
+
+describe('Bedrock inference profiles win a family tie', () => {
+  // models.dev lists the bare in-region id AND its cross-region inference
+  // profile(s) with the same family and release date. Bedrock refuses the bare
+  // id for these models ("Invocation of model ID openai.gpt-5.6-luna with
+  // on-demand throughput isn't supported") — so a tie must never surface it.
+  test('global. beats the bare in-region id; us./eu. beat bare too', () => {
+    expect(
+      ids([
+        { id: 'amazon-bedrock/openai.gpt-5.6-luna', family: 'gpt-luna', released: '2026-07-09', provider: 'amazon-bedrock' },
+        { id: 'amazon-bedrock/global.openai.gpt-5.6-luna', family: 'gpt-luna', released: '2026-07-09', provider: 'amazon-bedrock' },
+        { id: 'amazon-bedrock/anthropic.claude-fable-5', family: 'claude-fable', released: '2026-06-09', provider: 'amazon-bedrock' },
+        { id: 'amazon-bedrock/us.anthropic.claude-fable-5', family: 'claude-fable', released: '2026-06-09', provider: 'amazon-bedrock' },
+      ]),
+    ).toEqual(['amazon-bedrock/global.openai.gpt-5.6-luna', 'amazon-bedrock/us.anthropic.claude-fable-5']);
+  });
+
+  test('global. beats a regional profile on a tie', () => {
+    expect(
+      ids([
+        { id: 'amazon-bedrock/us.anthropic.claude-fable-5', family: 'claude-fable', released: '2026-06-09', provider: 'amazon-bedrock' },
+        { id: 'amazon-bedrock/global.anthropic.claude-fable-5', family: 'claude-fable', released: '2026-06-09', provider: 'amazon-bedrock' },
+      ]),
+    ).toEqual(['amazon-bedrock/global.anthropic.claude-fable-5']);
+  });
+
+  test('a newer release still wins over an older profile — the rank only breaks ties', () => {
+    expect(
+      ids([
+        { id: 'amazon-bedrock/global.openai.gpt-5.5', family: 'gpt', released: '2026-04-23', provider: 'amazon-bedrock' },
+        { id: 'amazon-bedrock/openai.gpt-5.6-sol', family: 'gpt', released: '2026-07-09', provider: 'amazon-bedrock' },
+      ]),
+    ).toEqual(['amazon-bedrock/openai.gpt-5.6-sol']);
+  });
+
+  test('bedrockInferenceProfileRank: global > regional > bare, provider prefix tolerated', () => {
+    expect(bedrockInferenceProfileRank('global.openai.gpt-5.6-sol')).toBe(2);
+    expect(bedrockInferenceProfileRank('amazon-bedrock/global.openai.gpt-5.6-sol')).toBe(2);
+    expect(bedrockInferenceProfileRank('us.anthropic.claude-fable-5')).toBe(1);
+    expect(bedrockInferenceProfileRank('apac.anthropic.claude-sonnet-5')).toBe(1);
+    expect(bedrockInferenceProfileRank('openai.gpt-5.6-sol')).toBe(0);
+    expect(bedrockInferenceProfileRank('zai.glm-5')).toBe(0);
   });
 });

--- a/packages/llm-catalog/src/enablement.ts
+++ b/packages/llm-catalog/src/enablement.ts
@@ -58,10 +58,35 @@ function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
 }
 
 /** The newest member of a group; ties and undated models resolve by catalog order. */
+/**
+ * Amazon Bedrock lists most current models three ways: the bare in-region id
+ * (`openai.gpt-5.6-luna`), regional cross-region inference profiles
+ * (`us.` / `eu.` / `jp.` / `apac.` / `au.`), and a `global.` profile — same
+ * family, same release date. For these models Bedrock REFUSES the bare id
+ * ("Invocation of model ID … with on-demand throughput isn't supported. Retry
+ * your request with the ID or ARN of an inference profile"), verified live
+ * 2026-08-25 on gpt-5.6-luna/terra and grok-4.6. Rank: global 2 > regional 1
+ * > bare 0. A provider prefix (`amazon-bedrock/…`) is tolerated.
+ */
+export function bedrockInferenceProfileRank(id: string): 0 | 1 | 2 {
+  const bare = id.includes('/') ? id.slice(id.indexOf('/') + 1) : id;
+  if (bare.startsWith('global.')) return 2;
+  if (/^(us|eu|jp|apac|au|ca|sa|us-gov)\./.test(bare)) return 1;
+  return 0;
+}
+
+// Newest first; on a release-date tie the Bedrock inference profile wins over
+// the bare id (see bedrockInferenceProfileRank) — otherwise the FIRST listed
+// id won, and models.dev lists the bare id first.
 function newest(models: EnablementCandidate[]): EnablementCandidate {
-  return models.reduce((best, model) =>
-    (releasedAt(model) ?? 0) > (releasedAt(best) ?? 0) ? model : best,
-  );
+  return models.reduce((best, model) => {
+    const a = releasedAt(model) ?? 0;
+    const b = releasedAt(best) ?? 0;
+    if (a !== b) return a > b ? model : best;
+    return bedrockInferenceProfileRank(model.id) > bedrockInferenceProfileRank(best.id)
+      ? model
+      : best;
+  });
 }
 
 /**

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -4,6 +4,7 @@ export {
   DEFAULT_ENABLEMENT_WINDOW_MONTHS,
   defaultEnabledModelIds,
   type EnablementCandidate,
+  bedrockInferenceProfileRank,
 } from './enablement';
 
 // ─── Kortix-owned provider auth requirements ────────────────────────────────

--- a/packages/llm-gateway/src/pipeline/simple-handler.test.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.test.ts
@@ -138,6 +138,104 @@ describe('simple gateway pipeline', () => {
     expect(traces[0]?.response).toBeUndefined();
   });
 
+  test('retries a bare Bedrock id with its inference profile when Bedrock refuses on-demand invocation', async () => {
+    const usage: UsageEvent[] = [];
+    const traces: GatewayTrace[] = [];
+    const bedrockGrok: UpstreamDescriptor = {
+      ...primary,
+      provider: 'amazon-bedrock',
+      kind: 'bedrock',
+      resolvedModel: 'xai.grok-4.6',
+    };
+    const urls: string[] = [];
+    const response = await handleChatCompletions(
+      {
+        hooks: { ...hooks(usage, traces), resolveUpstream: async () => [bedrockGrok] },
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async (input) => {
+          const url = typeof input === 'string' ? input : ((input as { url?: string }).url ?? String(input));
+          urls.push(url);
+          if (url.includes('/model/xai.grok-4.6/')) {
+            return new Response(
+              JSON.stringify({
+                message:
+                  'Invocation of model ID xai.grok-4.6 with on-demand throughput isn’t supported. Retry your request with the ID or ARN of an inference profile that contains this model.',
+              }),
+              { status: 400, headers: { 'content-type': 'application/json' } },
+            );
+          }
+          return new Response(
+            JSON.stringify({
+              output: { message: { role: 'assistant', content: [{ text: 'pong' }] } },
+              stopReason: 'end_turn',
+              usage: { inputTokens: 12, outputTokens: 1, totalTokens: 13 },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        },
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({
+          model: 'amazon-bedrock/xai.grok-4.6',
+          messages: [{ role: 'user', content: 'Reply with the single word pong.' }],
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { choices: Array<{ message: { content: string } }> };
+    expect(body.choices[0]?.message.content).toBe('pong');
+    expect(urls.map((u) => new URL(u).pathname.replace(/^.*\/model\//, '/model/'))).toEqual([
+      '/model/xai.grok-4.6/converse',
+      '/model/global.xai.grok-4.6/converse',
+    ]);
+    expect(traces).toHaveLength(1);
+    expect(traces[0]).toMatchObject({
+      status: 200,
+      ok: true,
+      resolvedModel: 'global.xai.grok-4.6',
+      attempts: 2,
+      candidatesTried: ['amazon-bedrock', 'amazon-bedrock:global.xai.grok-4.6'],
+    });
+    expect(usage).toHaveLength(1);
+    expect(usage[0]).toMatchObject({ model: 'global.xai.grok-4.6' });
+  });
+
+  test('a Bedrock 400 that is NOT the on-demand refusal is passed through with no retry', async () => {
+    const usage: UsageEvent[] = [];
+    const traces: GatewayTrace[] = [];
+    let calls = 0;
+    const response = await handleChatCompletions(
+      {
+        hooks: {
+          ...hooks(usage, traces),
+          resolveUpstream: async () => [
+            { ...primary, provider: 'amazon-bedrock', kind: 'bedrock', resolvedModel: 'openai.gpt-5.5' },
+          ],
+        },
+        logger: { info() {}, warn() {}, error() {} },
+        fetchImpl: async () => {
+          calls += 1;
+          return new Response(JSON.stringify({ message: 'The provided model identifier is invalid.' }), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          });
+        },
+      },
+      {
+        authorization: 'Bearer token',
+        rawBody: JSON.stringify({
+          model: 'amazon-bedrock/openai.gpt-5.5',
+          messages: [{ role: 'user', content: 'pong?' }],
+        }),
+      },
+    );
+    expect(calls).toBe(1);
+    expect(response.status).toBe(400);
+    expect(traces[0]).toMatchObject({ attempts: 1, candidatesTried: ['amazon-bedrock'] });
+  });
+
   test('settles one successful response exactly once', async () => {
     const usage: UsageEvent[] = [];
     const traces: GatewayTrace[] = [];

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -201,6 +201,28 @@ function refundHold(hooks: GatewayHooks, principal: AuthedPrincipal): void {
   void hooks.recordUsage(event).catch(() => {});
 }
 
+// Cross-region inference profile prefixes to try, best first. `global.` serves
+// every commercial region; `us.` is the widest regional profile.
+const BEDROCK_PROFILE_PREFIXES = ['global.', 'us.'] as const;
+
+// A Bedrock descriptor whose resolved id carries no profile prefix — the only
+// shape the inference-profile retry applies to.
+function bedrockBareModelId(descriptor: UpstreamDescriptor): string | null {
+  if (descriptor.kind !== 'bedrock') return null;
+  const id = descriptor.resolvedModel;
+  if (!id || /^(global|us|eu|jp|apac|au|ca|sa|us-gov)\./.test(id)) return null;
+  return id;
+}
+
+// Bedrock's exact refusal of a bare id (ASCII and curly apostrophe both seen).
+function needsInferenceProfile(error: unknown): boolean {
+  return (
+    error instanceof UpstreamHttpError &&
+    error.status === 400 &&
+    /on-demand throughput isn.t supported/i.test(error.body)
+  );
+}
+
 function rawProviderError(error: UpstreamHttpError): Response {
   return new Response(error.body || JSON.stringify({ error: { message: error.message } }), {
     status: error.status,
@@ -371,19 +393,33 @@ export async function handleChatCompletions(
     fetchImpl ?? ((input, init) => globalThis.fetch(input, init)),
     upstreamHeadersTimeoutMs(body, descriptor, streaming),
   );
+  // The descriptor actually served — swapped for its inference-profile twin
+  // when Bedrock refuses the bare id (see the retry below).
+  let served: UpstreamDescriptor = descriptor;
   let upstream: Response;
-  // The one retry this handler performs itself: an upstream that refuses the
-  // `reasoning_effort` PARAMETER (not the request) gets the same request once
-  // more without it. Kept only while such a retry is possible — the parsed
-  // graph is otherwise dropped before the provider wait, see below.
+  // The one retry this handler performs itself for a PARAMETER: an upstream
+  // that refuses `reasoning_effort` (not the request) gets the same request
+  // once more without it. Kept only while such a retry is possible — the
+  // parsed graph is otherwise dropped before the provider wait, see below.
   let retryWithoutEffort: Record<string, unknown> | null = retryWithoutReasoningEffortPossible(
     body,
-    descriptor,
+    served,
   )
     ? body
     : null;
+  // The one retry for a MODEL ID: Bedrock refuses the bare in-region id of
+  // most current models ("Invocation of model ID xai.grok-4.6 with on-demand
+  // throughput isn't supported. Retry your request with the ID or ARN of an
+  // inference profile") while the `global.` / `us.` profile of the same model
+  // answers. models.dev carries the bare id for every such model and the
+  // profile only for some (grok-4.6 has none), so the retry lives here: keep
+  // the body for a bare Bedrock id and re-dispatch once per profile prefix on
+  // exactly that 400.
+  const profileRetryBody = bedrockBareModelId(served) ? structuredClone(body) : null;
+  let attempts = 1;
+  const candidatesTried = [served.provider];
   try {
-    const dispatch = callUpstream(body, descriptor, {
+    const dispatch = callUpstream(body, served, {
       fetchImpl: dispatchFetch,
       signal: req.signal,
       requestId: id,
@@ -395,20 +431,45 @@ export async function handleChatCompletions(
     try {
       upstream = await dispatch;
     } catch (error) {
-      if (!retryWithoutEffort || !isUnknownParameterRejection(error, 'reasoning_effort'))
+      if (retryWithoutEffort && isUnknownParameterRejection(error, 'reasoning_effort')) {
+        const model = served.resolvedModel ?? routedModel;
+        noteBedrockOpenAiRejectsReasoningEffort(model);
+        logger.warn(
+          `[gateway] ${id}: ${served.provider} rejected reasoning_effort for ${model}; retrying once without it (the model is remembered)`,
+        );
+        const { reasoning_effort: _dropped, ...stripped } = retryWithoutEffort;
+        retryWithoutEffort = null;
+        attempts += 1;
+        upstream = await callUpstream(stripped, served, {
+          fetchImpl: dispatchFetch,
+          signal: req.signal,
+          requestId: id,
+        });
+      } else if (profileRetryBody && needsInferenceProfile(error)) {
+        let retried: Response | undefined;
+        let lastError: unknown = error;
+        for (const prefix of BEDROCK_PROFILE_PREFIXES) {
+          const candidate = { ...served, resolvedModel: `${prefix}${served.resolvedModel}` };
+          attempts += 1;
+          candidatesTried.push(`${served.provider}:${candidate.resolvedModel}`);
+          try {
+            retried = await callUpstream(structuredClone(profileRetryBody), candidate, {
+              fetchImpl: dispatchFetch,
+              signal: req.signal,
+              requestId: id,
+            });
+            served = candidate;
+            break;
+          } catch (retryError) {
+            lastError = retryError;
+            if (!needsInferenceProfile(retryError)) break;
+          }
+        }
+        if (!retried) throw lastError;
+        upstream = retried;
+      } else {
         throw error;
-      const model = descriptor.resolvedModel ?? routedModel;
-      noteBedrockOpenAiRejectsReasoningEffort(model);
-      logger.warn(
-        `[gateway] ${id}: ${descriptor.provider} rejected reasoning_effort for ${model}; retrying once without it (the model is remembered)`,
-      );
-      const { reasoning_effort: _dropped, ...stripped } = retryWithoutEffort;
-      retryWithoutEffort = null;
-      upstream = await callUpstream(stripped, descriptor, {
-        fetchImpl: dispatchFetch,
-        signal: req.signal,
-        requestId: id,
-      });
+      }
     }
     retryWithoutEffort = null;
   } catch (error) {
@@ -416,36 +477,36 @@ export async function handleChatCompletions(
     emit({
       ...identity(principal),
       requestedModel,
-      resolvedModel: descriptor.resolvedModel ?? routedModel,
-      provider: descriptor.provider,
-      billingMode: descriptor.billingMode,
+      resolvedModel: served.resolvedModel ?? routedModel,
+      provider: served.provider,
+      billingMode: served.billingMode,
       streaming,
       status: error instanceof UpstreamHttpError ? error.status : 502,
       ok: false,
       errorCode: 'upstream_error',
       errorMessage: error instanceof Error ? error.message : String(error),
-      attempts: 1,
-      candidatesTried: [descriptor.provider],
+      attempts,
+      candidatesTried,
     });
     if (error instanceof UpstreamHttpError) return rawProviderError(error);
     // A headers timeout is "try again", not "this request is malformed".
     const timedOut = (error as { name?: unknown })?.name === 'TimeoutError' && !req.signal?.aborted;
     if (timedOut)
       return gatewayErrorResponse(503, {
-        message: `Provider ${descriptor.provider} sent no response headers within ${UPSTREAM_HEADERS_TIMEOUT_MS}ms`,
+        message: `Provider ${served.provider} sent no response headers within ${UPSTREAM_HEADERS_TIMEOUT_MS}ms`,
         code: 'upstream_timeout',
-        provider: descriptor.provider,
+        provider: served.provider,
         requestedModel,
-        resolvedModel: descriptor.resolvedModel ?? routedModel,
+        resolvedModel: served.resolvedModel ?? routedModel,
         requestId: id,
         suggestion: 'Retry the request, or choose another model.',
       });
     return gatewayErrorResponse(502, {
       message: error instanceof Error ? error.message : 'Provider request failed',
       code: 'upstream_error',
-      provider: descriptor.provider,
+      provider: served.provider,
       requestedModel,
-      resolvedModel: descriptor.resolvedModel ?? routedModel,
+      resolvedModel: served.resolvedModel ?? routedModel,
       requestId: id,
       suggestion: 'Retry the request or choose another model.',
     });
@@ -464,11 +525,11 @@ export async function handleChatCompletions(
         }
       : EMPTY_USAGE;
     const { upstreamCost, finalCost } = calculateCost(
-      descriptor.resolvedModel ?? routedModel,
+      served.resolvedModel ?? routedModel,
       counts,
-      descriptor.billingMode === 'none' ? 0 : descriptor.markup,
+      served.billingMode === 'none' ? 0 : served.markup,
       usage?.upstreamCostHint,
-      descriptor.pricing,
+      served.pricing,
     );
     if (counts.promptTokens + counts.completionTokens > 0 || principal.billingHold) {
       await hooks.recordUsage({
@@ -477,11 +538,11 @@ export async function handleChatCompletions(
         actorUserId: principal.userId,
         projectId: principal.projectId,
         sessionId: principal.sessionId,
-        provider: descriptor.provider,
-        model: descriptor.resolvedModel ?? routedModel,
+        provider: served.provider,
+        model: served.resolvedModel ?? routedModel,
         upstreamCost,
         finalCost,
-        billingMode: descriptor.billingMode,
+        billingMode: served.billingMode,
         streaming,
         requestId: id,
         ...(principal.billingHold ? { billingHoldUsd: principal.billingHold.amountUsd } : {}),
@@ -490,16 +551,16 @@ export async function handleChatCompletions(
     emit({
       ...identity(principal),
       requestedModel,
-      resolvedModel: descriptor.resolvedModel ?? routedModel,
-      provider: descriptor.provider,
-      billingMode: descriptor.billingMode,
+      resolvedModel: served.resolvedModel ?? routedModel,
+      provider: served.provider,
+      billingMode: served.billingMode,
       streaming,
       status: streamError ? streamErrorTraceStatus(streamError) : upstream.status,
       ok: !streamError && upstream.ok,
       errorCode: streamError ? String(streamError.code ?? 'upstream_stream_error') : undefined,
       errorMessage: streamError?.message,
-      attempts: 1,
-      candidatesTried: [descriptor.provider],
+      attempts,
+      candidatesTried,
       usage: counts,
       upstreamCost,
       finalCost,


### PR DESCRIPTION
## Why (real-key sweep of every Bedrock model in the picker, Essentia account)

| Model (picker) | wire id | result |
|---|---|---|
| Claude Opus 5 (EU), Claude Sonnet 5 (JP), GLM-5, GPT-5.6 Sol (Global), MiniMax M2.5, NVIDIA Nemotron 3 Super | profile / on-demand ids | **200** |
| GPT-5.6 Luna, GPT-5.6 Terra, Grok 4.6 | bare `openai.gpt-5.6-luna`, `openai.gpt-5.6-terra`, `xai.grok-4.6` | **400** "on-demand throughput isn't supported… inference profile" — `global.openai.gpt-5.6-luna/-terra` 200; `global.`/`us.xai.grok-4.6` 200 on Bedrock but absent from models.dev |
| Claude Fable 5 (US) | any profile | 400 "data retention mode 'default' is not available for this model" — account-level Bedrock setting, not a request field (8 field guesses ignored) |
| GPT-5.5 | `openai.gpt-5.5` | 400 "model identifier is invalid" (models.dev entry) |

The picker's default view surfaces the bare id because `defaultEnabledModelIds` breaks a same-family/same-date tie by list order (bare first), and `providerFlagship` seeded a fresh BYOK Bedrock project with `amazon-bedrock/xai.grok-4.6` (that's the 400 every new Bedrock project's first turn got today).

## Change

- `@kortix/llm-catalog` `bedrockInferenceProfileRank` (global 2 > regional 1 > bare 0) breaks release-date ties in `newest()`; `providerFlagship` uses it too.
- Gateway: on exactly that 400 for a bare Bedrock id, re-dispatch once per profile prefix (`global.`, `us.`); trace carries `attempts`, `candidatesTried`, and the served profile id. Other 400s pass through untouched.
- Docs.

## Verified

`packages/llm-catalog` 76 pass (+4), `packages/llm-gateway` 311 pass (+2: retry path hits `/model/xai.grok-4.6/converse` then `/model/global.xai.grok-4.6/converse`, trace `attempts:2`; a different 400 → single call, passthrough), `apps/api` picker/enablement/catalog-models 35 pass; all `tsc` clean. Dev re-sweep after deploy follows in the thread.