### PR TITLE
docs(learnings): non-prod secrets profile must never hold a prod-reaching credential

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2884,3 +2884,37 @@ storage (`session/compaction.ts`, `message-v2.ts`); there is no native
 1.18.23 row shape, optimistic-skip race), `part-route-attachments.test.ts`,
 `resources.test.ts` ("memory guard"), `sandbox-reaper.test.ts` ("not
 re-probed until its back-off elapses").
+
+## A non-prod secrets profile must never hold a production-reaching credential
+
+Found 2026-08-26 while scoping Dotenvx Armor access. `apps/api/.env` — the
+local profile every Armor member decrypts daily — carried 22 secrets
+byte-identical to `apps/api/.env.prod`. One of them, `SUPABASE_MGMT_TOKEN`,
+was a personal Supabase management token that executed SQL on the Kortix
+PROD project (`POST /v1/projects/<ref>/database/query` → 201) and was used
+nowhere in the repository. Restricting the PROD keypair to the owner had
+protected nothing, because the same credentials lived in the file everyone
+had.
+
+**Rules.**
+1. Classify a profile by what its credentials can reach, not by which
+   database URL it names. A local DB with production vendor keys is a
+   production profile.
+2. A secret-classed key in `.env`, `.env.dev`, or `.env.staging` must not
+   equal its `.env.prod` value. Every exception is a listed debt with the
+   rotation that removes it.
+3. Delete a credential the code never reads. A dead key is pure exposure.
+4. Personal tokens never belong in a shared profile. Use a service credential
+   scoped to one environment.
+5. A per-key access control (Armor FGAC) only works after the split above.
+   Do the split first, then restrict the prod keypair.
+6. `.env.dev` is not customer-data-free: the dev Supabase project holds live
+   signups. Only `.env` qualifies for people without production clearance.
+
+*Automation:* `pnpm test:envs` runs `scripts/secrets-envs-separation.py`,
+which fails on any unlisted non-prod secret that equals its prod value;
+`scripts/secrets-shared-with-prod.allowlist` is the tracked exception list.
+
+*Incident:* no known misuse. The Armor audit log shows the PROD keypairs were
+decrypted by 4 members and 1 former member before the restriction; the shared
+vendor credentials remain to be rotated per the allowlist (PR #6910).


### PR DESCRIPTION
Learnings entry for the 2026-08-26 near-miss (shared prod credentials in `apps/api/.env`, personal Supabase management token with PROD SQL reach). Rule + automation pointer to `scripts/secrets-envs-separation.py` (PR #6910). Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790303942&installation_model_id=434224&pr_number=6911&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6911&signature=c6424286a02d2b627485fd4f97ccd20da61cf4a8afb764f5410e9081cd9687bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->