### PR TITLE
ci: portable image-digest recipe for supply-chain + keep the registry BuildKit cache alongside Blacksmith's sticky disk

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -63,6 +63,12 @@ assertions (`ubuntu-24.04-arm` pinned) and three amd64 matrix legs left on
 `queued` for a Blacksmith runner while ≤3 ran. No prod impact.
 *Enforcer:* `image-build-speed-workflow.test.ts` "every Linux job keeps the
 Blacksmith runner kill switch" rejects any bare label in any workflow.
+*Addendum (same day):* a vendor's cache claim is not a measurement. Five
+consecutive builds of one `cache-key` on Blacksmith's sticky-disk builder
+reused 0 layers (`WORKDIR /app` re-executed) while the registry cache reused
+34–45 on the same Dockerfile; `grep -c ' CACHED'` on the build log is the only
+proof of a warm build. Keep `cache-from`/`cache-to: type=registry` until a
+re-measurement shows the sticky disk hitting (PR #6905).
 
 ### Size sandbox memory from measured peak RSS, not nominal workload size (2026-08-24)
 

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -121,7 +121,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/api/Dockerfile:${{ matrix.platform }}
@@ -140,6 +143,8 @@ jobs:
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
+          cache-from: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-api:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-api,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
@@ -214,7 +219,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/llm-gateway/Dockerfile:${{ matrix.platform }}
@@ -232,6 +240,8 @@ jobs:
           build-args: |
             KORTIX_VERSION=${{ needs.version.outputs.version }}
             KORTIX_COMMIT=${{ needs.version.outputs.sha }}
+          cache-from: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-gateway:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-gateway,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:
@@ -329,7 +339,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/web/Dockerfile:${{ matrix.platform }}
@@ -344,6 +357,8 @@ jobs:
           context: .
           file: apps/web/Dockerfile
           platforms: ${{ matrix.platform }}
+          cache-from: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }}
+          cache-to: type=registry,ref=kortix/kortix-frontend:staging-buildcache-${{ matrix.arch }},mode=max
           outputs: type=image,name=kortix/kortix-frontend,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         env:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -364,7 +364,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/api/Dockerfile:linux/amd64
@@ -390,6 +393,8 @@ jobs:
           file: apps/api/Dockerfile
           platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-api:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-api:dev-buildcache,mode=max
           build-args: |
             SERVICE=apps/api
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
@@ -640,7 +645,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/llm-gateway/Dockerfile:linux/amd64
@@ -656,6 +664,8 @@ jobs:
           file: apps/llm-gateway/Dockerfile
           platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-gateway:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-gateway:dev-buildcache,mode=max
           build-args: |
             KORTIX_VERSION=${{ needs.dev-version.outputs.version }}
             KORTIX_COMMIT=${{ github.sha }}
@@ -806,7 +816,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/web/Dockerfile:linux/amd64
@@ -822,6 +835,8 @@ jobs:
           file: apps/web/Dockerfile
           platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=kortix/kortix-frontend:dev-buildcache
+          cache-to: type=registry,ref=kortix/kortix-frontend:dev-buildcache,mode=max
           tags: |
             kortix/kortix-frontend:dev-latest
       - name: Retag :dev-latest → :dev-<sha8>

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -453,17 +453,19 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        # Pins a buildx that honours `imagetools inspect --format`. The runner
-        # image's bundled buildx returned the human-readable listing instead
-        # (Blacksmith ubuntu-2404, 2026-08-25, run 32905182332), which broke
-        # the digest resolve and skipped SBOM + signing for that dev image.
-        uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@v4
       - name: Resolve image digest
         id: digest
         run: |
           set -euo pipefail
-          DIGEST="$(docker buildx imagetools inspect "$IMAGE" --format '{{.Manifest.Digest}}')"
+          # `--format` with the `.Manifest.Digest` template is not portable: buildx v0.23/v0.25
+          # print the default listing instead of the digest (Blacksmith
+          # ubuntu-2404 image, runs 32905182332 + 32907212034), which turned
+          # this into a multi-line $GITHUB_OUTPUT write and skipped SBOM +
+          # signing. `{{json .Manifest}}` is honoured everywhere and is what
+          # deploy-prod.yml already uses.
+          DIGEST="$(docker buildx imagetools inspect "$IMAGE" --format '{{json .Manifest}}' | jq -r '.digest // empty')"
+          case "$DIGEST" in sha256:*) ;; *) echo "::error::could not resolve digest for $IMAGE (got: ${DIGEST:-<empty>})"; exit 1 ;; esac
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           echo "ref=kortix/kortix-api@${DIGEST}" >> "$GITHUB_OUTPUT"
       - name: Generate SBOM

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -134,7 +134,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/api/Dockerfile:linux/amd64
@@ -174,7 +177,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/llm-gateway/Dockerfile:linux/amd64
@@ -232,7 +238,10 @@ jobs:
         # Layers persist on a Blacksmith sticky disk keyed by Dockerfile+platform,
         # shared by every workflow in this repo that builds the same image.
         # Off-Blacksmith (CI_RUNNER_* override) the action falls back to a plain
