### PR TITLE
fix(connectors): finish a connect the human walked away from

### DIFF
--- a/apps/api/src/connectors/notify-session.test.ts
+++ b/apps/api/src/connectors/notify-session.test.ts
@@ -47,6 +47,9 @@ test('a STOPPED session is still told its connector landed', async () => {
     accountId: 'acct-1',
   });
   expect(enqueued[0].text).toBe(connectorConnectedPrompt('gmail', 'gmail'));
+  // De-duped in the database, not by hoping one caller wins: the browser poll
+  // and the server-side completion watch both legitimately see the same connect.
+  expect(enqueued[0].idempotencyKey).toBe('connector-connected:session-1:gmail');
 });
 
 test('a running session is told too', async () => {

--- a/apps/api/src/connectors/notify-session.ts
+++ b/apps/api/src/connectors/notify-session.ts
@@ -73,6 +73,12 @@ export async function notifyConnectorSession(
     const { enqueueContinueSessionCommand, drainSessionLifecycleQueue } = await import(
       '../projects/session-lifecycle'
     );
+    // Idempotent by construction. Several callers legitimately observe the same
+    // connect landing — the browser poll, the server-side completion watch, a
+    // second tab on the same link — and the agent must be told exactly once.
+    // `enqueueContinueSessionCommand` de-dupes on this key with
+    // onConflictDoNothing, so the race is settled in the database rather than by
+    // hoping only one caller wins.
     await enqueueContinueSessionCommand({
       source: 'system:connector-connected',
       projectId,
@@ -80,6 +86,7 @@ export async function notifyConnectorSession(
       sessionId,
       actorUserId,
       text: connectorConnectedPrompt(slug, app),
+      idempotencyKey: `connector-connected:${sessionId}:${slug}`,
     });
     drainSessionLifecycleQueue({ limit: 1 }).catch(() => {});
     console.info('[connectors] connector connected, session notified', { sessionId, slug });

--- a/apps/api/src/setup-links/connector-completion-watch.test.ts
+++ b/apps/api/src/setup-links/connector-completion-watch.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Closing the modal must not strand the agent.
+ *
+ * The browser poll is what persists the credential and tells the waiting agent,
+ * so when the human closed the modal the poll died with it: Google completed,
+ * the account landed at the provider, and the session was never told. Pipedream
+ * masked this with its connect webhook; Composio has none, so the browser was
+ * the only completion path.
+ */
+import { expect, mock, test } from 'bun:test';
+
+let finalizeResults: Array<{ connected: boolean }> = [];
+let finalizeCalls = 0;
+const notified: Array<Record<string, unknown>> = [];
+
+mock.module('../connectors/db-deps', () => ({
+  dbConnectorRouterDeps: {
+    connectorFinalize: async () => {
+      const next = finalizeResults[Math.min(finalizeCalls, finalizeResults.length - 1)];
+      finalizeCalls += 1;
+      if (!next) throw new Error('provider blip');
+      return { provider: 'composio', ...next };
+    },
+  },
+}));
+
+// Deliberately NOT mocking ../connectors/notify-session: it is shared with the
+// public-app suite, and stubbing a shared module leaks across files even under
+// --isolate. Mock what it depends on instead, which also exercises the real
+// notifier rather than a stand-in.
+mock.module('../shared/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({ limit: async () => [{ status: 'stopped', accountId: 'acct-1', metadata: {} }] }),
+      }),
+    }),
+  },
+}));
+mock.module('../projects/session-lifecycle', () => ({
+  enqueueContinueSessionCommand: async (input: Record<string, unknown>) => {
+    notified.push({
+      sessionId: input.sessionId,
+      projectId: input.projectId,
+      uid: input.actorUserId,
+      slug: 'gmail',
+      app: 'gmail',
+      idempotencyKey: input.idempotencyKey,
+    });
+    return { row: {}, deduped: false };
+  },
+  drainSessionLifecycleQueue: async () => ({}),
+}));
+
+const { watchConnectorCompletion, connectorCompletionWatchActive } = await import(
+  './connector-completion-watch'
+);
+
+const base = { projectId: 'p1', slug: 'gmail', app: 'gmail', sid: 's1', uid: 'u1' };
+const noSleep = async () => {};
+
+async function settle() {
+  for (let i = 0; i < 50; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 5));
+}
+
+test('a connect completed after the modal closed still tells the agent', async () => {
+  finalizeCalls = 0; notified.length = 0;
+  finalizeResults = [{ connected: false }, { connected: false }, { connected: true }];
+  watchConnectorCompletion({ ...base, sleep: noSleep });
+  await settle();
+  expect(notified).toHaveLength(1);
+  expect(notified[0]).toMatchObject({
+    sessionId: 's1',
+    projectId: 'p1',
+    idempotencyKey: 'connector-connected:s1:gmail',
+  });
+});
+
+test('no session waiting → no watch, because there is nobody to tell', async () => {
+  finalizeCalls = 0; notified.length = 0;
+  finalizeResults = [{ connected: true }];
+  watchConnectorCompletion({ ...base, sid: null, sleep: noSleep });
+  await settle();
+  expect(notified).toHaveLength(0);
+  expect(connectorCompletionWatchActive('p1', 'gmail')).toBe(false);
+});
+
+test('reopening the link does not stack a second watch', async () => {
+  finalizeCalls = 0; notified.length = 0;
+  finalizeResults = [{ connected: true }];
+  let release!: () => void;
+  const held = new Promise<void>((r) => { release = r; });
+  watchConnectorCompletion({ ...base, slug: 'held', sleep: () => held });
+  expect(connectorCompletionWatchActive('p1', 'held')).toBe(true);
+  watchConnectorCompletion({ ...base, slug: 'held', sleep: () => held });
+  release();
+  await settle();
+  expect(notified).toHaveLength(1);
+});
+
+test('the window closes instead of polling forever', async () => {
+  finalizeCalls = 0; notified.length = 0;
+  finalizeResults = [{ connected: false }];
+  let clock = 0;
+  watchConnectorCompletion({
+    ...base,
+    slug: 'never',
+    now: () => (clock += 60_000),
+    sleep: noSleep,
+  });
+  await settle();
+  expect(notified).toHaveLength(0);
+  expect(connectorCompletionWatchActive('p1', 'never')).toBe(false);
+});

