### PR TITLE
docs(secrets): PROD dotenvx keys are owner-only via Armor FGAC

### DIFF
--- a/.claude/skills/dotenvx-secrets/SKILL.md
+++ b/.claude/skills/dotenvx-secrets/SKILL.md
@@ -13,9 +13,30 @@ All API and web profiles belong to the single Armor organization **`kortix`**.
 Always pass `--team kortix` when pushing or pulling. Never rely on the CLI's
 personal-team default.
 
-Production uses the same organization and access token as non-production.
-Keep production pulls as a separate, explicit command. This is an operational
-guardrail, not an authorization boundary.
+Access is scoped **per member, per armored key** (Dotenvx Armor FGAC, Business
+plan; one armored key == one `.env*` file). Since 2026-08-26 the two PROD keys
+(`apps/api/.env.prod`, `apps/web/.env.prod`) are granted to the **owner only**.
+Every other member (admin or member role) has all `.env`, `.env.dev`, and
+`.env.staging` keys. Armor refuses a non-owner `dotenvx run -f .env.prod`
+(`PERMISSION_DENIED` on CLI 2.x); that is the intended boundary, not a broken login.
+
+Manage access with `dotenvx curl` (CLI >= 2.18):
+
+```sh
+dotenvx curl "https://armor.dotenvx.com/api/teams/kortix/members"          # member ids + roles
+dotenvx curl "https://armor.dotenvx.com/api/armor/keypairs?per=100"        # keys, named per file
+dotenvx curl "https://armor.dotenvx.com/api/teams/kortix/members/<id>/keypairs/<public_key>/grant"  --request POST
+dotenvx curl "https://armor.dotenvx.com/api/teams/kortix/members/<id>/keypairs/<public_key>/revoke" --request POST
+dotenvx curl "https://armor.dotenvx.com/api/logs?team=kortix&events=keypair/access&keypair=<public_key>"  # who decrypted it
+```
+
+Use the `/api/teams/kortix/...` routes: the PROD public keys also exist in the
+leftover `kortix-ai-prod` team, so the bare `/api/armor/keypairs/...` routes
+return `DOTENVX_TEAM_REQUIRED`. There is no read endpoint for the access
+matrix; read it in the web UI (`Keypair › Team` tab) or infer it from
+`/api/logs`. A grant/revoke takes effect on the next `dotenvx run`; it cannot
+retract a private key already pulled into a local `.env.keys` — rotate the
+keypair for that.
 
 ## The four environments (local-run secrets)
 
@@ -68,7 +89,7 @@ This re-encrypts the file in place (value becomes `KEY=encrypted:…`). Then com
 | Read a secret                                | `dotenvx get KEY -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`)                                                             |
 | Add / change a secret                        | `dotenvx set KEY value -f apps/api/.env` (or `.env.dev` / `.env.staging` / `.env.prod`), then commit                                          |
 | First time / new machine (non-prod profiles) | `dotenvx armor login` then, from each app directory, `for f in .env .env.dev .env.staging; do dotenvx armor pull --team kortix -f "$f"; done` |
-| Pull prod (explicitly)                       | From each app directory: `dotenvx armor pull --team kortix -f .env.prod`                                                                      |
+| Run against prod (owner only)                | `pnpm dev:prod-env` — decrypts through Armor at run time; do **not** `armor pull -f .env.prod` into `.env.keys`                             |
 | Share a NEW profile / rotated key            | Push every profile with `--team kortix`                                                                                                       |
 | Remove a key from the cloud                  | `dotenvx armor down --team kortix -f <file>`                                                                                                  |
 


### PR DESCRIPTION
## What
- `.claude/skills/dotenvx-secrets/SKILL.md`: replace "same access token … not an authorization boundary" with the Armor FGAC model, the `dotenvx curl` grant/revoke/logs recipes, and remove the `armor pull -f .env.prod` onboarding step.

## Why
Armor (Business plan) scopes access per member per armored key. On 2026-08-26 the two PROD keys were restricted to the owner; every other key stays granted to every member. Docs now match the live state.

## Live state (read-only `dotenvx curl` evidence)
- `GET /api/teams/kortix` → `plan: business`, 5/10 members
- 8× `keypair_access/revoke` events at 04:09 on `02ed13d3…` (api .env.prod) and `02eef95d…` (web .env.prod) for ino/jay/vukasin/allen
- 24× grant on the 6 non-prod keys → `changed:false, granted:true` (already had them)
- 0 `armor pull`/`armor down` events on PROD keys → no teammate has the PROD private key in a local `.env.keys`; no rotation needed
- CI: `deploy-prod.yml:1217` uses GitHub secret `WEB_DOTENV_PRIVATE_KEY_PROD` — untouched, no rotation

## Not verified
- Whether Armor enforces the grant on the legacy `/api/keypair` route used by the repo-pinned dotenvx 1.75.1 (`pnpm dev:prod-env`). Ask a non-owner to run it; expected: refusal.

Docs-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790302319&installation_model_id=434224&pr_number=6909&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6909&signature=181fe34eae243c1061341bec00a7b2d8545b6f20020262ea445403fee79ae875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->