-        # local buildx builder, so the build still works, only cold.
+        # local buildx builder. The registry cache-from/cache-to below stays:
+        # measured 2026-08-25, five consecutive sticky-disk builds of this key
+        # reused 0 layers while the registry cache reused 34-45 (see
+        # docs/runbooks/ci-runners.md, "Docker layer cache").
         uses: useblacksmith/setup-docker-builder@v2
         with:
           cache-key: apps/web/Dockerfile:linux/amd64

--- a/.github/workflows/promote-self-host-stable.yml
+++ b/.github/workflows/promote-self-host-stable.yml
@@ -75,7 +75,7 @@ jobs:
             # Zero rebuild, multi-arch preserved.
             echo "Promoting $IMAGE:$VERSION → $IMAGE:stable"
             docker buildx imagetools create --tag "$IMAGE:stable" "$IMAGE:$VERSION"
-            DIGEST="$(docker buildx imagetools inspect "$IMAGE:stable" --format '{{.Manifest.Digest}}' 2>/dev/null || echo '?')"
+            DIGEST="$(docker buildx imagetools inspect "$IMAGE:stable" --format '{{json .Manifest}}' 2>/dev/null | jq -r '.digest // "?"')"
             echo "✓ $IMAGE:stable → $VERSION ($DIGEST)"
           done
 