--- a/apps/api/src/setup-links/connector-completion-watch.ts
+++ b/apps/api/src/setup-links/connector-completion-watch.ts
@@ -1,0 +1,94 @@
+/**
+ * Finish a connect the human walked away from.
+ *
+ * The hosted authorization page runs in a popup on the provider's origin and
+ * cannot call back into us, so the browser polls `/finalize` to learn the
+ * account landed — and that poll is what persists the credential and tells the
+ * waiting agent. Close the modal and the poll dies with it: the human finishes
+ * Google, sees nothing happen, and the agent sits there having been told
+ * nothing.
+ *
+ * Pipedream never fully had this problem because its connect webhook lands the
+ * credential server-side regardless of the browser. Composio has no such
+ * webhook wired, so the browser was the ONLY completion path for it.
+ *
+ * This is the server-side half: a bounded poll started when the link is opened,
+ * on the same schedule the browser uses, that finalizes and notifies whether or
+ * not anyone is still watching. The browser poll stays primary — it is what
+ * makes the open modal feel instant; this only catches what it drops.
+ *
+ * Deliberately in-process and best-effort, matching the redundancy role the
+ * Pipedream webhook already plays. It is NOT a durable job: a deploy mid-window
+ * loses the watch, and the next `/finalize` from any surface still settles it.
+ * The notification itself is de-duplicated in the database
+ * (`enqueueContinueSessionCommand` idempotency key), so this racing the browser
+ * cannot produce two prompts.
+ */
+import { notifyConnectorSession } from '../connectors/notify-session';
+
+const POLL_INTERVAL_MS = 5_000;
+const WINDOW_MS = 5 * 60_000;
+
+/** One watch per connector per project — reopening the link must not stack them. */
+const active = new Set<string>();
+
+export interface ConnectorCompletionWatch {
+  projectId: string;
+  slug: string;
+  app: string;
+  /** Session that minted the link, or null when nobody is waiting on it. */
+  sid: string | null;
+  uid: string | null;
+  /** Injected in tests. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms).unref?.());
+
+export function watchConnectorCompletion(input: ConnectorCompletionWatch): void {
+  // Nothing to tell anyone. The credential still lands through the browser poll
+  // or the next finalize; there is just no agent waiting on the answer.
+  if (!input.sid) return;
+  const key = `${input.projectId}:${input.slug}`;
+  if (active.has(key)) return;
+  active.add(key);
+  void runWatch(input, key).catch(() => {
+    /* best-effort by construction — never surface into the connect response */
+  });
+}
+
+async function runWatch(input: ConnectorCompletionWatch, key: string): Promise<void> {
+  const now = input.now ?? Date.now;
+  const sleep = input.sleep ?? defaultSleep;
+  const startedAt = now();
+  try {
+    const { dbConnectorRouterDeps } = await import('../connectors/db-deps');
+    while (now() - startedAt < WINDOW_MS) {
+      await sleep(POLL_INTERVAL_MS);
+      let connected = false;
+      try {
+        const result = await dbConnectorRouterDeps.connectorFinalize?.(
+          input.projectId,
+          input.slug,
+          input.uid ?? '',
+          undefined,
+        );
+        connected = result?.connected === true;
+      } catch {
+        // A provider blip is not a verdict. Keep asking until the window closes.
+        continue;
+      }
+      if (!connected) continue;
+      await notifyConnectorSession(input.sid!, input.projectId, input.uid, input.slug, input.app);
+      return;
+    }
+  } finally {
+    active.delete(key);
+  }
+}
+
+/** Exported for tests: is a watch running for this connector? */
+export function connectorCompletionWatchActive(projectId: string, slug: string): boolean {
+  return active.has(`${projectId}:${slug}`);
+}

