### PR TITLE
chore(api): reaper drip log carries probed + backoffMs

### DIFF
--- a/apps/api/src/projects/reaping/box-reaper.ts
+++ b/apps/api/src/projects/reaping/box-reaper.ts
@@ -590,6 +590,10 @@ export async function reapAndReconcileSandboxes(
               externalId: row.externalId,
               provider: row.provider,
               turns: turns.length,
+              // Was the daemon ASKED this pass, or is this a backed-off drip?
+              // Without this the log cannot tell 20 s drips from 20 s probes.
+              probed: backedOffProbes === 0,
+              backoffMs: probeBackoff.get(row.sandboxId)?.backoffMs ?? null,
               deadlineAt: row.deadlineAt.toISOString(),
               extended,
             });


### PR DESCRIPTION
Follow-up to #6907. On Essentia the drip line still arrives every 20 s (the deadline drip continues by design while the probe backs off), so the log alone could not prove the probe cadence. The warn now carries `probed` (was the daemon asked this pass) and `backoffMs`. No behaviour change. `sandbox-reaper.test.ts` 149 pass; `tsc` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790297023&installation_model_id=434224&pr_number=6908&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6908&signature=6ded20f30fa5b2eae7e4907eca484ce7ea65dee19c839c5a9485607600af4d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->