### PR TITLE
fix(api,sdk): readiness clocks die with their attempt; a stopped queue re-delivers exactly once

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3054,3 +3054,55 @@ the same lineage, same provider, recent — convergence does not rebuild the bas
 rootfs. *Enforcer:* `last-ready-image.test.ts` (predecessor served while the new
 identity builds; first build still blocks) and `e2b.test.ts` (a resume never
 consults a template at all).
+
+## A retry that inherits the previous attempt's budget is not a retry
+
+*Incident (2026-08-26, Essentia, session `29861dfa` / box `inqwpv4a`).* The
+first production outing of the automatic wake-cooldown ladder (see "A stamped
+failure is a cooldown, never a gravestone") defeated itself.
+
+Attempt 1 failed at ~13:27 in a post-roll build storm. The cooldown rung
+re-attempted at ~13:33: the resume launched the entrypoint, the daemon booted
+through 13:34:48.8, authenticated to the gateway at 13:34:48.5–49.1 and claimed
+its initial turn at **13:34:49.216** — and `/start` parked the box at
+**13:34:49.202**. The boot lost by **14 ms**.
+
+`opencodeBootWaitFirstSeenAt` was stamped during attempt 1 and cleared by
+nothing: `parkEstablishedRuntime` copies the whole metadata object, the wake
+claim stripped only four of the ten readiness-clock keys, and
+`clearRuntimeReadinessClocks` stripped the first eight **by hardcoded index**.
+Only a human Restart (`prepareInPlaceRestartMetadata`, which loops the whole
+list) cleared it. So the 10-minute hard cap was ~7 minutes old before attempt 2
+started booting, and **every automatic rung after the first five minutes was
+deterministically doomed, regardless of progress.**
+
+**The rules.**
+
+1. **Every automatic retry re-baselines the same clocks a human retry does.** An
+   attempt judged against a predecessor's budget is not an attempt. The only
+   thing an automatic rung keeps that a human restart clears is the
+   consecutive-failure accounting that drives its own escalation.
+2. **Never write a key list twice.** The four/eight/ten split existed because
+   three call sites hand-wrote `- 'key'` chains. Generate every chain from the
+   single exported list; index-addressed subsets (`KEYS[0] … KEYS[7]`) silently
+   stop covering a list that grows.
+3. **Scope a budget to its attempt, causally.** `staleOpencodeReadyReason` now
+   ignores any clock stamped before this attempt's boot epoch
+   (`runtimeBootEpochMs` = newest of `runtimeWakeStartedAt`,
+   `providerRunningConfirmedAt`, `initSucceededAt`). This is **not** a
+   progress reset: a stub launcher that changes phase for ever is still caught
+   at the cap, because only a NEW attempt moves the epoch. Do not "fix" an
+   inherited budget by making the hard cap progress-aware — that undoes
+   "A boot budget measures lack of progress, not wall-clock".
+4. **`jsonb - $1` is ambiguous; strip keys as literals.** Postgres cannot
+   choose between `jsonb - text` and `jsonb - integer` for an untyped
+   parameter. A bind-parameter strip inside a `try/catch` that only
+   `console.warn`s fails invisibly — which is the likeliest reason the
+   ready-path clear never cleared anything in production.
+
+*Automation:* `unit-session-restart-url-contract.test.ts` — "an automatic rung
+never inherits the previous attempt boot budget" (8 tests, including "a stub
+launcher that changes phase for ever is still caught at the cap" and
+"who resets the retry accounting"); `e2e-project-session-contract.test.ts` —
+"the automatic rung re-baselines the boot clocks but KEEPS the failure
+accounting".

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3106,3 +3106,30 @@ launcher that changes phase for ever is still caught at the cap" and
 "who resets the retry accounting"); `e2e-project-session-contract.test.ts` —
 "the automatic rung re-baselines the boot clocks but KEEPS the failure
 accounting".
+
+## An alarm on a metric the workload violates by design is noise, and noise trains you to delete the real page (2026-08-26)
+
+**When:** adding or reviewing any CloudWatch/SNS alarm, especially compliance
+alarms that exist to satisfy a control (Drata DCF-86) rather than an incident.
+`TargetResponseTime` Average ≥ 2 s on the gateway and API ALBs fired on 6–11 s
+averages — normal, because the gateway streams LLM completions and the API
+holds SSE `/event` streams for minutes. The alarm flapped ALARM/OK every 5–10
+min; each flap fanned out through **two** alarm sets on the same ALB (a
+hand-made `compliance-*` set from the 2026-07-27 evidence pass, never in
+Terraform, plus the `kortix-alb-*` set) × **three** email subscriptions on the
+same person = ~300 emails in one day and zero incidents. The 5xx alarms in the
+same inbox — the ones that page a real outage — had 3 messages each and were
+being trashed with the rest. Rules: **(1) before adding a threshold alarm, name
+the request shape that violates it in steady state; if streaming, long-poll or
+SSE traffic crosses it by design, alarm on errors and host health instead.
+(2) One alarm set per resource, and it lives in code — a console-made duplicate
+is drift, and the reconciler that owns the family deletes it. (3) A reconciler
+that can only create is half a reconciler: it must also delete what it retires,
+or a deleted alarm is resurrected on the next tick and Terraform's forget/destroy
+is undone.** `removed { lifecycle { destroy = false } }` lets the automatic
+apply pass its no-delete guard while the Lambda does the real deletion.
+*Enforcer:* `functions/test_alb_alarm_reconciler.py` — `ALARM_SPECS` contains no
+`TargetResponseTime`; retired `kortix-alb-*-target-response-time` (including the
+per-target-group variants Terraform never managed) and `compliance-*` alarms in
+`AWS/ApplicationELB` are deleted; `compliance-*-cpu-high` and every desired
+alarm survive.

--- a/apps/api/src/__tests__/e2e-project-session-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-project-session-contract.test.ts
@@ -1465,6 +1465,68 @@ describe('project session API contract', () => {
     expect(body.reason).not.toBe('runtime_wake_failed');
   });
 
