### PR TITLE
docs(secrets): dev signups are synthetic per owner; gate on shared vendor keys instead

### DIFF
--- a/.claude/skills/dotenvx-secrets/SKILL.md
+++ b/.claude/skills/dotenvx-secrets/SKILL.md
@@ -60,9 +60,12 @@ There are **four environments**, each a separate encrypted file with its **own k
   remaining shared vendor keys with the reason and the rotation that removes
   each line. Do not add to that file to make the test pass — split the
   credential.
-- **`.env.dev` is NOT customer-data-free.** The `Kortix DEV` Supabase project
-  holds live signups from dev.kortix.com (2,793 users on 2026-08-26). Treat
-  dev like a production-adjacent environment for access decisions.
+- **`.env.dev`**: the `Kortix DEV` Supabase project holds signups from
+  dev.kortix.com (2,793 users on 2026-08-26). The owner classifies them as
+  synthetic test accounts, so dev is not customer data. It is still not safe
+  for people without production clearance until every prod-shared vendor key
+  in `scripts/secrets-shared-with-prod.allowlist` is split (dev/staging carry
+  the prod AWS IAM user, Daytona key, and Pipedream client today).
 - **`.env.prod`** is the owner-only record of every production credential;
   AWS Secrets Manager mirrors it for the deployed stack. Dead-in-code keys
   (Betterstack ClickHouse, JustAVPS) stay only in `.env.prod`.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -2908,8 +2908,10 @@ had.
    scoped to one environment.
 5. A per-key access control (Armor FGAC) only works after the split above.
    Do the split first, then restrict the prod keypair.
-6. `.env.dev` is not customer-data-free: the dev Supabase project holds live
-   signups. Only `.env` qualifies for people without production clearance.
+6. Classify each environment's data explicitly. The dev Supabase project
+   holds 2.7k signups that the owner classifies as synthetic; that decision
+   is recorded, not assumed. Until the shared vendor keys are split, only
+   `.env` qualifies for people without production clearance.
 
 *Automation:* `pnpm test:envs` runs `scripts/secrets-envs-separation.py`,
 which fails on any unlisted non-prod secret that equals its prod value;


### PR DESCRIPTION
Owner (2026-08-26) classifies the 2,793 dev.kortix.com signups as synthetic test accounts. Correct the dotenvx-secrets skill and the learnings rule: dev is not customer data; the remaining blocker for handing `.env.dev` to uncleared people is the prod-shared vendor keys in `scripts/secrets-shared-with-prod.allowlist`. Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790304237&installation_model_id=434224&pr_number=6912&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6912&signature=c76b972fc536cf7c3d6a94fc8c66f13c43797d3acf908000402b382368adcda9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->