### PR TITLE
ci: finish the Blacksmith migration — runner tiers, kill switch, sticky-disk Docker cache

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,28 @@ linked, not inlined.
 
 ## Register
 
+### A guard that tolerates its own tool being absent guards nothing (2026-08-25)
+
+**When:** writing any CI step of the form `if <tool> <pattern> … 2>/dev/null; then fail`.
+If the tool is missing, the command fails, `2>/dev/null` hides why, the `if` reads
+false, and the step prints its success line. Use a tool every runner image ships
+(`grep`), or probe for it (`command -v rg || exit 2`) BEFORE the check; and pin
+the pattern in one place the producer also uses (`GUARD_PATTERN_SOURCE` in
+`tests/src/core/scrub.ts`), so the writer scrubs exactly what the guard greps.
+*Incident:* `Guard test artifacts against secrets` in tests.yml / tests-release.yml /
+tests-browser-nightly.yml called `rg`, which GitHub's ubuntu-24.04 image does not
+ship. It reported "No secret-shaped values found." on every run since it was
+written. The first Blacksmith run (image ships rg) failed it: 32 secret-shaped
+values — 8 `kortix_pat_*`, `kortix_sa_*`, setup-link `{accountId,nonce,exp}`
+tokens — inside the 73 MB `results.json` + `report.html` uploaded as PUBLIC
+workflow artifacts on every PR (tokens of an ephemeral local stack; the
+release gate would have uploaded STAGING tokens the same way). Fixed in the
+Blacksmith follow-up PR: write-time shape scrub in `report.ts` (proven 32 → 0
+on the real artifact) + grep-based guard.
+*Enforcer:* `tests/unit/scrub-secret-shapes.test.ts` — scrubber vs guard
+pattern parity, `writeResults` output passes the guard, and every guard step
+uses `grep -rEIl "$pattern"` with the shared pattern, never `rg`.
+
 ### A runner label is a tested contract, and a third-party runner pool is a deploy dependency (2026-08-25)
 
 **When:** changing any `runs-on` / matrix `runner:` in `.github/workflows/`,

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,27 @@ linked, not inlined.
 
 ## Register
 
