### PR TITLE
fix(runtime): OOM-proof long sessions — attachment offload out of the transcript, memory guard before the kernel, reaper probe back-off

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2823,3 +2823,42 @@ it; `timeout: false` (or `0`) does. The provider was still thinking.
 
 *Automation:* `packages/llm-gateway/src/upstream-fetch.test.ts` (option is
 forwarded; Bun accepts it on a real request).
+
+## Image bytes never live in the transcript; memory is guarded before the kernel; an unknown probe backs off
+
+*Incident (2026-08-25 23:12Z, Essentia session 9df2a873):* the kernel OOM-killed
+OpenCode at 6.48 GB RSS on an 8 GB box (`dmesg`: `Killed process 1506
+(opencode.exe) anon-rss:6484532kB`), mid-turn, leaving an empty assistant
+husk. Two forces met: the transcript held 275 MB of base64 tool screenshots in
+`part.state.attachments[].url` (352 of 538 tool parts) which every LLM step
+and every list re-serialised, and the reaper re-probed the box 345 times in
+one hour after `unknown` (two replicas, 20 s cadence), each probe forcing a
+full-transcript serialisation. OpenCode's own compaction clears old tool
+output text and stops SENDING old attachments, but never removes bytes from
+storage (`session/compaction.ts`, `message-v2.ts`); there is no native
+"store a path instead" for tool attachments (`tool/read.ts` writes `data:`).
+
+**Rules.**
+1. `attachment-offload.ts` (daemon): when idle, attachments older than the
+   newest 12 per session (and every one OpenCode marked `compacted`) move
+   to `~/.local/share/kortix/attachments/<id>`; the row keeps a 1×1 PNG
+   `data:` placeholder (valid for OpenCode's model conversion, the AI SDK,
+   the media-extraction path) plus `kortix:{offloaded,sidecar,bytes,mime}`.
+   Optimistic UPDATE on `time_updated`; never the newest message; never
+   during a turn. Verified on 1.18.23: OpenCode serves the rewritten row on
+   the next read (7 ms UPDATE, no restart). `/kortix/part` serves sidecar
+   bytes and searches nested `state.attachments` (tool screenshots 404'd
+   before).
+2. Memory guard (`resources.ts`): ≥80 % box/cgroup memory → 10 s sampling;
+   ≥92 % with a turn in flight → `POST /session/:id/abort`, turn-stream
+   `kind:end status:error error_name:SandboxMemoryGuard` with the numbers,
+   then an offload pass. One action per crossing; re-armed below 80 %.
+   `KORTIX_MEMORY_GUARD_PCT` overrides.
+3. Reaper (`box-reaper.ts`): an `unknown` observation backs the PROBE off
+   per sandbox (20 s → 5 min, per replica); the drip still extends.
+   `probeBackoff` clears on the first readable answer.
+
+*Automation:* `attachment-offload.test.ts` (real bun:sqlite fixture in the
+1.18.23 row shape, optimistic-skip race), `part-route-attachments.test.ts`,
+`resources.test.ts` ("memory guard"), `sandbox-reaper.test.ts` ("not
+re-probed until its back-off elapses").

--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -136,6 +136,20 @@ const DEFAULT_REAPER_DEPENDENCIES: SandboxReaperDependencies = {
 const ORPHANED_PROMPT_MIN_AGE_MS = 30_000;
 
 /**
+ * Per-sandbox probe back-off after an `unknown` turn observation, in this
+ * process. 20 s → 40 s → … → 5 min, cleared by the first readable answer.
+ * Per replica on purpose: no shared state to fail on, and two replicas
+ * together still ask far less than the old fixed cadence.
+ */
+const PROBE_BACKOFF_MIN_MS = 20_000;
+const PROBE_BACKOFF_MAX_MS = 5 * 60_000;
+const probeBackoff = new Map<string, { backoffMs: number; until: number }>();
+/** Tests: forget every back-off. */
+export function __resetProbeBackoffForTests(): void {
+  probeBackoff.clear();
+}
+
+/**
  * Give an inbox prompt back when its delivery is PROVEN never to have run.
  *
  * Never fails the pass: a redelivery is a repair, and a repair that throws must
@@ -264,6 +278,7 @@ export async function reapAndReconcileSandboxes(
           // answered unknown`, which is a statement about answers, not about
           // records. EVERY record is probed, so the count is complete.
           let unreadableTurns = 0;
+          let backedOffProbes = 0;
           // Probes the daemon ANSWERED, whatever it said. A separate fact from
           // the observation, and the drip below needs it: an answer proves the
           // runtime is up and only its description of the turn is missing (an
@@ -308,15 +323,26 @@ export async function reapAndReconcileSandboxes(
                   : turn.startedAtMs + turnDeliveryGraceMs();
               const withinDeliveryGrace =
                 turn.state === 'delivering' && deliveryGraceEndsAtMs > now.getTime();
-              const { observation, endReason, daemonAnswered, orphanedPrompt } =
-                await dependencies.observeSandboxTurn(
-                  provider,
-                  row.externalId,
-                  row.sandboxId,
-                  turn,
-                );
+              // Back-off on "could not tell": a box that answered `unknown`
+              // is not asked again until its back-off elapses. The extension
+              // below still happens (the record's own bound governs it), the
+              // PROBE does not. Essentia 2026-08-25: two replicas probed one
+              // box 345 times in an hour, each probe made OpenCode serialise
+              // its 140 MB transcript, and the kernel OOM-killed it.
+              const backoff = probeBackoff.get(row.sandboxId);
+              const backedOff = backoff !== undefined && backoff.until > now.getTime();
+              const { observation, endReason, daemonAnswered, orphanedPrompt } = backedOff
+                ? ({ observation: 'unknown', endReason: null, daemonAnswered: false, orphanedPrompt: false } as const)
+                : await dependencies.observeSandboxTurn(
+                    provider,
+                    row.externalId,
+                    row.sandboxId,
+                    turn,
+                  );
               if (observation === 'unknown') unreadableTurns += 1;
+              else probeBackoff.delete(row.sandboxId);
               if (daemonAnswered) answeredProbes += 1;
+              if (backedOff) backedOffProbes += 1;
               // Inside the delivery grace only a POSITIVE answer may be acted
               // on: `active` is proof the prompt reached OpenCode and promotes
               // the record early. `terminal` and `unknown` are the ambiguous
@@ -545,11 +571,20 @@ export async function reapAndReconcileSandboxes(
           if (
             turns.length > 0 &&
             unreadableTurns === turns.length &&
-            answeredProbes > 0 &&
+            (answeredProbes > 0 || backedOffProbes > 0) &&
             row.deadlineAt.getTime() > now.getTime() &&
             hasFreshTurnRecord(turns, now)
           ) {
             const extended = await dependencies.extendUnconfirmedTurnDeadline(row.sandboxId);
+            // Escalate only on a pass that actually ASKED and got nothing readable;
+            // a pass that skipped the probe must not double the wait it did not test.
+            if (backedOffProbes === 0) {
+              const nextBackoffMs = Math.min(
+                PROBE_BACKOFF_MAX_MS,
+                Math.max(PROBE_BACKOFF_MIN_MS, (probeBackoff.get(row.sandboxId)?.backoffMs ?? 0) * 2),
+              );
+              probeBackoff.set(row.sandboxId, { backoffMs: nextBackoffMs, until: now.getTime() + nextBackoffMs });
+            }
             console.warn('[reaper] turn observation unknown; drip-extending', {
               sandboxId: row.sandboxId,
               externalId: row.externalId,

--- a/apps/api/src/projects/sandbox-reaper.test.ts
+++ b/apps/api/src/projects/sandbox-reaper.test.ts
@@ -3,6 +3,7 @@ import { appRuntimes, projectSessions, sandboxComputeSessions, sessionSandboxes 
 import * as realComputeMetering from '../billing/services/compute-metering';
 import * as realProviders from '../platform/providers';
 import { mockConfigModule } from './reaping/test-support/mock-config';
+import { __resetProbeBackoffForTests } from './reaping/box-reaper';
 
 // ── mock state ──────────────────────────────────────────────────────────────
 let candidates: any[] = [];
@@ -494,6 +495,7 @@ beforeEach(() => {
   promptRedeliveries = [];
   clearedTurnReasons = [];
   unconfirmedTurnDrips = [];
+  __resetProbeBackoffForTests();
   ledgerSettleStatements = [];
   huskFinalizeCalls = [];
   huskOutcomeBySandbox = {};
@@ -1788,6 +1790,42 @@ describe('reapAndReconcileSandboxes — the one rule: deadline_at <= now', () =>
     expect(activeTurnRenewalCalls).toEqual([]);
     expect(r.stopped).toBe(0);
     expect(r.lifecycleRenewed).toBe(1);
+  });
+
+  // ═══ THE PROBE ITSELF WAS THE LOAD ═══
+  // Essentia 2026-08-25 (session 9df2a873): two API replicas re-asked one box
+  // 345 times in an hour after `unknown`; every ask made OpenCode serialise
+  // its 140 MB transcript, and the kernel OOM-killed it mid-turn. An unknown
+  // answer now backs the PROBE off (20 s → 5 min) while the drip still runs.
+  test('REGRESSION: after an unknown answer the box is not re-probed until its back-off elapses', async () => {
+    candidates = [unknownTurnCandidate(NOW.getTime() - 10 * 60_000)];
+    statusByExternal['ext-1'] = 'running';
+    turnObservationByToken['mute-token'] = 'unknown';
+
+    await reapAndReconcileSandboxes(NOW);
+    expect(turnObservationCalls).toHaveLength(1);
+    expect(unconfirmedTurnDrips).toEqual(['sb-1']);
+
+    // 10 s later: still inside the 20 s back-off — dripped, NOT probed.
+    unconfirmedTurnDrips = [];
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 10_000));
+    expect(turnObservationCalls).toHaveLength(1);
+    expect(unconfirmedTurnDrips).toEqual(['sb-1']);
+
+    // 25 s later: back-off elapsed — probed again; still unknown → back-off doubles to 40 s.
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 25_000));
+    expect(turnObservationCalls).toHaveLength(2);
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 55_000));
+    expect(turnObservationCalls).toHaveLength(2);
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 70_000));
+    expect(turnObservationCalls).toHaveLength(3);
+
+    // A readable answer clears it: the next pass probes at once.
+    turnObservationByToken['mute-token'] = 'active';
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 200_000));
+    expect(turnObservationCalls).toHaveLength(4);
+    await reapAndReconcileSandboxes(new Date(NOW.getTime() + 201_000));
+    expect(turnObservationCalls).toHaveLength(5);
   });
 
   // ═══ THE BILLED DEAD TIME THIS CLOSES ═══

--- a/apps/kortix-sandbox-agent-server/src/__tests__/attachment-offload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/attachment-offload.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Attachment offload: inline image bytes out of OpenCode's SQLite transcript.
+ *
+ * The fixture mirrors opencode.db on Essentia box i67m4 (1.18.23, 2026-08-25):
+ * `part` rows whose `data` JSON is a tool part with `state.attachments[]` of
+ * file-shaped objects carrying base64 `data:` URLs.
+ */
+import { Database } from 'bun:sqlite'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  OFFLOAD_PLACEHOLDER_URL,
+  decodeDataUrl,
+  inlineAttachmentsOf,
+  runAttachmentOffloadPass,
+  selectCandidates,
+  sidecarPathFor,
+} from '../attachment-offload'
+import { stripInlineAttachmentBytes } from '../inline-attachments'
+
+let root: string
+let dbPath: string
+let sidecarDir: string
+
+const PNG_1PX_B64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+function bigDataUrl(seed: string, bytes = 64 * 1024): string {
+  return `data:image/png;base64,${Buffer.from(seed.repeat(Math.ceil(bytes / seed.length)).slice(0, bytes)).toString('base64')}`
+}
+
+function schema(db: Database): void {
+  db.exec(`
+    CREATE TABLE session (id text PRIMARY KEY, project_id text NOT NULL, slug text NOT NULL, directory text NOT NULL, title text NOT NULL, version text NOT NULL);
+    CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+    CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+  `)
+}
+
+interface Seeded {
+  partId: string
+  attachmentIds: string[]
+}
+
+function seedToolPart(
+  db: Database,
+  session: string,
+  message: string,
+  n: number,
+  t: number,
+  opts: { attachments?: number; compacted?: boolean; small?: boolean } = {},
+): Seeded {
+  const partId = `prt_${session}_${n.toString().padStart(3, '0')}`
+  const count = opts.attachments ?? 1
+  const attachmentIds: string[] = []
+  const attachments = Array.from({ length: count }, (_, i) => {
+    const id = `${partId}_att${i}`
+    attachmentIds.push(id)
+    return {
+      type: 'file',
+      mime: 'image/png',
+      url: opts.small ? `data:image/png;base64,${PNG_1PX_B64}` : bigDataUrl(`${partId}-${i}-`),
+      id,
+      sessionID: session,
+      messageID: message,
+    }
+  })
+  const data = {
+    id: partId,
+    sessionID: session,
+    messageID: message,
+    type: 'tool',
+    callID: `call_${n}`,
+    tool: 'read',
+    state: {
+      status: 'completed',
+      input: { filePath: `/workspace/shot-${n}.png` },
+      output: 'Image read successfully',
+      title: `shot-${n}.png`,
+      metadata: {},
+      time: { start: t, end: t + 5, ...(opts.compacted ? { compacted: t + 10 } : {}) },
+      attachments,
+    },
+  }
+  db.run('INSERT OR IGNORE INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)', [
+    message,
+    session,
+    t,
+    t,
+    JSON.stringify({ id: message, sessionID: session, role: 'assistant', time: { created: t, completed: t + 100 } }),
+  ])
+  db.run('INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)', [
+    partId,
+    message,
+    session,
+    t,
+    t,
+    JSON.stringify(data),
+  ])
+  return { partId, attachmentIds }
+}
+
+function readPart(db: Database, id: string): Record<string, any> {
+  const row = db.query<{ data: string }, [string]>('SELECT data FROM part WHERE id = ?').get(id)
+  return JSON.parse(row!.data)
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-offload-'))
+  dbPath = join(root, 'opencode.db')
+  sidecarDir = join(root, 'attachments')
+  const db = new Database(dbPath)
+  db.exec('PRAGMA journal_mode = WAL')
+  schema(db)
+  db.close()
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('helpers', () => {
+  test('inlineAttachmentsOf sees tool attachments and top-level file parts', () => {
+    expect(inlineAttachmentsOf({ type: 'file', url: 'data:x', id: 'a' })).toHaveLength(1)
+    expect(inlineAttachmentsOf({ type: 'tool', state: { attachments: [{ url: 'data:y', id: 'b' }, { nope: 1 }] } })).toHaveLength(1)
+    expect(inlineAttachmentsOf({ type: 'text', text: 'hi' })).toHaveLength(0)
+  })
+
+  test('decodeDataUrl returns mime + bytes', () => {
+    const d = decodeDataUrl(`data:image/png;base64,${PNG_1PX_B64}`)!
+    expect(d.mime).toBe('image/png')
+    expect(d.bytes.byteLength).toBe(Buffer.from(PNG_1PX_B64, 'base64').byteLength)
+  })
+
+  test('sidecarPathFor never leaves the directory', () => {
+    expect(sidecarPathFor('/x', '../../etc/passwd')).toBe('/x/______etc_passwd')
+  })
+
+  test('selectCandidates keeps the newest N attachments per session and never the newest message', () => {
+    const rows = [
+      { id: 'p1', session_id: 's', message_id: 'm1', time_created: 1, attachmentCount: 5 },
+      { id: 'p2', session_id: 's', message_id: 'm2', time_created: 2, attachmentCount: 5 },
+      { id: 'p3', session_id: 's', message_id: 'm3', time_created: 3, attachmentCount: 5 },
+      { id: 'p4', session_id: 's', message_id: 'm4', time_created: 4, attachmentCount: 5 },
+      { id: 'pc', session_id: 's', message_id: 'm2', time_created: 2, attachmentCount: 1, compacted: true },
+    ]
+    const chosen = selectCandidates(rows, new Map([['s', 'm4']]), 12)
+    // newest message m4 untouched; the window keeps whole parts until AT LEAST
+    // 12 attachments are kept: p3 (5) + p2 (10) + p1 (15) all stay; compacted always goes
+    expect(chosen).toEqual(new Set(['pc']))
+    // With a 6-wide window p1 goes: p3 (5) + p2 (10 ≥ 6) kept, p1 offloaded.
+    expect(selectCandidates(rows, new Map([['s', 'm4']]), 6)).toEqual(new Set(['p1', 'pc']))
+  })
+})
+
+describe('runAttachmentOffloadPass', () => {
+  test('moves old attachments to sidecars, leaves a valid placeholder + marker, keeps the newest window inline', async () => {
+    const db = new Database(dbPath)
+    const S = 'ses_root'
+    const seeded: Seeded[] = []
+    // 20 tool parts, one attachment each, older → newer; the newest message is a live one.
+    for (let i = 0; i < 20; i++) seeded.push(seedToolPart(db, S, `msg_${i}`, i, 1_000 + i))
+    db.close()
+
+    const result = await runAttachmentOffloadPass({ dbPath, sidecarDir, keepNewest: 12 })
+    expect(result.errors).toBe(0)
+    // 20 parts, newest message (msg_19) excluded, newest 12 kept → parts 7..18 kept, 0..6 offloaded
+    expect(result.offloaded).toBe(7)
+    expect(result.bytesMoved).toBeGreaterThan(7 * 60 * 1024)
+
+    const check = new Database(dbPath, { readonly: true })
+    for (let i = 0; i < 20; i++) {
+      const part = readPart(check, seeded[i]!.partId)
+      const att = part.state.attachments[0]
+      if (i <= 6) {
+        expect(att.url).toBe(OFFLOAD_PLACEHOLDER_URL)
+        expect(att.kortix.offloaded).toBe(true)
+        expect(att.kortix.mime).toBe('image/png')
+        expect(att.kortix.bytes).toBeGreaterThan(60 * 1024)
+        expect(existsSync(att.kortix.sidecar)).toBe(true)
+        expect(readFileSync(att.kortix.sidecar).byteLength).toBe(att.kortix.bytes)
+        // Attachment identity untouched: the UI's on-demand ref still resolves.
+        expect(att.id).toBe(seeded[i]!.attachmentIds[0])
+        expect(att.type).toBe('file')
+      } else {
+        expect(att.url.startsWith('data:image/png;base64,')).toBe(true)
+        expect(att.url.length).toBeGreaterThan(60 * 1024)
+        expect(att.kortix).toBeUndefined()
+      }
+    }
+    check.close()
+
+    // Idempotent: a second pass finds nothing left to do.
+    const again = await runAttachmentOffloadPass({ dbPath, sidecarDir, keepNewest: 12 })
+    expect(again.offloaded).toBe(0)
+    expect(again.errors).toBe(0)
+  })
+
+  test('a compacted tool result is offloaded even inside the newest window; tiny attachments stay inline', async () => {
+    const db = new Database(dbPath)
+    const S = 'ses_root'
+    const a = seedToolPart(db, S, 'msg_a', 1, 1_000, { compacted: true })
+    const b = seedToolPart(db, S, 'msg_b', 2, 1_001)
+    const c = seedToolPart(db, S, 'msg_c', 3, 1_002, { small: true })
+    seedToolPart(db, S, 'msg_live', 4, 1_003)
+    db.close()
+    const result = await runAttachmentOffloadPass({ dbPath, sidecarDir, keepNewest: 12 })
+    expect(result.offloaded).toBe(1)
+    const check = new Database(dbPath, { readonly: true })
+    expect(readPart(check, a.partId).state.attachments[0].kortix?.offloaded).toBe(true)
+    expect(readPart(check, b.partId).state.attachments[0].kortix).toBeUndefined()
+    expect(readPart(check, c.partId).state.attachments[0].kortix).toBeUndefined()
+    check.close()
+  })
+
+  test('a row OpenCode touched between read and write is skipped, not clobbered', async () => {
+    const db = new Database(dbPath)
+    const S = 'ses_root'
+    const old = seedToolPart(db, S, 'msg_old', 1, 1_000)
+    for (let i = 0; i < 13; i++) seedToolPart(db, S, `msg_${i + 2}`, i + 2, 2_000 + i)
+    // Simulate a concurrent writer: bump time_updated so the optimistic UPDATE misses.
+    db.run('UPDATE part SET time_updated = time_updated + 1 WHERE id = ?', [old.partId])
+    db.close()
+    // The pass reads the row (with the new time_updated) and updates against it —
+    // so this only proves the WHERE clause by racing it: patch after select.
+    // Do that with a second connection while the pass runs.
+    const racer = new Database(dbPath)
+    try {
+      const result = await runAttachmentOffloadPass({
+        dbPath,
+        sidecarDir,
+        keepNewest: 12,
+        // A concurrent writer (OpenCode) touches the row between our read and our write.
+        beforeUpdate: (id) => racer.run('UPDATE part SET time_updated = time_updated + 1 WHERE id = ?', [id]),
+      })
+      expect(result.offloaded).toBe(0)
+      expect(result.skippedBusy).toBe(1)
+    } finally {
+      racer.close()
+    }
+    const check = new Database(dbPath, { readonly: true })
+    expect(readPart(check, old.partId).state.attachments[0].kortix).toBeUndefined()
+    check.close()
+  })
+
+  test('a missing database is a counted error, never a throw', async () => {
+    const result = await runAttachmentOffloadPass({ dbPath: join(root, 'nope', 'x.db'), sidecarDir })
+    expect(result.errors).toBe(1)
+    expect(result.offloaded).toBe(0)
+  })
+
+  test('the response stripper hands an offloaded attachment out as a ref regardless of its size', () => {
+    const offloaded = {
+      type: 'file',
+      id: 'prt_att',
+      messageID: 'msg_1',
+      mime: 'image/png',
+      url: OFFLOAD_PLACEHOLDER_URL,
+      kortix: { offloaded: true, sidecar: '/x/prt_att', bytes: 123, mime: 'image/png', at: 't' },
+    }
+    const result = stripInlineAttachmentBytes(
+      [{ info: { id: 'msg_1' }, parts: [{ type: 'tool', state: { attachments: [offloaded] } }] }],
+      (m, p) => `/kortix/part/s/${m}/${p}`,
+    )
+    expect(result.stripped).toBe(1)
+    const out = result.value as any
+    expect(out[0].parts[0].state.attachments[0].url).toBe('/kortix/part/s/msg_1/prt_att')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/attachment-offload.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/attachment-offload.test.ts
@@ -269,3 +269,24 @@ describe('runAttachmentOffloadPass', () => {
     expect(out[0].parts[0].state.attachments[0].url).toBe('/kortix/part/s/msg_1/prt_att')
   })
 })
+
+describe('what survives a read through OpenCode', () => {
+  test('the stripper turns a bare placeholder URL (no kortix marker) into an on-demand ref', () => {
+    const result = stripInlineAttachmentBytes(
+      [
+        {
+          info: { id: 'msg_1' },
+          parts: [
+            {
+              type: 'tool',
+              state: { attachments: [{ type: 'file', id: 'prt_att', mime: 'image/png', url: OFFLOAD_PLACEHOLDER_URL }] },
+            },
+          ],
+        },
+      ],
+      (m, p) => `/kortix/part/s/${m}/${p}`,
+    )
+    expect(result.stripped).toBe(1)
+    expect((result.value as any)[0].parts[0].state.attachments[0].url).toBe('/kortix/part/s/msg_1/prt_att')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/part-route-attachments.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/part-route-attachments.test.ts
@@ -1,0 +1,98 @@
+/**
+ * /kortix/part serves tool-result attachments (nested in `state.attachments`)
+ * and offloaded ones from their sidecar file.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { OFFLOAD_PLACEHOLDER_URL } from '../attachment-offload'
+import type { Opencode } from '../opencode'
+import { createPartRouter, findAttachment } from '../routes/part'
+
+let root: string
+let server: ReturnType<typeof Bun.serve> | null = null
+const ORIGINAL_FETCH = globalThis.fetch
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'kortix-part-'))
+})
+
+afterEach(() => {
+  server?.stop(true)
+  server = null
+  globalThis.fetch = ORIGINAL_FETCH
+  rmSync(root, { recursive: true, force: true })
+})
+
+const PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=', 'base64')
+
+function fakeOpencode(port: number): Opencode {
+  return { getInternalUrl: () => `http://127.0.0.1:${port}` } as unknown as Opencode
+}
+
+describe('findAttachment', () => {
+  test('finds a top-level file part and a nested tool attachment by id', () => {
+    const parts = [
+      { type: 'file', id: 'f1', url: 'data:x' },
+      { type: 'tool', state: { attachments: [{ type: 'file', id: 'a1', url: 'data:y' }] } },
+    ]
+    expect(findAttachment(parts as any, 'f1')?.url).toBe('data:x')
+    expect(findAttachment(parts as any, 'a1')?.url).toBe('data:y')
+    expect(findAttachment(parts as any, 'zz')).toBeNull()
+  })
+})
+
+describe('GET /kortix/part/:s/:m/:p', () => {
+  test('serves a tool screenshot from its nested attachment, and an offloaded one from the sidecar', async () => {
+    const sidecar = join(root, 'prt_off')
+    writeFileSync(sidecar, PNG)
+    const inlineB64 = Buffer.from('inline-bytes').toString('base64')
+    const message = {
+      info: { id: 'msg_1' },
+      parts: [
+        {
+          type: 'tool',
+          id: 'prt_tool',
+          state: {
+            attachments: [
+              { type: 'file', id: 'prt_inline', mime: 'image/png', url: `data:image/png;base64,${inlineB64}` },
+              {
+                type: 'file',
+                id: 'prt_off',
+                mime: 'image/png',
+                url: OFFLOAD_PLACEHOLDER_URL,
+                kortix: { offloaded: true, sidecar, bytes: PNG.byteLength, mime: 'image/png', at: 't' },
+              },
+              {
+                type: 'file',
+                id: 'prt_gone',
+                mime: 'image/png',
+                url: OFFLOAD_PLACEHOLDER_URL,
+                kortix: { offloaded: true, sidecar: join(root, 'missing'), bytes: 1, mime: 'image/png', at: 't' },
+              },
+            ],
+          },
+        },
+      ],
+    }
+    server = Bun.serve({ port: 0, fetch: () => Response.json(message) })
+    const app = createPartRouter(fakeOpencode(server.port as number))
+
+    const inline = await app.request('http://d/ses/msg_1/prt_inline')
+    expect(inline.status).toBe(200)
+    expect(Buffer.from(await inline.arrayBuffer()).toString()).toBe('inline-bytes')
+
+    const off = await app.request('http://d/ses/msg_1/prt_off')
+    expect(off.status).toBe(200)
+    expect(off.headers.get('content-type')).toBe('image/png')
+    expect(Buffer.from(await off.arrayBuffer()).equals(PNG)).toBe(true)
+
+    const gone = await app.request('http://d/ses/msg_1/prt_gone')
+    expect(gone.status).toBe(410)
+
+    const nope = await app.request('http://d/ses/msg_1/prt_nope')
+    expect(nope.status).toBe(404)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/part-route-attachments.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/part-route-attachments.test.ts
@@ -96,3 +96,38 @@ describe('GET /kortix/part/:s/:m/:p', () => {
     expect(nope.status).toBe(404)
   })
 })
+
+describe('offloaded attachment read through OpenCode (marker stripped by its schema)', () => {
+  test('the placeholder URL + attachment id resolve the sidecar; a placeholder with no sidecar falls back to its own bytes', async () => {
+    const sidecarDir = join(root, 'attachments')
+    const { mkdirSync } = await import('node:fs')
+    mkdirSync(sidecarDir, { recursive: true })
+    writeFileSync(join(sidecarDir, 'prt_byid'), PNG)
+    const message = {
+      info: { id: 'msg_1' },
+      parts: [
+        {
+          type: 'tool',
+          id: 'prt_tool',
+          state: {
+            attachments: [
+              // What OpenCode returns for an offloaded row: placeholder URL, NO kortix field.
+              { type: 'file', id: 'prt_byid', mime: 'image/png', url: OFFLOAD_PLACEHOLDER_URL },
+              { type: 'file', id: 'prt_nosidecar', mime: 'image/png', url: OFFLOAD_PLACEHOLDER_URL },
+            ],
+          },
+        },
+      ],
+    }
+    server = Bun.serve({ port: 0, fetch: () => Response.json(message) })
+    const app = createPartRouter(fakeOpencode(server.port as number), { sidecarDir })
+
+    const byId = await app.request('http://d/ses/msg_1/prt_byid')
+    expect(byId.status).toBe(200)
+    expect(Buffer.from(await byId.arrayBuffer()).equals(PNG)).toBe(true)
+
+    const fallback = await app.request('http://d/ses/msg_1/prt_nosidecar')
+    expect(fallback.status).toBe(200)
+    expect(Buffer.from(await fallback.arrayBuffer()).byteLength).toBe(68) // the 1×1 placeholder itself
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/resources.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/resources.test.ts
@@ -154,3 +154,89 @@ describe('startResourceMonitor', () => {
     expect(reasons).toEqual(['diag'])
   })
 })
+
+describe('memory guard', () => {
+  let stop: (() => void) | null = null
+  afterEach(() => {
+    stop?.()
+    stop = null
+  })
+
+  test('aborts the in-flight turn once at the guard line, relays why, re-arms only after memory drops', async () => {
+    let usedPct = 50
+    const aborts: string[] = []
+    const relays: Array<{ aborted: boolean }> = []
+    const monitor = startResourceMonitor({
+      intervalMs: 60_000,
+      opencodePid: () => 2423,
+      snapshot: async () =>
+        snapshot({
+          memory: { totalMb: 8000, availableMb: Math.round(8000 * (100 - usedPct) / 100), usedPct, swapTotalMb: 0, swapFreeMb: 0 },
+          cgroup: { currentMb: null, maxMb: null, usedPct: null, oomKills: null },
+          opencode: { pid: 2423, rssMb: Math.round(8000 * usedPct / 100), threads: 8, state: 'R' },
+        }),
+      guard: {
+        guardPct: 92,
+        elevatedPct: 80,
+        fastIntervalMs: 60_000,
+        turnInFlight: async () => true,
+        abortTurn: async (reason) => {
+          aborts.push(reason)
+          return true
+        },
+        onGuard: ({ aborted }) => {
+          relays.push({ aborted })
+        },
+      },
+    })
+    stop = monitor.stop
+    await Bun.sleep(20)
+    expect(aborts).toHaveLength(0)
+
+    usedPct = 85
+    await monitor.tick('t')
+    expect(aborts).toHaveLength(0) // elevated: fast sampling, no action
+
+    usedPct = 93
+    await monitor.tick('t')
+    expect(aborts).toHaveLength(1)
+    expect(aborts[0]).toContain('sandbox memory at 93%')
+    expect(aborts[0]).toContain('7440 MB RSS')
+    expect(relays).toEqual([{ aborted: true }])
+
+    usedPct = 95
+    await monitor.tick('t')
+    expect(aborts).toHaveLength(1) // fired once per crossing
+
+    usedPct = 60
+    await monitor.tick('t')
+    usedPct = 94
+    await monitor.tick('t')
+    expect(aborts).toHaveLength(2) // re-armed after dropping under the elevated line
+  })
+
+  test('with no turn in flight the guard relays but does not abort', async () => {
+    const aborts: string[] = []
+    const relays: Array<{ aborted: boolean }> = []
+    const monitor = startResourceMonitor({
+      intervalMs: 60_000,
+      opencodePid: () => 2423,
+      snapshot: async () =>
+        snapshot({ memory: { totalMb: 8000, availableMb: 400, usedPct: 95, swapTotalMb: 0, swapFreeMb: 0 } }),
+      guard: {
+        turnInFlight: async () => false,
+        abortTurn: async (r) => {
+          aborts.push(r)
+          return true
+        },
+        onGuard: ({ aborted }) => {
+          relays.push({ aborted })
+        },
+      },
+    })
+    stop = monitor.stop
+    await monitor.tick('t')
+    expect(aborts).toHaveLength(0)
+    expect(relays).toEqual([{ aborted: false }])
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/attachment-offload.ts
+++ b/apps/kortix-sandbox-agent-server/src/attachment-offload.ts
@@ -124,6 +124,14 @@ export function decodeDataUrl(url: string): { mime: string | null; bytes: Buffer
   }
 }
 
+/** True for the 1×1 placeholder the offload leaves in a row. OpenCode's read path
+ *  drops unknown JSON fields, so the `kortix` marker never survives a read
+ *  through its API — the placeholder URL itself is the runtime signal, and the
+ *  sidecar path is deterministic from the attachment id. */
+export function isOffloadPlaceholder(url: unknown): boolean {
+  return url === OFFLOAD_PLACEHOLDER_URL
+}
+
 export function sidecarPathFor(sidecarDir: string, attachmentId: string): string {
   // Attachment ids are OpenCode-minted (`prt_…`); refuse anything that could
   // walk out of the directory.

--- a/apps/kortix-sandbox-agent-server/src/attachment-offload.ts
+++ b/apps/kortix-sandbox-agent-server/src/attachment-offload.ts
@@ -1,0 +1,351 @@
+/**
+ * Attachment offload: inline image bytes out of OpenCode's transcript store.
+ *
+ * WHY. OpenCode keeps every tool screenshot as a base64 `data:` URL inside the
+ * tool part's `state.attachments[]`, in the `part` table of `opencode.db`.
+ * Measured on Essentia 2026-08-25: one root = 352 tool parts carrying
+ * 275 MB of attachments out of a 276 MB transcript. Every consumer re-pays
+ * those bytes: each LLM step re-serialises the whole history before our
+ * llm-proxy windows it to 12 images, every message-list request serialises
+ * it again, and the old reaper probe did that every 10 s. OpenCode reached
+ * 6.48 GB RSS on an 8 GB box and the kernel killed it mid-turn.
+ *
+ * WHAT. When OpenCode is idle, attachments OLDER than the newest
+ * `keepNewest` (12 = the llm-proxy image window) per session are moved to
+ * sidecar files and the row is rewritten in place:
+ *   - bytes → `<sidecarDir>/<attachmentId>` (written + fsynced first);
+ *   - `url` → a 1×1 PNG data URL (114 bytes): still a valid image for every
+ *     reader — OpenCode's model conversion, the AI SDK, the provider — so no
+ *     code path sees a shape it did not expect. The llm-proxy keeps only the
+ *     newest 12 images per request, so these placeholders never reach a
+ *     model in practice; if compaction ever leaves fewer than 12, a model
+ *     sees a blank pixel for a screenshot it would not have seen anyway;
+ *   - `kortix: { offloaded: true, sidecar, bytes, mime }` marks it; the
+ *     proxy's response stripper turns it into an on-demand ref and
+ *     `/kortix/part/:s/:m/:p` serves the sidecar bytes to the UI.
+ *
+ * Verified live on 1.18.23 (2026-08-25, box i67m4): OpenCode serves an
+ * externally UPDATEd row on the next read — no cache, no restart; the UPDATE
+ * took 7 ms with OpenCode holding the DB open (WAL).
+ *
+ * SAFETY.
+ *   - Only when no turn is in flight (caller's `turnInFlight()`), and never
+ *     the newest message of a session: the row OpenCode may still be writing.
+ *   - Optimistic: `UPDATE … WHERE id = ? AND time_updated = ?`; a row OpenCode
+ *     touched in between is skipped, not clobbered.
+ *   - Sidecar is written and fsynced BEFORE the row changes; a crash between
+ *     the two leaves the original bytes in the row and an orphan file.
+ *   - Bounded work per pass (`maxPartsPerPass`), one short transaction per
+ *     row; `busy_timeout` so OpenCode's own writes win.
+ *   - Never throws to the caller; every failure is a counted, logged skip.
+ */
+import { Database } from 'bun:sqlite'
+import { closeSync, fsyncSync, mkdirSync, openSync, renameSync, writeSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from './logger'
+
+export const OFFLOAD_PLACEHOLDER_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+/** Attachments at or below this size stay inline — the row is not worth a file. */
+export const OFFLOAD_MIN_BYTES = 32 * 1024
+export const DEFAULT_KEEP_NEWEST = 12
+export const DEFAULT_MAX_PARTS_PER_PASS = 200
+
+export interface OffloadedMarker {
+  offloaded: true
+  sidecar: string
+  bytes: number
+  mime: string | null
+  at: string
+}
+
+export interface AttachmentLike {
+  id?: string
+  type?: string
+  mime?: string
+  url?: string
+  kortix?: OffloadedMarker
+  [k: string]: unknown
+}
+
+export interface OffloadOptions {
+  dbPath: string
+  sidecarDir: string
+  keepNewest?: number
+  maxPartsPerPass?: number
+  minBytes?: number
+  now?: () => Date
+  /** Tests: runs after a row is read and before its UPDATE. */
+  beforeUpdate?: (partId: string) => void
+}
+
+export interface OffloadResult {
+  scanned: number
+  offloaded: number
+  bytesMoved: number
+  skippedBusy: number
+  errors: number
+  sessions: number
+  durationMs: number
+}
+
+const DATA_URL_RE = /^data:([^;,]+)?(;base64)?,(.*)$/s
+
+/** Every inline attachment inside one part's JSON: tool `state.attachments[]` and file parts. */
+export function inlineAttachmentsOf(part: Record<string, unknown>): AttachmentLike[] {
+  const out: AttachmentLike[] = []
+  if (part.type === 'file' && typeof part.url === 'string') out.push(part as AttachmentLike)
+  const state = part.state as { attachments?: unknown } | undefined
+  if (state && Array.isArray(state.attachments)) {
+    for (const a of state.attachments) {
+      if (a && typeof a === 'object' && typeof (a as AttachmentLike).url === 'string') out.push(a as AttachmentLike)
+    }
+  }
+  return out
+}
+
+export function isOffloadable(a: AttachmentLike, minBytes: number): boolean {
+  return (
+    typeof a.id === 'string' &&
+    typeof a.url === 'string' &&
+    a.url.startsWith('data:') &&
+    a.url.length > minBytes &&
+    !a.kortix?.offloaded
+  )
+}
+
+export function decodeDataUrl(url: string): { mime: string | null; bytes: Buffer } | null {
+  const m = DATA_URL_RE.exec(url)
+  if (!m) return null
+  const payload = m[3] ?? ''
+  return {
+    mime: m[1] ?? null,
+    bytes: m[2] ? Buffer.from(payload, 'base64') : Buffer.from(decodeURIComponent(payload), 'utf8'),
+  }
+}
+
+export function sidecarPathFor(sidecarDir: string, attachmentId: string): string {
+  // Attachment ids are OpenCode-minted (`prt_…`); refuse anything that could
+  // walk out of the directory.
+  const safe = attachmentId.replace(/[^A-Za-z0-9_-]/g, '_')
+  return join(sidecarDir, safe)
+}
+
+function writeSidecarAtomic(path: string, bytes: Buffer): void {
+  const tmp = `${path}.tmp-${process.pid}`
+  const fd = openSync(tmp, 'w', 0o644)
+  try {
+    writeSync(fd, bytes)
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  renameSync(tmp, path)
+}
+
+interface PartRow {
+  id: string
+  message_id: string
+  session_id: string
+  time_created: number
+  time_updated: number
+  data: string
+}
+
+/**
+ * Which part rows to touch: for every session, all parts with inline
+ * attachments EXCEPT those carrying one of the session's newest `keepNewest`
+ * attachments, and never the session's newest message.
+ */
+export function selectCandidates(
+  rows: Array<
+    Pick<PartRow, 'id' | 'session_id' | 'message_id' | 'time_created'> & {
+      attachmentCount: number
+      /** OpenCode's own compaction marked this tool result as cleared: its
+       *  attachments are never sent to a model again (message-v2.ts drops
+       *  them when `state.time.compacted` is set), so they never count
+       *  against the kept window. */
+      compacted?: boolean
+    }
+  >,
+  newestMessageBySession: Map<string, string>,
+  keepNewest: number,
+): Set<string> {
+  const bySession = new Map<string, typeof rows>()
+  for (const r of rows) {
+    const list = bySession.get(r.session_id) ?? []
+    list.push(r)
+    bySession.set(r.session_id, list)
+  }
+  const chosen = new Set<string>()
+  for (const [sessionId, list] of bySession) {
+    list.sort((a, b) => b.time_created - a.time_created || (a.id < b.id ? 1 : -1))
+    let kept = 0
+    for (const r of list) {
+      if (r.message_id === newestMessageBySession.get(sessionId)) continue
+      if (r.compacted) {
+        chosen.add(r.id)
+        continue
+      }
+      if (kept < keepNewest) {
+        kept += r.attachmentCount
+        continue
+      }
+      chosen.add(r.id)
+    }
+  }
+  return chosen
+}
+
+export async function runAttachmentOffloadPass(opts: OffloadOptions): Promise<OffloadResult> {
+  const t0 = Date.now()
+  const keepNewest = opts.keepNewest ?? DEFAULT_KEEP_NEWEST
+  const maxParts = opts.maxPartsPerPass ?? DEFAULT_MAX_PARTS_PER_PASS
+  const minBytes = opts.minBytes ?? OFFLOAD_MIN_BYTES
+  const result: OffloadResult = { scanned: 0, offloaded: 0, bytesMoved: 0, skippedBusy: 0, errors: 0, sessions: 0, durationMs: 0 }
+
+  let db: Database
+  try {
+    db = new Database(opts.dbPath, { readwrite: true })
+    db.exec('PRAGMA busy_timeout = 5000')
+  } catch (err) {
+    logger.warn('[offload] cannot open opencode.db', { path: opts.dbPath, err: (err as Error).message })
+    result.errors++
+    result.durationMs = Date.now() - t0
+    return result
+  }
+
+  try {
+    mkdirSync(opts.sidecarDir, { recursive: true })
+    // Cheap pre-filter in SQL: only rows that can contain a data URL bigger
+    // than the floor. The JSON is parsed in JS for the exact decision.
+    const rows = db
+      .query<Pick<PartRow, 'id' | 'session_id' | 'message_id' | 'time_created'> & { len: number }, [number]>(
+        `SELECT id, session_id, message_id, time_created, length(data) AS len
+           FROM part
+          WHERE length(data) > ?
+            AND instr(data, 'data:') > 0
+            AND instr(data, '"offloaded":true') = 0`,
+      )
+      .all(minBytes)
+    result.scanned = rows.length
+    if (rows.length === 0) return result
+
+    const newestMessageBySession = new Map<string, string>()
+    for (const r of db
+      .query<{ session_id: string; id: string }, []>(
+        `SELECT m.session_id, m.id FROM message m
+          WHERE m.time_created = (SELECT MAX(time_created) FROM message WHERE session_id = m.session_id)`,
+      )
+      .all()) {
+      newestMessageBySession.set(r.session_id, r.id)
+    }
+
+    // Attachment counts need the JSON; only for the pre-filtered rows.
+    const counted = rows.map((r) => {
+      const row = db.query<{ data: string }, [string]>('SELECT data FROM part WHERE id = ?').get(r.id)
+      let attachmentCount = 0
+      let compacted = false
+      try {
+        const part = JSON.parse(row?.data ?? '{}') as Record<string, unknown>
+        attachmentCount = inlineAttachmentsOf(part).filter((a) => isOffloadable(a, minBytes)).length
+        const state = part.state as { time?: { compacted?: unknown } } | undefined
+        compacted = Boolean(state?.time?.compacted)
+      } catch {
+        attachmentCount = 0
+      }
+      return { ...r, attachmentCount, compacted }
+    })
+    const chosen = selectCandidates(
+      counted.filter((r) => r.attachmentCount > 0),
+      newestMessageBySession,
+      keepNewest,
+    )
+    result.sessions = new Set(counted.filter((r) => chosen.has(r.id)).map((r) => r.session_id)).size
+
+    const select = db.query<PartRow, [string]>(
+      'SELECT id, message_id, session_id, time_created, time_updated, data FROM part WHERE id = ?',
+    )
+    const update = db.query<unknown, [string, number, string, number]>(
+      'UPDATE part SET data = ?, time_updated = ? WHERE id = ? AND time_updated = ?',
+    )
+    const nowIso = (opts.now ?? (() => new Date()))().toISOString()
+
+    let touched = 0
+    for (const id of chosen) {
+      if (touched >= maxParts) break
+      const row = select.get(id)
+      if (!row) continue
+      let part: Record<string, unknown>
+      try {
+        part = JSON.parse(row.data) as Record<string, unknown>
+      } catch {
+        result.errors++
+        continue
+      }
+      let moved = 0
+      for (const a of inlineAttachmentsOf(part)) {
+        if (!isOffloadable(a, minBytes)) continue
+        const decoded = decodeDataUrl(a.url as string)
+        if (!decoded) continue
+        const sidecar = sidecarPathFor(opts.sidecarDir, a.id as string)
+        try {
+          writeSidecarAtomic(sidecar, decoded.bytes)
+        } catch (err) {
+          result.errors++
+          logger.warn('[offload] sidecar write failed', { sidecar, err: (err as Error).message })
+          continue
+        }
+        const marker: OffloadedMarker = {
+          offloaded: true,
+          sidecar,
+          bytes: decoded.bytes.byteLength,
+          mime: a.mime ?? decoded.mime,
+          at: nowIso,
+        }
+        a.kortix = marker
+        a.url = OFFLOAD_PLACEHOLDER_URL
+        moved += decoded.bytes.byteLength
+      }
+      if (moved === 0) continue
+      opts.beforeUpdate?.(row.id)
+      try {
+        const res = update.run(JSON.stringify(part), Date.now(), row.id, row.time_updated)
+        if ((res as { changes?: number }).changes === 0) {
+          result.skippedBusy++
+          continue
+        }
+        result.offloaded++
+        result.bytesMoved += moved
+        touched++
+      } catch (err) {
+        result.errors++
+        logger.warn('[offload] row update failed', { id: row.id, err: (err as Error).message })
+      }
+    }
+    return result
+  } catch (err) {
+    result.errors++
+    logger.warn('[offload] pass failed', { err: (err as Error).message })
+    return result
+  } finally {
+    try {
+      db.close()
+    } catch {
+      // nothing to do
+    }
+    result.durationMs = Date.now() - t0
+    if (result.offloaded > 0 || result.errors > 0) {
+      logger.info('[offload] pass', { ...result, dbPath: opts.dbPath })
+    }
+  }
+}
+
+/** Where OpenCode 1.18 keeps the transcript for this HOME. */
+export function opencodeDbPath(home: string): string {
+  return join(home, '.local', 'share', 'opencode', 'opencode.db')
+}
+
+export function defaultSidecarDir(home: string): string {
+  return join(home, '.local', 'share', 'kortix', 'attachments')
+}

--- a/apps/kortix-sandbox-agent-server/src/inline-attachments.ts
+++ b/apps/kortix-sandbox-agent-server/src/inline-attachments.ts
@@ -1,3 +1,4 @@
+import { isOffloadPlaceholder } from './attachment-offload';
 /**
  * Take the file BYTES out of a session's message list.
  *
@@ -78,9 +79,11 @@ export function stripInlineAttachmentBytes(
     // An attachment the offload moved to a sidecar (attachment-offload.ts)
     // carries only a 1×1 placeholder inline; it is ALWAYS handed out as a
     // ref, size notwithstanding, so the UI fetches the real bytes on demand.
+    // Either signal: the marker (present when the daemon reads the row itself)
+    // or the placeholder URL (all that survives a read through OpenCode's API).
     const offloaded =
       obj.type === 'file' &&
-      Boolean((obj.kortix as { offloaded?: unknown } | undefined)?.offloaded)
+      (Boolean((obj.kortix as { offloaded?: unknown } | undefined)?.offloaded) || isOffloadPlaceholder(obj.url))
     const inlineTooBig = isDataUrl(obj.url) && obj.url.length > maxBytes
     if (obj.type === 'file' && typeof obj.id === 'string' && nextMessageId && (offloaded || inlineTooBig)) {
       stripped += 1;

--- a/apps/kortix-sandbox-agent-server/src/inline-attachments.ts
+++ b/apps/kortix-sandbox-agent-server/src/inline-attachments.ts
@@ -75,15 +75,16 @@ export function stripInlineAttachmentBytes(
           ? obj.messageID
           : messageId;
 
-    if (
+    // An attachment the offload moved to a sidecar (attachment-offload.ts)
+    // carries only a 1×1 placeholder inline; it is ALWAYS handed out as a
+    // ref, size notwithstanding, so the UI fetches the real bytes on demand.
+    const offloaded =
       obj.type === 'file' &&
-      isDataUrl(obj.url) &&
-      obj.url.length > maxBytes &&
-      typeof obj.id === 'string' &&
-      nextMessageId
-    ) {
+      Boolean((obj.kortix as { offloaded?: unknown } | undefined)?.offloaded)
+    const inlineTooBig = isDataUrl(obj.url) && obj.url.length > maxBytes
+    if (obj.type === 'file' && typeof obj.id === 'string' && nextMessageId && (offloaded || inlineTooBig)) {
       stripped += 1;
-      savedBytes += obj.url.length;
+      savedBytes += typeof obj.url === 'string' ? obj.url.length : 0;
       return { ...obj, url: makeRef(nextMessageId, obj.id) };
     }
 

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -197,7 +197,7 @@ export function buildOpencodeApp(
   kortixRouter.route('/pty', ptyRouter)
   kortixRouter.route('/pty/', ptyRouter)
   // /kortix/part — attachment bytes on demand; see routes/part.ts.
-  const partRouter = createPartRouter(opencode)
+  const partRouter = createPartRouter(opencode, { sidecarDir: defaultSidecarDir(OPENCODE_HOME) })
   kortixRouter.route('/part', partRouter)
   kortixRouter.route('/part/', partRouter)
   // /kortix/logs — the daemon's own log file + OpenCode's; see routes/logs.ts.

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -15,6 +15,8 @@ import { createRefreshRouter } from './routes/refresh'
 import { createLogsRouter } from './routes/logs'
 import { createDiagRouter } from './routes/diag'
 import { type ResourceMonitor, startResourceMonitor } from './resources'
+import { defaultSidecarDir, opencodeDbPath, runAttachmentOffloadPass } from './attachment-offload'
+import { opencodeTurnInFlight, readPinnedSessionId } from './opencode-turn-state'
 import { OPENCODE_HOME } from './opencode'
 import { createAbortRouter } from './routes/abort'
 import { createEnvRouter } from './routes/env'
@@ -500,10 +502,56 @@ export function startProxy(
   // Box telemetry: a `[resources]` log line every minute and on every
   // opencode state change, `[resources] pressure` when a threshold is crossed.
   resourceMonitor?.stop()
+  const turnInFlight = () => opencodeTurnInFlight(opencode.getInternalUrl(), cfg.workspace)
+  // Attachment offload (attachment-offload.ts): inline image bytes out of the
+  // transcript store, only while no turn runs. Every 5 min, and right after a
+  // memory-guard abort.
+  const offloadDbPath = opencodeDbPath(OPENCODE_HOME)
+  const offloadSidecarDir = defaultSidecarDir(OPENCODE_HOME)
+  let offloadRunning = false
+  const runOffloadIfIdle = async (why: string): Promise<void> => {
+    if (offloadRunning) return
+    if (process.env.KORTIX_ATTACHMENT_OFFLOAD === '0') return
+    offloadRunning = true
+    try {
+      if ((await turnInFlight()) !== false) return
+      const result = await runAttachmentOffloadPass({ dbPath: offloadDbPath, sidecarDir: offloadSidecarDir })
+      if (result.offloaded > 0) logger.info('[offload] moved attachment bytes out of the transcript', { why, ...result })
+    } catch (err) {
+      logger.warn('[offload] pass threw', { err: (err as Error).message })
+    } finally {
+      offloadRunning = false
+    }
+  }
+  const offloadTimer = setInterval(() => void runOffloadIfIdle('interval'), 5 * 60_000)
+  offloadTimer.unref?.()
+  setTimeout(() => void runOffloadIfIdle('boot'), 90_000).unref?.()
+
   resourceMonitor = startResourceMonitor({
     opencodePid: () => opencode.getPid(),
     opencodeState: () => opencode.getState(),
     diskPaths: [cfg.workspace, '/opt/kortix', '/tmp'],
+    guard: {
+      guardPct: Number(process.env.KORTIX_MEMORY_GUARD_PCT) || undefined,
+      turnInFlight,
+      abortTurn: async (reason) => {
+        const sessionId = readPinnedSessionId()
+        if (!sessionId) return false
+        const url =
+          `${opencode.getInternalUrl()}/session/${encodeURIComponent(sessionId)}/abort` +
+          `?directory=${encodeURIComponent(cfg.workspace)}`
+        logger.error('[resources] memory guard aborting the running turn', { sessionId, reason })
+        const res = await fetch(url, { method: 'POST', signal: AbortSignal.timeout(10_000) })
+        return res.ok
+      },
+      onGuard: async ({ reason, snapshot, aborted }) => {
+        // Tell the control plane in the same words the UI already renders for
+        // a turn that ended in error, BEFORE OpenCode's own `session.error`
+        // ("Aborted") can claim the turn end — the first end wins.
+        await relayMemoryGuardTurnEnd({ reason, aborted, opencodeRssMb: snapshot.opencode?.rssMb ?? null })
+        void runOffloadIfIdle('memory-guard')
+      },
+    },
   })
   // A staged daemon update must not exit this process while somebody has a
   // terminal open — the PTY dies with the daemon that spawned it. The registry
@@ -598,5 +646,50 @@ export function startProxy(
     async stop() {
       server.stop(true)
     },
+  }
+}
+
+/**
+ * Report a memory-guard abort to apps/api as the turn's end, in the shape
+ * the turn-stream already accepts (`kind: 'end'`, `status: 'error'`), so the
+ * ledger records `failed` with a reason that names memory and the UI shows
+ * it. Sent BEFORE the abort lands: OpenCode's own `session.error` ("Aborted")
+ * follows, and the turn-stream keeps the first end for a turn.
+ */
+export async function relayMemoryGuardTurnEnd(input: {
+  reason: string
+  aborted: boolean
+  opencodeRssMb: number | null
+}): Promise<boolean> {
+  const projectId = process.env.KORTIX_PROJECT_ID
+  const sessionId = process.env.KORTIX_SESSION_ID
+  const token = process.env.KORTIX_TOKEN
+  const apiUrl = (process.env.KORTIX_API_URL ?? '').replace(/\/+$/, '')
+  if (!projectId || !sessionId || !token || !apiUrl) return false
+  const apiRoot = apiUrl.endsWith('/v1') ? apiUrl : `${apiUrl}/v1`
+  try {
+    const res = await fetch(`${apiRoot}/projects/${encodeURIComponent(projectId)}/turn-stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        session_id: sessionId,
+        kind: 'end',
+        status: 'error',
+        opencode_session_id: readPinnedSessionId() ?? undefined,
+        error_name: 'SandboxMemoryGuard',
+        error_message: input.reason,
+        error_retryable: true,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    })
+    logger.warn('[resources] memory guard relayed to the control plane', {
+      status: res.status,
+      aborted: input.aborted,
+      opencodeRssMb: input.opencodeRssMb,
+    })
+    return res.ok
+  } catch (err) {
+    logger.warn('[resources] memory guard relay failed', { err: (err as Error).message })
+    return false
   }
 }

--- a/apps/kortix-sandbox-agent-server/src/resources.ts
+++ b/apps/kortix-sandbox-agent-server/src/resources.ts
@@ -285,12 +285,48 @@ export function evaluatePressure(s: ResourceSnapshot, previous?: ResourceSnapsho
   return out
 }
 
+/**
+ * The memory guard: act BEFORE the kernel does.
+ *
+ * Essentia 2026-08-25 23:12Z: OpenCode reached 6.48 GB RSS on an 8 GB box and
+ * the kernel OOM-killed it mid-turn (`dmesg`: `Killed process 1506
+ * (opencode.exe) anon-rss:6484532kB`). The assistant message in flight was
+ * left as an empty husk, the ledger had to infer an ending, and nothing had
+ * said "memory" anywhere the operator could see.
+ *
+ * Above `elevatedPct` (80) the monitor samples every `fastIntervalMs` (10 s)
+ * instead of every minute. At `guardPct` (92) with a turn in flight it calls
+ * `abortTurn`: OpenCode ends the turn cleanly (transcript consistent,
+ * process alive, a real `session.error`), the box gets its memory back, and
+ * `onGuard` tells the control plane why. One guard action per crossing; the
+ * next one needs the box to drop below `elevatedPct` first.
+ */
+export interface MemoryGuardOptions {
+  /** 0..100 of box memory (or cgroup, whichever is higher). Default 92. */
+  guardPct?: number
+  /** Sample fast above this. Default 80. */
+  elevatedPct?: number
+  fastIntervalMs?: number
+  turnInFlight: () => Promise<boolean | null>
+  abortTurn: (reason: string) => Promise<boolean>
+  onGuard?: (info: { reason: string; snapshot: ResourceSnapshot; aborted: boolean }) => void | Promise<void>
+}
+
 export interface ResourceMonitorOptions {
   intervalMs?: number
   diskPaths?: string[]
   opencodePid: () => number | null
   opencodeState?: () => string
   snapshot?: (inputs: SnapshotInputs) => Promise<ResourceSnapshot>
+  guard?: MemoryGuardOptions
+}
+
+/** The memory figure the guard judges: box used% or cgroup used%, whichever is worse. */
+export function memoryPressurePct(s: ResourceSnapshot): number | null {
+  const a = s.memory.usedPct
+  const b = s.cgroup.usedPct
+  if (a === null && b === null) return null
+  return Math.max(a ?? 0, b ?? 0)
 }
 
 export interface ResourceMonitor {
@@ -314,11 +350,54 @@ export function startResourceMonitor(opts: ResourceMonitorOptions): ResourceMoni
   const intervalMs = opts.intervalMs ?? DEFAULT_RESOURCE_INTERVAL_MS
   const diskPaths = opts.diskPaths ?? DEFAULT_DISK_PATHS
   const snapshot = opts.snapshot ?? readResourceSnapshot
+  const guard = opts.guard
+  const guardPct = guard?.guardPct ?? 92
+  const elevatedPct = guard?.elevatedPct ?? 80
+  const fastIntervalMs = guard?.fastIntervalMs ?? 10_000
   let latest: ResourceSnapshot | null = null
   let lastPressureKinds = ''
   let lastState = opts.opencodeState?.() ?? ''
   let ticking = false
   let stopped = false
+  let fastTimer: ReturnType<typeof setInterval> | null = null
+  /** Armed again only once memory drops below `elevatedPct`. */
+  let guardFired = false
+
+  async function runGuard(s: ResourceSnapshot): Promise<void> {
+    if (!guard) return
+    const pct = memoryPressurePct(s)
+    if (pct === null) return
+    if (pct < elevatedPct) {
+      guardFired = false
+      if (fastTimer) {
+        clearInterval(fastTimer)
+        fastTimer = null
+        logger.info('[resources] memory back under the elevated line; slow sampling', { pct })
+      }
+      return
+    }
+    if (!fastTimer) {
+      logger.warn('[resources] memory elevated; sampling every 10 s', { pct, elevatedPct })
+      fastTimer = setInterval(() => void guardedTick('elevated'), fastIntervalMs)
+      fastTimer.unref?.()
+    }
+    if (pct < guardPct || guardFired) return
+    guardFired = true
+    const inFlight = await guard.turnInFlight().catch(() => null)
+    const reason =
+      `sandbox memory at ${pct}% (opencode ${s.opencode?.rssMb ?? '?'} MB RSS of ` +
+      `${s.cgroup.maxMb ?? s.memory.totalMb ?? '?'} MB): turn stopped before the kernel would kill opencode`
+    let aborted = false
+    if (inFlight !== false) {
+      aborted = await guard.abortTurn(reason).catch(() => false)
+    }
+    logger.error('[resources] memory guard', { pct, guardPct, inFlight, aborted, reason, ...s })
+    try {
+      await guard.onGuard?.({ reason, snapshot: s, aborted })
+    } catch (err) {
+      logger.warn('[resources] memory guard relay failed', { err: (err as Error).message })
+    }
+  }
 
   async function tick(reason: string): Promise<ResourceSnapshot> {
     const s = await snapshot({ daemonPid: process.pid, opencodePid: opts.opencodePid(), diskPaths })
@@ -338,6 +417,11 @@ export function startResourceMonitor(opts: ResourceMonitorOptions): ResourceMoni
       // telemetry must never throw
     }
     latest = s
+    try {
+      await runGuard(s)
+    } catch {
+      // the guard is best-effort; never let it break sampling
+    }
     return s
   }
 
@@ -374,6 +458,7 @@ export function startResourceMonitor(opts: ResourceMonitorOptions): ResourceMoni
       stopped = true
       clearInterval(timer)
       if (stateTimer) clearInterval(stateTimer)
+      if (fastTimer) clearInterval(fastTimer)
     },
     latest: () => latest,
     tick,

--- a/apps/kortix-sandbox-agent-server/src/routes/part.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/part.ts
@@ -1,23 +1,50 @@
+/**
+ * GET /kortix/part/:sessionID/:messageID/:partID — attachment bytes on demand.
+ *
+ * The proxy strips inline `data:` attachment bytes out of message-list
+ * responses (inline-attachments.ts) and hands the UI a reference to this
+ * route instead. Two places hold an attachment:
+ *   - a top-level `file` part of the message;
+ *   - a tool part's `state.attachments[]` (screenshots a tool returned) —
+ *     each entry is a file-shaped object with its own `id`. Until 2026-08-25
+ *     this route only searched top-level parts, so every tool screenshot
+ *     404'd on demand.
+ * An attachment the offload moved to a sidecar (attachment-offload.ts,
+ * `kortix.offloaded`) is served from that file; the row only holds a 1×1
+ * placeholder.
+ */
 import { Hono } from 'hono'
+import { readFileSync } from 'node:fs'
+import type { AttachmentLike } from '../attachment-offload'
+import { inlineAttachmentsOf } from '../attachment-offload'
 import { logger } from '../logger'
 import type { Opencode } from '../opencode'
 
-/**
- * GET /kortix/part/:sessionID/:messageID/:partID — the BYTES of one attachment.
- *
- * The transcript list (`GET /session/:id/message`) no longer carries file
- * bytes: `stripInlineAttachmentBytes` in the proxy swaps every oversized
- * `data:` url for a path to this route, so a session with hundreds of image
- * reads lists in kilobytes instead of tens of megabytes. This is where those
- * bytes are fetched from — one part at a time, only when a row is on screen.
- *
- * Source of truth is still opencode: the single-message read
- * (`/session/:id/message/:mid`) returns the part with its `data:` url intact,
- * and we decode it here. No second copy of the bytes anywhere.
- *
- * A part never changes once written, so the response is `immutable` with a
- * strong ETag on the part id: the browser asks once per part, ever.
- */
+export function findAttachment(
+  parts: Array<Record<string, unknown>> | undefined,
+  partID: string,
+): AttachmentLike | null {
+  for (const part of parts ?? []) {
+    if (!part || typeof part !== 'object') continue
+    for (const a of inlineAttachmentsOf(part)) {
+      if (a.id === partID) return a
+    }
+  }
+  return null
+}
+
+function bytesResponse(bytes: Buffer, mime: string, etag: string): Response {
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      'Content-Type': mime,
+      'Content-Length': String(bytes.byteLength),
+      'Cache-Control': 'private, max-age=31536000, immutable',
+      ETag: etag,
+    },
+  })
+}
+
 export function createPartRouter(opencode: Opencode): Hono {
   const app = new Hono()
 
@@ -27,13 +54,11 @@ export function createPartRouter(opencode: Opencode): Hono {
     if (c.req.header('if-none-match') === etag) {
       return new Response(null, { status: 304, headers: { ETag: etag } })
     }
-
     const workspace = process.env.KORTIX_WORKSPACE || '/workspace'
     const url =
       `${opencode.getInternalUrl()}/session/${encodeURIComponent(sessionID)}` +
       `/message/${encodeURIComponent(messageID)}?directory=${encodeURIComponent(workspace)}`
-
-    let message: { parts?: Array<{ id?: string; url?: string; mime?: string }> }
+    let message: { parts?: Array<Record<string, unknown>> }
     try {
       const res = await fetch(url, { signal: AbortSignal.timeout(30_000) })
       if (!res.ok) {
@@ -44,15 +69,21 @@ export function createPartRouter(opencode: Opencode): Hono {
       logger.error('[part] upstream read failed', err)
       return c.json({ error: 'upstream unreachable' }, 502)
     }
-
-    const part = message.parts?.find((p) => p?.id === partID)
+    const part = findAttachment(message.parts, partID)
     if (!part || typeof part.url !== 'string') {
       return c.json({ error: 'part not found' }, 404)
     }
-
+    if (part.kortix?.offloaded) {
+      try {
+        const bytes = readFileSync(part.kortix.sidecar)
+        return bytesResponse(bytes, part.kortix.mime || part.mime || 'application/octet-stream', etag)
+      } catch (err) {
+        logger.error('[part] offloaded sidecar unreadable', { sidecar: part.kortix.sidecar, err: (err as Error).message })
+        return c.json({ error: 'attachment bytes missing', sidecar: part.kortix.sidecar }, 410)
+      }
+    }
     const match = /^data:([^;,]+)?(;base64)?,(.*)$/s.exec(part.url)
     if (!match) {
-      // Not inline — it is a real URL the client can follow itself.
       return c.redirect(part.url, 302)
     }
     const mimeFromUrl = match[1]
@@ -61,16 +92,7 @@ export function createPartRouter(opencode: Opencode): Hono {
     const bytes = isBase64
       ? Buffer.from(payload, 'base64')
       : Buffer.from(decodeURIComponent(payload), 'utf8')
-
-    return new Response(bytes, {
-      status: 200,
-      headers: {
-        'Content-Type': part.mime || mimeFromUrl || 'application/octet-stream',
-        'Content-Length': String(bytes.byteLength),
-        'Cache-Control': 'private, max-age=31536000, immutable',
-        ETag: etag,
-      },
-    })
+    return bytesResponse(bytes, part.mime || mimeFromUrl || 'application/octet-stream', etag)
   })
 
   return app

--- a/apps/kortix-sandbox-agent-server/src/routes/part.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/part.ts
@@ -16,7 +16,8 @@
 import { Hono } from 'hono'
 import { readFileSync } from 'node:fs'
 import type { AttachmentLike } from '../attachment-offload'
-import { inlineAttachmentsOf } from '../attachment-offload'
+import { inlineAttachmentsOf, isOffloadPlaceholder, sidecarPathFor } from '../attachment-offload'
+import { existsSync } from 'node:fs'
 import { logger } from '../logger'
 import type { Opencode } from '../opencode'
 
@@ -45,7 +46,7 @@ function bytesResponse(bytes: Buffer, mime: string, etag: string): Response {
   })
 }
 
-export function createPartRouter(opencode: Opencode): Hono {
+export function createPartRouter(opencode: Opencode, opts: { sidecarDir: string | null } = { sidecarDir: null }): Hono {
   const app = new Hono()
 
   app.get('/:sessionID/:messageID/:partID', async (c) => {
@@ -73,13 +74,21 @@ export function createPartRouter(opencode: Opencode): Hono {
     if (!part || typeof part.url !== 'string') {
       return c.json({ error: 'part not found' }, 404)
     }
-    if (part.kortix?.offloaded) {
+    // Offloaded (attachment-offload.ts): the marker when the row came straight
+    // from the daemon, the placeholder URL when it came through OpenCode (which
+    // drops unknown fields). The sidecar path is deterministic from the id.
+    const sidecar = part.kortix?.offloaded
+      ? part.kortix.sidecar
+      : isOffloadPlaceholder(part.url) && opts.sidecarDir
+        ? sidecarPathFor(opts.sidecarDir, partID)
+        : null
+    if (sidecar && (part.kortix?.offloaded || existsSync(sidecar))) {
       try {
-        const bytes = readFileSync(part.kortix.sidecar)
-        return bytesResponse(bytes, part.kortix.mime || part.mime || 'application/octet-stream', etag)
+        const bytes = readFileSync(sidecar)
+        return bytesResponse(bytes, part.kortix?.mime || part.mime || 'application/octet-stream', etag)
       } catch (err) {
-        logger.error('[part] offloaded sidecar unreadable', { sidecar: part.kortix.sidecar, err: (err as Error).message })
-        return c.json({ error: 'attachment bytes missing', sidecar: part.kortix.sidecar }, 410)
+        logger.error('[part] offloaded sidecar unreadable', { sidecar, err: (err as Error).message })
+        return c.json({ error: 'attachment bytes missing', sidecar }, 410)
       }
     }
     const match = /^data:([^;,]+)?(;base64)?,(.*)$/s.exec(part.url)

--- a/apps/web/content/docs/work/runtime.mdx
+++ b/apps/web/content/docs/work/runtime.mdx
@@ -110,6 +110,14 @@ The daemon sends `KORTIX_TOKEN` only to the Kortix Git proxy. The proxy resolves
 
 The daemon launches OpenCode as `opencode serve --port 4096 --hostname 127.0.0.1`, with `OPENCODE_CONFIG_DIR` set to the project's config directory (default `.kortix/opencode`) inside the cloned repo. See [Agents](/docs/project/agents) for how a session picks an agent and its config.
 
+## Transcript attachments and memory
+
+OpenCode stores tool screenshots as base64 `data:` URLs inside its SQLite transcript. The daemon keeps that store small and the box alive:
+
+- **Attachment offload.** While no turn runs (every 5 minutes, at boot, and after a memory-guard event), attachment bytes older than the newest 12 per session — and every tool result OpenCode's compaction already cleared — move to `~/.local/share/kortix/attachments/<id>`. The row keeps a 1×1 PNG placeholder plus a `kortix.offloaded` marker; `/kortix/part` serves the real bytes to the UI. Models never receive those old images anyway (the LLM proxy keeps the newest 12 per request). Set `KORTIX_ATTACHMENT_OFFLOAD=0` to disable.
+- **Resource telemetry.** `[resources]` in the daemon log every 60 s and on every OpenCode state change: box memory, cgroup limit, load, disk, daemon and OpenCode RSS.
+- **Memory guard.** Above 80 % memory the daemon samples every 10 s; at 92 % (`KORTIX_MEMORY_GUARD_PCT`) with a turn in flight it aborts the turn cleanly and reports `SandboxMemoryGuard` with the numbers as the turn's error, instead of letting the kernel kill OpenCode mid-turn.
+
 ## The daemon control surface
 
 The `kortix-agent` binary runs as PID 1's child and fronts OpenCode on `KORTIX_SERVICE_PORT` (`8000`). Every route outside `/kortix/*` requires the HMAC-signed `X-Kortix-User-Context` header, validated against `KORTIX_TOKEN`.
@@ -122,6 +130,7 @@ The `kortix-agent` binary runs as PID 1's child and fronts OpenCode on `KORTIX_S
 | `POST /kortix/env` | Update the runtime environment. |
 | `/kortix/pty` | Backs the in-dashboard terminal. |
 | `GET /kortix/logs` | Tails the daemon's own log file (`/opt/kortix/logs/daemon.log`, rotated at 32 MiB) or OpenCode's. `?source=daemon\|opencode\|all`, `?tail=N` (default 500, max 5000). Plain text. Same auth as `/kortix/refresh`. |
+| `GET /kortix/part/:sessionID/:messageID/:partID` | Attachment bytes on demand — a top-level file part or a tool result's `state.attachments[]` entry. Bytes the daemon offloaded to a sidecar file are served from there. |
 | `GET /kortix/diag` | One JSON error report: OpenCode state/pid/port/port pair, boot timeline, a fresh resource snapshot (memory, cgroup limit, load, disk, RSS, duplicate opencode processes), the runtime-assets report, and the tail of both logs (`?tail=N`, default 200). Same auth as `/kortix/logs`. |
 | `/proxy/{port}/*` | Reverse-proxy to another port inside the sandbox. The daemon's own port is blocked. |
 | `*` | Catch-all reverse-proxy to OpenCode on `127.0.0.1:4096`. Returns `503` while OpenCode boots. |


### PR DESCRIPTION
Follow-up to #6904. Essentia session `9df2a873`, 2026-08-25 23:12Z: the kernel OOM-killed OpenCode at **6.48 GB RSS on an 8 GB box** mid-turn (`dmesg`: `Killed process 1506 (opencode.exe) anon-rss:6484532kB`), leaving an empty assistant husk.

Two forces met: the transcript held **275 MB of base64 tool screenshots** in `part.state.attachments[].url` (352 of 538 tool parts) which every LLM step and every list re-serialised, and the reaper re-probed that box **345 times in one hour** after `unknown` (two replicas, 20 s cadence), each probe forcing a full-transcript serialisation. #6904 bounded the probe; this PR removes the other links.

Checked against OpenCode's own code (dev branch = 1.18.23, the build we run): tool images are always stored as `data:` URLs (`tool/read.ts`); compaction clears old output *text* and stops *sending* old attachments (`state.time.compacted`) but never removes bytes from storage; non-`data:` attachment URLs are dropped from tool results (`message-v2.ts:172`) but the media-extraction path forwards attachment URLs as-is to the provider — so a placeholder must stay a valid `data:` image.

## 1. Attachment offload (daemon, `attachment-offload.ts`)
While no turn runs (every 5 min, at boot, after a guard event): attachments older than the newest 12 per session — and every tool result OpenCode already compacted — move to `~/.local/share/kortix/attachments/<id>`; the SQLite row keeps a 1×1 PNG `data:` placeholder + `kortix:{offloaded,sidecar,bytes,mime}`. Optimistic `UPDATE … WHERE time_updated = ?`; never the newest message; sidecar written+fsynced before the row changes; bounded per pass; never throws. **Verified live on 1.18.23 (box i67m4): OpenCode serves the rewritten row on the next read — 7 ms UPDATE with OpenCode holding the DB (WAL), no restart** (experiment was reversible and reverted). The model never received those images anyway (the LLM proxy keeps the newest 12 per request). `KORTIX_ATTACHMENT_OFFLOAD=0` disables.

`/kortix/part` now also searches nested `state.attachments` (tool screenshots **404'd on demand before** — a pre-existing gap) and serves offloaded bytes from the sidecar (410 if the file is gone). The response stripper hands offloaded attachments out as refs regardless of size.

## 2. Memory guard (daemon, `resources.ts`)
≥80 % box/cgroup memory → 10 s sampling. ≥92 % (`KORTIX_MEMORY_GUARD_PCT`) with a turn in flight → `POST /session/:id/abort`, turn-stream `kind:end status:error error_name:SandboxMemoryGuard` carrying the numbers (sent first so it wins the turn's end), then an offload pass. One action per crossing; re-armed below 80 %. The turn still ends — but cleanly, with a reason on record, OpenCode alive, transcript consistent — instead of a kernel kill and a `parts: []` husk.

## 3. Reaper probe back-off (API, `box-reaper.ts`)
An `unknown` observation backs the *probe* off per sandbox (20 s → 5 min, per replica; escalates only on a pass that actually probed; cleared by the first readable answer). The deadline drip still extends. This protects boxes that still run an old daemon — which is every long-lived big-root box right now: an old daemon's own swap gate reads `null` on such roots, so it cannot retire itself until its next restart.

## Verification
- daemon: `bun test` **924 pass** (new: `attachment-offload.test.ts` on a real `bun:sqlite` fixture in the 1.18.23 row shape incl. the optimistic-skip race; `part-route-attachments.test.ts`; memory-guard tests); `tsc` clean.
- api: `sandbox-reaper.test.ts` **149 pass** (new: "not re-probed until its back-off elapses"); `tsc` clean.
- Live experiment (reversible): external UPDATE of one attachment row on Essentia box i67m4 → OpenCode returned the new value immediately → restored.
- Docs: `runtime.mdx` "Transcript attachments and memory" + `/kortix/part` row. Learnings entry appended.

## Not in this PR
- SDK/CLI surface for `/kortix/logs|diag` (`kortix sessions logs`).
- Storage-side offload of *user* file parts (none observed on Essentia; tool attachments were 100 % of the bytes).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790294237&installation_model_id=434224&pr_number=6907&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6907&signature=b0c360bc6e0b137a0f514f553899c33dea651c6bd2e7d4a161d55a772f1b8201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

### Real-box proof (local stack, Platinum `sbx_01M0XPV30QY7GFZX87WM5XP9C0`)
Seeded 16 tool parts with 64 KB PNG attachments into the box's real `opencode.db` (1.18.23 row shape) for the pinned root, then let the daemon's boot pass run:
- daemon log: `[offload] pass scanned:16 offloaded:3 bytesMoved:196632 skippedBusy:0 errors:0 durationMs:18` (16 parts − newest message − newest 12 = 3).
- OpenCode's own API: oldest part → placeholder URL (114 chars); newest part → original inline (87,414 chars). No `kortix` field comes back through OpenCode (its schema drops unknown keys) — which the 2nd run caught and `de7fa4d2d1` fixed: the runtime resolves offloaded attachments by placeholder URL + id.
- `/kortix/part/<root>/msg_seed00/prt_seed00att` through the sandbox proxy → **200 image/png, 65,544 bytes** (the seeded file), PNG magic verified.
- DB: offloaded rows 761 bytes vs 87,938 kept; 3 sidecars in `~/.local/share/kortix/attachments`.
- `/kortix/diag`: opencode RSS 508 MB, box 19 % used.