+  test('the automatic rung re-baselines the boot clocks but KEEPS the failure accounting', async () => {
+    // Essentia 2026-08-26, session 29861dfa / box inqwpv4a. Attempt 1's
+    // `opencodeBootWaitFirstSeenAt` survived the cooldown rung, so attempt 2's
+    // boot was judged against a 10-minute cap that had already run ~7 minutes.
+    // It was parked at 13:34:49.202 — 14 ms before its daemon claimed its first
+    // turn at 13:34:49.216.
+    sessionRow = { ...sessionRow!, status: 'stopped', error: null };
+    const attempt1 = new Date(Date.now() - 11 * 60_000).toISOString();
+    sessionSandboxRows = [
+      {
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        projectId: PROJECT_ID,
+        provider: 'platinum',
+        externalId: 'platinum-rung-rebaseline',
+        baseUrl: null,
+        status: 'stopped',
+        config: {},
+        metadata: {
+          initStatus: 'ready',
+          stopReason: 'runtime_boot_failed',
+          runtimeParkReason: 'runtime_not_ready_timeout',
+          runtimeStartFailureCount: 2,
+          runtimeStartFailedAt: attempt1,
+          runtimeStartRetryAfterAt: new Date(Date.now() - 1_000).toISOString(),
+          // Attempt 1's clocks, which nothing used to clear.
+          opencodeBootWaitFirstSeenAt: attempt1,
+          opencodeNotReadyWaitStartedAt: attempt1,
+          opencodeReadyWaitReason: 'not_ready',
+          opencodeBootPhase: 'config-deps|opencode=starting',
+        },
+        lastUsedAt: null,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    ];
+
+    expect(
+      await resumeStoppedSandbox({
+        sandboxId: SESSION_ID,
+        sessionId: SESSION_ID,
+        accountId: ACCOUNT_ID,
+        provider: 'platinum',
+        externalId: 'platinum-rung-rebaseline',
+        metadata: sessionSandboxRows[0]!.metadata as Record<string, unknown>,
+      }),
+    ).toBe(true);
+
+    const claimed = sessionSandboxRows[0]?.metadata as Record<string, unknown>;
+    // Every readiness clock is gone: attempt 2 boots against a clean budget.
+    expect(claimed.opencodeBootWaitFirstSeenAt).toBeUndefined();
+    expect(claimed.opencodeBootPhase).toBeUndefined();
+    expect(claimed.opencodeNotReadyWaitStartedAt).toBeUndefined();
+    expect(claimed.opencodeReadyWaitReason).toBeUndefined();
+    // …and the escalation accounting survives, unlike a human Restart.
+    expect(claimed.runtimeStartFailureCount).toBe(2);
+    expect(claimed.runtimeStartFailedAt).toBe(attempt1);
+    // The claim is live, so /start reports a wake rather than a stamp.
+    expect(typeof claimed.runtimeWakeId).toBe('string');
+  });
+
   test('concurrent stopped-session resumes issue one provider start and open one meter', async () => {
     sessionRow = { ...sessionRow!, status: 'stopped', error: null };
     sessionSandboxRows = [

--- a/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
+++ b/apps/api/src/__tests__/unit-session-restart-url-contract.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import {
+  RUNTIME_READINESS_CLOCK_KEYS,
+  STALE_OPENCODE_BOOT_HARD_MS,
   prepareInPlaceRestartMetadata,
   opencodeReadyWaitPatch,
+  runtimeBootEpochMs,
   staleOpencodeReadyReason,
 } from '../projects/session-lifecycle/readiness-clocks';
+import { RUNTIME_WAKE_CLAIM_CLEARED_KEYS } from '../projects/routes/shared';
 
 const source = readFileSync(
   new URL('../projects/session-lifecycle/actions.ts', import.meta.url),
@@ -139,5 +143,143 @@ describe('progress-aware OpenCode boot budget (Essentia 2026-08-25 17:23 double 
     expect(staleOpencodeReadyReason(metadata, 'not_ready', now, 90_000, 10 * 60_000)).toBe(
       'runtime_not_ready_timeout',
     );
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// The automatic cooldown rung must not inherit the previous attempt's boot
+// budget. Essentia 2026-08-26, session 29861dfa / box inqwpv4a: attempt 1
+// failed ~13:27; the rung re-attempted ~13:33; the daemon booted through
+// 13:34:48.8, authenticated to the gateway 13:34:48.5-49.1 and claimed its
+// initial turn at 13:34:49.216 — and `/start` parked the box at 13:34:49.202.
+// It lost by 14 ms to a 10-minute cap that had been running since attempt 1.
+// ───────────────────────────────────────────────────────────────────────────
+describe('an automatic rung never inherits the previous attempt boot budget', () => {
+  const attempt1 = new Date('2026-08-26T13:24:00.000Z');
+  // The cooldown rung's wake finalized here — the boot epoch for attempt 2.
+  const attempt2 = new Date('2026-08-26T13:33:50.000Z');
+  const park = new Date('2026-08-26T13:34:49.202Z');
+
+  /** The row as attempt 1 left it, after the park and the rung's resume. */
+  const inherited = {
+    opencodeBootWaitFirstSeenAt: attempt1.toISOString(),
+    opencodeNotReadyWaitStartedAt: attempt1.toISOString(),
+    opencodeReadyWaitReason: 'not_ready',
+    opencodeBootPhase: 'config-deps|opencode=starting',
+    providerRunningConfirmedAt: attempt2.toISOString(),
+    // Survives the rung on purpose — it drives the cooldown escalation.
+    runtimeStartFailureCount: 1,
+  };
+
+  test('THE INCIDENT: the inherited hard cap no longer parks attempt 2 mid-boot', () => {
+    // 10m49s after attempt 1's first observation, 59s into attempt 2's boot.
+    expect(park.getTime() - attempt1.getTime()).toBeGreaterThan(STALE_OPENCODE_BOOT_HARD_MS);
+    expect(park.getTime() - attempt2.getTime()).toBeLessThan(STALE_OPENCODE_BOOT_HARD_MS);
+    expect(staleOpencodeReadyReason(inherited, 'not_ready', park.getTime())).toBeNull();
+  });
+
+  test('the inherited PER-REASON clock does not stale a fresh boot either', () => {
+    // 5-minute default budget, ~11 minutes of inherited clock.
+    expect(
+      staleOpencodeReadyReason(inherited, 'not_ready', park.getTime(), 5 * 60_000),
+    ).toBeNull();
+  });
+
+  test('the next observation re-baselines both clocks onto this attempt', () => {
+    const patch = opencodeReadyWaitPatch(
+      inherited,
+      'not_ready',
+      'config-deps|opencode=starting',
+      park,
+    );
+    // Written even though the phase is UNCHANGED: the clock it would have
+    // returned null for belongs to the previous attempt.
+    if (!patch) throw new Error('expected a re-baselining patch');
+    expect(patch.opencodeBootWaitFirstSeenAt).toBe(park.toISOString());
+    expect(patch.opencodeNotReadyWaitStartedAt).toBe(park.toISOString());
+    // The cooldown accounting is untouched by a re-baseline.
+    expect(patch.runtimeStartFailureCount).toBe(1);
+  });
+
+  test('the budget still bounds THIS attempt — the guard is causal, not a reset', () => {
+    const rebaselined = {
+      ...inherited,
+      opencodeBootWaitFirstSeenAt: attempt2.toISOString(),
+      opencodeNotReadyWaitStartedAt: attempt2.toISOString(),
+    };
+    const past = attempt2.getTime() + STALE_OPENCODE_BOOT_HARD_MS + 1_000;
+    expect(staleOpencodeReadyReason(rebaselined, 'not_ready', past)).toBe(
+      'runtime_not_ready_timeout',
+    );
+  });
+
+  test('a stub launcher that changes phase for ever is still caught at the cap', () => {
+    // The learning this must not undo: progress restarts the per-reason clock,
+    // never the hard cap. Only a NEW boot attempt restarts the cap.
+    let row: Record<string, unknown> = { providerRunningConfirmedAt: attempt2.toISOString() };
+    for (let i = 0; i < 40; i += 1) {
+      const t = new Date(attempt2.getTime() + i * 20_000);
+      row = opencodeReadyWaitPatch(row, 'not_ready', `phase-${i}`, t) ?? row;
+    }
+    const past = attempt2.getTime() + STALE_OPENCODE_BOOT_HARD_MS + 1_000;
+    expect(row.opencodeBootWaitFirstSeenAt).toBe(attempt2.toISOString());
+    expect(staleOpencodeReadyReason(row, 'not_ready', past)).toBe('runtime_not_ready_timeout');
+  });
+
+  test('a boot with advancing phase is never staled inside the cap', () => {
+    let row: Record<string, unknown> = { providerRunningConfirmedAt: attempt2.toISOString() };
+    for (let i = 0; i < 8; i += 1) {
+      const t = new Date(attempt2.getTime() + i * 60_000);
+      row = opencodeReadyWaitPatch(row, 'not_ready', `phase-${i}`, t) ?? row;
+      expect(staleOpencodeReadyReason(row, 'not_ready', t.getTime() + 59_000, 5 * 60_000)).toBeNull();
+    }
+  });
+
+  test('runtimeBootEpochMs takes the NEWEST mark, and is inert without one', () => {
+    expect(runtimeBootEpochMs({})).toBeNull();
+    expect(
+      runtimeBootEpochMs({
+        initSucceededAt: attempt1.toISOString(),
+        providerRunningConfirmedAt: attempt2.toISOString(),
+      }),
+    ).toBe(attempt2.getTime());
+    // No epoch ⇒ the guard cannot fire, so legacy rows behave exactly as before.
+    expect(
+      staleOpencodeReadyReason(
+        { opencodeBootWaitFirstSeenAt: attempt1.toISOString() },
+        'not_ready',
+        park.getTime(),
+      ),
+    ).toBe('runtime_not_ready_timeout');
+  });
+});
+
+describe('who resets the retry accounting', () => {
+  test('a human restart resets the failure episode; an automatic rung must not', () => {
+    const failing = {
+      stopReason: 'runtime_boot_failed',
+      runtimeStartFailureCount: 3,
+      runtimeStartFailedAt: '2026-08-26T13:27:00.000Z',
+      runtimeStartRetryAfterAt: '2026-08-26T13:37:00.000Z',
+      opencodeBootWaitFirstSeenAt: '2026-08-26T13:24:00.000Z',
+      opencodeBootPhase: 'config-deps|opencode=starting',
+    };
+    // Human Restart: clocks AND accounting gone, so the ladder starts over.
+    const restarted = prepareInPlaceRestartMetadata(failing, new Date('2026-08-26T13:40:00.000Z'));
+    for (const key of RUNTIME_READINESS_CLOCK_KEYS) {
+      if (key === 'runtimeWakeStartedAt' || key === 'runtimeWakeProviderStatus') continue;
+      expect(restarted[key]).toBeUndefined();
+    }
+    expect(restarted.runtimeStartFailureCount).toBeUndefined();
+    expect(restarted.runtimeStartFailedAt).toBeUndefined();
+    expect(restarted.stopReason).toBeUndefined();
+
+    // The automatic rung's claim keeps the accounting so the cooldown escalates.
+    expect(RUNTIME_WAKE_CLAIM_CLEARED_KEYS).not.toContain('runtimeStartFailureCount');
+    expect(RUNTIME_WAKE_CLAIM_CLEARED_KEYS).not.toContain('runtimeStartFailedAt');
+    // …and it drops EVERY readiness clock, which is what the incident needed.
+    for (const key of RUNTIME_READINESS_CLOCK_KEYS) {
+      expect(RUNTIME_WAKE_CLAIM_CLEARED_KEYS).toContain(key);
+    }
   });
 });

--- a/apps/api/src/projects/routes/shared.ts
+++ b/apps/api/src/projects/routes/shared.ts
@@ -4,7 +4,7 @@ import type {
   SessionStartResult,
 } from '@kortix/api-contract';
 import { changeRequests, projectSessions, sessionSandboxes } from '@kortix/db';
-import { and, eq, sql } from 'drizzle-orm';
+import { type SQL, and, eq, sql } from 'drizzle-orm';
 import {
   markComputeSessionAlive,
   reopenComputeForSandbox,
@@ -71,6 +71,54 @@ import {
 } from '../session-lifecycle/runtime-wake-fence';
 
 /**
+ * `metadata - 'a' - 'b' - …`, generated from a key list.
+ *
+ * Hand-written `-` chains are how the readiness clocks drifted apart: the wake
+ * claim stripped four of the ten, `clearRuntimeReadinessClocks` stripped eight
+ * by hardcoded index, and `opencodeBootWaitFirstSeenAt` was therefore cleared
+ * by nothing except a human Restart. That immortal clock parked session
+ * 29861dfa's second attempt 14 ms before its daemon claimed its first turn
+ * (2026-08-26). One generator, one list, no drift.
+ */
+function stripMetadataKeys(keys: readonly string[]): SQL {
+  return keys.reduce<SQL>((acc, key) => {
+    // A LITERAL, not a bind parameter. `jsonb - $1` leaves the parameter type
+    // unknown and Postgres cannot choose between `jsonb - text` and
+    // `jsonb - integer`. Every key here is a compile-time constant from a
+    // frozen list, and this guard keeps it that way.
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(key)) {
+      throw new Error(`refusing to strip a non-identifier metadata key: ${key}`);
+    }
+    return sql`${acc} - ${sql.raw(`'${key}'`)}`;
+  }, sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)`);
+}
+
+/**
+ * Keys a WAKE CLAIM drops. The readiness clocks are appended, so a re-attempt
+ * boots against a clean budget.
+ *
+ * Deliberately ABSENT: `runtimeStartFailureCount` and `runtimeStartFailedAt`.
+ * They drive the escalating cooldown between automatic rungs and must survive
+ * one — unlike an explicit human Restart, which resets the whole episode
+ * (`prepareInPlaceRestartMetadata`).
+ */
+export const RUNTIME_WAKE_CLAIM_CLEARED_KEYS = [
+  'runtimeIdentityState',
+  'runtimeUnavailableReason',
+  'runtimeUnavailableAt',
+  'preservedExternalId',
+  'needsReprovision',
+  'runtimeWakeError',
+  'runtimeWakeFailedAt',
+  'runtimeWakeRetryAfterAt',
+  'runtimeStartRetryAfterAt',
+  'runtimeWakeCleanupUntilAt',
+  'runtimeWakeLateStartStoppedAt',
+  'runtimeWakeProgressAt',
+  ...RUNTIME_READINESS_CLOCK_KEYS,
+] as const;
+
+/**
  * Resume a hibernated (status='stopped') session sandbox IN PLACE instead of
  * destroying it and cold-reprovisioning a fresh one. A stopped row whose
  * `externalId` is still set is a powered-down VM whose disk — the repo clone,
@@ -123,25 +171,7 @@ export async function resumeStoppedSandbox(
     .update(sessionSandboxes)
     .set({
       updatedAt: now,
-      metadata: sql`(
-        coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
-          - 'runtimeIdentityState'
-          - 'runtimeUnavailableReason'
-          - 'runtimeUnavailableAt'
-          - 'preservedExternalId'
-          - 'needsReprovision'
-          - 'runtimeWakeError'
-          - 'runtimeWakeFailedAt'
-          - 'runtimeWakeRetryAfterAt'
-          - 'runtimeStartRetryAfterAt'
-          - 'runtimeWakeCleanupUntilAt'
-          - 'runtimeWakeLateStartStoppedAt'
-          - 'runtimeWakeProgressAt'
-          - 'opencodeReadyWaitStartedAt'
-          - 'opencodeReadyWaitReason'
-          - 'opencodeUnreachableWaitStartedAt'
-          - 'opencodeNotReadyWaitStartedAt'
-        ) || ${JSON.stringify(wakePatch)}::jsonb`,
+      metadata: sql`(${stripMetadataKeys(RUNTIME_WAKE_CLAIM_CLEARED_KEYS)}) || ${JSON.stringify(wakePatch)}::jsonb`,
     })
     .where(
       and(
@@ -639,15 +669,11 @@ async function clearRuntimeReadinessClocks(
     await db
       .update(sessionSandboxes)
       .set({
-        metadata: sql`coalesce(${sessionSandboxes.metadata}, '{}'::jsonb)
-          - ${RUNTIME_READINESS_CLOCK_KEYS[0]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[1]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[2]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[3]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[4]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[5]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[6]}
-          - ${RUNTIME_READINESS_CLOCK_KEYS[7]}`,
+        // EVERY key. This used to strip the first eight by index, leaving
+        // `opencodeBootPhase` and `opencodeBootWaitFirstSeenAt` on a row whose
+        // daemon had just reported READY — so the next boot wait on that row
+        // inherited a spent hard cap.
+        metadata: stripMetadataKeys(RUNTIME_READINESS_CLOCK_KEYS),
         updatedAt: new Date(),
       })
       .where(eq(sessionSandboxes.sandboxId, row.sandboxId));

--- a/apps/api/src/projects/session-lifecycle/inbox-hold-settle.test.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-hold-settle.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { WIRE_ID_TIME_SCALE, wireIdTime } from '../wire-message-id';
 import type { PlacementTipMessage } from './forwarded-placement';
-import { type HoldSettleDeps, settleInboxHoldAfterStop } from './inbox-hold-settle';
+import {
+  type HoldSettleDeps,
+  settleInboxHoldAfterStop,
+  stopPausedOnWireScope,
+} from './inbox-hold-settle';
 
 const id = (ms: number, tail: string) =>
   `msg_${((BigInt(ms) * WIRE_ID_TIME_SCALE + BigInt(1)) & BigInt(0xffffffffffff)).toString(16).padStart(12, '0')}${tail}`;
@@ -145,5 +150,57 @@ describe('settleInboxHoldAfterStop', () => {
     expect(out.unreadable).toBe(true);
     expect(calls.hold).toHaveLength(0);
     expect(calls.close).toHaveLength(0);
+  });
+
+  test('a released Stop delivers a held-back prompt exactly once', async () => {
+    // The whole point of holding it back: after this settle the row is an
+    // ordinary queued+held row and OpenCode no longer holds a copy — so the
+    // release POSTs the prompt for the first and only time.
+    const tip = tipOf([{ id: u1, role: 'user' }, { id: u2, role: 'user' }]);
+    const { deps, calls } = fakeDeps({
+      tips: [tip],
+      listStopPaused: async () => [{ commandId: 'c2', wireIds: [u2] }],
+    });
+    const out = await settleInboxHoldAfterStop('s', deps);
+    expect(out.heldBack).toBe(1);
+    // Exactly one copy taken out, exactly one row re-queued, nothing closed as
+    // delivered (which would have made the release a no-op instead).
+    expect(calls.remove).toEqual([['s', u2]]);
+    expect(calls.hold).toEqual([['c2']]);
+    expect(calls.close).toHaveLength(0);
+  });
+});
+
+/**
+ * The predicate `listStopPaused` runs. Every behavioural test above stubs
+ * `listStopPaused`, so the live query was the one part of this module nothing
+ * could catch regressing — and it HAD regressed: it excluded
+ * `result.held = 'true'`, which is the exact marker `holdInboxPrompts` writes
+ * on every forwarded row a Stop pauses, moments before this settle starts.
+ */
+describe('stopPausedOnWireScope', () => {
+  const compiled = () => {
+    const q = new PgDialect().sqlToQuery(stopPausedOnWireScope('ses-1')!);
+    return { sql: q.sql.replace(/\s+/g, ' ').trim(), params: q.params };
+  };
+
+  test('does NOT exclude a row the Stop just marked held', () => {
+    // The row this whole module exists for. Excluding it is what made the
+    // release re-POST a prompt OpenCode still held, and the user saw the same
+    // prompt twice.
+    expect(compiled().sql).not.toContain("'held'");
+  });
+
+  test('selects only this session\'s composer prompts that went out recently', () => {
+    const { sql, params } = compiled();
+    // The inbox scope: this session, `continue_session`, and a client message
+    // id (which is what separates a composer prompt from an automation one).
+    expect(params).toContain('ses-1');
+    expect(params).toContain('continue_session');
+    expect(sql).toContain("->>'clientMessageId'");
+    // On the wire, both ways a POST that landed is recorded.
+    expect(sql).toContain("IN ('forwarded', 'delivered')");
+    // Recent only — an old delivered row is history, not a Stop's business.
+    expect(sql).toContain("interval '10 minutes'");
   });
 });

--- a/apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts
+++ b/apps/api/src/projects/session-lifecycle/inbox-hold-settle.ts
@@ -26,6 +26,29 @@
  *
  * Best-effort end to end: a box that cannot be read leaves the rows exactly
  * as the instant hold marked them, which is the pre-existing behaviour.
+ *
+ * THE CONTRACT A STOP HAS WITH A QUEUED PROMPT
+ *
+ * Stop pauses the queue; it never throws a prompt away and never runs one
+ * behind the user's back. Every prompt the Stop caught ends up in exactly one
+ * of three states, and each of them delivers AT MOST ONCE more:
+ *
+ *  - HELD (`queued`, `result.held`) — the ordinary outcome. The prompt is on
+ *    screen as "Held — stopped" with Send now / Remove.
+ *  - DELIVERED — the aborted step had already read it, so it belongs to the
+ *    interrupted turn and no release may send it again.
+ *  - REMOVED — the user deleted the row.
+ *
+ * A hold is lifted by an ACTION, never by a timer: sending anything new
+ * (`POST .../prompts` → `releaseInboxHold`), "send now" on one row
+ * (`retryInboxPrompt`), or Resume (`POST .../prompts/hold {held:false}`).
+ * `INBOX_HOLD_MS` (24 h) is a horizon, not a scheduler — it exists so a browser
+ * that never comes back cannot hold a prompt for ever.
+ *
+ * "Delivers at most once more" is what step 3 below buys. Without it a held
+ * forwarded row is released straight back onto the queue while OpenCode still
+ * holds the copy it was POSTed as, and the re-mint puts a SECOND user message
+ * with the same text into the transcript.
  */
 
 import { sessionLifecycleCommands } from '@kortix/db';
@@ -52,6 +75,40 @@ const TIP_LIMIT = 16;
  *  the turn the user stopped. */
 const CLAIMED_SETTLE_MS = 3_000;
 const CLAIMED_POLL_MS = 100;
+/**
+ * The rows this settle is about: one prompt of THIS session that has been
+ * POSTed to OpenCode and is not finished.
+ *
+ * ON THE WIRE is two `result.status` values, not one. `forwarded` is what
+ * `markCommandForwarded` writes when the POST lands; `delivered` is what the
+ * daemon's acceptance relay writes when OpenCode PERSISTS the message, which
+ * happens long before any step reads it — so a `delivered` row is just as
+ * likely to be unreached by a Stop. Only recent ones: an old delivered row is
+ * history.
+ *
+ * IT DOES NOT EXCLUDE `result.held`, and that is the whole point. The hold
+ * route runs `holdInboxPrompts(sessionId, true)` — which stamps every
+ * forwarded row `{stop_paused: true, held: true}` — and THEN starts this
+ * settle. Excluding held rows therefore excluded exactly the rows the Stop had
+ * just paused: the ones this module exists to take back out of OpenCode. Their
+ * copy stayed in the transcript, the release re-POSTed the prompt under a
+ * re-minted wire id, and the user saw the same prompt twice — once unanswered,
+ * once answered (the "KNOWN COST" documented in `holdInboxPrompts`). The
+ * exclusion was invisible to the unit tests because every one of them stubs
+ * `listStopPaused`; see the compiled-SQL test that now pins it.
+ *
+ * A row that is `queued` and held (this settle's own `holdAsQueued` outcome,
+ * or a prompt that never went out) is still excluded — by `status`
+ * (`succeeded`) and by `result.status`, not by the held marker.
+ */
+export function stopPausedOnWireScope(sessionId: string) {
+  return and(
+    inboxScope(sessionId),
+    eq(sessionLifecycleCommands.status, 'succeeded'),
+    sql`${sessionLifecycleCommands.result}->>'status' IN ('forwarded', 'delivered')`,
+    sql`(${sessionLifecycleCommands.result}->>'forwarded_at')::timestamptz > now() - interval '10 minutes'`,
+  );
+}
 
 export interface StopPausedRow {
   commandId: string;
@@ -92,20 +149,7 @@ const liveDeps: HoldSettleDeps = {
         forwarded: sql<string | null>`${sessionLifecycleCommands.result}->>'forwarded_message_id'`,
       })
       .from(sessionLifecycleCommands)
-      .where(
-        and(
-          inboxScope(sessionId),
-          eq(sessionLifecycleCommands.status, 'succeeded'),
-          // ON THE WIRE: forwarded, or already confirmed `delivered` by the
-          // daemon's acceptance relay — that relay fires when OpenCode
-          // PERSISTS the message, long before any step reads it, so a
-          // `delivered` row is just as likely to be unreached by a Stop. Only
-          // the recent ones: an old delivered row is history.
-          sql`${sessionLifecycleCommands.result}->>'status' IN ('forwarded', 'delivered')`,
-          sql`COALESCE(${sessionLifecycleCommands.result}->>'held', '') <> 'true'`,
-          sql`(${sessionLifecycleCommands.result}->>'forwarded_at')::timestamptz > now() - interval '10 minutes'`,
-        ),
-      );
+      .where(stopPausedOnWireScope(sessionId));
     return rows.map((row) => ({
       commandId: row.commandId,
       wireIds: [row.wire, row.redelivered, row.forwarded].filter(

--- a/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
+++ b/apps/api/src/projects/session-lifecycle/readiness-clocks.ts
@@ -14,11 +14,26 @@ export const RUNTIME_READINESS_CLOCK_KEYS = [
 ] as const;
 
 /**
- * Absolute ceiling on one OpenCode boot wait, phase changes or not. The
+ * Absolute ceiling on ONE OpenCode boot wait, phase changes or not. The
  * per-reason budgets below restart on progress; this one never does, so a box
  * that keeps changing phase without ever becoming ready is still bounded.
+ *
+ * "ONE boot wait" is load-bearing and was not enforced. See
+ * {@link runtimeBootEpochMs}.
  */
 export const STALE_OPENCODE_BOOT_HARD_MS = 10 * 60 * 1000;
+
+/**
+ * Marks that identify the current boot attempt: when the wake was claimed, when
+ * the provider confirmed the box RUNNING, and when the provisioner finished.
+ * A readiness clock stamped BEFORE the newest of these belongs to an earlier
+ * attempt on the same row.
+ */
+const RUNTIME_BOOT_EPOCH_KEYS = [
+  'runtimeWakeStartedAt',
+  'providerRunningConfirmedAt',
+  'initSucceededAt',
+] as const;
 
 /**
  * Keys an explicit in-place restart clears on top of the readiness clocks: the
@@ -58,6 +73,47 @@ export function prepareInPlaceRestartMetadata(
   };
 }
 
+/**
+ * When the CURRENT boot attempt began, or null when the row carries no mark.
+ *
+ * A readiness clock older than this was written by a previous attempt on the
+ * same row and is not evidence about this one.
+ *
+ * *Incident (2026-08-26, Essentia, session 29861dfa / box inqwpv4a).* Attempt 1
+ * failed during a post-roll build storm at ~13:27. The automatic cooldown rung
+ * re-attempted at ~13:33: the resume launched the entrypoint, the daemon booted
+ * through 13:34:48.8, authenticated to the gateway at 13:34:48.5–49.1 and
+ * claimed its initial turn at 13:34:49.216 — but `/start` parked the box at
+ * **13:34:49.202**. The boot lost by 14 ms to a budget it had not spent:
+ * `opencodeBootWaitFirstSeenAt` was stamped during ATTEMPT 1 and nothing
+ * cleared it, so the 10-minute hard cap was already ~7 minutes old when
+ * attempt 2's boot started. Every automatic rung after the first was
+ * deterministically doomed.
+ *
+ * Two fixes, and this is the second one — defence in depth. The first is that
+ * a wake claim now clears every readiness clock (routes/shared.ts). This guard
+ * makes an inherited clock harmless even if some future path forgets, and it
+ * does so CAUSALLY: it does not reset the budget on progress (a stub launcher
+ * respawning in a loop changes phase forever and must still be caught at the
+ * cap — see the learning "A boot budget measures lack of progress, not
+ * wall-clock"). It only refuses to charge this attempt for a previous one.
+ */
+export function runtimeBootEpochMs(metadata: RuntimeReadinessMetadata): number | null {
+  let newest: number | null = null;
+  for (const key of RUNTIME_BOOT_EPOCH_KEYS) {
+    const parsed = parseTimestampMs(metadata[key]);
+    if (parsed !== null && (newest === null || parsed > newest)) newest = parsed;
+  }
+  return newest;
+}
+
+/** A clock stamped before this boot attempt began is not evidence about it. */
+function clockForThisBoot(clockMs: number | null, bootEpochMs: number | null): number | null {
+  if (clockMs === null) return null;
+  if (bootEpochMs !== null && clockMs < bootEpochMs) return null;
+  return clockMs;
+}
+
 export function staleOpencodeReadyReason(
   metadata: RuntimeReadinessMetadata,
   reason: string,
@@ -66,7 +122,11 @@ export function staleOpencodeReadyReason(
   hardCapMs = STALE_OPENCODE_BOOT_HARD_MS,
 ): string | null {
   if (reason !== 'not_ready' && reason !== 'unreachable') return null;
-  const firstSeenMs = parseTimestampMs(metadata.opencodeBootWaitFirstSeenAt);
+  const bootEpochMs = runtimeBootEpochMs(metadata);
+  const firstSeenMs = clockForThisBoot(
+    parseTimestampMs(metadata.opencodeBootWaitFirstSeenAt),
+    bootEpochMs,
+  );
   if (firstSeenMs && nowMs - firstSeenMs > hardCapMs) {
     return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
   }
@@ -78,7 +138,10 @@ export function staleOpencodeReadyReason(
     metadata.opencodeReadyWaitReason === undefined || metadata.opencodeReadyWaitReason === reason
       ? metadata.opencodeReadyWaitStartedAt
       : null;
-  const readyWaitStartedAtMs = parseTimestampMs(reasonStartedAt) ?? parseTimestampMs(legacyStartedAt);
+  const readyWaitStartedAtMs = clockForThisBoot(
+    parseTimestampMs(reasonStartedAt) ?? parseTimestampMs(legacyStartedAt),
+    bootEpochMs,
+  );
   if (!readyWaitStartedAtMs || nowMs - readyWaitStartedAtMs <= staleAfterMs) return null;
   return reason === 'not_ready' ? 'runtime_not_ready_timeout' : 'runtime_unreachable_timeout';
 }
@@ -112,13 +175,24 @@ export function opencodeReadyWaitPatch(
 ): RuntimeReadinessMetadata | null {
   const reasonClockKey =
     reason === 'unreachable' ? 'opencodeUnreachableWaitStartedAt' : 'opencodeNotReadyWaitStartedAt';
+  const bootEpochMs = runtimeBootEpochMs(metadata);
+  // A clock stamped before this boot attempt began belongs to the previous one.
+  // Treat it as absent so the patch re-baselines it, instead of leaving the row
+  // carrying a budget it has already half spent (session 29861dfa).
+  const firstSeenMs = parseTimestampMs(metadata.opencodeBootWaitFirstSeenAt);
+  // INHERITED, not merely absent: the key exists and predates this attempt.
+  const inheritedFirstSeen =
+    firstSeenMs !== null && bootEpochMs !== null && firstSeenMs < bootEpochMs;
   const previousPhase =
-    typeof metadata.opencodeBootPhase === 'string' ? metadata.opencodeBootPhase : undefined;
+    !inheritedFirstSeen && typeof metadata.opencodeBootPhase === 'string'
+      ? metadata.opencodeBootPhase
+      : undefined;
   const phaseChanged = bootPhase !== undefined && bootPhase !== previousPhase;
   const legacyClockRunning =
     metadata.opencodeReadyWaitReason === reason &&
     typeof metadata.opencodeReadyWaitStartedAt === 'string';
-  const clockRunning = typeof metadata[reasonClockKey] === 'string' || legacyClockRunning;
+  const clockRunning =
+    !inheritedFirstSeen && (typeof metadata[reasonClockKey] === 'string' || legacyClockRunning);
   if (clockRunning && !phaseChanged) return null;
   const startedAt = now.toISOString();
   return {
@@ -127,7 +201,7 @@ export function opencodeReadyWaitPatch(
     opencodeReadyWaitReason: reason,
     [reasonClockKey]: startedAt,
     opencodeBootWaitFirstSeenAt:
-      typeof metadata.opencodeBootWaitFirstSeenAt === 'string'
+      !inheritedFirstSeen && typeof metadata.opencodeBootWaitFirstSeenAt === 'string'
         ? metadata.opencodeBootWaitFirstSeenAt
         : startedAt,
     ...(bootPhase !== undefined ? { opencodeBootPhase: bootPhase } : {}),

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,33 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-26 — session `session-ux` (WS-R) — stop-release: a re-minted prompt's echo must find ITS OWN bubble — DONE
+
+**Files:** `browser/stores/sync-store.ts` (`registerOptimisticEcho` follows the
+alias chain) · `browser/stores/sync-store.test.ts` (one new case). **Public
+surface: unchanged** — same signature, same semantics, strictly more of the
+calls the host already makes now take effect.
+
+**Why.** User report (2026-08-26): a prompt queued mid-turn, then Stop, then
+the queued prompt delivers — and the transcript shows the user bubble twice.
+The host (`apps/web/src/features/session/session-chat.tsx:2749`) registers the
+alias from the id the inbox ROW reports as the prompt's origin
+(`wire_message_id` — the id this tab minted and painted). That id stops being
+optimistic at the FIRST echo, and the drain re-mints on every later delivery:
+a Stop takes the runtime copy back out (`message.removed` →
+`reclaimRemovedMessage` re-marks the ECHO optimistic), then the release
+re-mints again. `registerOptimisticEcho` refused every registration after the
+first because its `optimisticID` argument was no longer optimistic, so the
+re-delivery's echo matched no alias. With one send in flight the ordinal
+fallback still guessed right; with two it correctly refuses to guess, and the
+echo was DROPPED — each prompt stayed on screen as a bubble nothing would ever
+confirm. Fix: when the named id is not optimistic, follow
+`optimisticEchoes` to the id that IS on screen and register from there.
+
+**Gates:** `pnpm --filter @kortix/sdk typecheck` clean · `bun run test` 2644
+pass 0 fail across 176 files · `smoke:install` pass. New test fails on the
+parent commit (echoes land as `msg_fwd*`, not `msg_rel*`).
+
 ### 2026-08-26 — session `session-random-pause` — transcript freeze mid-turn: unbreakable repair loop — DONE
 
 **Files:** `react/use-session-sync.ts` (`livenessBusy` + `UseSessionSyncOptions`

--- a/packages/sdk/src/browser/stores/sync-store.test.ts
+++ b/packages/sdk/src/browser/stores/sync-store.test.ts
@@ -3383,6 +3383,72 @@ describe("useSyncStore — a removed user message the control plane still owns k
 		expect(useSyncStore.getState().parts.msg_c2?.[0]?.id).toBe("prt_1");
 	});
 
+	test("a re-minted prompt taken back out by Stop is superseded by ITS OWN re-delivery", () => {
+		// The stop-release path, end to end, for TWO prompts queued mid-turn:
+		//
+		//   opt  -> the id this tab painted (the wire id it minted)
+		//   fwd  -> the drain re-mints above the live turn on the first delivery
+		//   Stop -> the settle deletes the fwd copy (message.removed) and holds
+		//           the row; the bubble goes back to being optimistic under `fwd`
+		//   rel  -> the release re-mints AGAIN, so the echo carries a third id
+		//
+		// The inbox row always names {wire_message_id: opt, message_id: <newest>},
+		// so the alias the host registers is opt -> rel. `opt` stopped being
+		// optimistic at the first supersede, and the bubble on screen is `fwd`:
+		// unless the alias follows that chain, the echo matches nothing, and with
+		// two sends in flight the ordinal fallback refuses to guess — each echo is
+		// inserted BESIDE its own bubble and the user sees every prompt twice.
+		const store = useSyncStore.getState();
+		for (const n of ["1", "2"]) {
+			store.optimisticAdd("ses_1", userMessage(`msg_opt${n}`), [
+				textPart(`prt_${n}`, `msg_opt${n}`, `prompt ${n}`),
+			]);
+			store.markOptimisticDispatched("ses_1", `msg_opt${n}`);
+			store.markOptimisticInboxBacked("ses_1", `msg_opt${n}`);
+			// First delivery: the row names the re-minted id before the echo lands.
+			store.registerOptimisticEcho("ses_1", `msg_opt${n}`, `msg_fwd${n}`);
+			store.applyEvent({
+				type: "message.updated",
+				properties: { info: userMessage(`msg_fwd${n}`) },
+			} as never);
+		}
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_fwd1",
+			"msg_fwd2",
+		]);
+
+		// Stop: the settle takes both copies back out of OpenCode.
+		for (const n of ["1", "2"]) {
+			store.applyEvent({
+				type: "message.removed",
+				properties: { sessionID: "ses_1", messageID: `msg_fwd${n}` },
+			} as never);
+		}
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_fwd1",
+			"msg_fwd2",
+		]);
+
+		// Release: the row re-mints once more and names the new id against the
+		// SAME wire id it has always reported.
+		for (const n of ["1", "2"]) {
+			store.registerOptimisticEcho("ses_1", `msg_opt${n}`, `msg_rel${n}`);
+		}
+		for (const n of ["1", "2"]) {
+			store.applyEvent({
+				type: "message.updated",
+				properties: { info: userMessage(`msg_rel${n}`) },
+			} as never);
+		}
+		expect(useSyncStore.getState().messages.ses_1.map((m) => m.id)).toEqual([
+			"msg_rel1",
+			"msg_rel2",
+		]);
+		// And the host's key for each bubble still points at the id it painted.
+		expect(useSyncStore.getState().optimisticOriginOf("ses_1", "msg_rel1")).toBe("msg_opt1");
+		expect(useSyncStore.getState().optimisticOriginOf("ses_1", "msg_rel2")).toBe("msg_opt2");
+	});
+
 	test("message.removed for a message nobody owns still removes it", () => {
 		const store = useSyncStore.getState();
 		store.upsertMessage("ses_1", userMessage("msg_x"));

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -1492,9 +1492,25 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 	},
 
 	registerOptimisticEcho: (sessionID, optimisticID, echoID) => {
-		if (!isOptimistic(sessionID, optimisticID)) return;
 		if (optimisticID === echoID) return;
-		recordOptimisticEcho(sessionID, optimisticID, echoID);
+		// The caller always names the id the ROW reports as this prompt's origin
+		// — its `wire_message_id`, the id this tab minted and painted. That id
+		// stops being optimistic the moment the FIRST echo supersedes it, and
+		// after a Stop takes the prompt back out of the runtime the bubble on
+		// screen is that echo (`reclaimRemovedMessage` re-marks it optimistic),
+		// not the wire id. Registering against the wire id alone therefore did
+		// nothing on every second and later re-mint, and the drain re-mints on
+		// every one of them: the re-delivery's echo then matched no alias, and
+		// with more than one send in flight the ordinal fallback correctly
+		// refuses to guess — so the echo was dropped and the prompt stayed on
+		// screen as a bubble nothing would ever confirm.
+		//
+		// Follow the chain to the id that IS on screen and register from there.
+		const live = isOptimistic(sessionID, optimisticID)
+			? optimisticID
+			: optimisticEchoes.get(sessionID)?.get(optimisticID);
+		if (!live || live === echoID || !isOptimistic(sessionID, live)) return;
+		recordOptimisticEcho(sessionID, live, echoID);
 	},
 
 	reclaimRemovedMessage: (sessionID, messageID) => {


### PR DESCRIPTION
Round 6 of the session-UX overhaul — two defects caught live within hours of round 5 shipping.

## Readiness clocks were immortal (api)
Round 5's cooldown ladder lost its first production outing by 14ms: the box was parked at 13:34:49.202 while its daemon claimed the initial turn at 13:34:49.216. Mechanism: `opencodeBootWaitFirstSeenAt` (feeding the 10-min hard cap) survived across attempts — `RUNTIME_READINESS_CLOCK_KEYS` was cleared inconsistently at four call sites (human Restart: all 10; wake claim: 4; `clearRuntimeReadinessClocks`: hardcoded `KEYS[0..7]`; park: none). Second defect: the READY path's clear used `jsonb - $1` bind params Postgres can't type-resolve, inside a warn-swallowed catch — likely never cleared anything in production. Fix: one exported key list + `stripMetadataKeys()` emitting SQL literals; a causal `runtimeBootEpochMs()` guard so stale verdicts ignore clocks stamped before the current attempt; the hard cap itself stays (the 2026-08-25 learning: it exists to catch phase-changing-forever stubs — pinned by test). `runtimeStartFailureCount` deliberately survives rungs so cooldown escalation still climbs.

## Stop-release queue truth (api + sdk)
A queued prompt released after Stop rendered twice (user-reported). Both sides were broken:
- server: `settleInboxHoldAfterStop`'s row query excluded `held='true'` — the exact marker the same request stamps milliseconds earlier — so the settle skipped precisely its targets and the release re-POSTed under a re-minted id while OpenCode still held the original. Proven by live-DB SQL A/B; every behavioural test had stubbed the listing, so a compiled-SQL tripwire now fails if the `held` clause returns.
- sdk: `registerOptimisticEcho` refused ids past the first re-mint (`opt → fwd → rel`), dropping the echo; it now follows the alias chain.
Contract pinned by tests: Stop → held/delivered/removed prompts each deliver **at most once more**, released only by an action; a released prompt delivers exactly once; WS-P's `'unreachable'` retry keys untouched. Live UI: 40 samples of queue-two → Stop → Resume, every prompt exactly one bubble.

## Gates (combined tree)
- apps/api canonical `bash scripts/test.sh`: 8500 pass / 0 fail (730 files), tsc clean
- packages/sdk: 2644/0 `--isolate`, typecheck clean, smoke:install pass
- apps/web: 2640/0 session tests (no web changes needed — host already registers aliases)
- 9 new clock tests incl. the 14ms timeline replay + stub-launcher backstop; e2e on real `resumeStoppedSandbox`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790344532&installation_model_id=434224&pr_number=6920&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6920&signature=fe87658178a4a9766a9e04fe67869e1306d0030b8e9ca03bc6fc6334368b97a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->