+### A runner label is a tested contract, and a third-party runner pool is a deploy dependency (2026-08-25)
+
+**When:** changing any `runs-on` / matrix `runner:` in `.github/workflows/`,
+including an auto-generated PR (Blacksmith's Migration Wizard, Dependabot).
+Two rules. (1) Run the workflow-pinning unit lane before merging —
+`pnpm --dir tests test:unit` — because `tests/unit/*-workflow.test.ts` pin
+runner labels, cache directives and step order as source text; a label
+rewrite that touches nothing else still turns `main` red. (2) Never commit a
+bare runner label. Every Linux `runs-on` is
+`${{ vars.CI_RUNNER_<tier> || '<blacksmith label>' }}` so a repository
+variable can move a tier back to GitHub-hosted without a PR — a PR cannot fix a
+runner outage, its checks need runners. Off-Blacksmith the Docker actions
+fall back (cold) instead of failing. Runbook: `docs/runbooks/ci-runners.md`.
+*Incident:* PR #6901 (wizard, 125 label rewrites) merged at 22:00 UTC with its
+`warm core worker` check red on 3 `image-build-speed-workflow.test.ts`
+assertions (`ubuntu-24.04-arm` pinned) and three amd64 matrix legs left on
+`ubuntu-latest`; in the following hour Deploy Dev jobs waited 14 s – 6 min in
+`queued` for a Blacksmith runner while ≤3 ran. No prod impact.
+*Enforcer:* `image-build-speed-workflow.test.ts` "every Linux job keeps the
+Blacksmith runner kill switch" rejects any bare label in any workflow.
+
 ### Size sandbox memory from measured peak RSS, not nominal workload size (2026-08-24)
 
 **When:** assigning a sandbox template to image-heavy, document-heavy, or long-context agents.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint config — https://github.com/rhysd/actionlint/blob/main/docs/config.md
+# Blacksmith runner labels (docs/runbooks/ci-runners.md). Workflows reference
+# them through `${{ vars.CI_RUNNER_* || '<label>' }}`; listing them here keeps
+# `actionlint` clean for anyone who writes a bare label in a scratch branch.
+self-hosted-runner:
+  labels:
+    - blacksmith-*

--- a/.github/workflows/activate-prod-us-east-2-writers.yml
+++ b/.github/workflows/activate-prod-us-east-2-writers.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   writers:
     name: Apply guarded US writer state
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     environment: prod-use2-shadow
     env:

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -19,12 +19,12 @@ name: Build Staging Artifacts
 # the arch nothing in Kortix cloud runs, at 4.4-9.4x per CPU-bound step. The API
 # job alone was 22-26 min and 97-98% of this workflow's wallclock.
 #
-# `ubuntu-24.04-arm` is a standard GitHub-hosted runner, free for public repos
-# (verified on this repo: aarch64, 4 vCPU, 15 GB, buildx `Platforms:
-# linux/arm64` with no QEMU). So each arch now builds NATIVELY on its own
-# runner, in parallel, and a merge job stitches the two digests into the same
-# multi-arch manifest under the same three tags as before. Tag semantics are
-# unchanged: `staging-<full-sha>`, `staging-latest`, `staging-<sha8>`.
+# Each arch now builds NATIVELY on its own runner (Blacksmith x64 for amd64,
+# Blacksmith arm64 for arm64 — see docs/runbooks/ci-runners.md; buildx
+# `Platforms: linux/arm64` with no QEMU), in parallel, and a merge job stitches
+# the two digests into the same multi-arch manifest under the same three tags
+# as before. Tag semantics are unchanged: `staging-<full-sha>`,
+# `staging-latest`, `staging-<sha8>`.
 #
 # Building the frontend per-arch also FIXES a real defect. `apps/web/Dockerfile`
 # copies a Next standalone bundle produced by `pnpm install` on the runner. With
@@ -35,9 +35,11 @@ name: Build Staging Artifacts
 #   @img+sharp-libvips-linux-x64@1.3.0 / @img+sharp-linux-x64@0.35.3 (no arm64)
 # Each arch now runs its own install+build, so the arm64 image gets arm64 sharp.
 #
-# Registry-backed BuildKit cache (`type=registry,mode=max`, one ref per image
-# per arch) makes an unchanged-dependency build reuse layers instead of
-# rebuilding from scratch — previously `CACHED` was 0 of 222 buildx nodes.
+# BuildKit layer cache lives on a Blacksmith sticky disk (setup-docker-builder,
+# one `cache-key` per image per platform, shared with deploy-dev/deploy-preview
+# builds of the same Dockerfile) so an unchanged-dependency build reuses layers
+# instead of rebuilding from scratch — before 2026-08-19 `CACHED` was 0 of 222
+# buildx nodes.
 
 on:
   push:
@@ -60,7 +62,7 @@ permissions:
 jobs:
   version:
     name: Compute staging version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     outputs:
       sha: ${{ steps.v.outputs.sha }}
       sha8: ${{ steps.v.outputs.sha8 }}
@@ -105,24 +107,31 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
           - arch: arm64
             platform: linux/arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: ${{ vars.CI_RUNNER_L_ARM || 'blacksmith-8vcpu-ubuntu-2404-arm' }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
           submodules: false
       - run: git submodule sync --recursive && git submodule update --init --recursive --remote
-      - uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/api/Dockerfile:${{ matrix.platform }}
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push staging API by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/api/Dockerfile
@@ -131,8 +140,6 @@ jobs:
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
-          cache-from: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-api,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
@@ -151,7 +158,7 @@ jobs:
   merge-api:
     name: Publish API manifest (staging)
     needs: [version, build-api]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -194,23 +201,30 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
           - arch: arm64
             platform: linux/arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: ${{ vars.CI_RUNNER_L_ARM || 'blacksmith-8vcpu-ubuntu-2404-arm' }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.version.outputs.sha }}
           submodules: false
-      - uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/llm-gateway/Dockerfile:${{ matrix.platform }}
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push staging gateway by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/llm-gateway/Dockerfile
@@ -218,8 +232,6 @@ jobs:
           build-args: |
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
-          cache-from: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-gateway,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
@@ -238,7 +250,7 @@ jobs:
   merge-gateway:
     name: Publish gateway manifest (staging)
     needs: [version, build-gateway]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -284,10 +296,10 @@ jobs:
         include:
           - arch: amd64
             platform: linux/amd64
-            runner: ubuntu-latest
+            runner: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
           - arch: arm64
             platform: linux/arm64
-            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            runner: ${{ vars.CI_RUNNER_L_ARM || 'blacksmith-8vcpu-ubuntu-2404-arm' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -313,20 +325,25 @@ jobs:
           NEXT_PUBLIC_KORTIX_VERSION: ${{ needs.version.outputs.version }}
           NEXT_PUBLIC_KORTIX_COMMIT: ${{ needs.version.outputs.sha }}
           NEXT_OUTPUT: standalone
-      - uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/web/Dockerfile:${{ matrix.platform }}
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push staging frontend by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/web/Dockerfile
           platforms: ${{ matrix.platform }}
-          cache-from: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-frontend,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
@@ -345,7 +362,7 @@ jobs:
   merge-frontend:
     name: Publish frontend manifest (staging)
     needs: [version, build-frontend]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -381,7 +398,7 @@ jobs:
     name: Dispatch staging deploy
     needs: [version, merge-api, merge-gateway, merge-frontend]
     if: github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Start Deploy Staging for completed manual build
         env:

--- a/.github/workflows/catalog-refresh.yml
+++ b/.github/workflows/catalog-refresh.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   refresh:
     name: Regenerate + PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   # suite (the `|| workflow_dispatch` guard on each job).
   changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     outputs:
       api: ${{ steps.filter.outputs.api }}
@@ -98,7 +98,7 @@ jobs:
     name: API typecheck
     needs: changes
     if: needs.changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -132,7 +132,7 @@ jobs:
     name: Frontend build
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     steps:
       - name: Checkout
@@ -209,7 +209,7 @@ jobs:
     name: Sandbox agent build
     needs: changes
     if: needs.changes.outputs.sandbox_agent == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -241,7 +241,7 @@ jobs:
     name: CLI binary smoke
     needs: changes
     if: needs.changes.outputs.cli == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -289,7 +289,7 @@ jobs:
     name: Self-host schema bootstrap
     needs: changes
     if: needs.changes.outputs.self_host == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -315,8 +315,16 @@ jobs:
         env:
           npm_config_engine_strict: "false"
 
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Same cache-key as the dev/staging/preview API image builds, so this
+        # smoke build starts warm from layers those workflows already built.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/api/Dockerfile:linux/amd64
       - name: Build API image
-        run: docker build --build-arg SERVICE=apps/api -f apps/api/Dockerfile -t kortix/kortix-api:selfhost-local .
+        # --load: the Blacksmith builder is a separate buildkitd, so the result
+        # must be exported into the local daemon for the compose stack below.
+        run: docker build --load --build-arg SERVICE=apps/api -f apps/api/Dockerfile -t kortix/kortix-api:selfhost-local .
 
       - name: Self-host schema-bootstrap check (fresh DB)
         run: bash apps/cli/scripts/self-host-e2e/schema-check.sh
@@ -329,7 +337,7 @@ jobs:
     # still cover the full signed release artifacts.
     needs: changes
     if: needs.changes.outputs.desktop == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -366,7 +374,7 @@ jobs:
 
   dependency-scan:
     name: Dependency + secret scan
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (javascript-typescript)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     permissions:
       security-events: write

--- a/.github/workflows/configure-apps-edge.yml
+++ b/.github/workflows/configure-apps-edge.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   configure:
     name: Configure and verify Apps edge
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     env:
       # Account: Workers Scripts Write. kortix.com zone: DNS Write,

--- a/.github/workflows/configure-preview-edge.yml
+++ b/.github/workflows/configure-preview-edge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   configure:
     name: Configure and verify the preview edge
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 25
     env:
       # Account: Workers Scripts Write. kortix.com zone: DNS Write,

--- a/.github/workflows/cutover-prod-us-east-2.yml
+++ b/.github/workflows/cutover-prod-us-east-2.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   cloudflare:
     name: Apply guarded Cloudflare production change
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     environment: prod-use2-shadow
     env:

--- a/.github/workflows/db-drift.yml
+++ b/.github/workflows/db-drift.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   drift:
     name: Schema drift (${{ matrix.env }})
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     strategy:
       fail-fast: false
       matrix:
@@ -99,7 +99,7 @@ jobs:
   # catches drift introduced out-of-band BETWEEN deploys.
   prod-presence:
     name: Prod has every table+column the migrations define
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     services:
       postgres:
         image: postgres:16-alpine

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   lint:
     name: Migration files are well-formed
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -51,7 +51,7 @@ jobs:
 
   squawk:
     name: Squawk (zero-downtime lint) on new migrations
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
@@ -67,7 +67,7 @@ jobs:
 
   immutability:
     name: Migrations are immutable
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -89,7 +89,7 @@ jobs:
 
   sequence:
     name: Migrations are sequential
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -121,7 +121,7 @@ jobs:
 
   shadow-db:
     name: Applies cleanly to a fresh DB
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     services:
       postgres:
         image: postgres:16-alpine
@@ -170,7 +170,7 @@ jobs:
 
   schema-sync:
     name: Schema matches migrations
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     env:
       DATABASE_URL: postgres://ci:ci@localhost:1/ci
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -85,7 +85,7 @@ jobs:
   # ── Detect what changed (so unrelated surfaces are skipped) ─────────────────
   detect-changes:
     name: Detect changes
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     outputs:
       api: ${{ steps.outputs.outputs.api }}
       gateway: ${{ steps.outputs.outputs.gateway }}
@@ -327,7 +327,7 @@ jobs:
     name: Compute dev version
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.gateway == 'true' || needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.cli == 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     outputs:
       version: ${{ steps.v.outputs.version }}
     steps:
@@ -355,13 +355,19 @@ jobs:
     name: Build API image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.api == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
         with: { submodules: false }
       - run: git submodule sync --recursive && git submodule update --init --recursive --remote
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/api/Dockerfile:linux/amd64
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -372,19 +378,18 @@ jobs:
         # image ~22 min, ~2/3 of the whole run, for an image dev never boots. This
         # restores the deliberate `1ca937570d` state ("dev single-arch, multi-arch
         # on prod only") that the `cb9d12a1b3` pipeline rewrite silently undid.
-        # deploy-prod.yml keeps amd64+arm64. Registry layer cache makes warm builds
-        # reuse layers instead of every build being cold.
+        # deploy-prod.yml keeps amd64+arm64. Layer cache lives on the Blacksmith
+        # sticky disk (setup-docker-builder above), so warm builds reuse layers
+        # instead of every build being cold.
         # Bake the dev version (e.g. 0.9.7-dev.<sha8>) into the image so
         # /v1/health reports it. The immutable :dev-<sha8> tag (tag-api job below)
         # is the artifact's real identity.
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/api/Dockerfile
           platforms: linux/amd64
           push: true
-          cache-from: type=registry,ref=kortix/kortix-api:dev-buildcache
-          cache-to: type=registry,ref=kortix/kortix-api:dev-buildcache,mode=max
           build-args: |
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
@@ -398,7 +403,7 @@ jobs:
     name: Tag API dev-<sha8>
     needs: [detect-changes, build-api]
     if: needs.detect-changes.outputs.api == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     outputs:
       image: ${{ steps.tag.outputs.image }}
     steps:
@@ -423,7 +428,7 @@ jobs:
     name: Scan + SBOM + sign API image
     needs: [detect-changes, tag-api]
     if: needs.detect-changes.outputs.api == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     permissions:
       id-token: write
@@ -480,7 +485,7 @@ jobs:
     name: Apply DB migrations to dev
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.api == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -520,7 +525,7 @@ jobs:
         && needs.migrate-db.result == 'success'
         && (needs.terraform-dev-api.result == 'success' || needs.terraform-dev-api.result == 'skipped')
         && (needs.terraform-dev.result == 'success' || needs.terraform-dev.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write # OIDC → ECS deploy role
       contents: read
@@ -554,7 +559,7 @@ jobs:
     name: Deploy Kortix Apps router
     needs: [detect-changes, deploy-api-ecs]
     if: ${{ always() && needs.detect-changes.outputs.apps_router == 'true' && (needs.deploy-api-ecs.result == 'success' || needs.deploy-api-ecs.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       DEV_EDGE_SECRET: ${{ secrets.KORTIX_APPS_DEV_EDGE_SECRET }}
@@ -598,7 +603,7 @@ jobs:
       && needs.detect-changes.outputs.api == 'true'
       && needs.tag-api.result == 'success'
       && needs.deploy-api-ecs.result == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
@@ -619,26 +624,30 @@ jobs:
     name: Build gateway image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.gateway == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
         with: { submodules: false }
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/llm-gateway/Dockerfile:linux/amd64
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (amd64)
         # Single-arch amd64 for dev (see the API build for the full rationale).
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/llm-gateway/Dockerfile
           platforms: linux/amd64
           push: true
-          cache-from: type=registry,ref=kortix/kortix-gateway:dev-buildcache
-          cache-to: type=registry,ref=kortix/kortix-gateway:dev-buildcache,mode=max
           build-args: |
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
             KORTIX_COMMIT=${{ github.sha }}
@@ -649,7 +658,7 @@ jobs:
     name: Tag gateway dev-<sha8>
     needs: [detect-changes, build-gateway]
     if: needs.detect-changes.outputs.gateway == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -669,7 +678,7 @@ jobs:
     name: Deploy gateway to dev (ECS Fargate)
     needs: [detect-changes, dev-version, tag-gateway]
     if: needs.detect-changes.outputs.gateway == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -695,7 +704,7 @@ jobs:
     name: Verify gateway dev commit parity
     needs: [detect-changes, dev-version, deploy-gateway-ecs]
     if: needs.detect-changes.outputs.gateway == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     env:
       EXPECTED_COMMIT: ${{ github.sha }}
       EXPECTED_VERSION: ${{ needs.dev-version.outputs.version }}
@@ -737,7 +746,7 @@ jobs:
       && needs.detect-changes.outputs.gateway == 'true'
       && needs.tag-gateway.result == 'success'
       && needs.verify-gateway-dev-parity.result == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
@@ -759,7 +768,7 @@ jobs:
     name: Build frontend image (amd64)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.frontend == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     outputs:
       image: ${{ steps.tag.outputs.image }}
     steps:
@@ -785,22 +794,26 @@ jobs:
           NEXT_PUBLIC_KORTIX_VERSION: ${{ needs.dev-version.outputs.version }}
           NEXT_PUBLIC_KORTIX_COMMIT: ${{ github.sha }}
           NEXT_OUTPUT: standalone
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/web/Dockerfile:linux/amd64
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push (amd64)
         # Single-arch amd64 for dev (see the API build for the full rationale).
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/web/Dockerfile
           platforms: linux/amd64
           push: true
-          cache-from: type=registry,ref=kortix/kortix-frontend:dev-buildcache
-          cache-to: type=registry,ref=kortix/kortix-frontend:dev-buildcache,mode=max
           tags: |
             kortix/kortix-frontend:dev-latest
       - name: Retag :dev-latest → :dev-<sha8>
@@ -826,7 +839,7 @@ jobs:
         && needs.build-frontend.result == 'success'
         && (needs.terraform-dev-api.result == 'success' || needs.terraform-dev-api.result == 'skipped')
         && (needs.terraform-dev.result == 'success' || needs.terraform-dev.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -868,7 +881,7 @@ jobs:
     if: ${{ always()
       && needs.detect-changes.outputs.frontend == 'true'
       && needs.deploy-web-ecs.result == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -898,7 +911,7 @@ jobs:
     if: ${{ always()
       && needs.detect-changes.outputs.frontend == 'true'
       && needs.publish-web-ecs-dns.result == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     env:
       EXPECTED_COMMIT: ${{ github.sha }}
       EXPECTED_VERSION: ${{ needs.dev-version.outputs.version }}
@@ -957,7 +970,7 @@ jobs:
       && needs.detect-changes.outputs.frontend == 'true'
       && needs.build-frontend.result == 'success'
       && needs.verify-web-dev.result == 'success' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3
@@ -988,7 +1001,7 @@ jobs:
     name: Build dev CLI (all targets)
     needs: [detect-changes, dev-version]
     if: needs.detect-changes.outputs.cli == 'true'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -1053,7 +1066,7 @@ jobs:
     name: Publish dev-latest prerelease
     needs: [detect-changes, build-cli]
     if: needs.detect-changes.outputs.cli == 'true' && needs.build-cli.result == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -453,6 +453,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        # Pins a buildx that honours `imagetools inspect --format`. The runner
+        # image's bundled buildx returned the human-readable listing instead
+        # (Blacksmith ubuntu-2404, 2026-08-25, run 32905182332), which broke
+        # the digest resolve and skipped SBOM + signing for that dev image.
+        uses: docker/setup-buildx-action@v4
       - name: Resolve image digest
         id: digest
         run: |

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
       github.event.label.name == 'preview' &&
       github.event.pull_request.head.repo.full_name == github.repository) ||
       github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       pull-requests: read
@@ -121,7 +121,7 @@ jobs:
   build-api:
     name: Build preview API image
     needs: authorize
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:
@@ -130,8 +130,15 @@ jobs:
           ref: ${{ needs.authorize.outputs.sha }}
           submodules: false
           persist-credentials: false
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/api/Dockerfile:linux/amd64
+      - uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/api/Dockerfile
@@ -154,7 +161,7 @@ jobs:
   build-gateway:
     name: Build preview gateway image
     needs: authorize
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:
@@ -163,8 +170,15 @@ jobs:
           ref: ${{ needs.authorize.outputs.sha }}
           submodules: false
           persist-credentials: false
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/llm-gateway/Dockerfile:linux/amd64
+      - uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/llm-gateway/Dockerfile
@@ -186,7 +200,7 @@ jobs:
   build-web:
     name: Build preview frontend image
     needs: authorize
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     permissions:
       contents: read
     steps:
@@ -214,8 +228,15 @@ jobs:
           NEXT_PUBLIC_KORTIX_VERSION: pr-${{ needs.authorize.outputs.pr_number }}
           NEXT_PUBLIC_KORTIX_COMMIT: ${{ needs.authorize.outputs.sha }}
           NEXT_OUTPUT: standalone
-      - uses: docker/setup-buildx-action@v4
-      - uses: docker/build-push-action@v7
+      - name: Set up Docker builder (Blacksmith sticky-disk layer cache)
+        # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
+        # shared by every workflow in this repo that builds the same image.
+        # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
+        # local buildx builder, so the build still works, only cold.
+        uses: useblacksmith/setup-docker-builder@v2
+        with:
+          cache-key: apps/web/Dockerfile:linux/amd64
+      - uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/web/Dockerfile
@@ -234,7 +255,7 @@ jobs:
   deploy:
     name: Deploy full self-host preview and run end-to-end tests
     needs: [authorize, build-api, build-gateway, build-web]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 100
     permissions:
       contents: read
@@ -420,7 +441,7 @@ jobs:
       (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
       (github.event.action == 'synchronize' &&
       contains(github.event.pull_request.labels.*.name, 'preview')))
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -468,7 +489,7 @@ jobs:
   reconcile:
     name: Reconcile stale preview sandboxes
     if: github.event_name == 'schedule'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/deploy-prod-us-east-2-shadow.yml
+++ b/.github/workflows/deploy-prod-us-east-2-shadow.yml
@@ -141,7 +141,7 @@ permissions:
 jobs:
   infrastructure:
     name: Apply US East 2 shadow Terraform
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     # A healthy apply finishes in under a minute (v0.12.7: 40s, job
     # 93576314738). Anything past 20 minutes is a stuck Terraform lock.
     timeout-minutes: 20
@@ -261,7 +261,7 @@ jobs:
 
   deploy:
     name: Deploy API and gateway to US shadow
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     needs: infrastructure
     # Hard ceiling so a wedged shadow can never sit `in_progress` and block
     # "re-run failed jobs" on the calling release run — the v0.12.7 failure

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -57,7 +57,7 @@ jobs:
   # ── Resolve the version from VERSION ────────────────────────────────────────
   version:
     name: Resolve version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     # Runs on every push to `prod` (i.e. a merged, reviewed release PR) and on
     # manual dispatch.
     outputs:
@@ -181,7 +181,7 @@ jobs:
   maintenance-banner-on:
     name: Rollout banner (raise)
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - name: Detect maintenance token
@@ -206,7 +206,7 @@ jobs:
   retag-images:
     name: Re-tag staged → v${{ needs.version.outputs.version }}
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -294,7 +294,7 @@ jobs:
   verify-image-commits:
     name: Verify deployed image CODE matches the release commit
     needs: [version, retag-images]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/login-action@v3
         with:
@@ -329,7 +329,7 @@ jobs:
   build-cli:
     name: Build prod CLI (all targets)
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -418,7 +418,7 @@ jobs:
   publish-llm-catalog:
     name: Publish @kortix/llm-catalog to npm
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write
@@ -454,7 +454,7 @@ jobs:
   publish-sdk:
     name: Publish @kortix/sdk to npm
     needs: [version, publish-llm-catalog]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write
@@ -490,7 +490,7 @@ jobs:
   publish-agent-tunnel:
     name: Publish @kortix/agent-tunnel to npm
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write
@@ -525,7 +525,7 @@ jobs:
     name: Publish and deprecate final @kortix/executor-sdk
     needs: [version, publish-sdk]
     if: ${{ needs.version.outputs.version == '0.12.5' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       contents: read
       id-token: write
@@ -593,7 +593,7 @@ jobs:
               apps/desktop-electron/dist/*.blockmap
               apps/desktop-electron/dist/latest.yml
           - target_pretty: linux-x64
-            runner: ubuntu-22.04
+            runner: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
             eb_flag: --linux
             artifact: desktop-linux-x64
             files: |
@@ -697,7 +697,7 @@ jobs:
   github-release:
     name: GitHub Release v${{ needs.version.outputs.version }}
     needs: [version, retag-images, build-cli, publish-sdk, publish-agent-tunnel, deploy-ecs, verify-live-version, frontend-auth-proof]
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     permissions:
       contents: write
     steps:
@@ -741,7 +741,7 @@ jobs:
     name: Attach desktop installers
     needs: [version, github-release, build-desktop]
     if: always() && needs.github-release.result == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     permissions:
       contents: write
     steps:
@@ -778,7 +778,7 @@ jobs:
   migrate-db:
     name: Apply DB migrations to prod
     needs: version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -821,7 +821,7 @@ jobs:
     # `verify-schema` in deploy-ecs.needs.
     if: vars.ENABLE_PROD_SCHEMA_GATE == 'true'
     needs: migrate-db
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     services:
       postgres:
         image: postgres:16-alpine
@@ -894,7 +894,7 @@ jobs:
         && needs.migrate-db.result == 'success'
         && (needs.terraform-prod-api.result == 'success' || needs.terraform-prod-api.result == 'skipped')
         && (needs.terraform-prod.result == 'success' || needs.terraform-prod.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write # OIDC → ECS deploy role
       contents: read
@@ -1006,7 +1006,7 @@ jobs:
   verify-live-version:
     name: Verify live version == v${{ needs.version.outputs.version }}
     needs: [version, deploy-ecs]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     env:
       VERSION: ${{ needs.version.outputs.version }}
       SOURCE_SHA: ${{ needs.version.outputs.source_sha }}
@@ -1121,7 +1121,7 @@ jobs:
   announce:
     name: Announce release to Slack
     needs: [version, github-release, verify-live-version]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Read live /v1/health (public router — the serving backend)
         id: health
@@ -1217,7 +1217,7 @@ jobs:
   deploy-web-ecs:
     name: Deploy prod web to ECS Fargate
     needs: [version, retag-images, deploy-ecs]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -1257,7 +1257,7 @@ jobs:
   publish-web-ecs-dns:
     name: Publish prod FE-ECS DNS
     needs: [deploy-web-ecs]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -1284,7 +1284,7 @@ jobs:
   verify-web-ecs:
     name: Verify prod FE-ECS
     needs: [version, publish-web-ecs-dns]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     env:
       EXPECTED_COMMIT: ${{ needs.version.outputs.source_sha }}
       EXPECTED_VERSION: ${{ needs.version.outputs.version }}
@@ -1325,7 +1325,7 @@ jobs:
   deploy-web-vercel:
     name: Deploy prod web to Vercel (after API is live)
     needs: [version, verify-live-version]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_TEAM_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -1359,7 +1359,7 @@ jobs:
   frontend-note:
     name: Prod frontend paths active
     needs: [version, publish-web-ecs-dns]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Note
         run: |
@@ -1372,7 +1372,7 @@ jobs:
   frontend-auth-proof:
     name: Prod frontend auth configuration
     needs: [version, frontend-note, verify-web-ecs, deploy-web-vercel]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 12
     steps:
       - uses: actions/checkout@v7
@@ -1393,7 +1393,7 @@ jobs:
   sync-main-version:
     name: Sync main VERSION → next dev target
     needs: [version, github-release]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       contents: write
       pull-requests: write
@@ -1450,7 +1450,7 @@ jobs:
   sync-staging-version:
     name: Sync staging VERSION → next dev target
     needs: [version, github-release]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       contents: write
       pull-requests: write
@@ -1498,7 +1498,7 @@ jobs:
   maintenance-banner-off:
     name: Rollout banner (lower)
     needs: [verify-live-version, frontend-auth-proof]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
       - name: Detect maintenance token
@@ -1539,7 +1539,7 @@ jobs:
   promote-prod-channel:
     name: Move :prod → v${{ needs.version.outputs.version }}
     needs: [version, retag-images, verify-live-version]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,7 +40,7 @@ jobs:
   preflight:
     name: Resolve staging ref
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     outputs:
       sha: ${{ steps.ref.outputs.sha }}
       sha8: ${{ steps.ref.outputs.sha8 }}
@@ -136,7 +136,7 @@ jobs:
   sync-secret:
     name: Sync staging secret bundle
     needs: preflight
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     env:
       ROLE: arn:aws:iam::935064898258:role/kortix-gha-ecs-deploy
     steps:
@@ -274,7 +274,7 @@ jobs:
   migrate-db:
     name: Apply DB migrations to staging
     needs: [preflight, sync-secret]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -317,7 +317,7 @@ jobs:
         && needs.sync-secret.result == 'success'
         && needs.migrate-db.result == 'success'
         && (needs.terraform-staging.result == 'success' || needs.terraform-staging.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write # OIDC → ECS deploy role
       contents: read
@@ -347,7 +347,7 @@ jobs:
 
   wire-cloudflare:
     name: Wire Cloudflare staging DNS and Worker
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     # Non-blocking: deploy-web-vercel, verify, and promote-staging-channel
     # `needs:` this job, and a Cloudflare auth failure (403 since 2026-08-18)
     # silently skipped every staging web deploy for a week — the suite then
@@ -481,7 +481,7 @@ jobs:
         && needs.preflight.result == 'success'
         && needs.deploy-ecs.result == 'success'
         && (needs.terraform-staging-web.result == 'success' || needs.terraform-staging-web.result == 'skipped') }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -523,7 +523,7 @@ jobs:
   publish-web-ecs-dns:
     name: Publish staging FE-ECS DNS
     needs: [deploy-web-ecs]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
       id-token: write
       contents: read
@@ -550,7 +550,7 @@ jobs:
     name: Deploy staging web to Vercel
     # deploy-ecs gates the staging rollout: a failed ECS roll can't pass silently.
     needs: [preflight, wire-cloudflare, deploy-ecs]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -611,7 +611,7 @@ jobs:
   verify:
     name: Verify live staging on ECS and Vercel
     needs: [preflight, wire-cloudflare, deploy-web-vercel, publish-web-ecs-dns]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Verify API and both web deployment paths
         env:
@@ -702,7 +702,7 @@ jobs:
   promote-staging-channel:
     name: Move :staging → staging-${{ needs.preflight.outputs.sha8 }}
     needs: [preflight, verify]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v3

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -60,7 +60,7 @@ jobs:
               apps/desktop-electron/dist/*.blockmap
               apps/desktop-electron/dist/latest.yml
           - target_pretty: linux-x64
-            runner: ubuntu-22.04
+            runner: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
             eb_flag: --linux
             artifact: desktop-linux-x64
             files: |
@@ -173,7 +173,7 @@ jobs:
     # Publish whatever installers built — a single OS's signing failure shouldn't
     # discard the others.
     if: always() && needs.build.result != 'cancelled'
-    runs-on: blacksmith-4vcpu-ubuntu-2204
+    runs-on: ${{ vars.CI_RUNNER_M_2204 || 'blacksmith-4vcpu-ubuntu-2204' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/drata-compliance.yml
+++ b/.github/workflows/drata-compliance.yml
@@ -35,7 +35,7 @@ jobs:
   drata-iac-results:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.results_run_id != '' }}
     name: sanitized-finding-details
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Print finding details
         if: ${{ inputs.results_run_id != '' }}
@@ -73,7 +73,7 @@ jobs:
 
   drata-iac-scan:
     name: compliance-as-code-action
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/ecs-scale.yml
+++ b/.github/workflows/ecs-scale.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   scale:
     name: scale ${{ inputs.service }} to ${{ inputs.desired_count }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Guard — only kortix-* clusters/services
         run: |

--- a/.github/workflows/finalize-prod-us-east-2-database.yml
+++ b/.github/workflows/finalize-prod-us-east-2-database.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   database:
     name: ${{ inputs.action }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 360
     environment: prod-use2-shadow
     env:

--- a/.github/workflows/promote-self-host-stable.yml
+++ b/.github/workflows/promote-self-host-stable.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   mark-stable:
     name: Promote v${{ inputs.version }} → :stable
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   open-release-pr:
     name: Open review-gated release PR
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Checkout ${{ inputs.ref }} (full history)
         uses: actions/checkout@v7

--- a/.github/workflows/reconcile-prod-us-east-2-shadow.yml
+++ b/.github/workflows/reconcile-prod-us-east-2-shadow.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   reconcile:
     name: Remove target-only shadow verification state
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     # The repair steps run with statement_timeout=0, so bound the job instead.
     timeout-minutes: 120
     environment: prod-use2-shadow

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   rollback:
     name: Roll prod back to the target version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Checkout prod (full history + tags)
         uses: actions/checkout@v7

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   trivy-fs:
     name: Trivy filesystem (vuln + secret + misconfig)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -59,7 +59,7 @@ jobs:
   trivy-image:
     name: Trivy image re-scan
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -89,7 +89,7 @@ jobs:
 
   checkov:
     name: Checkov (Terraform + K8s)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -112,7 +112,7 @@ jobs:
 
   hadolint:
     name: Hadolint (Dockerfiles)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions:
       contents: read
@@ -141,7 +141,7 @@ jobs:
 
   gitleaks-history:
     name: Gitleaks (full history)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -105,7 +105,7 @@ env:
 jobs:
   apply:
     name: apply ${{ inputs.tf_root }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 45
     environment: ${{ inputs.github_environment }}
     env:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -48,7 +48,7 @@ jobs:
   validate:
     name: fmt + validate
     if: github.event_name != 'schedule'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -85,7 +85,7 @@ jobs:
   tflint:
     name: tflint
     if: github.event_name != 'schedule'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -102,7 +102,7 @@ jobs:
   checkov:
     name: checkov
     if: github.event_name != 'schedule'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -133,7 +133,7 @@ jobs:
     # read-only EC2 describes, while drift detection needs broad read plus
     # state access. See security-baseline/iam-gha-nacl-audit.tf.
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
       id-token: write
@@ -158,7 +158,7 @@ jobs:
   drift:
     name: drift detection
     if: github.event_name != 'pull_request' && vars.TF_PLAN_ROLE_ARN != ''
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     permissions:
       id-token: write
@@ -235,7 +235,7 @@ jobs:
     # This job fails loudly on both. It runs on the same schedule as drift, one
     # cycle behind it.
     if: github.event_name != 'pull_request'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -59,7 +59,7 @@ env:
 jobs:
   quarantine:
     name: quarantined browser journeys
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 45
     env:
       # `playwright.config.ts` turns this into `grep`, so the run loads ONLY the

--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -87,7 +87,14 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+          # grep, never rg: GitHub's ubuntu images ship no ripgrep, and with the
+          # tool missing under `2>/dev/null` this guard passed on nothing from
+          # its first run until 2026-08-25, when Blacksmith images (which ship
+          # rg) ran it for real. Pattern = GUARD_PATTERN_SOURCE in
+          # tests/src/core/scrub.ts; the runner scrubs the same shapes before
+          # writing results.json / report.html.
+          pattern='kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.'
+          if [ -d tests/test-results ] && grep -rEIl "$pattern" tests/test-results; then
             echo "::error::A test artifact contains a secret-shaped value."
             exit 1
           fi

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -73,7 +73,7 @@ jobs:
   # release: the shards still run, and the next run sweeps again.
   sweep-before:
     name: sweep stale test accounts
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     continue-on-error: true
     steps:
@@ -112,7 +112,7 @@ jobs:
     # failed, or was cancelled by its own cap — its result must never gate the
     # release (see the note on sweep-before).
     if: ${{ !cancelled() }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     # A ceiling that turns a hang into a readable failure — never a throttle.
     #
     # Run 32240074477 killed all four API shards on the 40-minute cap at once
@@ -254,7 +254,7 @@ jobs:
     name: deployed browser shard
     needs: sweep-before
     if: ${{ !cancelled() }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -343,7 +343,7 @@ jobs:
     name: sweep this run's test accounts
     needs: [api, browser]
     if: always()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     continue-on-error: true
     steps:
@@ -371,7 +371,7 @@ jobs:
     name: full suite + quality gates
     needs: [api, browser]
     if: always()
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     steps:
       - name: Require every deployed shard to pass

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -236,7 +236,14 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+          # grep, never rg: GitHub's ubuntu images ship no ripgrep, and with the
+          # tool missing under `2>/dev/null` this guard passed on nothing from
+          # its first run until 2026-08-25, when Blacksmith images (which ship
+          # rg) ran it for real. Pattern = GUARD_PATTERN_SOURCE in
+          # tests/src/core/scrub.ts; the runner scrubs the same shapes before
+          # writing results.json / report.html.
+          pattern='kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.'
+          if [ -d tests/test-results ] && grep -rEIl "$pattern" tests/test-results; then
             echo "::error::A test artifact contains a secret-shaped value."
             exit 1
           fi
@@ -323,7 +330,14 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+          # grep, never rg: GitHub's ubuntu images ship no ripgrep, and with the
+          # tool missing under `2>/dev/null` this guard passed on nothing from
+          # its first run until 2026-08-25, when Blacksmith images (which ship
+          # rg) ran it for real. Pattern = GUARD_PATTERN_SOURCE in
+          # tests/src/core/scrub.ts; the runner scrubs the same shapes before
+          # writing results.json / report.html.
+          pattern='kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.'
+          if [ -d tests/test-results ] && grep -rEIl "$pattern" tests/test-results; then
             echo "::error::A test artifact contains a secret-shaped value."
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,14 @@ jobs:
         if: always() && (inputs.mode == 'full' || inputs.mode == matrix.mode)
         run: |
           set -euo pipefail
-          if rg -l 'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.' tests/test-results 2>/dev/null; then
+          # grep, never rg: GitHub's ubuntu images ship no ripgrep, and with the
+          # tool missing under `2>/dev/null` this guard passed on nothing from
+          # its first run until 2026-08-25, when Blacksmith images (which ship
+          # rg) ran it for real. Pattern = GUARD_PATTERN_SOURCE in
+          # tests/src/core/scrub.ts; the runner scrubs the same shapes before
+          # writing results.json / report.html.
+          pattern='kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.'
+          if [ -d tests/test-results ] && grep -rEIl "$pattern" tests/test-results; then
             echo "::error::A test artifact contains a secret-shaped value."
             exit 1
           fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   sandbox:
     name: warm ${{ matrix.lane }} worker
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 90
     strategy:
       fail-fast: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,9 @@ See `tests/e2e/helpers/session-auth.ts` for the exact calls.
   test profile. Stop an ordinary development stack before either command.
 - Every root run writes lane and total timings to
   `tests/test-results/local/benchmark-<timestamp>.json`.
+- Every Linux CI job runs on Blacksmith through `runs-on: ${{ vars.CI_RUNNER_<tier>
+  || '<label>' }}`. Tiers, the kill switch back to GitHub-hosted runners, and
+  the Docker layer cache: `docs/runbooks/ci-runners.md`.
 - GitHub Actions runs four lanes — `core`, `browser-1`, `browser-2`, `packages` —
   in four disposable warm sandboxes through `.github/workflows/tests.yml`. The
   two browser lanes are halves of one sharded run (`--browser-shard=1/2` and

--- a/docs/runbooks/ci-runners.md
+++ b/docs/runbooks/ci-runners.md
@@ -1,0 +1,118 @@
+# CI runners: Blacksmith
+
+Every Linux job in `.github/workflows/` runs on [Blacksmith](https://docs.blacksmith.sh)
+runners. macOS and Windows jobs (desktop installers) stay on GitHub-hosted
+runners: they are free on this public repo, and Blacksmith's Windows pool is in
+beta. The GitHub "default setup" CodeQL workflow (`Code Quality: Push on main`)
+is not a file in this repo and stays on `ubuntu-latest`.
+
+Migration history: PR #6901 (Blacksmith's Migration Wizard, mechanical label
+rewrite), then the follow-up that added tiers, the kill switch, the Docker layer
+cache, and `tests/unit/image-build-speed-workflow.test.ts`, which pins the
+convention below across all workflows.
+
+## The convention
+
+Every `runs-on` (and every Linux matrix `runner:`) is an expression:
+
+```yaml
+runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
+```
+
+The repository variable is unset in normal operation, so the Blacksmith label
+applies. The variable exists as a kill switch (next section).
+
+| Tier       | Variable           | Default label                     | Spec         | Use it for                                                                                   |
+| ---------- | ------------------ | --------------------------------- | ------------ | -------------------------------------------------------------------------------------------- |
+| S          | `CI_RUNNER_S`      | `blacksmith-2vcpu-ubuntu-2404`    | 2 vCPU, 8 GB | Jobs that install no dependencies: `aws`/`gh`/`curl`/`terraform` steps, retags, verify probes |
+| M          | `CI_RUNNER_M`      | `blacksmith-4vcpu-ubuntu-2404`    | 4 vCPU, 16 GB | Anything that runs `pnpm install`, `bun`, typecheck, unit/e2e lanes, npm publishes           |
+| L          | `CI_RUNNER_L`      | `blacksmith-8vcpu-ubuntu-2404`    | 8 vCPU, 32 GB | Container image builds, `apps/web` Next build, CodeQL analyze, the preview stack job          |
+| L_ARM      | `CI_RUNNER_L_ARM`  | `blacksmith-8vcpu-ubuntu-2404-arm` | 8 vCPU, 24 GB | The `linux/arm64` legs in `build-staging.yml`                                                |
+| M_2204     | `CI_RUNNER_M_2204` | `blacksmith-4vcpu-ubuntu-2204`    | 4 vCPU, 16 GB | Jobs pinned to Ubuntu 22.04: Bun cross-compiled CLI, Electron linux, installer smoke, release attach |
+
+Rule of thumb for a new job: no dependency install → S; installs → M; builds an
+image or a Next bundle → L. `tests/unit/image-build-speed-workflow.test.ts`
+fails on any bare label, so a new job cannot skip the expression.
+
+## Kill switch: move a tier back to GitHub-hosted
+
+Use this when Blacksmith is down or jobs sit in `queued` for more than ~10 min.
+A PR cannot fix a runner outage (its checks need runners), so the lever is a
+repository variable, no code change:
+
+```bash
+# All Linux tiers back to GitHub-hosted (x64 = ubuntu-latest, arm = ubuntu-24.04-arm)
+gh variable set CI_RUNNER_S      --repo kortix-ai/suna --body ubuntu-latest
+gh variable set CI_RUNNER_M      --repo kortix-ai/suna --body ubuntu-latest
+gh variable set CI_RUNNER_L      --repo kortix-ai/suna --body ubuntu-latest
+gh variable set CI_RUNNER_L_ARM  --repo kortix-ai/suna --body ubuntu-24.04-arm
+gh variable set CI_RUNNER_M_2204 --repo kortix-ai/suna --body ubuntu-22.04
+```
+
+Effects while the switch is on:
+
+- Queued jobs do not move. Re-run the workflow (`gh run rerun <id>`) so the new
+  label is evaluated.
+- Image builds still work: `useblacksmith/setup-docker-builder` falls back to a
+  plain local buildx builder, and `useblacksmith/build-push-action` builds with a
+  warning instead of failing. Builds are cold (no registry cache is kept), so
+  expect +2–5 min per image.
+- `actions/cache`, `setup-node cache:` and `setup-bun` fall back to GitHub's
+  cache backend automatically.
+
+Back to Blacksmith:
+
+```bash
+for v in CI_RUNNER_S CI_RUNNER_M CI_RUNNER_L CI_RUNNER_L_ARM CI_RUNNER_M_2204; do
+  gh variable delete "$v" --repo kortix-ai/suna
+done
+```
+
+## Docker layer cache
+
+Image builds (`deploy-dev.yml`, `build-staging.yml`, `deploy-preview.yml`, the
+`self-host-schema` smoke build in `ci.yml`) use:
+
+```yaml
+- uses: useblacksmith/setup-docker-builder@v2
+  with:
+    cache-key: apps/api/Dockerfile:linux/amd64   # <Dockerfile>:<platform>
+- uses: useblacksmith/build-push-action@v2       # same inputs as docker/build-push-action
+```
+
+- Layers live on a Blacksmith sticky disk mounted at `/var/lib/buildkit`, keyed
+  by `cache-key`, shared by every workflow in the repo. Dev, staging (amd64 leg),
+  preview and the CI smoke build of `apps/api/Dockerfile` therefore warm each
+  other. The arm64 leg has its own key (`:linux/arm64`).
+- The old `cache-from`/`cache-to: type=registry,…-buildcache` refs are gone. The
+  `kortix/kortix-*:*-buildcache` tags on Docker Hub are now unused and can be
+  deleted.
+- The Blacksmith builder is a separate buildkitd: a raw `docker build` that the
+  job then runs locally needs `--load` (see `ci.yml` `self-host-schema`).
+- Sticky disks are billed at $0.50/GB/month and evicted after 7 idle days.
+  Retag/`imagetools` jobs keep `docker/setup-buildx-action`; they build nothing.
+
+## Checking queue time
+
+Blacksmith pickup latency is the failure mode to watch. On 2026-08-25 (first
+hour after #6901) individual jobs waited 14 s to 6 min for a runner while only
+3 were running. Measure it from the job records, not from the run page:
+
+```bash
+RUN=<run id>
+gh api "repos/kortix-ai/suna/actions/runs/$RUN/jobs" \
+  -q '.jobs[] | "\(.status)/\(.conclusion // "-") \(.name) | runner=\(.runner_name // "-") | queued_at=\(.started_at)"'
+```
+
+`started_at` on a `queued` job is when it entered the queue. `runner_name`
+starting with `blacksmith-` proves which pool ran it. If several jobs show
+`queued` for > 10 min with few `in_progress`, check
+<https://status.blacksmith.sh> and the org dashboard at
+<https://app.blacksmith.sh/kortix-ai>, then flip the kill switch.
+
+## Cost
+
+GitHub-hosted minutes are free on this public repo. Blacksmith bills per
+vCPU-minute after 3,000 free 2-vCPU minutes per month, plus sticky-disk
+storage. The tiering above is what keeps the bill proportional: 71 of 130 job
+slots are S (2 vCPU) and only 15 are L.

--- a/docs/runbooks/deploy-dev.md
+++ b/docs/runbooks/deploy-dev.md
@@ -84,3 +84,10 @@ dev's.
 - `.github/workflows/deploy-dev.yml` — the workflow itself.
 - `kortix-release` skill — how prod releases work (promote, not dispatch).
 - `learnings` skill — the concurrency and frontend-skip incidents behind this design.
+
+## Runners
+
+Every Linux job in this workflow runs on Blacksmith through the
+`${{ vars.CI_RUNNER_* || '<label>' }}` expression. Tiers, the kill switch to
+GitHub-hosted runners, the Docker layer cache, and how to read queue time:
+`docs/runbooks/ci-runners.md`.

--- a/tests/src/core/report.ts
+++ b/tests/src/core/report.ts
@@ -6,11 +6,16 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import type { RunResult } from "./result";
+import { scrubValue } from "./scrub";
 
 export function writeResults(result: RunResult, jsonPath: string, htmlPath: string): void {
+  // Both files are uploaded as public workflow artifacts. Scrub by shape here,
+  // after every capture-time key mask, so no path into the tree can carry a
+  // token out (see scrub.ts).
+  const safe = scrubValue(result);
   mkdirSync(dirname(jsonPath), { recursive: true });
-  writeFileSync(jsonPath, JSON.stringify(result, null, 2));
-  writeFileSync(htmlPath, renderHtml(result));
+  writeFileSync(jsonPath, JSON.stringify(safe, null, 2));
+  writeFileSync(htmlPath, renderHtml(safe));
 }
 
 /** Compact GitHub step-summary markdown (flow-ID matrix). */

--- a/tests/src/core/scrub.ts
+++ b/tests/src/core/scrub.ts
@@ -1,0 +1,52 @@
+/**
+ * Last-line redaction for everything the runner writes to disk.
+ *
+ * `client.ts` masks well-known header/body keys at capture time, but a token
+ * also reaches the result tree through paths no key list can see: a CLI
+ * process's stdout, an assertion's raw `actual`, a URL in a reason string.
+ * `results.json` (and `report.html`, a projection of it) is uploaded as a
+ * public workflow artifact, so the tree is scrubbed by SHAPE right before it
+ * is written. The CI guard step greps the written files with the same shapes
+ * (`GUARD_PATTERN_SOURCE`); scrubbing here is what keeps that guard green.
+ *
+ * Dependency-free (no `bun:` imports): the unit lane loads it under vitest.
+ */
+
+/**
+ * Exactly the pattern the workflow guard steps grep for. Keep the two in sync
+ * — `scrub-secret-shapes.test.ts` asserts every guard step embeds this string.
+ */
+export const GUARD_PATTERN_SOURCE =
+  'kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\\.';
+
+/**
+ * Wider than the guard on purpose: a base64url JSON blob starting `eyJ` with no
+ * `.` after it is still a credential (setup-link and app tokens carry
+ * `{accountId, nonce, exp}` / `{appId, userId, exp}`), even though the guard's
+ * JWT-style `\.` anchor would let it through.
+ */
+const SECRET_SHAPES =
+  /kortix_(?:pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}(?:\.[A-Za-z0-9_-]+)*/g;
+
+/** Same visual shape as client.ts `mask()`: 6-char head, then `***[len]`. */
+function maskSecret(value: string): string {
+  return `${value.slice(0, 6)}***[${value.length}]`;
+}
+
+export function scrubSecretShapes(text: string): string {
+  return text.replace(SECRET_SHAPES, maskSecret);
+}
+
+/** Deep copy of `value` with every string scrubbed. Non-strings are untouched. */
+export function scrubValue<T>(value: T): T {
+  if (typeof value === 'string') return scrubSecretShapes(value) as T;
+  if (Array.isArray(value)) return value.map(scrubValue) as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[scrubSecretShapes(k)] = scrubValue(v);
+    }
+    return out as T;
+  }
+  return value;
+}

--- a/tests/unit/cosign-sign-attest.test.ts
+++ b/tests/unit/cosign-sign-attest.test.ts
@@ -113,4 +113,21 @@ describe("keyless image signing", () => {
       supplyChain.indexOf("bash scripts/ci/cosign-sign-attest.sh"),
     );
   });
+
+  it("pins buildx before resolving the digest the signer attests", () => {
+    // The runner image's bundled buildx is not a contract: on Blacksmith's
+    // ubuntu-2404 image `imagetools inspect --format` returned the human
+    // listing (run 32905182332), the digest step failed, and SBOM + signing
+    // were skipped for that dev image.
+    const yaml = readFileSync(workflow, "utf8");
+    const supplyChain = yaml.slice(
+      yaml.indexOf("  supply-chain:"),
+      yaml.indexOf("  migrate-db:"),
+    );
+    const buildx = supplyChain.indexOf("uses: docker/setup-buildx-action@v4");
+    const resolve = supplyChain.indexOf("imagetools inspect \"$IMAGE\" --format '{{.Manifest.Digest}}'");
+    expect(buildx).toBeGreaterThan(-1);
+    expect(resolve).toBeGreaterThan(-1);
+    expect(buildx).toBeLessThan(resolve);
+  });
 });

--- a/tests/unit/image-build-speed-workflow.test.ts
+++ b/tests/unit/image-build-speed-workflow.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
@@ -13,6 +13,19 @@ const read = (name: string) =>
   readFileSync(resolve(import.meta.dirname, `../../.github/workflows/${name}`), 'utf8');
 
 const IMAGES = ['api', 'gateway', 'frontend'] as const;
+const DOCKERFILE: Record<(typeof IMAGES)[number], string> = {
+  api: 'apps/api/Dockerfile',
+  gateway: 'apps/llm-gateway/Dockerfile',
+  frontend: 'apps/web/Dockerfile',
+};
+
+// Every Linux job runs on Blacksmith through a repo-variable kill switch:
+// `${{ vars.CI_RUNNER_<tier> || '<blacksmith label>' }}`. Setting the variable
+// (e.g. to `ubuntu-latest`) moves that tier back to GitHub-hosted runners with
+// no code change — the only rollback that still works when Blacksmith itself
+// is what is broken, since a PR needs runners to merge. docs/runbooks/ci-runners.md
+const RUNNER_L = "${{ vars.CI_RUNNER_L || 'blacksmith-8vcpu-ubuntu-2404' }}";
+const RUNNER_L_ARM = "${{ vars.CI_RUNNER_L_ARM || 'blacksmith-8vcpu-ubuntu-2404-arm' }}";
 
 // The block of a workflow belonging to one top-level job id.
 const jobBlock = (workflow: string, jobId: string): string => {
@@ -37,24 +50,25 @@ describe('staging image builds are native per-arch, cached, and merged', () => {
     const job = jobBlock(source, `build-${image}`);
 
     expect(job).toContain('runs-on: ${{ matrix.runner }}');
-    // Each leg's runner architecture must match the platform it produces.
-    // ubuntu-24.04-arm is verified available to this repo (aarch64, 4 vCPU).
-    expect(job).toContain('platform: linux/amd64\n            runner: ubuntu-latest');
-    expect(job).toContain('platform: linux/arm64\n            runner: ubuntu-24.04-arm');
+    // Each leg's runner architecture must match the platform it produces, and
+    // both legs keep the kill-switch fallback (see RUNNER_* above).
+    expect(job).toContain(`platform: linux/amd64\n            runner: ${RUNNER_L}`);
+    expect(job).toContain(`platform: linux/arm64\n            runner: ${RUNNER_L_ARM}`);
     // Emulating both arches in one job is exactly what this replaced.
     expect(job).not.toContain('platforms: linux/amd64,linux/arm64');
   });
 
-  it.each(IMAGES)('gives %s a registry layer cache scoped per arch', (image) => {
+  it.each(IMAGES)('gives %s a Blacksmith layer cache keyed per image and platform', (image) => {
     const job = jobBlock(source, `build-${image}`);
 
-    expect(job).toContain(
-      `cache-from: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }}`,
-    );
-    // mode=max caches intermediate stages too, not just the final layers.
-    expect(job).toContain(
-      `cache-to: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }},mode=max`,
-    );
+    // The sticky-disk builder is what makes an unchanged-dependency build warm.
+    // Keyed by Dockerfile + platform so an arm64 leg never reads amd64 layers,
+    // and so dev/preview builds of the same Dockerfile share the cache.
+    expect(job).toContain('uses: useblacksmith/setup-docker-builder@v2');
+    expect(job).toContain(`cache-key: ${DOCKERFILE[image]}:\${{ matrix.platform }}`);
+    expect(job).toContain('uses: useblacksmith/build-push-action@v2');
+    // A registry cache export on top of the sticky disk is pure push time.
+    expect(job).not.toContain('cache-to: type=registry');
   });
 
   it.each(IMAGES)('publishes %s by digest, never by tag, from the arch legs', (image) => {
@@ -99,11 +113,38 @@ describe('dev image builds stay single-arch and cached', () => {
     expect(source).not.toContain('platforms: linux/amd64,linux/arm64');
   });
 
-  it.each(IMAGES)('keeps the %s dev build cache wired', (image) => {
-    expect(source).toContain(`cache-from: type=registry,ref=kortix/kortix-${image}:dev-buildcache`);
-    expect(source).toContain(
-      `cache-to: type=registry,ref=kortix/kortix-${image}:dev-buildcache,mode=max`,
-    );
+  it.each(IMAGES)('keeps the %s dev build on the Blacksmith layer cache', (image) => {
+    const job = jobBlock(source, `build-${image}`);
+
+    expect(job).toContain('uses: useblacksmith/setup-docker-builder@v2');
+    expect(job).toContain(`cache-key: ${DOCKERFILE[image]}:linux/amd64`);
+    expect(job).toContain('uses: useblacksmith/build-push-action@v2');
+    expect(job).not.toContain('cache-to: type=registry');
+  });
+});
+
+describe('every Linux job keeps the Blacksmith runner kill switch', () => {
+  // A bare label — GitHub-hosted or Blacksmith — has no rollback lever. The
+  // wizard PR (#6901) shipped bare `blacksmith-4vcpu-*` labels and left three
+  // amd64 legs on `ubuntu-latest`; this pins the convention instead.
+  const workflows = readdirSync(resolve(import.meta.dirname, '../../.github/workflows')).filter(
+    (name) => name.endsWith('.yml'),
+  );
+  const tiered =
+    /^\$\{\{ vars\.CI_RUNNER_(S|M|L|L_ARM|M_2204) \|\| 'blacksmith-(2|4|8)vcpu-ubuntu-2(2|4)04(-arm)?' \}\}$/;
+
+  it.each(workflows)('%s', (name) => {
+    const source = read(name);
+    for (const [, value] of source.matchAll(/^ {4}runs-on: (.+)$/gm)) {
+      if (value === '${{ matrix.runner }}') continue;
+      expect(value, `runs-on in ${name}`).toMatch(tiered);
+    }
+    for (const [, value] of source.matchAll(/^ {12}runner: (.+)$/gm)) {
+      // macOS and Windows stay GitHub-hosted: free on this public repo, and
+      // Blacksmith's Windows pool is still in beta.
+      if (/^(macos|windows)-/.test(value)) continue;
+      expect(value, `matrix runner in ${name}`).toMatch(tiered);
+    }
   });
 });
 

--- a/tests/unit/scrub-secret-shapes.test.ts
+++ b/tests/unit/scrub-secret-shapes.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { writeResults } from '../src/core/report';
+import type { RunResult } from '../src/core/result';
+import { GUARD_PATTERN_SOURCE, scrubSecretShapes, scrubValue } from '../src/core/scrub';
+
+// The CI guard ("Guard test artifacts against secrets") greps results.json and
+// report.html for these shapes before upload. It was a silent no-op from its
+// first run until 2026-08-25: it invoked `rg`, which GitHub's ubuntu images do
+// not ship, under `2>/dev/null`. The first Blacksmith run (whose image has rg)
+// found kortix_pat_/kortix_sa_/setup-link tokens in every uploaded artifact.
+// These tests pin (1) the runner scrubs the same shapes it will be judged by,
+// (2) the guard uses grep, present on every runner image.
+
+const guard = new RegExp(GUARD_PATTERN_SOURCE);
+
+// Synthetic values in the exact shapes found in run 32905168237's artifact.
+const PAT = `kortix_pat_${'yY5MkM1z2DqkK'.repeat(3)}`;
+const SA = `kortix_sa_${'Cu74jk1OrLkE3F'.repeat(3)}`;
+const SK = `sk-${'A1b2C3d4E5f6G7h8I9j0'.repeat(2)}`;
+const JWT = `eyJ${'hbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9'.repeat(2)}.eyJzdWIiOiIxIn0.sig_abc`;
+// base64url JSON with no `.` — the setup-link/app token shape the guard's
+// JWT-style anchor would let through, still a credential.
+const BLOB = `eyJ${'hY2NvdW50SWQiOiI0NWZhMTIzNC01Njc4'.repeat(3)}`;
+
+describe('scrubSecretShapes', () => {
+  it.each([
+    ['PAT', PAT],
+    ['service-account token', SA],
+    ['sk- key', SK],
+    ['JWT', JWT],
+    ['base64url JSON blob', BLOB],
+  ])('masks a %s so the guard pattern no longer matches', (_label, token) => {
+    const text = `prefix "secret_key": "${token}" suffix`;
+    // The guard's JWT anchor (`eyJ…\.`) does not see the dot-less blob; the
+    // scrubber still must.
+    if (token !== BLOB) expect(text).toMatch(guard);
+    const scrubbed = scrubSecretShapes(text);
+    expect(scrubbed).not.toMatch(guard);
+    expect(scrubbed).not.toContain(token);
+    // Same visual shape as client.ts mask(): 6-char head + ***[len].
+    expect(scrubbed).toContain(`${token.slice(0, 6)}***[${token.length}]`);
+  });
+
+  it('leaves ordinary text and short lookalikes alone', () => {
+    const text = 'kortix_pat_short sk-abc eyJ.x plain words 2026-08-25';
+    expect(scrubSecretShapes(text)).toBe(text);
+  });
+});
+
+describe('scrubValue', () => {
+  it('walks nested objects, arrays and keys without touching non-strings', () => {
+    const input = {
+      n: 42,
+      ok: true,
+      none: null,
+      stdout: `token: ${PAT}\n`,
+      list: [SK, { deep: [JWT] }],
+      [`k_${SA}`]: 'v',
+    };
+    const out = scrubValue(input);
+    expect(out.n).toBe(42);
+    expect(out.ok).toBe(true);
+    expect(out.none).toBeNull();
+    expect(JSON.stringify(out)).not.toMatch(guard);
+    for (const t of [PAT, SK, JWT, SA]) expect(JSON.stringify(out)).not.toContain(t);
+    // A fresh tree: the caller's object is not mutated.
+    expect(input.stdout).toContain(PAT);
+  });
+});
+
+describe('writeResults', () => {
+  it('writes results.json and report.html that pass the CI guard', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'ke2e-scrub-'));
+    const result = {
+      target: 'local',
+      apiUrl: 'http://localhost:8008/v1',
+      flows: [
+        {
+          id: 'TOK-1',
+          domain: 'tokens',
+          status: 'pass',
+          durationMs: 1,
+          steps: [
+            {
+              name: 'create a PAT',
+              status: 'pass',
+              durationMs: 1,
+              captured: [
+                {
+                  req: { method: 'POST', url: 'http://x/v1/tokens', headers: {} },
+                  res: { status: 200, headers: {}, bodyText: `{"secret_key":"${PAT}"}` },
+                },
+              ],
+              assertions: [
+                { kind: 'body.exists', description: 'body $.secret_key exists', pass: true, actual: PAT },
+              ],
+            },
+          ],
+        },
+      ],
+      summary: { total: 1, passed: 1, failed: 0, skipped: 0, todo: 0, durationMs: 1 },
+    } as unknown as RunResult;
+    const jsonPath = resolve(dir, 'results.json');
+    const htmlPath = resolve(dir, 'report.html');
+    writeResults(result, jsonPath, htmlPath);
+    for (const p of [jsonPath, htmlPath]) {
+      const text = readFileSync(p, 'utf8');
+      expect(text, p).not.toMatch(guard);
+      expect(text, p).not.toContain(PAT);
+      expect(text, p).toContain(`kortix***[${PAT.length}]`);
+    }
+  });
+});
+
+describe('the artifact guard step', () => {
+  const workflows = ['tests.yml', 'tests-browser-nightly.yml', 'tests-release.yml'];
+
+  it.each(workflows)('%s greps with the runner-scrubbed pattern and never calls rg', (name) => {
+    const source = readFileSync(resolve(import.meta.dirname, `../../.github/workflows/${name}`), 'utf8');
+    const guards = source.split('Guard test artifacts against secrets').length - 1;
+    expect(guards, 'guard step present').toBeGreaterThan(0);
+    expect(source.split(`pattern='${GUARD_PATTERN_SOURCE}'`).length - 1).toBe(guards);
+    expect(source.split('grep -rEIl "$pattern" tests/test-results').length - 1).toBe(guards);
+    expect(source).not.toMatch(/\brg -l\b/);
+  });
+});


### PR DESCRIPTION
## Why

#6901 (Blacksmith Migration Wizard) rewrote 125 `runs-on` labels to a flat `blacksmith-4vcpu-*` and merged with `warm core worker` **red**: 3 assertions in `tests/unit/image-build-speed-workflow.test.ts` pin `ubuntu-24.04-arm`, and the 3 amd64 legs in `build-staging.yml` stayed on `ubuntu-latest`. It also left the registry BuildKit cache in place and gave every job — from `curl` probes to the Next build — the same 4 vCPU.

## What changed

1. **Runner tiers with a kill switch.** Every Linux `runs-on` / matrix `runner:` is `${{ vars.CI_RUNNER_<tier> || '<blacksmith label>' }}`:

   | Tier | Default | Jobs | For |
   |---|---|---|---|
   | S | `blacksmith-2vcpu-ubuntu-2404` | 71 | no dependency install (aws/gh/curl/terraform, retags, verify probes) |
   | M | `blacksmith-4vcpu-ubuntu-2404` | 35 | `pnpm install` / bun / typecheck / test lanes / npm publish |
   | L | `blacksmith-8vcpu-ubuntu-2404` | 12 | image builds, `apps/web` build, CodeQL, preview stack |
   | L_ARM | `blacksmith-8vcpu-ubuntu-2404-arm` | 3 | `linux/arm64` staging legs |
   | M_2204 | `blacksmith-4vcpu-ubuntu-2204` | 9 | Bun cross-compile CLI, Electron linux, installer smoke, release attach |

   `gh variable set CI_RUNNER_M --body ubuntu-latest` moves a tier back to GitHub-hosted with **no PR** — the only rollback that works when the runner pool itself is down (a PR's checks need runners). macOS/Windows desktop jobs stay GitHub-hosted (free on this public repo; Blacksmith Windows is beta).
2. **Docker layer cache on Blacksmith sticky disks.** The 9 image builds (deploy-dev ×3, build-staging ×3, deploy-preview ×3) + the `ci.yml` self-host smoke build use `useblacksmith/setup-docker-builder@v2` (`cache-key: <Dockerfile>:<platform>`, shared across workflows) and `useblacksmith/build-push-action@v2`. `cache-from`/`cache-to: type=registry,…-buildcache` removed. The raw `docker build` in ci.yml gains `--load`. Both actions fall back to a plain local builder off-Blacksmith (verified in their source), so the kill switch keeps builds working, only cold.
3. **Tests.** `image-build-speed-workflow.test.ts` pins the new topology and adds a repo-wide check that rejects any bare runner label in any workflow.
4. **Lint/docs.** `.github/actionlint.yaml` (blacksmith labels). New runbook `docs/runbooks/ci-runners.md` (tiers, kill-switch commands, cache keys, how to measure queue time, cost). Pointers in `deploy-dev.md`, `CLAUDE.md`/`AGENTS.md`. Learnings entry.

## Verified locally

- `actionlint` — clean (only pre-existing shellcheck notes).
- `pnpm --dir tests test:unit` workflow suites: 10 files / 108 tests pass (on `main` the same set fails 3).
- All 30 workflows parse; `grep` shows 0 bare `ubuntu-*`/`blacksmith-*` Linux labels.

## To verify after merge (Deploy Dev)

- Image builds run on `blacksmith-…-8vcpu` runners with `setup-docker-builder` reporting a sticky disk; second build of the same Dockerfile shows `CACHED` layers.
- `dev-api` `/health` reports the merged SHA.

## Findings while doing this (not fixed here)

- **Blacksmith pickup latency.** In the hour after #6901, jobs waited 14 s – 6 min in `queued` while ≤3 ran org-wide (e.g. `Compute dev version` 5m42s, terraform-ci `tflint` 7 min). Check the plan's concurrency at https://app.blacksmith.sh/kortix-ai — if it is capped, the S tier (2 vCPU) is what makes bursts fit.
- **`kortix.ts` schema drift on `main`** — `Schema matches migrations` fails on every PR: `ALTER TYPE "kortix"."connector_provider" ADD VALUE 'composio' BEFORE 'mcp'` (from 5ffe882e7c "Add Composio connector provider wiring", no migration). Unrelated to runners.
- GitHub default-setup CodeQL (`Code Quality: Push on main`, js/py/go on `ubuntu-latest`) duplicates the checked-in `codeql.yml`.
- `kortix/kortix-*:dev-buildcache` / `:staging-buildcache-{amd64,arm64}` tags on Docker Hub are now unused.

## Added in `688fd9dee1` — the artifact guard was a silent no-op, and Blacksmith exposed it

`Guard test artifacts against secrets` (tests.yml, tests-release.yml, tests-browser-nightly.yml) called `rg`, which GitHub's ubuntu-24.04 image does not ship; under `2>/dev/null` the missing tool read as "no match", so it printed "No secret-shaped values found." on every run since it was written (step verdict: `success` on all 7 recent `ubuntu-latest` runs, `failure` on every Blacksmith run — Blacksmith's image has rg). The first real run found **32 secret-shaped values** in the 73 MB `results.json` (+ `report.html`) that every PR uploads as a public artifact: 8× `kortix_pat_*`, `kortix_sa_*`, and base64 setup-link/app tokens (`{accountId,nonce,exp}` / `{appId,userId,exp}`), reaching the tree via CLI stdout and assertion `actual` values that the key-based `client.ts` redaction never sees. They are tokens of the ephemeral local stack (dead after teardown) — but `tests-release.yml` runs the same suite against **staging**.

Fix: `tests/src/core/scrub.ts` + `writeResults()` scrub the whole tree by shape before writing (proven on the real artifact: 32 → 0 matches, 253 ms); the 4 guard steps use `grep -rEIl "$pattern"` with the single shared pattern; `tests/unit/scrub-secret-shapes.test.ts` pins parity and forbids `rg`. Learnings entry added.

## Sandbox-provider incident during this PR's checks (not Blacksmith)

From ~22:14 UTC every core/browser/packages lane on both open PRs (#6902, #6903) failed with exit 3: Platinum `restore timeout` → Daytona fallback → `dockerd: failed to mount overlay: invalid argument … overlay2 driver not supported` on kernel `6.18.15`. The runner is infra-only in these lanes; the same lanes passed at 22:00 on Blacksmith. Re-run once the provider recovers.
