### PR TITLE
fix(runtime): long turns — bounded turn probe, port-as-process, Bun 300 s fetch idle opt-out, daemon log + resources + /kortix/diag

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2779,6 +2779,14 @@ settled by hand.
    crossed, and `GET /kortix/diag` returns state + resources + runtime
    report + both log tails in one document. Ask the box before guessing.
 
+*Cost of the old probe, measured (2026-08-25 23:12Z, session 9df2a873):* the
+reaper visited that box 345 times in one hour; every visit made OpenCode
+JSON-serialise its 140 MB root (~48 GB of serialisation per hour) for an
+answer that never fit the budget. OpenCode reached 6.48 GB RSS on an 8 GB
+box and the kernel OOM-killed it mid-turn (`dmesg`: `Killed process 1506
+(opencode.exe) anon-rss:6484532kB`). An unbounded probe is not only blind,
+it is a memory attack on the process it probes.
+
 *Automation:* `orphaned-turn-finalize.test.ts` ("turn probes read a bounded
 window, never the whole root"); the stub fetch there serves `?limit=` and
 `/message/:id` the way 1.18.23 does.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2691,3 +2691,35 @@ side.
 
 *Incident:* no prod outage — caught on local dev, but the identical code
 paths ship to prod, where every /compact would have 503'd the same way.
+
+## A turn probe never lists the whole root — the list is unbounded, the budget is not
+
+*Incident (2026-08-25, Essentia sessions 9c8749ac and 9df2a873):* the reaper
+asks the daemon `GET /kortix/health?turn=1&turn_session_id&turn_message_id`
+and acts on `turn_in_flight`. The daemon answered it by fetching the root's
+ENTIRE OpenCode message list inside a 5 s budget. On 9c8749ac that list was
+276.7 MB (inline base64 image parts; `?limit=20` alone was 26 MB). The read
+never fit, the daemon answered `turn_in_flight: null` ("could not tell") on
+every visit, the reaper drip-extended the box on that non-answer for 2.5 h
+after OpenCode had finished the turn (`exiting loop` 21:00:18Z, probe still
+null at 22:10Z), and the session rendered "working" until the ledger row was
+settled by hand.
+
+**Rules.**
+1. `observeOpencodeDelivery` / `inspectOpencodeRoot` read the newest
+   `TURN_PROBE_WINDOW` (12) messages via `?limit=` — the newest N in
+   chronological order (verified on OpenCode 1.18.23) — with a 20 s budget.
+   A prompt older than the window is proved by `GET /session/:id/message/:id`
+   (~400 bytes; 404 `NotFoundError` when absent). Only a proven absence is
+   `abandoned`; a failed by-id read stays `null`.
+2. Any new daemon read of a session transcript states its bound in the
+   request. Roots grow for hours; "the list" is never small.
+3. The daemon's `activePort` must answer. The readiness probe adopts the
+   other half of the port pair when OUR live child answers only there
+   (`adoptStrayActivePort`, logged at error level with both ports and the
+   pid). Same box, same day: daemon `starting` on 4096 for 2 h while pid 2423
+   served on 4097 — every prompt 503'd and no turn end was ever observed.
+
+*Automation:* `orphaned-turn-finalize.test.ts` ("turn probes read a bounded
+window, never the whole root"); the stub fetch there serves `?limit=` and
+`/message/:id` the way 1.18.23 does.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2714,11 +2714,27 @@ settled by hand.
    `abandoned`; a failed by-id read stays `null`.
 2. Any new daemon read of a session transcript states its bound in the
    request. Roots grow for hours; "the list" is never small.
-3. The daemon's `activePort` must answer. The readiness probe adopts the
-   other half of the port pair when OUR live child answers only there
-   (`adoptStrayActivePort`, logged at error level with both ports and the
-   pid). Same box, same day: daemon `starting` on 4096 for 2 h while pid 2423
-   served on 4097 — every prompt 503'd and no turn end was ever observed.
+3. The live opencode port is a property of the PROCESS (`childPorts`,
+   `livePort()` in opencode.ts), never a variable beside it. Same box, same
+   day: the daemon reported `starting` on 4096 for 2 h while its own child
+   (pid 2423) served on 4097 — every prompt 503'd and no turn end was ever
+   observed. The verified reload (two opencodes, promote the proven one) is
+   by design; a bookkeeping variable that can drift from the process is not.
+   The verifier also declines when the candidate half already answers: the
+   incumbent would otherwise "prove" a candidate that died on EADDRINUSE and
+   promotion would kill the only opencode the box has.
+4. The daemon log is on the box: every logger line also lands in
+   `KORTIX_DAEMON_LOG_FILE` (default `/opt/kortix/logs/daemon.log`, rotated at
+   32 MiB to `.1`), readable with `GET /kortix/logs?source=daemon|opencode|all&tail=N`
+   through the sandbox proxy (`/v1/p/<external_id>/8000/kortix/logs`). A
+   daemon whose only log is a stream nobody keeps cannot be debugged after
+   the fact — that is why this entry says "unproven".
+5. Box telemetry is on record: `[resources]` every 60 s and on every OpenCode
+   state change (memory, cgroup limit + oom_kill counter, load, disk on
+   /workspace + /opt/kortix + /tmp, daemon + opencode RSS, duplicate
+   `opencode serve` pids), `[resources] pressure` when a threshold is
+   crossed, and `GET /kortix/diag` returns state + resources + runtime
+   report + both log tails in one document. Ask the box before guessing.
 
 *Automation:* `orphaned-turn-finalize.test.ts` ("turn probes read a bounded
 window, never the whole root"); the stub fetch there serves `?limit=` and

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2723,3 +2723,30 @@ settled by hand.
 *Automation:* `orphaned-turn-finalize.test.ts` ("turn probes read a bounded
 window, never the whole root"); the stub fetch there serves `?limit=` and
 `/message/:id` the way 1.18.23 does.
+
+## Bun's fetch has a hidden 300 s idle timeout — every model hop opts out
+
+*Incident (2026-08-25 22:04Z, Essentia session 9c27242e):* a turn on
+`codex/gpt-5.6-sol` at reasoning effort `max` died after 273.8 s with
+`{"message":"The operation timed out.","code":"upstream_timeout"}`. Nothing in
+this repo sets a 300 s timer; the gateway's own budgets are 90 s / 5 min for
+response headers and 90 min for body inactivity. Measured on Bun 1.3.14 the
+same night: `fetch` throws `TimeoutError: The operation timed out.` at 300.0 s
+when the socket is idle (no headers, or headers then silence); a stream that
+drips a byte every 60 s lives past 420 s; a caller `signal` does NOT disable
+it; `timeout: false` (or `0`) does. The provider was still thinking.
+
+**Rules.**
+1. Every fetch on the model path passes `timeout: false`: gateway → provider
+   (`upstreamFetch`, `packages/llm-gateway/src/upstream-fetch.ts`, used by
+   both `callUpstream` and the AI-SDK transport), API relay → gateway
+   (`apps/api/src/llm-gateway/wire.ts`), box llm-proxy → API
+   (`kortix-sandbox-agent-server/src/llm-proxy.ts`). The gateway's explicit
+   timeouts are the only ones on that path.
+2. A timeout you did not write is still yours to know about. When an error
+   message is not in the repo, measure the runtime before blaming the
+   provider: `bun-idle.ts` (headers-then-silence, no-headers, drip, option
+   variants) took 12 minutes and settled it.
+
+*Automation:* `packages/llm-gateway/src/upstream-fetch.test.ts` (option is
+forwarded; Bun accepts it on a real request).

--- a/apps/api/src/llm-gateway/wire.ts
+++ b/apps/api/src/llm-gateway/wire.ts
@@ -391,12 +391,18 @@ export function mountLlmGateway(app: OpenAPIHono): void {
     headers.delete('host');
     headers.delete('connection');
     const query = new URL(c.req.url).search;
-    const init: RequestInit & { duplex?: 'half' } = {
+    const init: RequestInit & { duplex?: 'half'; timeout?: false } = {
       method: c.req.method,
       headers,
       // Without this a client disconnect never reached the gateway, so the
       // provider kept generating — and billing — a turn nobody would read.
       signal: c.req.raw.signal,
+      // Bun's fetch has a default 300 s IDLE timeout that a `signal` does not
+      // disable (measured on 1.3.14: `TimeoutError: The operation timed out.`
+      // at 300.0 s). A non-streaming model call, or a streaming one before
+      // the gateway's first synthetic byte, can be silent longer than that.
+      // The gateway owns the model-hop timeouts; this relay must not add one.
+      timeout: false,
     };
     if (c.req.method !== 'GET' && c.req.method !== 'HEAD') {
       init.body = c.req.raw.body;

--- a/apps/kortix-sandbox-agent-server/src/__tests__/daemon-log-file-and-logs-route.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/daemon-log-file-and-logs-route.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The daemon log lands on disk and is readable through GET /kortix/logs —
+ * and the sink can never hurt the box.
+ *
+ * 2026-08-25: two hours of an Essentia daemon reporting `starting` on the wrong
+ * port could be fenced but not proven, because its stdout lived on a stream
+ * nobody kept (E2B envd). Every line now also lands in a file on the box.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Config } from '../config'
+import {
+  DAEMON_LOG_BUFFER_CAP_BYTES,
+  DAEMON_LOG_MAX_LINE_BYTES,
+  __daemonLogSinkStateForTests,
+  __flushDaemonLogFileForTests,
+  __resetLoggerFileSinkForTests,
+  daemonLogFilePath,
+  enableDaemonLogFile,
+  logger,
+} from '../logger'
+import { createLogsRouter, tailFile } from '../routes/logs'
+
+let root: string
+const savedEnv = { file: process.env.KORTIX_DAEMON_LOG_FILE, max: process.env.KORTIX_DAEMON_LOG_MAX_BYTES }
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-daemon-log-'))
+  process.env.KORTIX_DAEMON_LOG_FILE = join(root, 'logs', 'agent.log')
+  delete process.env.KORTIX_DAEMON_LOG_MAX_BYTES
+  __resetLoggerFileSinkForTests()
+})
+
+afterEach(async () => {
+  // Drain before the tmp dir goes away: a flush in flight must not outlive its dir.
+  await __flushDaemonLogFileForTests()
+  if (savedEnv.file === undefined) delete process.env.KORTIX_DAEMON_LOG_FILE
+  else process.env.KORTIX_DAEMON_LOG_FILE = savedEnv.file
+  if (savedEnv.max === undefined) delete process.env.KORTIX_DAEMON_LOG_MAX_BYTES
+  else process.env.KORTIX_DAEMON_LOG_MAX_BYTES = savedEnv.max
+  __resetLoggerFileSinkForTests()
+  rmSync(root, { recursive: true, force: true })
+})
+
+async function readLines(path: string): Promise<Array<Record<string, unknown>>> {
+  await __flushDaemonLogFileForTests()
+  return readFileSync(path, 'utf8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l))
+}
+
+describe('daemon log file sink', () => {
+  test('off until enabled: importing the logger never touches the disk', () => {
+    logger.info('[test] before enable')
+    expect(existsSync(join(root, 'logs'))).toBe(false)
+  })
+
+  test('every level lands as one JSON line, directory created on demand', async () => {
+    expect(enableDaemonLogFile().path).toBe(join(root, 'logs', 'agent.log'))
+    logger.info('[test] hello', { a: 1 })
+    logger.error('[test] boom', new Error('kaput'))
+    const lines = await readLines(daemonLogFilePath() as string)
+    expect(lines.map((l) => l.msg)).toEqual(['[test] hello', '[test] boom'])
+    expect(lines[0]?.a).toBe(1)
+    expect((lines[1]?.error as { message: string }).message).toBe('kaput')
+  })
+
+  test('a single oversized line is truncated, never written whole', async () => {
+    enableDaemonLogFile()
+    logger.info('[test] big', { blob: 'x'.repeat(DAEMON_LOG_MAX_LINE_BYTES * 3) })
+    await __flushDaemonLogFileForTests()
+    const text = readFileSync(daemonLogFilePath() as string, 'utf8')
+    expect(text.length).toBeLessThanOrEqual(DAEMON_LOG_MAX_LINE_BYTES + 1)
+    expect(text).toContain('[truncated]')
+  })
+
+  test('memory is bounded: oldest lines are dropped and the drop is recorded', async () => {
+    enableDaemonLogFile()
+    // Do not flush between lines: everything below queues behind the cap.
+    const line = 'y'.repeat(60 * 1024)
+    for (let i = 0; i < 40; i++) logger.info(`[test] ${i}`, { line })
+    const state = __daemonLogSinkStateForTests()
+    expect(state.pendingBytes).toBeLessThanOrEqual(DAEMON_LOG_BUFFER_CAP_BYTES)
+    expect(state.dropped).toBeGreaterThan(0)
+    const lines = await readLines(daemonLogFilePath() as string)
+    expect(lines.some((l) => String(l.msg).startsWith('[logger] dropped'))).toBe(true)
+  })
+
+  test('rotates to <file>.1 past KORTIX_DAEMON_LOG_MAX_BYTES', async () => {
+    process.env.KORTIX_DAEMON_LOG_MAX_BYTES = '100000'
+    enableDaemonLogFile()
+    const path = daemonLogFilePath() as string
+    for (let round = 0; round < 6; round++) {
+      for (let i = 0; i < 400; i++) logger.info(`[test] ${round}/${i} ${'x'.repeat(80)}`)
+      await __flushDaemonLogFileForTests()
+    }
+    expect(existsSync(`${path}.1`)).toBe(true)
+    expect(statSync(path).size).toBeLessThan(2 * 100000 + 64 * 1024)
+  })
+
+  test('an unwritable path disables the sink for good and stdout keeps flowing', async () => {
+    writeFileSync(join(root, 'not-a-dir'), 'file')
+    process.env.KORTIX_DAEMON_LOG_FILE = join(root, 'not-a-dir', 'agent.log')
+    __resetLoggerFileSinkForTests()
+    enableDaemonLogFile()
+    logger.info('[test] one')
+    await __flushDaemonLogFileForTests()
+    expect(__daemonLogSinkStateForTests().disabled).toBe(true)
+    // Still no throw, still no growth.
+    logger.info('[test] two')
+    expect(__daemonLogSinkStateForTests().pendingBytes).toBe(0)
+  })
+
+  test('KORTIX_DAEMON_LOG_FILE=off keeps the sink off even when enabled', () => {
+    process.env.KORTIX_DAEMON_LOG_FILE = 'off'
+    __resetLoggerFileSinkForTests()
+    expect(enableDaemonLogFile().path).toBeNull()
+    logger.info('[test] nothing on disk')
+    expect(existsSync(join(root, 'logs'))).toBe(false)
+  })
+
+  test('a ctx that cannot be serialized does not lose the line', async () => {
+    enableDaemonLogFile()
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    logger.warn('[test] cyclic', cyclic)
+    const lines = await readLines(daemonLogFilePath() as string)
+    expect(lines[0]?.msg).toBe('[test] cyclic')
+    expect(lines[0]?.ctx).toBe('[unserializable]')
+  })
+})
+
+describe('tailFile', () => {
+  test('returns the last N lines and null for a missing file', () => {
+    const p = join(root, 't.log')
+    writeFileSync(p, Array.from({ length: 50 }, (_, i) => `l${i}`).join('\n') + '\n')
+    expect(tailFile(p, 3)).toBe('l47\nl48\nl49\n')
+    expect(tailFile(join(root, 'missing.log'), 3)).toBeNull()
+  })
+})
+
+describe('GET /kortix/logs', () => {
+  const token = 'sandbox-token'
+  const cfg = { sandboxToken: token } as Config
+
+  test('401 without the service bearer or a user context', async () => {
+    const app = createLogsRouter(cfg, { opencodeHome: root })
+    const res = await app.request('http://d/?tail=10')
+    expect(res.status).toBe(401)
+  })
+
+  test('tails the daemon log for the service caller, and both sources on demand', async () => {
+    enableDaemonLogFile()
+    logger.info('[test] first')
+    logger.info('[test] second')
+    await __flushDaemonLogFileForTests()
+    mkdirSync(join(root, '.local', 'share', 'opencode', 'log'), { recursive: true })
+    writeFileSync(join(root, '.local', 'share', 'opencode', 'log', 'opencode.log'), 'oc-1\noc-2\n')
+    const app = createLogsRouter(cfg, { opencodeHome: root })
+
+    const agent = await app.request('http://d/?tail=1', { headers: { Authorization: `Bearer ${token}` } })
+    expect(agent.status).toBe(200)
+    expect(agent.headers.get('content-type')).toContain('text/plain')
+    const agentText = await agent.text()
+    expect(agentText).toContain('[test] second')
+    expect(agentText).not.toContain('[test] first')
+
+    const all = await app.request('http://d/?source=all&tail=5', { headers: { Authorization: `Bearer ${token}` } })
+    expect(all.status).toBe(200)
+    const allText = await all.text()
+    expect(allText).toContain('==> ')
+    expect(allText).toContain('oc-2')
+    expect(allText).toContain('[test] first')
+
+    const bad = await app.request('http://d/?source=nope', { headers: { Authorization: `Bearer ${token}` } })
+    expect(bad.status).toBe(400)
+  })
+
+  test('404 when no requested source exists on disk', async () => {
+    const app = createLogsRouter(cfg, { opencodeHome: root })
+    const res = await app.request('http://d/?source=opencode', { headers: { Authorization: `Bearer ${token}` } })
+    expect(res.status).toBe(404)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/diag-route.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/diag-route.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /kortix/diag — one call, the whole error report.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { Config } from '../config'
+import { __flushDaemonLogFileForTests, __resetLoggerFileSinkForTests, enableDaemonLogFile, logger } from '../logger'
+import type { Opencode } from '../opencode'
+import { startResourceMonitor } from '../resources'
+import { createDiagRouter } from '../routes/diag'
+
+let root: string
+const savedEnv = process.env.KORTIX_DAEMON_LOG_FILE
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-diag-'))
+  process.env.KORTIX_DAEMON_LOG_FILE = join(root, 'daemon.log')
+  __resetLoggerFileSinkForTests()
+})
+
+afterEach(async () => {
+  await __flushDaemonLogFileForTests()
+  if (savedEnv === undefined) delete process.env.KORTIX_DAEMON_LOG_FILE
+  else process.env.KORTIX_DAEMON_LOG_FILE = savedEnv
+  __resetLoggerFileSinkForTests()
+  rmSync(root, { recursive: true, force: true })
+})
+
+const fakeOpencode = {
+  getState: () => 'ok',
+  getPid: () => 4242,
+  getActivePort: () => 4097,
+  getInternalUrl: () => 'http://127.0.0.1:4097',
+  getBinaryPath: () => '/opt/kortix/opencode.current',
+} as unknown as Opencode
+
+describe('GET /kortix/diag', () => {
+  const token = 'sandbox-token'
+  const cfg = {
+    sandboxToken: token,
+    workspace: '/workspace',
+    servicePort: 8000,
+    opencodeInternalPort: 4096,
+    opencodeStandbyPort: 4097,
+  } as Config
+
+  test('401 without credentials', async () => {
+    const app = createDiagRouter(cfg, {
+      opencode: fakeOpencode,
+      bootTime: Date.now(),
+      bootState: { repoMaterializationError: null, timeline: [] },
+      opencodeHome: root,
+      resources: () => null,
+    })
+    expect((await app.request('http://d/')).status).toBe(401)
+  })
+
+  test('returns state, resources, runtime report, and both log tails in one document', async () => {
+    enableDaemonLogFile()
+    logger.info('[test] diag-line')
+    await __flushDaemonLogFileForTests()
+    mkdirSync(join(root, '.local', 'share', 'opencode', 'log'), { recursive: true })
+    writeFileSync(join(root, '.local', 'share', 'opencode', 'log', 'opencode.log'), 'oc-line\n')
+    const monitor = startResourceMonitor({ intervalMs: 60_000, opencodePid: () => 4242 })
+    try {
+      const app = createDiagRouter(cfg, {
+        opencode: fakeOpencode,
+        bootTime: Date.now() - 5_000,
+        bootState: { repoMaterializationError: null, timeline: [{ label: 'proxy-up', atMs: 12 }] },
+        opencodeHome: root,
+        resources: () => monitor,
+      })
+      const res = await app.request('http://d/?tail=50', { headers: { Authorization: `Bearer ${token}` } })
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, any>
+      expect(body.opencode).toMatchObject({ state: 'ok', pid: 4242, port: 4097, port_pair: [4096, 4097] })
+      expect(body.daemon.uptime_s).toBeGreaterThanOrEqual(5)
+      expect(body.daemon.daemon_log_file).toBe(join(root, 'daemon.log'))
+      expect(body.boot.timeline).toEqual([{ label: 'proxy-up', atMs: 12 }])
+      expect(body.resources).not.toBeNull()
+      expect(Array.isArray(body.resources.disks)).toBe(true)
+      expect(body.logs.tail).toBe(50)
+      expect(String(body.logs.daemon)).toContain('[test] diag-line')
+      expect(body.logs.opencode).toBe('oc-line\n')
+      // Never a secret dump.
+      expect(JSON.stringify(body)).not.toContain(token)
+    } finally {
+      monitor.stop()
+    }
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/initial-turn-lifecycle.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/initial-turn-lifecycle.test.ts
@@ -180,6 +180,19 @@ describe('daemon-delivered initial turn lifecycle', () => {
     const server = Bun.serve({
       port: 0,
       async fetch(request) {
+        const path = new URL(request.url).pathname;
+        // The routes the probe reads on OpenCode 1.18.23: `msg_new` was never
+        // written to this root, so the by-id read is a 404 `NotFoundError`,
+        // and an idle root is absent from `/session/status`.
+        if (request.method === 'GET' && /\/message\/[^/]+$/.test(path)) {
+          return Response.json(
+            { name: 'NotFoundError', data: { message: 'Message not found: msg_new' } },
+            { status: 404 },
+          );
+        }
+        if (request.method === 'GET' && path.endsWith('/session/status')) {
+          return Response.json({});
+        }
         if (request.method === 'GET') {
           return Response.json([
             { info: { id: 'msg_older', role: 'user' } },

--- a/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/orphaned-turn-finalize.test.ts
@@ -16,7 +16,7 @@ import { afterEach, describe, expect, test } from 'bun:test'
 
 
 import { finalizeOrphanedTurn } from '../main'
-import { inspectOpencodeRoot,
+import { TURN_PROBE_WINDOW, inspectOpencodeRoot,
   observeOpencodeDelivery,
   opencodeDeliveryInFlight,
   opencodeTurnInFlight,
@@ -37,6 +37,7 @@ function stubFetch(
     abortThrows?: boolean;
     sessionStatus?: unknown;
     sessionStatusOk?: boolean;
+    messageByIdOk?: boolean;
   } = {},
 ) {
   calls = []
@@ -52,7 +53,30 @@ function stubFetch(
       return new Response(JSON.stringify(opts.sessionStatus ?? {}), { status: 200 });
     }
     if (opts.messagesOk === false) return new Response('nope', { status: 503 });
-    return new Response(JSON.stringify(messages), { status: 200 });
+    // `GET /session/:id/message/:messageId` — one message by id, 404
+    // `NotFoundError` when the root has no such message (OpenCode 1.18.23).
+    const byId = (url.split('?')[0] ?? '').match(/\/message\/([^/]+)$/);
+    if (byId) {
+      if (opts.messageByIdOk === false) return new Response('nope', { status: 503 });
+      const id = decodeURIComponent(byId[1] ?? '');
+      const hit = Array.isArray(messages)
+        ? (messages as Array<{ info?: { id?: string } }>).find((m) => m.info?.id === id)
+        : undefined;
+      if (!hit) {
+        return new Response(
+          JSON.stringify({ name: 'NotFoundError', data: { message: `Message not found: ${id}` } }),
+          { status: 404 },
+        );
+      }
+      return new Response(JSON.stringify(hit), { status: 200 });
+    }
+    // `GET /session/:id/message?limit=N` — the newest N, chronological.
+    const limit = Number(new URL(url).searchParams.get('limit') ?? '');
+    const page =
+      Array.isArray(messages) && Number.isFinite(limit) && limit > 0
+        ? (messages as unknown[]).slice(-limit)
+        : messages;
+    return new Response(JSON.stringify(page), { status: 200 });
   };
 }
 
@@ -807,5 +831,92 @@ describe('Essentia d1b74954 replay — a streaming turn under a pty wake-up', ()
   test('an unreadable status is unknown — never a licence to end it', async () => {
     stubFetch(incidentTranscript, { sessionStatusOk: false });
     expect(await opencodeDeliveryInFlight(BASE, WORKSPACE, ROOT_2, LIVE_TURN)).toBeNull();
+  });
+});
+
+describe('turn probes read a bounded window, never the whole root', () => {
+  // 2026-08-25, Essentia: one root's full message list was 276.7 MB (inline
+  // base64 image parts). Parsing it never fit the probe budget, the daemon
+  // answered `turn_in_flight: null` on every reaper visit for 2.5 hours after
+  // the turn had finished, and the session showed "working" until the ledger
+  // was settled by hand. `?limit=` keeps the read proportional to the
+  // question; a prompt older than the window is proved by fetching it by id.
+  const stepsAfter = (prompt: string, n: number, last: Record<string, unknown>) => [
+    { info: { id: prompt, role: 'user' } },
+    ...Array.from({ length: n - 1 }, (_, i) => ({
+      info: { id: `msg_step_${i}`, role: 'assistant', parentID: prompt, time: { completed: 1 + i } },
+    })),
+    { info: { id: 'msg_step_last', role: 'assistant', parentID: prompt, ...last } },
+  ];
+
+  test('the list request carries limit=TURN_PROBE_WINDOW', async () => {
+    stubFetch([{ info: { id: 'msg_turn_1', role: 'user' } }]);
+    const raw: string[] = [];
+    const stubbed = globalThis.fetch;
+    (globalThis as { fetch: unknown }).fetch = async (input: unknown, init?: unknown) => {
+      raw.push(String(input));
+      return (stubbed as (i: unknown, n?: unknown) => Promise<Response>)(input, init);
+    };
+    await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1');
+    await inspectOpencodeRoot(BASE, WORKSPACE, SESSION);
+    const lists = raw.filter((u) => /\/message\?/.test(u));
+    expect(lists.length).toBe(2);
+    for (const u of lists) {
+      expect(new URL(u).searchParams.get('limit')).toBe(String(TURN_PROBE_WINDOW));
+    }
+  });
+
+  test("a prompt older than the window is proved by id and its newest step names 'completed'", async () => {
+    // 20 step messages after the prompt: the prompt is outside a 12-message
+    // window. Every message IN the window is after it, so the window alone
+    // answers the "how did it end" question; the by-id read only proves the
+    // prompt reached this root.
+    stubFetch(stepsAfter('msg_turn_1', 20, { time: { completed: 99 } }), {
+      sessionStatus: { [SESSION]: { type: 'idle' } },
+    });
+    expect(await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toEqual({
+      inFlight: false,
+      end: 'completed',
+    });
+    expect(calls).toContain(`GET ${BASE}/session/${SESSION}/message/msg_turn_1`);
+  });
+
+  test('a prompt older than the window whose newest step is still open is in flight while busy', async () => {
+    stubFetch(stepsAfter('msg_turn_1', 20, { time: {} }), {
+      sessionStatus: { [SESSION]: { type: 'busy' } },
+    });
+    expect(await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toEqual({
+      inFlight: true,
+      end: null,
+    });
+  });
+
+  test('a prompt missing from the window AND from the root is abandoned, nothing else is', async () => {
+    stubFetch(stepsAfter('msg_other', 20, { time: { completed: 99 } }), {
+      sessionStatus: { [SESSION]: { type: 'idle' } },
+    });
+    expect(await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toEqual({
+      inFlight: false,
+      end: 'abandoned',
+    });
+  });
+
+  test('a prompt missing from the window stays unreadable when the by-id read fails', async () => {
+    // A 503 on the by-id read is "could not tell", not "never arrived":
+    // calling it abandoned would redeliver a prompt that may be mid-turn.
+    stubFetch(stepsAfter('msg_turn_1', 20, { time: {} }), { messageByIdOk: false });
+    expect(await observeOpencodeDelivery(BASE, WORKSPACE, SESSION, 'msg_turn_1')).toEqual({
+      inFlight: null,
+      end: null,
+    });
+  });
+
+  test('inspectOpencodeRoot: a window of step messages after an older prompt is answered, not orphaned', async () => {
+    stubFetch(stepsAfter('msg_turn_1', 20, { time: {} }));
+    const inspection = await inspectOpencodeRoot(BASE, WORKSPACE, SESSION);
+    expect(inspection.known).toBe(true);
+    expect(inspection.hasMessages).toBe(true);
+    expect(inspection.orphanedPrompt).toBe(false);
+    expect(inspection.lastTurnIncomplete).toBe(true);
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/__tests__/resources.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resources.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Box resource telemetry — the numbers every "the session stopped"
+ * investigation needed and never had on record.
+ */
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  type ResourceSnapshot,
+  cgroupSnapshot,
+  evaluatePressure,
+  parseLoadavg,
+  parseMeminfo,
+  parseProcStatus,
+  readResourceSnapshot,
+  startResourceMonitor,
+} from '../resources'
+
+const MEMINFO = `MemTotal:        3985760 kB
+MemFree:          123456 kB
+MemAvailable:     398576 kB
+Buffers:           10000 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+`
+
+const STATUS = `Name:\topencode.exe
+State:\tS (sleeping)
+Pid:\t2423
+VmRSS:\t 2867200 kB
+Threads:\t41
+`
+
+function snapshot(overrides: Partial<ResourceSnapshot> = {}): ResourceSnapshot {
+  return {
+    at: '2026-08-25T22:00:00.000Z',
+    uptimeS: 100,
+    load: [0.5, 0.4, 0.3],
+    cpus: 2,
+    memory: { totalMb: 3892, availableMb: 2000, usedPct: 49, swapTotalMb: 0, swapFreeMb: 0 },
+    cgroup: { currentMb: 1000, maxMb: 3000, usedPct: 33, oomKills: 0 },
+    disks: [{ path: '/workspace', totalMb: 10000, freeMb: 5000, usedPct: 50 }],
+    daemon: { pid: 451, rssMb: 180, threads: 10, state: 'S' },
+    opencode: { pid: 2423, rssMb: 2800, threads: 41, state: 'S' },
+    opencodePids: [2423],
+    ...overrides,
+  }
+}
+
+describe('parsers', () => {
+  test('meminfo → MB and used% from MemAvailable', () => {
+    const m = parseMeminfo(MEMINFO)
+    expect(m.totalMb).toBe(3892)
+    expect(m.availableMb).toBe(389)
+    expect(m.usedPct).toBe(90)
+    expect(m.swapTotalMb).toBe(0)
+  })
+
+  test('loadavg', () => {
+    expect(parseLoadavg('1.25 0.80 0.40 2/345 6789\n')).toEqual([1.25, 0.8, 0.4])
+    expect(parseLoadavg('garbage')).toBeNull()
+  })
+
+  test('/proc/<pid>/status → rss, threads, state', () => {
+    expect(parseProcStatus(2423, STATUS)).toEqual({ pid: 2423, rssMb: 2800, threads: 41, state: 'S' })
+  })
+
+  test('cgroup v2: "max" is unlimited, oom_kill counter is read', () => {
+    expect(cgroupSnapshot('1073741824\n', 'max\n', 'low 0\nhigh 0\nmax 0\noom 0\noom_kill 2\n')).toEqual({
+      currentMb: 1024,
+      maxMb: null,
+      usedPct: null,
+      oomKills: 2,
+    })
+    expect(cgroupSnapshot('2147483648', '3221225472', null).usedPct).toBe(67)
+  })
+})
+
+describe('evaluatePressure', () => {
+  test('quiet box → no findings', () => {
+    expect(evaluatePressure(snapshot())).toEqual([])
+  })
+
+  test('memory, cgroup, disk, load, duplicate opencode, oom-kill rise are each named', () => {
+    const s = snapshot({
+      memory: { totalMb: 3892, availableMb: 100, usedPct: 97, swapTotalMb: 0, swapFreeMb: 0 },
+      cgroup: { currentMb: 2900, maxMb: 3000, usedPct: 97, oomKills: 3 },
+      disks: [{ path: '/workspace', totalMb: 10000, freeMb: 200, usedPct: 98 }],
+      load: [9, 8, 7],
+      opencodePids: [2423, 7259],
+    })
+    const kinds = evaluatePressure(s, snapshot()).map((f) => f.kind).sort()
+    expect(kinds).toEqual(['cgroup', 'disk', 'load', 'memory', 'oom-kill', 'opencode-duplicates'])
+  })
+
+  test('null fields never produce findings', () => {
+    const s = snapshot({
+      memory: { totalMb: null, availableMb: null, usedPct: null, swapTotalMb: null, swapFreeMb: null },
+      cgroup: { currentMb: null, maxMb: null, usedPct: null, oomKills: null },
+      disks: [{ path: '/x', totalMb: null, freeMb: null, usedPct: null }],
+      load: null,
+      cpus: null,
+      opencodePids: [],
+    })
+    expect(evaluatePressure(s)).toEqual([])
+  })
+})
+
+describe('readResourceSnapshot', () => {
+  test('never throws on a host without /proc; disks come from statfs', async () => {
+    const s = await readResourceSnapshot({ daemonPid: process.pid, opencodePid: null, diskPaths: ['/', '/definitely/missing'] })
+    expect(s.disks).toHaveLength(2)
+    expect(s.disks[0]?.totalMb === null || (s.disks[0]?.totalMb as number) > 0).toBe(true)
+    expect(s.disks[1]).toEqual({ path: '/definitely/missing', totalMb: null, freeMb: null, usedPct: null })
+    expect(s.opencode).toBeNull()
+    expect(typeof s.at).toBe('string')
+  })
+})
+
+describe('startResourceMonitor', () => {
+  let stop: (() => void) | null = null
+  afterEach(() => {
+    stop?.()
+    stop = null
+  })
+
+  test('ticks on start, on demand, and on an opencode state change; pressure logs once per change', async () => {
+    const reasons: string[] = []
+    let state = 'ok'
+    let pressured = false
+    const monitor = startResourceMonitor({
+      intervalMs: 60_000,
+      opencodePid: () => 2423,
+      opencodeState: () => state,
+      snapshot: async () => {
+        return pressured
+          ? snapshot({ memory: { totalMb: 3892, availableMb: 100, usedPct: 97, swapTotalMb: 0, swapFreeMb: 0 } })
+          : snapshot()
+      },
+    })
+    stop = monitor.stop
+    // The start tick is async; wait for it.
+    await Bun.sleep(20)
+    expect(monitor.latest()).not.toBeNull()
+
+    pressured = true
+    const s = await monitor.tick('diag')
+    reasons.push('diag')
+    expect(s.memory.usedPct).toBe(97)
+    expect(monitor.latest()?.memory.usedPct).toBe(97)
+
+    state = 'starting'
+    // The state watcher polls every 5 s; drive a tick directly to keep the test fast.
+    const t = await monitor.tick('opencode ok -> starting')
+    expect(t.memory.usedPct).toBe(97)
+    expect(reasons).toEqual(['diag'])
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload-process.e2e.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload-process.e2e.test.ts
@@ -108,3 +108,94 @@ describe('verified reload process promotion', () => {
     expect((await fetch(`${supervisor.getInternalUrl()}/session`)).status).toBe(200)
   }, 20_000)
 })
+
+describe('the live port is a property of the process, never a variable beside it', () => {
+  // Essentia 2026-08-25: the daemon reported `starting` + `opencode_port: 4096`
+  // for two hours while its own child (pid 2423) served on 4097. `activePort`
+  // had drifted from the process. Now every reader asks the process.
+  function fakeOpencode(): { workspace: string; configDir: string; binary: string } {
+    const workspace = join(root, 'workspace')
+    const configDir = join(root, 'config')
+    const binary = join(root, 'opencode')
+    mkdirSync(workspace)
+    mkdirSync(configDir)
+    writeFileSync(
+      binary,
+      '#!/usr/bin/env bun\nconst port = Number(Bun.argv[Bun.argv.indexOf("--port") + 1])\nBun.serve({ port, hostname: "127.0.0.1", fetch: () => Response.json([]) })\n',
+    )
+    chmodSync(binary, 0o755)
+    return { workspace, configDir, binary }
+  }
+
+  test('reconfigure() with a foreign port pair cannot move the daemon off the port its child serves', async () => {
+    const { workspace, configDir, binary } = fakeOpencode()
+    const primary = reservePort()
+    const standby = reservePort()
+    const cfg = {
+      workspace,
+      projectTarget: workspace,
+      opencodeInternalPort: primary,
+      opencodeStandbyPort: standby,
+      gitUserName: 'Kortix Agent',
+      gitUserEmail: 'agent@kortix.ai',
+    } as Config
+    supervisor = createOpencodeSupervisor(cfg, configDir, undefined, {
+      binaryPathOverride: binary,
+      configPathOverride: join(root, 'runtime-config.json'),
+    })
+    await supervisor.start()
+    expect(await waitForOpencodeReady(supervisor, workspace)).toBe(true)
+
+    const swapped = await supervisor.reloadVerified()
+    expect(swapped.outcome).toBe('swapped')
+    expect(supervisor.getActivePort()).toBe(standby)
+
+    // The only code path that rewrites the port variable without touching the
+    // process: a config whose pair does not contain the live port.
+    supervisor.reconfigure({ ...cfg, opencodeStandbyPort: reservePort() } as Config, configDir)
+
+    expect(supervisor.getActivePort()).toBe(standby)
+    expect(supervisor.getInternalUrl()).toBe(`http://127.0.0.1:${standby}`)
+    expect((await fetch(`${supervisor.getInternalUrl()}/session`)).status).toBe(200)
+    // reconfigure() marks `starting` until the next probe; the probe asks the
+    // process's real port, so it comes back `ok` on its own.
+    await waitFor(() => supervisor?.getState() === 'ok', 5_000)
+  }, 20_000)
+
+  test('a candidate half that already answers is declined, never "proven" by the incumbent', async () => {
+    const { workspace, configDir, binary } = fakeOpencode()
+    const primary = reservePort()
+    const standby = reservePort()
+    const cfg = {
+      workspace,
+      projectTarget: workspace,
+      opencodeInternalPort: primary,
+      opencodeStandbyPort: standby,
+      gitUserName: 'Kortix Agent',
+      gitUserEmail: 'agent@kortix.ai',
+    } as Config
+    supervisor = createOpencodeSupervisor(cfg, configDir, undefined, {
+      binaryPathOverride: binary,
+      configPathOverride: join(root, 'runtime-config.json'),
+    })
+    await supervisor.start()
+    expect(await waitForOpencodeReady(supervisor, workspace)).toBe(true)
+    const livePid = supervisor.getPid()
+
+    // Something else is already serving the session API on the idle half —
+    // the shape a drifted port pair produces (`opencode serve --port <busy>`
+    // exits at once with ServeError, so a candidate there is dead on arrival).
+    const squatter = Bun.serve({ port: standby, hostname: '127.0.0.1', fetch: () => Response.json([]) })
+    try {
+      const result = await supervisor.reloadVerified()
+      expect(result.outcome).toBe('kept-old')
+      if (result.outcome !== 'kept-old') throw new Error('unreachable')
+      expect(result.reason).toContain('already answers')
+      expect(supervisor.getPid()).toBe(livePid)
+      expect(processExists(livePid as number)).toBe(true)
+      expect(supervisor.getActivePort()).toBe(primary)
+    } finally {
+      squatter.stop(true)
+    }
+  }, 20_000)
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/verified-reload.test.ts
@@ -104,8 +104,8 @@ describe('readiness means the session API answers', () => {
       SRC.indexOf('function scheduleReadinessProbe()'),
       SRC.indexOf('\n  return {', SRC.indexOf('function scheduleReadinessProbe()')),
     );
-    expect(probe).toContain('const probedPort = activePort');
-    expect(probe).toContain('if (probedPort !== activePort)');
+    expect(probe).toContain('const probedPort = livePort()');
+    expect(probe).toContain('if (probedPort !== livePort())');
   });
 });
 
@@ -126,7 +126,7 @@ describe('the port pair', () => {
 
   test('chooses the idle half relative to the current active port', () => {
     const body = candidateBody();
-    expect(body).toContain('activePort === currentCfg.opencodeInternalPort');
+    expect(body).toContain('livePort() === currentCfg.opencodeInternalPort');
     expect(body).toContain('currentCfg.opencodeStandbyPort');
   });
 });

--- a/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/llm-proxy.ts
@@ -163,11 +163,16 @@ function createCredentialProxy(name: string, placeholderKey: string): Credential
             // duplex:'half' is required by Bun/undici when a request carries a
             // streaming body; valid at runtime even where the RequestInit type
             // omits it, so build + cast rather than inline.
-            const init: RequestInit & { duplex?: 'half' } = {
+            const init: RequestInit & { duplex?: 'half'; timeout?: false } = {
               method: req.method,
               headers,
               body,
               redirect: 'manual',
+              // Bun's fetch has a default 300 s IDLE timeout (measured on
+              // 1.3.14: `TimeoutError: The operation timed out.` at 300.0 s;
+              // a `signal` does not disable it, `timeout: false` does). The
+              // gateway owns every model-hop timeout; this proxy adds none.
+              timeout: false,
             }
             if (windowed === null && req.body) init.duplex = 'half'
             const upstreamRes = await fetch(target, init)

--- a/apps/kortix-sandbox-agent-server/src/logger.ts
+++ b/apps/kortix-sandbox-agent-server/src/logger.ts
@@ -1,8 +1,280 @@
 /**
- * Structured stdout logger. Keeps output greppable but lets us attach context.
+ * Structured logger: JSON lines to stdout/stderr AND, when enabled, to a file
+ * on the box.
+ *
+ * WHY THE FILE. Under E2B the daemon's stdout goes to envd and is not on disk;
+ * under Daytona/Platinum it goes to the container runtime and is gone with
+ * the container. On 2026-08-25 an Essentia box sat two hours with the daemon
+ * reporting `starting` on port 4096 while its own OpenCode served on 4097.
+ * The daemon log lines that name that transition (`[opencode] candidate
+ * promoted`, `[opencode] reconfigured`) existed only on a stream nobody kept,
+ * so the cause could be fenced but not proven. With the sink on, every line
+ * also lands in `KORTIX_DAEMON_LOG_FILE` (default `/opt/kortix/logs/daemon.log`),
+ * readable through `GET /kortix/logs` and the file API, and it survives daemon
+ * restarts and agent swaps (append).
+ *
+ * THE SINK MUST NEVER HURT THE BOX. The daemon fronts every byte of the
+ * session, so a logger that blocks, grows, or throws is worse than no log:
+ *   - opt-in: `enableDaemonLogFile()` is called by `main()` only. Importing the
+ *     logger (tests, tooling) never touches the disk;
+ *   - never blocks: lines go to an in-memory buffer; one async `appendFile`
+ *     is in flight at a time, on a 250 ms timer or when the buffer passes
+ *     64 KiB. stdout/stderr writes are unchanged;
+ *   - bounded memory: the buffer holds at most 1 MiB. If the disk cannot keep
+ *     up, the OLDEST lines are dropped and counted; the next flush records
+ *     `[logger] dropped N lines` so the gap is visible in the file;
+ *   - bounded lines: a single line is cut at 64 KiB (`…[truncated]`) before
+ *     it enters the buffer, so one oversized ctx cannot balloon the file;
+ *   - bounded disk: past `KORTIX_DAEMON_LOG_MAX_BYTES` (default 32 MiB) the
+ *     file is renamed to `<file>.1`, replacing the previous one — two
+ *     generations, ~64 MiB worst case;
+ *   - never throws, never recurses: every filesystem call is inside try/catch;
+ *     the first I/O error (EACCES, ENOSPC, EROFS, …) disables the sink for
+ *     the rest of the process and writes ONE plain line to stderr — not
+ *     through the logger;
+ *   - best-effort final flush on `process.exit`, synchronous and bounded by
+ *     the buffer cap.
+ *
+ * `KORTIX_DAEMON_LOG_FILE=off` keeps the sink off even when enabled.
  */
+import { appendFile, mkdir, rename, stat } from 'node:fs/promises'
+import { appendFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 
 type Level = 'debug' | 'info' | 'warn' | 'error'
+
+export const DEFAULT_DAEMON_LOG_FILE = '/opt/kortix/logs/daemon.log'
+const DEFAULT_MAX_FILE_BYTES = 32 * 1024 * 1024
+/** Memory the sink may hold while the disk catches up. */
+export const DAEMON_LOG_BUFFER_CAP_BYTES = 1024 * 1024
+/** Flush as soon as this much is pending, otherwise on the timer. */
+const FLUSH_THRESHOLD_BYTES = 64 * 1024
+const FLUSH_INTERVAL_MS = 250
+/** One line is never larger than this in the file. */
+export const DAEMON_LOG_MAX_LINE_BYTES = 64 * 1024
+const TRUNCATION_MARK = '…[truncated]"}\n'
+
+/** The file the daemon appends its log to, or null when the sink is off. */
+export function daemonLogFilePath(): string | null {
+  const raw = process.env.KORTIX_DAEMON_LOG_FILE
+  if (raw === undefined) return DEFAULT_DAEMON_LOG_FILE
+  const value = raw.trim()
+  if (value === '' || value.toLowerCase() === 'off' || value === '0') return null
+  return value
+}
+
+function maxFileBytes(): number {
+  const n = Number(process.env.KORTIX_DAEMON_LOG_MAX_BYTES)
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_FILE_BYTES
+}
+
+interface SinkState {
+  enabled: boolean
+  disabled: boolean
+  path: string | null
+  dirReady: boolean
+  pending: string[]
+  pendingBytes: number
+  dropped: number
+  flushing: boolean
+  timer: ReturnType<typeof setTimeout> | null
+  bytesSinceStat: number
+  exitHookInstalled: boolean
+  /** Bumped on every enable/reset: a flush from an older generation may not
+   *  disable or write into the sink that replaced it. */
+  generation: number
+}
+
+const sink: SinkState = {
+  enabled: false,
+  disabled: false,
+  path: null,
+  dirReady: false,
+  pending: [],
+  pendingBytes: 0,
+  dropped: 0,
+  flushing: false,
+  timer: null,
+  bytesSinceStat: 0,
+  exitHookInstalled: false,
+  generation: 0,
+}
+
+function stderrLine(msg: string, extra: Record<string, unknown>): void {
+  try {
+    process.stderr.write(JSON.stringify({ t: new Date().toISOString(), level: 'warn', msg, ...extra }) + '\n')
+  } catch {
+    // stderr itself failing is not this module's problem to solve
+  }
+}
+
+function disableSink(reason: string, err: unknown, generation = sink.generation): void {
+  if (sink.disabled || generation !== sink.generation) return
+  sink.disabled = true
+  sink.pending = []
+  sink.pendingBytes = 0
+  if (sink.timer) {
+    clearTimeout(sink.timer)
+    sink.timer = null
+  }
+  stderrLine('[logger] file sink disabled', {
+    path: sink.path,
+    reason,
+    err: err instanceof Error ? err.message : String(err),
+  })
+}
+
+/**
+ * Turn the file sink on for this process. Idempotent. Called by `main()`;
+ * tests call it against a tmp path via `KORTIX_DAEMON_LOG_FILE`.
+ */
+export function enableDaemonLogFile(): { path: string | null } {
+  sink.generation++
+  sink.path = daemonLogFilePath()
+  sink.disabled = false
+  sink.dirReady = false
+  sink.enabled = sink.path !== null
+  if (sink.enabled && !sink.exitHookInstalled) {
+    sink.exitHookInstalled = true
+    process.on('exit', flushSyncOnExit)
+  }
+  return { path: sink.path }
+}
+
+function truncateLine(text: string): string {
+  if (text.length <= DAEMON_LOG_MAX_LINE_BYTES) return text
+  return text.slice(0, DAEMON_LOG_MAX_LINE_BYTES - TRUNCATION_MARK.length) + TRUNCATION_MARK
+}
+
+function enqueue(text: string): void {
+  if (!sink.enabled || sink.disabled) return
+  const line = truncateLine(text)
+  sink.pending.push(line)
+  sink.pendingBytes += line.length
+  // Bounded memory: drop the OLDEST lines until under the cap. The count is
+  // written into the file at the next flush so the gap is visible.
+  while (sink.pendingBytes > DAEMON_LOG_BUFFER_CAP_BYTES && sink.pending.length > 1) {
+    const dropped = sink.pending.shift() as string
+    sink.pendingBytes -= dropped.length
+    sink.dropped++
+  }
+  if (sink.pendingBytes >= FLUSH_THRESHOLD_BYTES) {
+    void flush()
+  } else if (!sink.timer) {
+    sink.timer = setTimeout(() => {
+      sink.timer = null
+      void flush()
+    }, FLUSH_INTERVAL_MS)
+    // Never keep the process alive for a log flush.
+    sink.timer.unref?.()
+  }
+}
+
+function takePending(): string {
+  let chunk = ''
+  if (sink.dropped > 0) {
+    chunk +=
+      JSON.stringify({
+        t: new Date().toISOString(),
+        level: 'warn',
+        msg: `[logger] dropped ${sink.dropped} lines: file sink could not keep up`,
+      }) + '\n'
+    sink.dropped = 0
+  }
+  chunk += sink.pending.join('')
+  sink.pending = []
+  sink.pendingBytes = 0
+  return chunk
+}
+
+// Rotation happens BEFORE a write, so the live file always exists after a
+// flush and a reader never sees the gap between rename and next append.
+async function rotateIfNeeded(path: string): Promise<void> {
+  if (sink.bytesSinceStat < FLUSH_THRESHOLD_BYTES) return
+  sink.bytesSinceStat = 0
+  let size = 0
+  try {
+    size = (await stat(path)).size
+  } catch {
+    return
+  }
+  if (size >= maxFileBytes()) await rename(path, `${path}.1`)
+}
+
+async function flush(): Promise<void> {
+  if (sink.flushing || sink.disabled || !sink.enabled || !sink.path) return
+  if (sink.pending.length === 0 && sink.dropped === 0) return
+  sink.flushing = true
+  const path = sink.path
+  const generation = sink.generation
+  try {
+    if (!sink.dirReady) {
+      await mkdir(dirname(path), { recursive: true })
+      if (generation !== sink.generation) return
+      sink.dirReady = true
+    }
+    // Loop: lines enqueued while a write is in flight go out in the next
+    // pass, still with a single write in flight at any time.
+    while (!sink.disabled && generation === sink.generation && (sink.pending.length > 0 || sink.dropped > 0)) {
+      await rotateIfNeeded(path)
+      if (generation !== sink.generation) return
+      const chunk = takePending()
+      await appendFile(path, chunk, { mode: 0o644 })
+      sink.bytesSinceStat += chunk.length
+    }
+  } catch (err) {
+    disableSink('write failed', err, generation)
+  } finally {
+    if (generation === sink.generation) sink.flushing = false
+  }
+}
+
+function flushSyncOnExit(): void {
+  if (!sink.enabled || sink.disabled || !sink.path || !sink.dirReady) return
+  if (sink.pending.length === 0 && sink.dropped === 0) return
+  try {
+    appendFileSync(sink.path, takePending(), { mode: 0o644 })
+  } catch {
+    // exiting anyway
+  }
+}
+
+/** Tests: drain the buffer to disk. */
+export async function __flushDaemonLogFileForTests(): Promise<void> {
+  if (sink.timer) {
+    clearTimeout(sink.timer)
+    sink.timer = null
+  }
+  // A threshold-triggered flush may already be in flight; wait for it, then
+  // drain whatever arrived meanwhile.
+  for (let i = 0; i < 1_000 && sink.flushing; i++) await new Promise((r) => setTimeout(r, 2))
+  await flush()
+  for (let i = 0; i < 1_000 && (sink.flushing || sink.pending.length > 0) && !sink.disabled; i++) {
+    await new Promise((r) => setTimeout(r, 2))
+    await flush()
+  }
+}
+
+/** Tests: forget everything and re-read KORTIX_DAEMON_LOG_FILE on the next enable. */
+export function __resetLoggerFileSinkForTests(): void {
+  if (sink.timer) clearTimeout(sink.timer)
+  sink.generation++
+  sink.enabled = false
+  sink.disabled = false
+  sink.path = null
+  sink.dirReady = false
+  sink.pending = []
+  sink.pendingBytes = 0
+  sink.dropped = 0
+  sink.flushing = false
+  sink.timer = null
+  sink.bytesSinceStat = 0
+}
+
+/** Tests: the sink's current bookkeeping. */
+export function __daemonLogSinkStateForTests(): { pendingBytes: number; dropped: number; disabled: boolean } {
+  return { pendingBytes: sink.pendingBytes, dropped: sink.dropped, disabled: sink.disabled }
+}
 
 function emit(level: Level, msg: string, ctx?: Record<string, unknown> | unknown) {
   const line: Record<string, unknown> = {
@@ -19,8 +291,20 @@ function emit(level: Level, msg: string, ctx?: Record<string, unknown> | unknown
       line.ctx = ctx
     }
   }
-  const sink = level === 'error' || level === 'warn' ? process.stderr : process.stdout
-  sink.write(JSON.stringify(line) + '\n')
+  let text: string
+  try {
+    text = JSON.stringify(line) + '\n'
+  } catch {
+    // A ctx with a cycle or a throwing getter must not take the log line down.
+    text = JSON.stringify({ t: line.t, level, msg, ctx: '[unserializable]' }) + '\n'
+  }
+  const out = level === 'error' || level === 'warn' ? process.stderr : process.stdout
+  out.write(text)
+  try {
+    enqueue(text)
+  } catch (err) {
+    disableSink('enqueue failed', err)
+  }
 }
 
 export const logger = {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -13,7 +13,7 @@ import {
   runGitCredentialHelper,
   scheduleHistoryBackfill,
 } from './git'
-import { logger } from './logger'
+import { enableDaemonLogFile, logger } from './logger'
 import { MonitorRunner, parseMonitorSpecs } from './monitor-runner'
 import {
   catalogIsDegraded,
@@ -104,11 +104,19 @@ async function main() {
   const bootMark = (label: string) => {
     bootState.timeline.push({ label, atMs: Date.now() - bootTime })
   }
+  // The daemon's own log lands on the box from the first line (logger.ts):
+  // under E2B stdout goes to envd and is not on disk, which is why the
+  // 2026-08-25 port desync could be fenced but never proven.
+  const daemonLog = enableDaemonLogFile()
   logger.info('[boot] kortix-sandbox-agent-server starting', {
     servicePort: cfg.servicePort,
     opencodeInternalPort: cfg.opencodeInternalPort,
+    opencodeStandbyPort: cfg.opencodeStandbyPort,
     staticPort: cfg.staticPort,
     autoClone: cfg.autoClone,
+    pid: process.pid,
+    bun: typeof Bun !== 'undefined' ? Bun.version : null,
+    daemonLogFile: daemonLog.path,
   })
 
   // Bring the static web server up first. It only serves files off disk, so it

--- a/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode-turn-state.ts
@@ -35,6 +35,66 @@ export { OPENCODE_SESSION_PIN_PATH } from './runtime-state'
  */
 const OPENCODE_SESSION_ID = /^[A-Za-z0-9_-]{1,128}$/
 
+/**
+ * How many of a root's NEWEST messages a turn probe reads.
+ *
+ * Every probe here used to list the whole root. A root that has run for hours
+ * is not a small list: on 2026-08-25 one Essentia session's list was 276.7 MB
+ * (base64 image parts inline in every assistant message), and parsing it did
+ * not fit the probe's budget. The daemon then answered `turn_in_flight: null`
+ * — "could not tell" — on every reaper visit for 2.5 hours after the turn had
+ * actually finished, the reaper drip-extended the box on that non-answer, and
+ * the session showed "working" until a human settled the ledger by hand.
+ *
+ * OpenCode's `GET /session/:id/message?limit=N` returns the newest N in
+ * chronological order (same tail as the full list; verified on 1.18.23). A
+ * probe only ever asks about the newest user prompt and the assistant
+ * messages after it, so a window is the whole question. Twelve leaves room
+ * for the step messages a busy agent turn writes after one prompt; a prompt
+ * older than the window is proved by fetching that one message by id.
+ */
+export const TURN_PROBE_WINDOW = 12
+/** Twenty newest messages can still be ~26 MB on an image-heavy root. */
+export const TURN_PROBE_TIMEOUT_MS = 20_000
+
+function recentMessagesUrl(baseUrl: string, workspace: string, sessionId: string): string {
+  return (
+    `${baseUrl}/session/${encodeURIComponent(sessionId)}/message` +
+    `?directory=${encodeURIComponent(workspace)}&limit=${TURN_PROBE_WINDOW}`
+  )
+}
+
+/**
+ * Does this message exist on the root? `null` when OpenCode could not be read.
+ *
+ * `GET /session/:id/message/:messageId` is ~400 bytes and answers 404
+ * `NotFoundError` for an unknown id (verified on 1.18.23); it is how a prompt
+ * older than the probe window is told apart from one that never arrived.
+ */
+async function opencodeMessageExists(
+  baseUrl: string,
+  workspace: string,
+  sessionId: string,
+  messageId: string,
+): Promise<boolean | null> {
+  try {
+    const res = await fetch(
+      `${baseUrl}/session/${encodeURIComponent(sessionId)}/message/${encodeURIComponent(messageId)}` +
+        `?directory=${encodeURIComponent(workspace)}`,
+      { signal: AbortSignal.timeout(5_000) },
+    )
+    if (res.status === 404) return false
+    if (!res.ok) return null
+    // Strict on purpose: OpenCode's SPA catch-all answers 200 text/html for a
+    // route it does not have, and a 200 that is not THIS message must not be
+    // read as "the prompt is on record".
+    const body = (await res.json().catch(() => null)) as { info?: { id?: unknown } } | null
+    return body?.info?.id === messageId ? true : null
+  } catch {
+    return null
+  }
+}
+
 export function readPinnedSessionId(): string | null {
   try {
     const id = readFileSync(OPENCODE_SESSION_PIN_PATH, 'utf8').trim()
@@ -90,10 +150,14 @@ export async function inspectOpencodeRoot(
     known: false,
   }
   try {
-    const res = await fetch(
-      `${baseUrl}/session/${encodeURIComponent(sessionId)}/message?directory=${encodeURIComponent(workspace)}`,
-      { signal: AbortSignal.timeout(5_000) },
-    )
+    // Newest TURN_PROBE_WINDOW messages only; see the constant for why the
+    // whole root is never listed here. Everything this inspection derives —
+    // the newest assistant message, the newest prompt, whether that prompt
+    // has an answer — lives at the tail. A window with assistant messages and
+    // no user message means the prompt is older than the window and answered.
+    const res = await fetch(recentMessagesUrl(baseUrl, workspace, sessionId), {
+      signal: AbortSignal.timeout(TURN_PROBE_TIMEOUT_MS),
+    })
     if (!res.ok) return unknown
     const msgs = (await res.json()) as Array<{
       info?: {
@@ -287,10 +351,9 @@ export async function observeOpencodeDelivery(
 ): Promise<OpencodeDeliveryObservation> {
   const unreadable: OpencodeDeliveryObservation = { inFlight: null, end: null }
   try {
-    const response = await fetch(
-      `${baseUrl}/session/${encodeURIComponent(rootSessionId)}/message?directory=${encodeURIComponent(workspace)}`,
-      { signal: AbortSignal.timeout(5_000) },
-    )
+    const response = await fetch(recentMessagesUrl(baseUrl, workspace, rootSessionId), {
+      signal: AbortSignal.timeout(TURN_PROBE_TIMEOUT_MS),
+    })
     if (!response.ok) return unreadable
     const messages = (await response.json()) as Array<{
       info?: {
@@ -308,9 +371,18 @@ export async function observeOpencodeDelivery(
     // The prompt is not in this root at all — it never landed, or opencode lost
     // it across a restart. The reaper asks only after the full delivery grace,
     // so this is a delivery that failed, not one still on the wire.
-    if (userIndex < 0) return { inFlight: false, end: 'abandoned' }
-
-    const after = messages.slice(userIndex + 1)
+    // Not in the window: either the prompt is older than the window (a busy
+    // turn wrote TURN_PROBE_WINDOW+ step messages after it — every message in
+    // the window is then "after" it) or it never reached this root. One cheap
+    // read by id tells them apart; only a proven absence is `abandoned`.
+    let after = messages
+    if (userIndex >= 0) {
+      after = messages.slice(userIndex + 1)
+    } else {
+      const exists = await opencodeMessageExists(baseUrl, workspace, rootSessionId, messageId)
+      if (exists === null) return unreadable
+      if (!exists) return { inFlight: false, end: 'abandoned' }
+    }
     const assistants = after.filter(
       (message) => message.info?.role === 'assistant' && message.info.parentID === messageId,
     )

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -2265,11 +2265,51 @@ export function createOpencodeSupervisor(
       if (ready) {
         if (probedChild) reportReadyResponse(probedChild)
         markReady()
+      } else if (probedChild && (await adoptStrayActivePort(probedPort, probedChild))) {
+        reportReadyResponse(probedChild)
+        markReady()
       } else if (state !== 'starting') {
         state = 'starting'
       }
       scheduleReadinessProbe()
     }, interval)
+  }
+
+  /**
+   * The supervised opencode is alive but not on `activePort`: is it on the
+   * other half of the port pair? Adopt that half when it answers.
+   *
+   * Seen on an Essentia box on 2026-08-25: the daemon reported `starting`,
+   * `opencode_port: 4096`, pid 2423 — and pid 2423 was healthy on 4097
+   * (`/global/health` ok, 2.8 GB RSS, a turn had run to completion on it).
+   * Nothing listened on 4096. The readiness probe asked 4096 every 100 ms for
+   * two hours, the proxy gate 503'd every request, and the control plane
+   * never saw the turn end. The daemon log that would name the transition
+   * was not recoverable from the box, so this is a tripwire as much as a
+   * repair: it logs at error level with both ports and the pid.
+   *
+   * Safe against the verified reload: while a candidate boots on the idle
+   * half, the incumbent still answers on `activePort`, so this branch is
+   * never reached; after promotion `activePort` is the candidate's port and
+   * answers. It only fires when OUR live child answers nowhere but the other
+   * half — a state the supervisor never intends.
+   */
+  async function adoptStrayActivePort(probedPort: number, probedChild: ChildProcess): Promise<boolean> {
+    if (stopping || child !== probedChild) return false
+    if (probedChild.exitCode !== null || probedChild.signalCode !== null) return false
+    const otherPort =
+      probedPort === currentCfg.opencodeInternalPort
+        ? currentCfg.opencodeStandbyPort
+        : currentCfg.opencodeInternalPort
+    if (otherPort === probedPort || !(await checkReady(otherPort))) return false
+    if (stopping || child !== probedChild || activePort !== probedPort) return false
+    activePort = otherPort
+    logger.error('[opencode] active port desynced from the live opencode; adopted the answering half', {
+      staleActivePort: probedPort,
+      adoptedPort: otherPort,
+      pid: probedChild.pid ?? null,
+    })
+    return true
   }
 
   return {

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1699,6 +1699,15 @@ export function createOpencodeSupervisor(
   let currentProjectEnv = projectEnv
   let child: ChildProcess | null = null
   let activePort = cfg.opencodeInternalPort
+  // The port each spawned opencode was told to serve on. THIS is the truth
+  // about where the live process listens; `activePort` is only the plan for the
+  // next spawn. Every reader of the live port goes through livePort(), so the
+  // two can never disagree the way they did on Essentia 2026-08-25 (daemon
+  // `starting` on 4096 for two hours while its own child served on 4097).
+  const childPorts = new WeakMap<ChildProcess, number>()
+  function livePort(): number {
+    return (child ? childPorts.get(child) : undefined) ?? activePort
+  }
   let binaryPath: string | null = null
   let stopping = false
   let restartDelayMs = 500
@@ -1811,7 +1820,7 @@ export function createOpencodeSupervisor(
     bin: string,
     opts: { port?: number; supervise?: boolean } = {},
   ): Promise<ChildProcess> {
-    const port = opts.port ?? activePort
+    const port = opts.port ?? livePort()
     const supervise = opts.supervise !== false
     sweepBunExtractions()
     try {
@@ -1888,6 +1897,7 @@ export function createOpencodeSupervisor(
       stdio: ['ignore', 'inherit', 'inherit'],
       detached: true,
     })
+    childPorts.set(proc, port)
     proc.on('error', (err) => {
       logger.error('[opencode] spawn error', err)
     })
@@ -2076,9 +2086,23 @@ export function createOpencodeSupervisor(
     if (!binaryPath) return { ok: false, reason: 'opencode binary not resolved yet' }
     if (stopping) return { ok: false, reason: 'supervisor is shutting down' }
 
-    const candidatePort = activePort === currentCfg.opencodeInternalPort
+    const candidatePort = livePort() === currentCfg.opencodeInternalPort
       ? currentCfg.opencodeStandbyPort
       : currentCfg.opencodeInternalPort
+    // The idle half must be idle. `opencode serve --port <busy>` exits at once
+    // with ServeError (verified on 1.18.23), but `probeUntilReady` asks the
+    // PORT, not the process: whatever already answers there — the incumbent,
+    // if `activePort` has drifted from where opencode really listens — would
+    // "prove" a candidate that is already dead, and promotion would then kill
+    // the only opencode the box has. Decline instead, loudly.
+    if (await checkReady(candidatePort)) {
+      logger.error('[opencode] candidate port already answers; port pair is desynced, keeping the running instance', {
+        livePort: livePort(),
+        candidatePort,
+        pid: child?.pid ?? null,
+      })
+      return { ok: false, reason: `port ${candidatePort} already answers; the port pair is desynced` }
+    }
     let candidate: ChildProcess
     try {
       candidate = await spawnChild(binaryPath, { port: candidatePort, supervise: false })
@@ -2157,7 +2181,7 @@ export function createOpencodeSupervisor(
     }
   }
 
-  async function checkReady(port = activePort): Promise<boolean> {
+  async function checkReady(port = livePort()): Promise<boolean> {
     return probeOpencodeSessionApi(`http://127.0.0.1:${port}`, currentCfg.projectTarget, 2_000)
   }
 
@@ -2194,7 +2218,7 @@ export function createOpencodeSupervisor(
     if (!written) return false
     try {
       const res = await fetch(
-        `http://127.0.0.1:${activePort}/global/dispose`,
+        `http://127.0.0.1:${livePort()}/global/dispose`,
         { method: 'POST', signal: AbortSignal.timeout(15_000) },
       )
       // Content-type matters: the SPA catch-all also answers 200, so a status
@@ -2250,11 +2274,11 @@ export function createOpencodeSupervisor(
     const interval = state === 'ok' ? READY_LIVENESS_MS : READY_POLL_MS
     readinessTimer = setTimeout(async () => {
       if (stopping) return
-      const probedPort = activePort
+      const probedPort = livePort()
       const probedChild = child
       const ready = await checkReady(probedPort)
       if (stopping) return
-      if (probedPort !== activePort) {
+      if (probedPort !== livePort()) {
         scheduleReadinessProbe()
         return
       }
@@ -2265,9 +2289,6 @@ export function createOpencodeSupervisor(
       if (ready) {
         if (probedChild) reportReadyResponse(probedChild)
         markReady()
-      } else if (probedChild && (await adoptStrayActivePort(probedPort, probedChild))) {
-        reportReadyResponse(probedChild)
-        markReady()
       } else if (state !== 'starting') {
         state = 'starting'
       }
@@ -2275,42 +2296,6 @@ export function createOpencodeSupervisor(
     }, interval)
   }
 
-  /**
-   * The supervised opencode is alive but not on `activePort`: is it on the
-   * other half of the port pair? Adopt that half when it answers.
-   *
-   * Seen on an Essentia box on 2026-08-25: the daemon reported `starting`,
-   * `opencode_port: 4096`, pid 2423 — and pid 2423 was healthy on 4097
-   * (`/global/health` ok, 2.8 GB RSS, a turn had run to completion on it).
-   * Nothing listened on 4096. The readiness probe asked 4096 every 100 ms for
-   * two hours, the proxy gate 503'd every request, and the control plane
-   * never saw the turn end. The daemon log that would name the transition
-   * was not recoverable from the box, so this is a tripwire as much as a
-   * repair: it logs at error level with both ports and the pid.
-   *
-   * Safe against the verified reload: while a candidate boots on the idle
-   * half, the incumbent still answers on `activePort`, so this branch is
-   * never reached; after promotion `activePort` is the candidate's port and
-   * answers. It only fires when OUR live child answers nowhere but the other
-   * half — a state the supervisor never intends.
-   */
-  async function adoptStrayActivePort(probedPort: number, probedChild: ChildProcess): Promise<boolean> {
-    if (stopping || child !== probedChild) return false
-    if (probedChild.exitCode !== null || probedChild.signalCode !== null) return false
-    const otherPort =
-      probedPort === currentCfg.opencodeInternalPort
-        ? currentCfg.opencodeStandbyPort
-        : currentCfg.opencodeInternalPort
-    if (otherPort === probedPort || !(await checkReady(otherPort))) return false
-    if (stopping || child !== probedChild || activePort !== probedPort) return false
-    activePort = otherPort
-    logger.error('[opencode] active port desynced from the live opencode; adopted the answering half', {
-      staleActivePort: probedPort,
-      adoptedPort: otherPort,
-      pid: probedChild.pid ?? null,
-    })
-    return true
-  }
 
   return {
     prefetchBinary() {
@@ -2480,7 +2465,7 @@ export function createOpencodeSupervisor(
       if (!proven.ok) return { outcome: 'kept-old', reason: proven.reason }
 
       const previous = child
-      const previousPort = activePort
+      const previousPort = livePort()
       activePort = proven.port
       child = proven.candidate
       superviseChild(proven.candidate)
@@ -2542,11 +2527,11 @@ export function createOpencodeSupervisor(
     },
 
     getActivePort() {
-      return activePort
+      return livePort()
     },
 
     getInternalUrl() {
-      return `http://127.0.0.1:${activePort}`
+      return `http://127.0.0.1:${livePort()}`
     },
 
     getBinaryPath() {

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -12,6 +12,10 @@ import type { Opencode } from './opencode'
 import { isRepoMaterialized } from './git'
 import { createHealthRouter, type SandboxBootState } from './routes/health'
 import { createRefreshRouter } from './routes/refresh'
+import { createLogsRouter } from './routes/logs'
+import { createDiagRouter } from './routes/diag'
+import { type ResourceMonitor, startResourceMonitor } from './resources'
+import { OPENCODE_HOME } from './opencode'
 import { createAbortRouter } from './routes/abort'
 import { createEnvRouter } from './routes/env'
 import { createGitRouter } from './routes/git'
@@ -43,6 +47,10 @@ const STRIP_RESPONSE_HEADERS = new Set(['transfer-encoding', 'connection'])
 // create handling in the `open` websocket handler below.
 const KORTIX_PTY_WS_PATH_RE = /^\/kortix\/pty(?:\/([^/]+))?\/connect\/?$/
 const KORTIX_USER_CONTEXT_QUERY_PARAM = '__kortix_user_context'
+
+// One per process: the periodic box telemetry (resources.ts). Started by
+// startProxy, read by /kortix/diag. Null in unit tests that build the app only.
+let resourceMonitor: ResourceMonitor | null = null
 
 // Bound on waiting for opencode to respond to a proxied request. Applied only
 // to the wait for the response to arrive (headers), never to a streaming body
@@ -190,6 +198,20 @@ export function buildOpencodeApp(
   const partRouter = createPartRouter(opencode)
   kortixRouter.route('/part', partRouter)
   kortixRouter.route('/part/', partRouter)
+  // /kortix/logs — the daemon's own log file + OpenCode's; see routes/logs.ts.
+  const logsRouter = createLogsRouter(cfg, { opencodeHome: OPENCODE_HOME })
+  kortixRouter.route('/logs', logsRouter)
+  kortixRouter.route('/logs/', logsRouter)
+  // /kortix/diag — the whole error report in one JSON document; see routes/diag.ts.
+  const diagRouter = createDiagRouter(cfg, {
+    opencode,
+    bootTime,
+    bootState,
+    opencodeHome: OPENCODE_HOME,
+    resources: () => resourceMonitor,
+  })
+  kortixRouter.route('/diag', diagRouter)
+  kortixRouter.route('/diag/', diagRouter)
   if (envRouter) {
     kortixRouter.route('/env', envRouter)
     kortixRouter.route('/env/', envRouter)
@@ -475,6 +497,14 @@ export function startProxy(
   // Constructed once, outside reload() — pty state must survive a config
   // hot-swap (warm-snapshot restore) exactly like `opencode`/`bootState` do.
   const ptyRegistry = createPtyRegistry(cfg)
+  // Box telemetry: a `[resources]` log line every minute and on every
+  // opencode state change, `[resources] pressure` when a threshold is crossed.
+  resourceMonitor?.stop()
+  resourceMonitor = startResourceMonitor({
+    opencodePid: () => opencode.getPid(),
+    opencodeState: () => opencode.getState(),
+    diskPaths: [cfg.workspace, '/opt/kortix', '/tmp'],
+  })
   // A staged daemon update must not exit this process while somebody has a
   // terminal open — the PTY dies with the daemon that spawned it. The registry
   // is the only thing that knows, so it answers the question rather than the

--- a/apps/kortix-sandbox-agent-server/src/resources.ts
+++ b/apps/kortix-sandbox-agent-server/src/resources.ts
@@ -1,0 +1,381 @@
+/**
+ * Box resource telemetry: memory, cgroup limit, load, disk, process RSS.
+ *
+ * WHY. Every "the session stopped" investigation on 2026-08-22..25 needed the
+ * same numbers and none were on record: was the box out of memory (a 3 GB
+ * E2B box OOM-killing a 2.8 GB OpenCode), was the disk full, was the daemon
+ * or OpenCode the one growing, what did the load look like when the turn
+ * died. The daemon now logs a `[resources]` line on a fixed cadence, logs
+ * `[resources] pressure` the moment a threshold is crossed (and once more
+ * when it clears), and answers the same snapshot inside `GET /kortix/diag`.
+ *
+ * Cost. One snapshot is ~8 small reads under /proc and /sys plus two
+ * `statfs` calls, all async, all inside try/catch — a field that cannot be
+ * read is `null`, never an error. Nothing here can throw at a caller, and the
+ * interval timer is unref'd so it never keeps the process alive.
+ *
+ * Everything that parses text is a pure function on a string so it is
+ * testable on macOS, where /proc does not exist.
+ */
+import { readFile, readdir, statfs } from 'node:fs/promises'
+import { logger } from './logger'
+
+export interface MemorySnapshot {
+  totalMb: number | null
+  availableMb: number | null
+  /** 0..100, from MemAvailable; null when either input is missing. */
+  usedPct: number | null
+  swapTotalMb: number | null
+  swapFreeMb: number | null
+}
+
+export interface CgroupMemorySnapshot {
+  currentMb: number | null
+  /** null = unlimited ("max") or unreadable. */
+  maxMb: number | null
+  usedPct: number | null
+  /** cgroup v2 `memory.events` oom_kill counter; v1 has no cheap equivalent. */
+  oomKills: number | null
+}
+
+export interface DiskSnapshot {
+  path: string
+  totalMb: number | null
+  freeMb: number | null
+  usedPct: number | null
+}
+
+export interface ProcessSnapshot {
+  pid: number
+  rssMb: number | null
+  threads: number | null
+  /** `State:` letter from /proc/<pid>/status (R, S, D, Z, T) */
+  state: string | null
+}
+
+export interface ResourceSnapshot {
+  at: string
+  uptimeS: number | null
+  load: [number, number, number] | null
+  cpus: number | null
+  memory: MemorySnapshot
+  cgroup: CgroupMemorySnapshot
+  disks: DiskSnapshot[]
+  daemon: ProcessSnapshot | null
+  opencode: ProcessSnapshot | null
+  /** Distinct pids on the box whose cmdline mentions opencode: >1 is a finding. */
+  opencodePids: number[]
+}
+
+const MB = 1024 * 1024
+
+export function parseMeminfo(text: string): MemorySnapshot {
+  const kb = (key: string): number | null => {
+    const m = text.match(new RegExp(`^${key}:\\s+(\\d+)\\s*kB`, 'm'))
+    return m ? Number(m[1]) : null
+  }
+  const totalKb = kb('MemTotal')
+  const availKb = kb('MemAvailable')
+  const toMb = (v: number | null) => (v === null ? null : Math.round(v / 1024))
+  const usedPct =
+    totalKb !== null && availKb !== null && totalKb > 0
+      ? Math.round(((totalKb - availKb) / totalKb) * 100)
+      : null
+  return {
+    totalMb: toMb(totalKb),
+    availableMb: toMb(availKb),
+    usedPct,
+    swapTotalMb: toMb(kb('SwapTotal')),
+    swapFreeMb: toMb(kb('SwapFree')),
+  }
+}
+
+export function parseLoadavg(text: string): [number, number, number] | null {
+  const parts = text.trim().split(/\s+/).slice(0, 3).map(Number)
+  if (parts.length !== 3 || parts.some((n) => !Number.isFinite(n))) return null
+  return [parts[0] as number, parts[1] as number, parts[2] as number]
+}
+
+export function parseProcStatus(pid: number, text: string): ProcessSnapshot {
+  const rss = text.match(/^VmRSS:\s+(\d+)\s*kB/m)
+  const threads = text.match(/^Threads:\s+(\d+)/m)
+  const state = text.match(/^State:\s+(\S)/m)
+  return {
+    pid,
+    rssMb: rss ? Math.round(Number(rss[1]) / 1024) : null,
+    threads: threads ? Number(threads[1]) : null,
+    state: state ? (state[1] as string) : null,
+  }
+}
+
+export function parseCgroupBytes(text: string | null): number | null {
+  if (text === null) return null
+  const v = text.trim()
+  if (v === '' || v === 'max') return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function parseCgroupOomKills(text: string | null): number | null {
+  if (text === null) return null
+  const m = text.match(/^oom_kill\s+(\d+)/m)
+  return m ? Number(m[1]) : null
+}
+
+export function cgroupSnapshot(
+  current: string | null,
+  max: string | null,
+  events: string | null,
+): CgroupMemorySnapshot {
+  const currentBytes = parseCgroupBytes(current)
+  const maxBytes = parseCgroupBytes(max)
+  const currentMb = currentBytes === null ? null : Math.round(currentBytes / MB)
+  const maxMb = maxBytes === null ? null : Math.round(maxBytes / MB)
+  return {
+    currentMb,
+    maxMb,
+    usedPct:
+      currentBytes !== null && maxBytes !== null && maxBytes > 0
+        ? Math.round((currentBytes / maxBytes) * 100)
+        : null,
+    oomKills: parseCgroupOomKills(events),
+  }
+}
+
+async function readText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8')
+  } catch {
+    return null
+  }
+}
+
+async function diskSnapshot(path: string): Promise<DiskSnapshot> {
+  try {
+    const s = await statfs(path)
+    const total = Number(s.blocks) * Number(s.bsize)
+    const free = Number(s.bavail) * Number(s.bsize)
+    return {
+      path,
+      totalMb: Math.round(total / MB),
+      freeMb: Math.round(free / MB),
+      usedPct: total > 0 ? Math.round(((total - free) / total) * 100) : null,
+    }
+  } catch {
+    return { path, totalMb: null, freeMb: null, usedPct: null }
+  }
+}
+
+async function processSnapshot(pid: number | null): Promise<ProcessSnapshot | null> {
+  if (pid === null || !Number.isFinite(pid) || pid <= 0) return null
+  const text = await readText(`/proc/${pid}/status`)
+  if (text === null) return { pid, rssMb: null, threads: null, state: null }
+  return parseProcStatus(pid, text)
+}
+
+/** Pids whose /proc/<pid>/cmdline mentions `opencode`. Linux only; [] elsewhere. */
+export async function findOpencodePids(): Promise<number[]> {
+  let entries: string[]
+  try {
+    entries = await readdir('/proc')
+  } catch {
+    return []
+  }
+  const pids: number[] = []
+  await Promise.all(
+    entries
+      .filter((e) => /^\d+$/.test(e))
+      .map(async (e) => {
+        const cmd = await readText(`/proc/${e}/cmdline`)
+        if (cmd && /opencode/.test(cmd) && /\bserve\b/.test(cmd.replace(/\0/g, ' '))) pids.push(Number(e))
+      }),
+  )
+  return pids.sort((a, b) => a - b)
+}
+
+export interface SnapshotInputs {
+  daemonPid: number
+  opencodePid: number | null
+  diskPaths: string[]
+}
+
+export async function readResourceSnapshot(inputs: SnapshotInputs): Promise<ResourceSnapshot> {
+  const [meminfo, loadavg, uptime, cgCurrent, cgMax, cgEvents, cgV1Usage, cgV1Limit, daemon, opencode, disks, opencodePids] =
+    await Promise.all([
+      readText('/proc/meminfo'),
+      readText('/proc/loadavg'),
+      readText('/proc/uptime'),
+      readText('/sys/fs/cgroup/memory.current'),
+      readText('/sys/fs/cgroup/memory.max'),
+      readText('/sys/fs/cgroup/memory.events'),
+      readText('/sys/fs/cgroup/memory/memory.usage_in_bytes'),
+      readText('/sys/fs/cgroup/memory/memory.limit_in_bytes'),
+      processSnapshot(inputs.daemonPid),
+      processSnapshot(inputs.opencodePid),
+      Promise.all(inputs.diskPaths.map(diskSnapshot)),
+      findOpencodePids(),
+    ])
+  const cgroup =
+    cgCurrent !== null || cgMax !== null
+      ? cgroupSnapshot(cgCurrent, cgMax, cgEvents)
+      : cgroupSnapshot(cgV1Usage, cgV1Limit, null)
+  let cpus: number | null = null
+  try {
+    cpus = (await import('node:os')).cpus().length || null
+  } catch {
+    cpus = null
+  }
+  return {
+    at: new Date().toISOString(),
+    uptimeS: uptime ? Math.round(Number(uptime.split(/\s+/)[0])) || null : null,
+    load: loadavg ? parseLoadavg(loadavg) : null,
+    cpus,
+    memory: meminfo
+      ? parseMeminfo(meminfo)
+      : { totalMb: null, availableMb: null, usedPct: null, swapTotalMb: null, swapFreeMb: null },
+    cgroup,
+    disks,
+    daemon,
+    opencode,
+    opencodePids,
+  }
+}
+
+export interface PressureFinding {
+  kind: 'memory' | 'cgroup' | 'disk' | 'load' | 'opencode-duplicates' | 'oom-kill'
+  detail: string
+}
+
+export const PRESSURE_THRESHOLDS = {
+  memoryUsedPct: 90,
+  cgroupUsedPct: 90,
+  diskUsedPct: 90,
+  /** load1 per cpu */
+  loadPerCpu: 4,
+}
+
+/** Pure: which thresholds does this snapshot cross? */
+export function evaluatePressure(s: ResourceSnapshot, previous?: ResourceSnapshot | null): PressureFinding[] {
+  const out: PressureFinding[] = []
+  if (s.memory.usedPct !== null && s.memory.usedPct >= PRESSURE_THRESHOLDS.memoryUsedPct) {
+    out.push({ kind: 'memory', detail: `box memory ${s.memory.usedPct}% used, ${s.memory.availableMb} MB available` })
+  }
+  if (s.cgroup.usedPct !== null && s.cgroup.usedPct >= PRESSURE_THRESHOLDS.cgroupUsedPct) {
+    out.push({ kind: 'cgroup', detail: `cgroup memory ${s.cgroup.usedPct}% of ${s.cgroup.maxMb} MB limit` })
+  }
+  for (const d of s.disks) {
+    if (d.usedPct !== null && d.usedPct >= PRESSURE_THRESHOLDS.diskUsedPct) {
+      out.push({ kind: 'disk', detail: `${d.path} ${d.usedPct}% used, ${d.freeMb} MB free` })
+    }
+  }
+  if (s.load && s.cpus && s.load[0] / s.cpus >= PRESSURE_THRESHOLDS.loadPerCpu) {
+    out.push({ kind: 'load', detail: `load1 ${s.load[0]} on ${s.cpus} cpu` })
+  }
+  if (s.opencodePids.length > 1) {
+    out.push({ kind: 'opencode-duplicates', detail: `${s.opencodePids.length} opencode serve processes: ${s.opencodePids.join(',')}` })
+  }
+  if (
+    s.cgroup.oomKills !== null &&
+    previous?.cgroup.oomKills !== null &&
+    previous?.cgroup.oomKills !== undefined &&
+    s.cgroup.oomKills > previous.cgroup.oomKills
+  ) {
+    out.push({ kind: 'oom-kill', detail: `cgroup oom_kill rose ${previous.cgroup.oomKills} -> ${s.cgroup.oomKills}` })
+  }
+  return out
+}
+
+export interface ResourceMonitorOptions {
+  intervalMs?: number
+  diskPaths?: string[]
+  opencodePid: () => number | null
+  opencodeState?: () => string
+  snapshot?: (inputs: SnapshotInputs) => Promise<ResourceSnapshot>
+}
+
+export interface ResourceMonitor {
+  stop(): void
+  /** The most recent snapshot, or null before the first tick. */
+  latest(): ResourceSnapshot | null
+  /** Take one now (also logs it). */
+  tick(reason: string): Promise<ResourceSnapshot>
+}
+
+export const DEFAULT_RESOURCE_INTERVAL_MS = 60_000
+export const DEFAULT_DISK_PATHS = ['/workspace', '/opt/kortix', '/tmp']
+
+/**
+ * Log a `[resources]` line every `intervalMs` (default 60 s), and a
+ * `[resources] pressure` warning when a threshold is first crossed / cleared.
+ * Also logs immediately when the OpenCode state string changes, so a
+ * `starting`/`down` transition always has the box numbers next to it.
+ */
+export function startResourceMonitor(opts: ResourceMonitorOptions): ResourceMonitor {
+  const intervalMs = opts.intervalMs ?? DEFAULT_RESOURCE_INTERVAL_MS
+  const diskPaths = opts.diskPaths ?? DEFAULT_DISK_PATHS
+  const snapshot = opts.snapshot ?? readResourceSnapshot
+  let latest: ResourceSnapshot | null = null
+  let lastPressureKinds = ''
+  let lastState = opts.opencodeState?.() ?? ''
+  let ticking = false
+  let stopped = false
+
+  async function tick(reason: string): Promise<ResourceSnapshot> {
+    const s = await snapshot({ daemonPid: process.pid, opencodePid: opts.opencodePid(), diskPaths })
+    try {
+      const findings = evaluatePressure(s, latest)
+      const kinds = findings.map((f) => f.kind).sort().join(',')
+      logger.info('[resources]', { reason, opencodeState: opts.opencodeState?.() ?? null, ...s })
+      if (kinds !== lastPressureKinds) {
+        if (findings.length > 0) {
+          logger.warn('[resources] pressure', { findings, opencodeState: opts.opencodeState?.() ?? null })
+        } else {
+          logger.info('[resources] pressure cleared', { previously: lastPressureKinds })
+        }
+        lastPressureKinds = kinds
+      }
+    } catch {
+      // telemetry must never throw
+    }
+    latest = s
+    return s
+  }
+
+  async function guardedTick(reason: string): Promise<void> {
+    if (ticking || stopped) return
+    ticking = true
+    try {
+      await tick(reason)
+    } catch {
+      // never
+    } finally {
+      ticking = false
+    }
+  }
+
+  const timer = setInterval(() => void guardedTick('interval'), intervalMs)
+  timer.unref?.()
+  // State transitions get their own snapshot within 5 s.
+  const stateTimer = opts.opencodeState
+    ? setInterval(() => {
+        const now = opts.opencodeState?.() ?? ''
+        if (now !== lastState) {
+          const from = lastState
+          lastState = now
+          void guardedTick(`opencode ${from || '?'} -> ${now}`)
+        }
+      }, 5_000)
+    : null
+  stateTimer?.unref?.()
+  void guardedTick('start')
+
+  return {
+    stop() {
+      stopped = true
+      clearInterval(timer)
+      if (stateTimer) clearInterval(stateTimer)
+    },
+    latest: () => latest,
+    tick,
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/routes/diag.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/diag.ts
@@ -1,0 +1,104 @@
+/**
+ * GET /kortix/diag — one call, the whole error report.
+ *
+ * Everything an incident needs from a box, in one JSON document:
+ *   - the daemon's view of OpenCode (state, pid, port, boot phase, timeline)
+ *   - a fresh resource snapshot (memory, cgroup, load, disk, RSS, duplicate
+ *     opencode processes) plus the last periodic one
+ *   - the runtime-assets convergence report (which build of what is live)
+ *   - the tail of the daemon log and of OpenCode's log (`?tail=N`, default
+ *     200, max 2000 — the plain-text `/kortix/logs` route serves more)
+ *   - process/runtime identity: daemon pid, Bun version, uptime, workspace
+ *
+ * Nothing secret: no env dump, no tokens. Same auth as `/kortix/logs`.
+ */
+import { Hono } from 'hono'
+import type { Config } from '../config'
+import { KORTIX_USER_CONTEXT_HEADER, verifyKortixUserContext } from '../kortix-user-context'
+import { daemonLogFilePath, logger } from '../logger'
+import type { Opencode } from '../opencode'
+import type { ResourceMonitor } from '../resources'
+import { runtimeConvergenceReport } from '../runtime-assets'
+import type { SandboxBootState } from './health'
+import { opencodeLogFilePath, tailFile } from './logs'
+
+const DEFAULT_DIAG_TAIL = 200
+const MAX_DIAG_TAIL = 2_000
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith('Bearer ')) return null
+  return header.slice('Bearer '.length).trim() || null
+}
+
+export interface DiagDeps {
+  opencode: Opencode
+  bootTime: number
+  bootState: SandboxBootState
+  opencodeHome: string
+  resources: () => ResourceMonitor | null
+}
+
+export function createDiagRouter(cfg: Config, deps: DiagDeps): Hono {
+  const router = new Hono()
+
+  router.get('/', async (c) => {
+    if (!cfg.sandboxToken) {
+      return c.json({ error: 'daemon not configured', detail: 'KORTIX_TOKEN unset' }, 503)
+    }
+    const serviceAuthenticated = bearerToken(c.req.header('Authorization')) === cfg.sandboxToken
+    if (!serviceAuthenticated) {
+      const auth = verifyKortixUserContext(c.req.header(KORTIX_USER_CONTEXT_HEADER), cfg.sandboxToken)
+      if (!auth.ok) {
+        logger.warn('[diag] reject', { reason: auth.reason })
+        return c.json({ error: 'unauthorized', reason: auth.reason }, 401)
+      }
+    }
+    const n = Number(c.req.query('tail'))
+    const tail = Number.isFinite(n) && n > 0 ? Math.min(Math.floor(n), MAX_DIAG_TAIL) : DEFAULT_DIAG_TAIL
+
+    const monitor = deps.resources()
+    const [resourcesNow, runtime] = await Promise.all([
+      monitor ? monitor.tick('diag').catch(() => null) : Promise.resolve(null),
+      runtimeConvergenceReport().catch((err) => ({ error: err instanceof Error ? err.message : String(err) })),
+    ])
+    const daemonLog = daemonLogFilePath()
+    const opencodeLog = opencodeLogFilePath(deps.opencodeHome)
+
+    return c.json({
+      at: new Date().toISOString(),
+      daemon: {
+        pid: process.pid,
+        bun: typeof Bun !== 'undefined' ? Bun.version : null,
+        uptime_s: Math.floor((Date.now() - deps.bootTime) / 1000),
+        workspace: cfg.workspace,
+        service_port: cfg.servicePort,
+        daemon_log_file: daemonLog,
+      },
+      opencode: {
+        state: deps.opencode.getState(),
+        pid: deps.opencode.getPid(),
+        port: deps.opencode.getActivePort(),
+        internal_url: deps.opencode.getInternalUrl(),
+        binary: deps.opencode.getBinaryPath(),
+        port_pair: [cfg.opencodeInternalPort, cfg.opencodeStandbyPort],
+        session_id: deps.bootState.initialOpenCodeSessionId ?? null,
+        log_file: opencodeLog,
+      },
+      boot: {
+        repo_materialization_error: deps.bootState.repoMaterializationError,
+        initial_session_error: deps.bootState.initialOpenCodeSessionError ?? null,
+        timeline: deps.bootState.timeline,
+      },
+      resources: resourcesNow,
+      resources_previous: monitor?.latest() ?? null,
+      runtime,
+      logs: {
+        tail,
+        daemon: daemonLog ? tailFile(daemonLog, tail) : null,
+        opencode: tailFile(opencodeLog, tail),
+      },
+    })
+  })
+
+  return router
+}

--- a/apps/kortix-sandbox-agent-server/src/routes/logs.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/logs.ts
@@ -13,7 +13,7 @@
  * verified user context for a principal who can see this session.
  */
 import { Hono } from 'hono'
-import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs'
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Config } from '../config'
 import { KORTIX_USER_CONTEXT_HEADER, verifyKortixUserContext } from '../kortix-user-context'
@@ -32,12 +32,19 @@ export function opencodeLogFilePath(home: string): string {
 
 /** The last `lines` lines of a file, reading only its tail. Null when absent. */
 export function tailFile(path: string, lines: number): string | null {
-  if (!existsSync(path)) return null
-  const size = statSync(path).size
-  const span = Math.min(size, TAIL_READ_CAP)
-  if (span === 0) return ''
-  const fd = openSync(path, 'r')
+  // Open first, then fstat the descriptor: no exists/stat-then-open window
+  // (the file can rotate underneath a reader at any time).
+  let fd: number
   try {
+    fd = openSync(path, 'r')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+  try {
+    const size = fstatSync(fd).size
+    const span = Math.min(size, TAIL_READ_CAP)
+    if (span === 0) return ''
     const buf = Buffer.alloc(span)
     readSync(fd, buf, 0, span, size - span)
     let text = buf.toString('utf8')

--- a/apps/kortix-sandbox-agent-server/src/routes/logs.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/logs.ts
@@ -1,0 +1,110 @@
+/**
+ * GET /kortix/logs — the daemon's own log and OpenCode's, from the box.
+ *
+ * `?source=daemon` (default) tails the daemon log file (see logger.ts),
+ * `?source=opencode` tails OpenCode's `~/.local/share/opencode/log/opencode.log`,
+ * `?source=all` returns both, each under a `==> <path> <==` header.
+ * `?tail=N` (default 500, max 5000) is the number of lines from the end.
+ *
+ * Plain text, so `curl … | grep` works. Reachable through the API's sandbox
+ * proxy (`/v1/p/<external_id>/8000/kortix/logs`) — the proxy authenticates
+ * with the sandbox service key and stamps the user context, exactly like
+ * `/kortix/refresh`, so the gate is the same one: the service bearer, or a
+ * verified user context for a principal who can see this session.
+ */
+import { Hono } from 'hono'
+import { closeSync, existsSync, openSync, readSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import type { Config } from '../config'
+import { KORTIX_USER_CONTEXT_HEADER, verifyKortixUserContext } from '../kortix-user-context'
+import { daemonLogFilePath, logger } from '../logger'
+
+export const DEFAULT_TAIL_LINES = 500
+export const MAX_TAIL_LINES = 5_000
+/** Read at most this many bytes from the end of a file for one tail. */
+const TAIL_READ_CAP = 4 * 1024 * 1024
+
+export type LogSource = 'daemon' | 'opencode'
+
+export function opencodeLogFilePath(home: string): string {
+  return join(home, '.local', 'share', 'opencode', 'log', 'opencode.log')
+}
+
+/** The last `lines` lines of a file, reading only its tail. Null when absent. */
+export function tailFile(path: string, lines: number): string | null {
+  if (!existsSync(path)) return null
+  const size = statSync(path).size
+  const span = Math.min(size, TAIL_READ_CAP)
+  if (span === 0) return ''
+  const fd = openSync(path, 'r')
+  try {
+    const buf = Buffer.alloc(span)
+    readSync(fd, buf, 0, span, size - span)
+    let text = buf.toString('utf8')
+    if (span < size) {
+      // Started mid-line: drop the partial first line.
+      const nl = text.indexOf('\n')
+      text = nl >= 0 ? text.slice(nl + 1) : ''
+    }
+    const parts = text.split('\n')
+    if (parts[parts.length - 1] === '') parts.pop()
+    return parts.slice(-lines).join('\n') + (parts.length ? '\n' : '')
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function parseTail(raw: string | undefined): number {
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_TAIL_LINES
+  return Math.min(Math.floor(n), MAX_TAIL_LINES)
+}
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith('Bearer ')) return null
+  return header.slice('Bearer '.length).trim() || null
+}
+
+export function createLogsRouter(cfg: Config, opts: { opencodeHome: string }): Hono {
+  const router = new Hono()
+
+  router.get('/', (c) => {
+    if (!cfg.sandboxToken) {
+      return c.json({ error: 'daemon not configured', detail: 'KORTIX_TOKEN unset' }, 503)
+    }
+    const serviceAuthenticated = bearerToken(c.req.header('Authorization')) === cfg.sandboxToken
+    if (!serviceAuthenticated) {
+      const auth = verifyKortixUserContext(c.req.header(KORTIX_USER_CONTEXT_HEADER), cfg.sandboxToken)
+      if (!auth.ok) {
+        logger.warn('[logs] reject', { reason: auth.reason })
+        return c.json({ error: 'unauthorized', reason: auth.reason }, 401)
+      }
+    }
+
+    const requested = (c.req.query('source') ?? 'daemon').trim().toLowerCase()
+    if (requested !== 'daemon' && requested !== 'opencode' && requested !== 'all') {
+      return c.json({ error: 'unknown source', detail: 'source must be daemon, opencode, or all' }, 400)
+    }
+    const lines = parseTail(c.req.query('tail'))
+    const sources: LogSource[] = requested === 'all' ? ['daemon', 'opencode'] : [requested]
+
+    const chunks: string[] = []
+    let found = 0
+    for (const source of sources) {
+      const path = source === 'daemon' ? daemonLogFilePath() : opencodeLogFilePath(opts.opencodeHome)
+      const label = path ?? '(daemon file sink disabled: KORTIX_DAEMON_LOG_FILE=off)'
+      const body = path ? tailFile(path, lines) : null
+      if (body !== null) found++
+      if (sources.length > 1) chunks.push(`==> ${label} <==\n`)
+      chunks.push(body ?? `(no log file at ${label})\n`)
+    }
+    const status = found === 0 ? 404 : 200
+    return c.text(chunks.join(''), status, {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-kortix-log-tail': String(lines),
+    })
+  })
+
+  return router
+}

--- a/apps/web/content/docs/work/runtime.mdx
+++ b/apps/web/content/docs/work/runtime.mdx
@@ -121,6 +121,8 @@ The `kortix-agent` binary runs as PID 1's child and fronts OpenCode on `KORTIX_S
 | `POST /kortix/abort` | Abort the current run. |
 | `POST /kortix/env` | Update the runtime environment. |
 | `/kortix/pty` | Backs the in-dashboard terminal. |
+| `GET /kortix/logs` | Tails the daemon's own log file (`/opt/kortix/logs/daemon.log`, rotated at 32 MiB) or OpenCode's. `?source=daemon\|opencode\|all`, `?tail=N` (default 500, max 5000). Plain text. Same auth as `/kortix/refresh`. |
+| `GET /kortix/diag` | One JSON error report: OpenCode state/pid/port/port pair, boot timeline, a fresh resource snapshot (memory, cgroup limit, load, disk, RSS, duplicate opencode processes), the runtime-assets report, and the tail of both logs (`?tail=N`, default 200). Same auth as `/kortix/logs`. |
 | `/proxy/{port}/*` | Reverse-proxy to another port inside the sandbox. The daemon's own port is blocked. |
 | `*` | Catch-all reverse-proxy to OpenCode on `127.0.0.1:4096`. Returns `503` while OpenCode boots. |
 

--- a/packages/llm-gateway/src/pipeline/simple-handler.ts
+++ b/packages/llm-gateway/src/pipeline/simple-handler.ts
@@ -1,3 +1,4 @@
+import { upstreamFetch } from '../upstream-fetch';
 import type {
   AuthedPrincipal,
   AuthorizeResult,
@@ -390,7 +391,10 @@ export async function handleChatCompletions(
   const streaming = body.stream === true;
   if (streaming) body.stream_options = { include_usage: true };
   const dispatchFetch = withUpstreamHeadersTimeout(
-    fetchImpl ?? ((input, init) => globalThis.fetch(input, init)),
+    // upstreamFetch, never bare globalThis.fetch: Bun's default 300 s idle
+    // timeout would end a silent `max`-effort reasoning stretch with
+    // `TimeoutError: The operation timed out.` (see upstream-fetch.ts).
+    fetchImpl ?? upstreamFetch,
     upstreamHeadersTimeoutMs(body, descriptor, streaming),
   );
   // The descriptor actually served — swapped for its inference-profile twin

--- a/packages/llm-gateway/src/transports/ai-sdk/index.ts
+++ b/packages/llm-gateway/src/transports/ai-sdk/index.ts
@@ -1,3 +1,4 @@
+import { upstreamFetch } from '../../upstream-fetch';
 import { CATALOG, catalogModelForWireModel } from '@kortix/llm-catalog';
 import { InvalidPromptError, generateText, streamText } from 'ai';
 import type { UpstreamDescriptor } from '../../domain';
@@ -237,7 +238,7 @@ export async function callUpstreamViaAiSdk(
     // Always wrapped — see guardEmptyChoicesFetch's doc comment — regardless
     // of whether the caller supplied its own fetchImpl (tests) or this falls
     // through to the platform default (production).
-    fetch: guardEmptyChoicesFetch(opts.fetch ?? ((input, init) => globalThis.fetch(input, init))),
+    fetch: guardEmptyChoicesFetch(opts.fetch ?? upstreamFetch),
     // Kortix-internal correlation id, mirrored onto the upstream request as a
     // best-effort header — every provider here tolerates unknown headers.
     // This is the ai-sdk-engine equivalent of what the retired native

--- a/packages/llm-gateway/src/upstream-fetch.test.ts
+++ b/packages/llm-gateway/src/upstream-fetch.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { upstreamFetch, withoutIdleTimeout } from './upstream-fetch';
+
+describe('upstreamFetch — Bun idle timeout is switched off on every provider call', () => {
+  // Measured on Bun 1.3.14 (2026-08-25): the runtime's default fetch idle
+  // timeout is 300 s, a caller `signal` does not disable it, `timeout: false`
+  // does. A `max`-effort reasoning stretch on codex/gpt-5.6-sol died at
+  // 273.8 s with "The operation timed out." because of it.
+  test('withoutIdleTimeout keeps every caller option and adds timeout:false', () => {
+    const signal = new AbortController().signal;
+    const init = withoutIdleTimeout({ method: 'POST', headers: { a: 'b' }, signal });
+    expect(init.timeout).toBe(false);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({ a: 'b' });
+    expect(init.signal).toBe(signal);
+  });
+
+  test('withoutIdleTimeout tolerates a missing init', () => {
+    expect(withoutIdleTimeout()).toEqual({ timeout: false });
+  });
+
+  test('upstreamFetch forwards timeout:false to the platform fetch', async () => {
+    const original = globalThis.fetch;
+    const seen: unknown[] = [];
+    (globalThis as { fetch: unknown }).fetch = async (_input: unknown, init?: unknown) => {
+      seen.push(init);
+      return new Response('ok');
+    };
+    try {
+      await upstreamFetch('http://127.0.0.1:1/x', { method: 'GET' });
+    } finally {
+      globalThis.fetch = original;
+    }
+    expect(seen).toEqual([{ method: 'GET', timeout: false }]);
+  });
+
+  test('Bun accepts timeout:false on a real request', async () => {
+    // A runtime that rejected the option would throw here, and the whole
+    // reason this module exists is a runtime-specific extension.
+    const server = Bun.serve({ port: 0, fetch: () => new Response('pong') });
+    try {
+      const res = await upstreamFetch(`http://127.0.0.1:${server.port}/`);
+      expect(await res.text()).toBe('pong');
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/llm-gateway/src/upstream-fetch.ts
+++ b/packages/llm-gateway/src/upstream-fetch.ts
@@ -1,0 +1,41 @@
+/**
+ * The platform `fetch`, with Bun's hidden idle timeout switched off.
+ *
+ * Bun's `fetch` carries a default 300 s IDLE timeout on the socket that no
+ * caller asked for and that the Fetch API does not describe. Measured on Bun
+ * 1.3.14 (2026-08-25):
+ *   - upstream sends headers, then nothing: throws at 300.0 s with
+ *     `TimeoutError: The operation timed out.`;
+ *   - upstream sends no headers at all: same, at 300.0 s;
+ *   - upstream drips a byte every 60 s: lives past 420 s — the timer is idle
+ *     time, not total time;
+ *   - a caller-provided `signal` does NOT disable it;
+ *   - `timeout: false` (or `0`) does.
+ *
+ * Incident: an Essentia turn on `codex/gpt-5.6-sol` at reasoning effort `max`
+ * died after 273.8 s with `{"message":"The operation timed out.","code":
+ * "upstream_timeout"}` — the provider was still thinking, silently, and the
+ * gateway's fetch to it was killed by this timer. Nothing in this repo set a
+ * 300 s timer; nothing in this repo could have logged one.
+ *
+ * The gateway owns every timeout on the provider hop explicitly: response
+ * headers (`withUpstreamHeadersTimeout`, 90 s direct / 5 min synthetic
+ * streaming) and body inactivity (`relayStream`, 90 min). A hidden third one
+ * makes those two a lie, so every upstream call goes through here.
+ *
+ * `timeout` is a Bun-only `RequestInit` extension; Node's undici ignores an
+ * unknown key, so this is safe under both runtimes.
+ */
+export type UpstreamFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface NoIdleTimeoutInit extends RequestInit {
+  /** Bun: `false` disables the runtime's default 300 s idle timeout. */
+  timeout: false;
+}
+
+export function withoutIdleTimeout(init?: RequestInit): NoIdleTimeoutInit {
+  return { ...init, timeout: false };
+}
+
+export const upstreamFetch: UpstreamFetch = (input, init) =>
+  globalThis.fetch(input, withoutIdleTimeout(init));


### PR DESCRIPTION
Two more causes of "the session stopped / shows working forever", both found on Essentia on 2026-08-25 and both reproduced with measurements — plus the observability that was missing when we tried to prove the third.

## 1. Turn probe listed the whole OpenCode root (daemon)

The reaper asks `GET /kortix/health?turn=1&turn_session_id&turn_message_id` and acts on `turn_in_flight`. The daemon answered by fetching the root's **entire** message list inside a 5 s budget. On session `9c8749ac` that list is **276.7 MB** (inline base64 image parts; `?limit=20` alone is 26 MB). The probe never fit, the daemon answered `turn_in_flight: null` on every visit for 2.5 h after OpenCode had finished the turn (`exiting loop` 21:00:18Z), the reaper drip-extended on the non-answer, and the session rendered "working" until the ledger row was settled by hand. A second root (`9df2a873`, 140 MB) was unreadable the same way while genuinely busy — past the 240-min grant that box would have been stopped mid-turn.

- `observeOpencodeDelivery` / `inspectOpencodeRoot` read the newest `TURN_PROBE_WINDOW` (12) messages via `?limit=` (newest N, chronological — verified on OpenCode 1.18.23) with a 20 s budget.
- A prompt older than the window is proved by `GET /session/:id/message/:id` (~400 bytes; 404 `NotFoundError` when absent). A 200 must carry `info.id` or it is unreadable — the SPA catch-all answers 200 text/html for unknown routes.

## 2. The live OpenCode port is a property of the process, not a variable beside it (daemon)

Same box, same day: the daemon reported `starting` + `opencode_port: 4096` for 2 h while its own child (pid 2423) served on 4097; every prompt 503'd and no turn end was ever observed. Running two OpenCodes and promoting the proven one (the verified reload) is by design; a bookkeeping variable (`activePort`) that can drift from the process is not.

- `childPorts` (WeakMap) stamps the port on every spawned process; `livePort()` is what every reader (readiness probe, proxy URL, dispose, candidate-port choice, promotion) now asks. `reconfigure()` — the only path that rewrote the variable without touching the process — cannot move the daemon off the port its child serves (e2e test).
- The verifier declines when the candidate half already answers: `opencode serve --port <busy>` exits at once with `ServeError` (verified on the box), so the incumbent would otherwise "prove" a dead candidate and promotion would kill the only OpenCode the box has (e2e test with a squatter on the idle half).

## 3. Bun's hidden 300 s fetch idle timeout (gateway, API relay, box llm-proxy)

Session `9c27242e`, 22:04Z: a `codex/gpt-5.6-sol` turn at effort `max` died after 273.8 s with `{"message":"The operation timed out.","code":"upstream_timeout"}`. Nothing in this repo sets a 300 s timer. Measured on Bun 1.3.14 (`bun-idle.ts`, `bun-idle2.ts`):

| upstream behaviour | fetch outcome |
|---|---|
| sends no headers | `TimeoutError "The operation timed out."` at 300.0 s |
| headers, then silence | same, 300.0 s |
| a byte every 60 s | resolves at 420 s (idle timer, not total) |
| silence + caller `signal` | still throws at 300.0 s |
| silence + `timeout: false` / `0` | alive at 480 s (harness kill) |

- `packages/llm-gateway/src/upstream-fetch.ts`: `upstreamFetch` (`timeout: false`) replaces bare `globalThis.fetch` in `callUpstream`'s dispatch and the AI-SDK transport.
- `apps/api/src/llm-gateway/wire.ts` and the box `llm-proxy.ts` pass `timeout: false` too.
- The gateway's explicit budgets (headers 90 s / 5 min synthetic, body inactivity 90 min) are now the only timeouts on the model path.

## 4. Observability: the daemon log is on the box, with resources and one-call diag

The port desync above could be fenced but not proven: under E2B the daemon's stdout goes to envd and is not on disk.

- **Daemon log file** (`logger.ts`): every line also lands in `KORTIX_DAEMON_LOG_FILE` (default `/opt/kortix/logs/daemon.log`), rotated at 32 MiB to `.1`. Built so it cannot hurt the box: opt-in from `main()` only; async buffered writes with one in-flight flush; 1 MiB memory cap dropping oldest lines (counted and recorded in the file); 64 KiB per-line cap; permanent self-disable on the first I/O error with one stderr line; a stale flush from an earlier generation can never disable a re-enabled sink; unref'd timers; best-effort sync flush on exit.
- **`GET /kortix/logs?source=daemon|opencode|all&tail=N`** — plain-text tail of the daemon log and/or OpenCode's, through the sandbox proxy (`/v1/p/<external_id>/8000/kortix/logs`). Same auth as `/kortix/refresh`.
- **Resource telemetry** (`resources.ts`): `[resources]` every 60 s and on every OpenCode state change — box memory, cgroup usage/limit + `oom_kill` counter, load, cpus, disk on `/workspace` + `/opt/kortix` + `/tmp`, daemon and OpenCode RSS/threads/state, and every `opencode serve` pid on the box (>1 is a finding). `[resources] pressure` once when a threshold is crossed, once when it clears. All reads async, all null-on-failure, never throws.
- **`GET /kortix/diag?tail=N`** — one JSON error report: OpenCode state/pid/port/port pair/binary, boot timeline, fresh + previous resource snapshot, runtime-assets report, both log tails, daemon pid/Bun version/uptime. No env dump, no tokens.
- Docs: `apps/web/content/docs/work/runtime.mdx` control-surface table.

## Verification

- `apps/kortix-sandbox-agent-server`: `bun test` — full suite green (see last commit); `tsc --noEmit` clean. New tests: bounded-window probe semantics; `livePort` under a foreign `reconfigure()`; squatter on the idle half → `kept-old`; logger sink (opt-in, JSON lines, truncation, memory cap + drop record, rotation, unwritable path, `off`, cyclic ctx); `/kortix/logs`; `/kortix/diag`; resource parsers, pressure evaluation, monitor.
- `packages/llm-gateway`: `bun test` 319 pass; `tsc` clean. `upstream-fetch.test.ts` asserts the option is forwarded and that Bun accepts it on a real request.
- `apps/api`: `tsc --noEmit` clean.
- Live: session `9c8749ac` — daemon refreshed to `ok`, turn `6d2bb94e` settled `completed`; OpenCode confirmed idle & message completed. `9df2a873` confirmed genuinely `busy` (real 1.5 h turn), probe unreadable until this ships.

Learnings appended (`SKILL.md`: "A turn probe never lists the whole root", "Bun's fetch has a hidden 300 s idle timeout").

### Real-box proof (local stack, Platinum)

Two fresh sessions on the worktree stack (`POST /projects/provision` → `POST …/sessions` → `/start` until `ready`), then through the sandbox proxy `/v1/p/<external_id>/8000/…` with the user JWT:

- `sbx_01M0XJQDFQV6KS5CM7V55TSTX0`: `/kortix/health` ok in 15 s; `/kortix/logs?source=daemon&tail=5` → 200 with `[boot] …`, `[resources] reason:"opencode starting -> ok" load:[0.07,0.02,0] cpus:2 memory:{totalMb:39…}`, `[runtime-assets] reconcile complete`; `source=all` → 200, `source=nope` → 400, no auth → 401.
- second box: `/kortix/diag?tail=40` → `daemon {pid:148, bun:"1.3.14", daemon_log_file:"/opt/kortix/logs/daemon.log"}`, `opencode {state:"ok", pid:203, port:4096, port_pair:[4096,4097], binary, session_id}`, `resources.memory {totalMb:3915, availableMb:3021, usedPct:23}`, `resources.disks` for `/workspace` `/opt/kortix` `/tmp`, `resources.opencode {rssMb:572, threads:8, state:"R"}`, `opencodePids:[203]`, 34 daemon-log lines (contains `[resources]` and `[boot]`), 40 OpenCode-log lines. (`cgroup` fields are null on Platinum — no cgroup limit exposed — by design null-on-absent.)