--- a/docs/runbooks/ci-runners.md
+++ b/docs/runbooks/ci-runners.md
@@ -90,6 +90,10 @@ Image builds (`deploy-dev.yml`, `build-staging.yml`, `deploy-preview.yml`, the
 - The Blacksmith builder is a separate buildkitd: a raw `docker build` that the
   job then runs locally needs `--load` (see `ci.yml` `self-host-schema`).
 - Sticky disks are billed at $0.50/GB/month and evicted after 7 idle days.
+- Do not script against `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'`:
+  buildx v0.23/v0.25 (Blacksmith image, and `setup-buildx-action`'s pin) print
+  the default listing for it. Use `--format '{{json .Manifest}}' | jq -r .digest`
+  (deploy-prod, deploy-dev `supply-chain`, promote-self-host-stable).
   Retag/`imagetools` jobs keep `docker/setup-buildx-action`; they build nothing.
 
 ## Checking queue time

--- a/docs/runbooks/ci-runners.md
+++ b/docs/runbooks/ci-runners.md
@@ -84,9 +84,15 @@ Image builds (`deploy-dev.yml`, `build-staging.yml`, `deploy-preview.yml`, the
   by `cache-key`, shared by every workflow in the repo. Dev, staging (amd64 leg),
   preview and the CI smoke build of `apps/api/Dockerfile` therefore warm each
   other. The arm64 leg has its own key (`:linux/arm64`).
-- The old `cache-from`/`cache-to: type=registry,…-buildcache` refs are gone. The
-  `kortix/kortix-*:*-buildcache` tags on Docker Hub are now unused and can be
-  deleted.
+- The registry cache (`cache-from`/`cache-to: type=registry,ref=kortix/kortix-*:…-buildcache,mode=max`)
+  stays on every build, on purpose. Measured 2026-08-25: five consecutive
+  sticky-disk builds of `apps/api/Dockerfile:linux/amd64` (runs 32906337717,
+  32907212034, 32908668613, …) reused **0** layers — even `WORKDIR /app`
+  re-executed — although the disk was obtained from the previous commit and
+  `/var/lib/buildkit/cache.db` changed between mounts; the registry cache on
+  the same Dockerfile reused 34–45 steps (`pnpm install`, `apt-get` skipped).
+  Raise with Blacksmith support before removing the registry cache again; the
+  proof is `grep -c ' CACHED'` on the build job log.
 - The Blacksmith builder is a separate buildkitd: a raw `docker build` that the
   job then runs locally needs `--load` (see `ci.yml` `self-host-schema`).
 - Sticky disks are billed at $0.50/GB/month and evicted after 7 idle days.

--- a/tests/unit/cosign-sign-attest.test.ts
+++ b/tests/unit/cosign-sign-attest.test.ts
@@ -114,20 +114,24 @@ describe("keyless image signing", () => {
     );
   });
 
-  it("pins buildx before resolving the digest the signer attests", () => {
-    // The runner image's bundled buildx is not a contract: on Blacksmith's
-    // ubuntu-2404 image `imagetools inspect --format` returned the human
-    // listing (run 32905182332), the digest step failed, and SBOM + signing
-    // were skipped for that dev image.
+  it("resolves the digest the signer attests with a portable imagetools format", () => {
+    // The runner image's buildx is not a contract: on Blacksmith's ubuntu-2404
+    // image `--format '{{.Manifest.Digest}}'` returned the human listing
+    // (runs 32905182332, 32907212034), the digest step failed, and SBOM +
+    // signing were skipped for that dev image.
     const yaml = readFileSync(workflow, "utf8");
     const supplyChain = yaml.slice(
       yaml.indexOf("  supply-chain:"),
       yaml.indexOf("  migrate-db:"),
     );
     const buildx = supplyChain.indexOf("uses: docker/setup-buildx-action@v4");
-    const resolve = supplyChain.indexOf("imagetools inspect \"$IMAGE\" --format '{{.Manifest.Digest}}'");
+    const resolve = supplyChain.indexOf("imagetools inspect \"$IMAGE\" --format '{{json .Manifest}}' | jq -r '.digest // empty'");
     expect(buildx).toBeGreaterThan(-1);
     expect(resolve).toBeGreaterThan(-1);
     expect(buildx).toBeLessThan(resolve);
+    // `{{.Manifest.Digest}}` prints the default listing on buildx v0.23/v0.25
+    // (Blacksmith's image); the json form is honoured on every version.
+    expect(yaml).not.toContain("{{.Manifest.Digest}}");
+    expect(supplyChain).toContain('case "$DIGEST" in sha256:*) ;; *)');
   });
 });

--- a/tests/unit/image-build-speed-workflow.test.ts
+++ b/tests/unit/image-build-speed-workflow.test.ts
@@ -67,8 +67,15 @@ describe('staging image builds are native per-arch, cached, and merged', () => {
     expect(job).toContain('uses: useblacksmith/setup-docker-builder@v2');
     expect(job).toContain(`cache-key: ${DOCKERFILE[image]}:\${{ matrix.platform }}`);
     expect(job).toContain('uses: useblacksmith/build-push-action@v2');
-    // A registry cache export on top of the sticky disk is pure push time.
-    expect(job).not.toContain('cache-to: type=registry');
+    // The registry cache stays alongside the sticky disk: measured 2026-08-25,
+    // five consecutive sticky-disk builds of one key reused 0 layers while the
+    // registry cache reused 34-45. mode=max caches intermediate stages too.
+    expect(job).toContain(
+      `cache-from: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }}`,
+    );
+    expect(job).toContain(
+      `cache-to: type=registry,ref=kortix/kortix-${image}:staging-buildcache-\${{ matrix.arch }},mode=max`,
+    );
   });
 
   it.each(IMAGES)('publishes %s by digest, never by tag, from the arch legs', (image) => {
@@ -119,7 +126,10 @@ describe('dev image builds stay single-arch and cached', () => {
     expect(job).toContain('uses: useblacksmith/setup-docker-builder@v2');
     expect(job).toContain(`cache-key: ${DOCKERFILE[image]}:linux/amd64`);
     expect(job).toContain('uses: useblacksmith/build-push-action@v2');
-    expect(job).not.toContain('cache-to: type=registry');
+    expect(job).toContain(`cache-from: type=registry,ref=kortix/kortix-${image}:dev-buildcache`);
+    expect(job).toContain(
+      `cache-to: type=registry,ref=kortix/kortix-${image}:dev-buildcache,mode=max`,
+    );
   });
 });
 


### PR DESCRIPTION
Follow-up to #6902. Two fixes, both measured on `main` after the merge.

## 1. `Scan + SBOM + sign API image` failed on Blacksmith (runs 32905182332, 32907212034)
`docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` prints the default listing on buildx v0.23 (Blacksmith image) and v0.25 (reproduced locally); only GitHub's v0.36 honoured it. `Resolve image digest` then wrote a multi-line `$GITHUB_OUTPUT` ("Invalid format 'MediaType: …'") and SBOM + keyless signing were skipped for the dev API image (deploys were unaffected). Pinning buildx (87590ccbb7) did not help — `setup-buildx-action` pins v0.23 too. Switch to `--format '{{json .Manifest}}' | jq -r .digest` (what deploy-prod already uses) with a `sha256:` sanity check; same in promote-self-host-stable. Both recipes agree locally on `kortix/kortix-api:dev-3aa4dfd0` → `sha256:cb7bc965…`. `cosign-sign-attest.test.ts` pins it.

## 2. The Blacksmith sticky-disk layer cache produced 0 hits in 5 consecutive builds — keep the registry cache
| build of `apps/api/Dockerfile:linux/amd64` | cache | `CACHED` steps |
|---|---|---|
| GitHub-hosted, run 32903204434 | registry | 34 / 157 |
| Blacksmith (wizard config), run 32905182332 | registry | 45 / 162 |
| Blacksmith tiered, merge deploy 32907212034 | sticky disk (4th build on key) | **0** / 162 |
| Blacksmith tiered, `ci.yml` dispatch 32908668613 | sticky disk (5th build on key) | **0** / 151 |

Each run logged `Sticky disk parent snapshot: commit-…` → `Successfully obtained sticky disk` → `Successfully committed sticky disk`, and `/var/lib/buildkit/cache.db` had a different hash on each mount — yet `WORKDIR /app` and `pnpm install` re-executed every time. Restoring `cache-from`/`cache-to: type=registry,…-buildcache,mode=max` on the 6 dev/staging builds (deploy-preview never had one) brings the proven hits back; the sticky disk stays and can only add. Runbook records the measurement; test requires both. Worth raising with Blacksmith support.

## Post-merge proof
`gh workflow run deploy-dev.yml -f surface=api` → `supply-chain` green, `grep -c ' CACHED'` on `Build API image` > 0.
