### PR TITLE
fix(setup-links): finalize when our own modal closes

### DIFF
--- a/apps/web/src/components/setup-links/setup-link-button.tsx
+++ b/apps/web/src/components/setup-links/setup-link-button.tsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import { Button } from '../ui/button';
 import { ConnectorIntake } from './connector-intake';
 import { SecretIntakeForm } from './secret-intake-form';
+import { onSetupLinkModalClose } from './setup-link-close-finalize';
 import { setupLinkChipLabel, type SetupLinkKind } from './util';
 
 function textOf(node: React.ReactNode): string {
@@ -42,6 +43,16 @@ export function SetupLinkButton({
 }) {
   const [open, setOpen] = useState(false);
   const Icon = kind === 'secret' ? KeyRound : Plug;
+
+  /**
+   * Closing the modal settles the connect. See `onSetupLinkModalClose` — the
+   * rule lives there so it is testable without a DOM.
+   */
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    void onSetupLinkModalClose({ open: next, kind, token });
+  };
+
   const label = setupLinkChipLabel(
     textOf(children),
     token,
@@ -57,7 +68,7 @@ export function SetupLinkButton({
         <span className="truncate">{label}</span>
       </Button>
 
-      <Modal open={open} onOpenChange={setOpen}>
+      <Modal open={open} onOpenChange={handleOpenChange}>
         <ModalContent className="lg:max-w-md">
           <ModalHeader>
             <ModalTitle>{kind === 'secret' ? 'Add a project secret' : 'Connect an app'}</ModalTitle>

--- a/apps/web/src/components/setup-links/setup-link-close-finalize.test.tsx
+++ b/apps/web/src/components/setup-links/setup-link-close-finalize.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Closing our own modal must settle the connect.
+ *
+ * The intake polls /finalize only while mounted, so closing the modal killed
+ * the poll mid-OAuth: the account landed at the provider and the agent was
+ * never told, leaving the human to prompt it anyway — the one thing this flow
+ * exists to remove. The modal is ours, so its close is a first-class signal
+ * that the human is done.
+ *
+ * `finalize` is injected rather than mocking '@kortix/sdk' wholesale: that
+ * module is imported for other things here (HostBoundaryError), and replacing
+ * it breaks the import graph instead of testing this rule.
+ */
+import { expect, test } from 'bun:test';
+import { onSetupLinkModalClose } from './setup-link-close-finalize';
+
+function recorder() {
+  const calls: string[] = [];
+  return { calls, finalize: async (token: string) => void calls.push(token) };
+}
+
+test('closing a CONNECTOR modal finalizes, so the agent is told', async () => {
+  const { calls, finalize } = recorder();
+  await onSetupLinkModalClose({ open: false, kind: 'connector', token: 'ksl_1', finalize });
+  expect(calls).toEqual(['ksl_1']);
+});
+
+test('opening it does not finalize', async () => {
+  const { calls, finalize } = recorder();
+  await onSetupLinkModalClose({ open: true, kind: 'connector', token: 'ksl_1', finalize });
+  expect(calls).toEqual([]);
+});
+
+test('a SECRET modal has no connect to settle', async () => {
+  const { calls, finalize } = recorder();
+  await onSetupLinkModalClose({ open: false, kind: 'secret', token: 'ksl_2', finalize });
+  expect(calls).toEqual([]);
+});
+
+test('a failing finalize never escapes — a closing dialog must not throw', async () => {
+  await onSetupLinkModalClose({
+    open: false,
+    kind: 'connector',
+    token: 'ksl_3',
+    finalize: async () => {
+      throw new Error('offline');
+    },
+  });
+  // Reaching here without rejecting is the assertion.
+  expect(true).toBe(true);
+});

--- a/apps/web/src/components/setup-links/setup-link-close-finalize.ts
+++ b/apps/web/src/components/setup-links/setup-link-close-finalize.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { finalizeConnectorSetupLink } from '@kortix/sdk';
+
+import { setupLinkApiBase, type SetupLinkKind } from './util';
+
+/**
+ * Settle a connect when our own modal closes.
+ *
+ * The intake polls `/finalize` only while it is mounted, so closing the modal
+ * killed the poll mid-OAuth: the account landed at the provider and the agent
+ * was never told, leaving the human to prompt it anyway. This modal is ours —
+ * its close is a first-class signal that the human is done, so ask once more on
+ * the way out.
+ *
+ * `/finalize` is idempotent, answers `{connected:false}` when the human
+ * abandoned it rather than finishing, and de-dupes the agent's follow-up on its
+ * own. Nothing here needs the answer, and a failure must never escape into a
+ * closing dialog.
+ *
+ * Extracted from the component so the rule is testable without a DOM.
+ */
+export async function onSetupLinkModalClose(input: {
+  open: boolean;
+  kind: SetupLinkKind;
+  token: string;
+  finalize?: (token: string) => Promise<unknown>;
+}): Promise<void> {
+  if (input.open || input.kind !== 'connector') return;
+  // Same base the intake passes: these public setup-link routes are addressed
+  // by backend url, not through the app's authenticated client.
+  const finalize =
+    input.finalize ?? ((token: string) => finalizeConnectorSetupLink(token, { backendUrl: setupLinkApiBase() }));
+  try {
+    await finalize(input.token);
+  } catch {
+    // The intake's own poll and the server-side watch both still cover this.
+  }
+}


### PR DESCRIPTION
## The symptom

Authorize the app, close the modal — nothing happens. The agent is never told, so you prompt it anyway.

## Root cause

The intake polls `/finalize` **only while it is mounted**. Closing the modal kills the poll mid-OAuth. The account is already at the provider; nothing ever asks for it.

## The fix

This modal is **ours**. Its close is a first-class signal that the human is done, so ask once more on the way out:

```ts
const handleOpenChange = (next: boolean) => {
  setOpen(next);
  void onSetupLinkModalClose({ open: next, kind, token });
};
```

That is the whole fix. No webhook, no provider callback, no inferring what happened inside a cross-origin popup.

Fire-and-forget on purpose: `/finalize` is idempotent, answers `{connected:false}` when the human abandoned it rather than finishing, and de-dupes the agent's follow-up on its own. Nothing here needs the answer, and a closing dialog must never wait on the network or throw.

## Testability

The rule lives in its own module so it can be tested without a DOM, and takes an injected `finalize`. Mocking `@kortix/sdk` wholesale broke the import graph (`HostBoundaryError` is imported from it elsewhere in this folder) instead of testing the rule — worth stating because that mistake looked like a passing test first.

## Verification

```
apps/web  setup-links      4 pass / 0 fail
apps/web  tsc --noEmit     19 errors — back to the pre-existing baseline
apps/web  eslint           exit=0
```

Cases covered: close finalizes, open does not, a secret modal has no connect to settle, and a failing finalize never escapes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288062&installation_model_id=434224&pr_number=6903&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6903&signature=ff9fb531281a3006c4d133abfc77d06119c8d9d138e7a61ce82669c0bd1c2c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->