--- a/apps/api/src/setup-links/public-app.ts
+++ b/apps/api/src/setup-links/public-app.ts
@@ -21,6 +21,7 @@ import { isValidSecretName, writeSharedProjectSecret } from '../projects/secrets
 import { db } from '../shared/db';
 import { TokenBucketRateLimiter, enforceRateLimit } from '../shared/rate-limit';
 import { resolveSetupLink } from './token';
+import { watchConnectorCompletion } from './connector-completion-watch';
 import { composioConfigured } from '../connectors/composio';
 import { connectorConnectedPrompt, notifyConnectorSession } from '../connectors/notify-session';
 
@@ -285,6 +286,16 @@ setupLinksPublicApp.post('/connectors/:token/start', async (c) => {
         ? c.json({ connect_url: null, connected: true })
         : c.json({ error: 'The provider did not return a connect URL' }, 502);
     }
+    // Start the server-side half now the human has a page to complete. Closing
+    // the modal kills the browser poll, and without this that is the end of it:
+    // the account lands at the provider and the agent is never told.
+    watchConnectorCompletion({
+      projectId: link.projectId,
+      slug: link.slug,
+      app: link.app,
+      sid: link.sid,
+      uid: link.uid,
+    });
     return c.json({ connect_url: started.connectUrl });
   } catch (err) {
     return c.json({ error: err instanceof Error ? err.message : 'Failed to start connect' }, 502);


### PR DESCRIPTION
## The symptom

Authorize Gmail, close the modal — and nothing happens. The account lands at the provider, but the agent is never told, so you still have to prompt it. That is precisely what this flow exists to remove.

## Root cause

**The browser poll IS the completion path.** `/finalize` is what persists the credential *and* notifies the waiting session, and the intake polls it only while its modal is mounted:

```
CONNECTOR_POLL_INTERVAL_MS = 5_000
CONNECTOR_POLL_WINDOW_MS   = 5 * 60_000   // dies with the component
```

Close the modal mid-OAuth and the poll dies with it. End of story.

Pipedream never fully had this problem — its connect webhook lands the credential server-side whether or not a browser is watching. **Composio has no such webhook wired, so for Composio the browser was the only completion path.** That is why this worked "before" and not now.

## The fix

`/start` now begins a bounded server-side watch on the same schedule the browser uses, which finalizes and notifies regardless of who is still looking.

- The browser poll stays **primary** — it is what makes an open modal feel instant. This only catches what it drops.
- In-process and best-effort **on purpose**, matching the redundancy role the Pipedream webhook already plays. A deploy mid-window loses the watch; the next `/finalize` from any surface still settles it. It is not pretending to be a durable job.
- One watch per `project:connector`, so reopening the link cannot stack them.
- No watch at all when the token carries no session — there is nobody to tell.

## De-duplication, settled in the database

Two halves can now legitimately observe the same connect. Rather than hope one wins, the notification de-dupes where races are actually settled:

```ts
idempotencyKey: `connector-connected:${sessionId}:${slug}`
```

`enqueueContinueSessionCommand` already de-dupes on that with `onConflictDoNothing`, so the agent is told exactly once no matter how many callers see it.

## A note on the test

The watch test deliberately does **not** stub `../connectors/notify-session`. That module is shared with the public-app suite, and stubbing it leaked across files even under `--isolate` — which turned two previously-green notification tests red. It mocks that module's own dependencies instead, so the real notifier runs.

## Verification

```
apps/api  setup-links + connectors   258 pass / 0 fail
pnpm --filter kortix-api typecheck   exit=0
```

4 new tests: completion after the modal closed, no-session → no watch, reopening does not stack, and the window closes instead of polling forever.