### PR TITLE
fix(compliance): grant DescribeTargetGroups to the ALB alarm reconciler; alarm on reconciler errors

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3133,3 +3133,24 @@ apply pass its no-delete guard while the Lambda does the real deletion.
 per-target-group variants Terraform never managed) and `compliance-*` alarms in
 `AWS/ApplicationELB` are deleted; `compliance-*-cpu-high` and every desired
 alarm survive.
+
+## A scheduled control that crashes is a control that never ran — alarm on the reconciler itself (2026-08-26)
+
+**When:** adding a boto3 call to any compliance Lambda
+(`infra/terraform/compliance-monitoring/functions/*`), or trusting that a
+scheduled reconciler "has been running". `fcf779ffb3` (2026-08-06) taught the
+ALB alarm reconciler to call `describe_target_groups`; its role only allowed
+`DescribeLoadBalancers`. Every 5-minute tick in 3 regions raised `AccessDenied`
+for 20 days. The schedule was ENABLED, the function Active, the apply green —
+and the alarms the reconciler exists to maintain silently stopped being
+maintained. It surfaced only because #6919 needed the reconciler to delete
+alarms and nothing was deleted. Rules: **(1) every AWS API a Lambda calls is
+asserted against its IAM policy in CI, not discovered in prod.** **(2) a
+scheduled control gets an `AWS/Lambda Errors ≥ 1` alarm to the same topic as
+the alarms it maintains; a control's own failure is the loudest alarm in the
+family.** **(3) "the apply succeeded" proves the code shipped, not that it ran
+— read the function's log group or its result payload before calling the
+change verified.** *Enforcer:*
+`infra/terraform/scripts/test_reconciler_iam_coverage.py` (terraform-ci) and
+`reconciler-health.tf` (`kortix-compliance-<function>-errors` alarms, 3
+regions).

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: python3 infra/terraform/scripts/test_web_waf_associations.py
       - name: ALB log bucket versioning regression test
         run: python3 infra/terraform/scripts/test_alb_log_bucket_versioning.py
+      - name: reconciler Lambda IAM coverage test
+        run: python3 infra/terraform/scripts/test_reconciler_iam_coverage.py
       - name: preview runtime contract tests
         run: python3 infra/scripts/test-ecs-preview-runtime.py
       - name: terraform validate (every root)

--- a/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
+++ b/infra/terraform/compliance-monitoring/ec2-cpu-reconciler.tf
@@ -30,12 +30,13 @@ resource "aws_iam_role" "ec2_cpu_reconciler" {
 }
 
 data "aws_iam_policy_document" "ec2_cpu_reconciler" {
-  # checkov:skip=CKV_AWS_356: DescribeInstances, DescribeLoadBalancers, DescribeAlarms, and X-Ray telemetry APIs do not support resource-level permissions; alarm writes remain ARN-scoped below.
+  # checkov:skip=CKV_AWS_356: DescribeInstances, DescribeLoadBalancers, DescribeTargetGroups, DescribeAlarms, and X-Ray telemetry APIs do not support resource-level permissions; alarm writes remain ARN-scoped below.
   statement {
     sid = "DiscoverInfrastructureAndAlarms"
     actions = [
       "ec2:DescribeInstances",
       "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeTargetGroups",
       "cloudwatch:DescribeAlarms",
     ]
     resources = ["*"]

--- a/infra/terraform/compliance-monitoring/reconciler-health.tf
+++ b/infra/terraform/compliance-monitoring/reconciler-health.tf
@@ -1,0 +1,94 @@
+# A reconciler that crashes is a control that never runs. The ALB alarm
+# reconciler raised AccessDenied on elasticloadbalancing:DescribeTargetGroups on
+# every five-minute tick from 2026-08-06 to 2026-08-26 and nobody knew: the
+# schedule was ENABLED, the function was Active, and CloudWatch only showed the
+# failure to someone who opened the log group. These alarms page the regional
+# alert topic on the first errored invocation and stay in ALARM until a tick
+# succeeds again.
+
+locals {
+  reconciler_functions = {
+    usw2 = {
+      provider_key = "usw2"
+      topic_arn    = data.aws_sns_topic.usw2_alerts.arn
+      functions = [
+        aws_lambda_function.usw2_alb_alarm_reconciler.function_name,
+        aws_lambda_function.usw2_ec2_cpu_reconciler.function_name,
+      ]
+    }
+    euw2 = {
+      provider_key = "euw2"
+      topic_arn    = data.aws_sns_topic.euw2_alerts.arn
+      functions = [
+        aws_lambda_function.euw2_alb_alarm_reconciler.function_name,
+        aws_lambda_function.euw2_ec2_cpu_reconciler.function_name,
+      ]
+    }
+    use2 = {
+      provider_key = "use2"
+      topic_arn    = aws_sns_topic.use2_alerts.arn
+      functions = [
+        aws_lambda_function.use2_alb_alarm_reconciler.function_name,
+      ]
+    }
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "usw2_reconciler_errors" {
+  for_each            = toset(local.reconciler_functions.usw2.functions)
+  alarm_name          = "kortix-compliance-${each.value}-errors"
+  alarm_description   = "SOC2 DCF-86: a compliance reconciler Lambda is failing; its alarms are no longer maintained"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  dimensions          = { FunctionName = each.value }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [local.reconciler_functions.usw2.topic_arn]
+  ok_actions          = [local.reconciler_functions.usw2.topic_arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "euw2_reconciler_errors" {
+  provider            = aws.euw2
+  for_each            = toset(local.reconciler_functions.euw2.functions)
+  alarm_name          = "kortix-compliance-${each.value}-errors"
+  alarm_description   = "SOC2 DCF-86: a compliance reconciler Lambda is failing; its alarms are no longer maintained"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  dimensions          = { FunctionName = each.value }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [local.reconciler_functions.euw2.topic_arn]
+  ok_actions          = [local.reconciler_functions.euw2.topic_arn]
+  tags                = local.alarm_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "use2_reconciler_errors" {
+  provider            = aws.use2
+  for_each            = toset(local.reconciler_functions.use2.functions)
+  alarm_name          = "kortix-compliance-${each.value}-errors"
+  alarm_description   = "SOC2 DCF-86: a compliance reconciler Lambda is failing; its alarms are no longer maintained"
+  namespace           = "AWS/Lambda"
+  metric_name         = "Errors"
+  dimensions          = { FunctionName = each.value }
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [local.reconciler_functions.use2.topic_arn]
+  ok_actions          = [local.reconciler_functions.use2.topic_arn]
+  tags                = local.alarm_tags
+}

--- a/infra/terraform/scripts/test_reconciler_iam_coverage.py
+++ b/infra/terraform/scripts/test_reconciler_iam_coverage.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Every AWS API a compliance reconciler Lambda calls must be granted by its role.
+
+The ALB alarm reconciler called elasticloadbalancing:DescribeTargetGroups from
+2026-08-06 and its role only allowed DescribeLoadBalancers. The function raised
+AccessDenied on every five-minute tick for 20 days while the schedule stayed
+ENABLED. This test reads the boto3 calls out of the Lambda sources and fails
+when the IAM policy document in ec2-cpu-reconciler.tf does not name each
+matching action.
+"""
+
+import pathlib
+import re
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+STACK = ROOT / "terraform/compliance-monitoring"
+POLICY = STACK / "ec2-cpu-reconciler.tf"
+FUNCTIONS = sorted(
+    path
+    for path in (STACK / "functions").glob("*_reconciler.py")
+    if not path.name.startswith("test_")
+)
+
+# boto3 client name -> IAM service prefix.
+SERVICE_PREFIX = {
+    "ec2": "ec2",
+    "elbv2": "elasticloadbalancing",
+    "cloudwatch": "cloudwatch",
+}
+# Calls that need no IAM action of their own.
+NON_API_METHODS = {"get_paginator"}
+
+
+def _camel(name: str) -> str:
+    return "".join(part.capitalize() for part in name.split("_"))
+
+
+def called_actions(source: str) -> set[str]:
+    actions: set[str] = set()
+    # <client>.<method>(  and  <client>.get_paginator("<method>")
+    for client, method in re.findall(r"\b(\w+)\.(\w+)\(", source):
+        if client in SERVICE_PREFIX and method not in NON_API_METHODS:
+            actions.add(f"{SERVICE_PREFIX[client]}:{_camel(method)}")
+    for client, method in re.findall(
+        r"\b(\w+)\.get_paginator\(\"(\w+)\"\)", source
+    ):
+        if client in SERVICE_PREFIX:
+            actions.add(f"{SERVICE_PREFIX[client]}:{_camel(method)}")
+    return actions
+
+
+class ReconcilerIamCoverageTests(unittest.TestCase):
+    def test_every_lambda_api_call_is_granted(self):
+        policy = POLICY.read_text()
+        self.assertTrue(FUNCTIONS, "no reconciler Lambda sources found")
+        for path in FUNCTIONS:
+            actions = called_actions(path.read_text())
+            self.assertTrue(actions, f"{path.name}: no boto3 calls detected")
+            for action in sorted(actions):
+                with self.subTest(function=path.name, action=action):
+                    self.assertTrue(
+                        f'"{action}"' in policy,
+                        f"{path.name} calls {action} but "
+                        f"{POLICY.relative_to(ROOT)} does not grant it",
+                    )
+
+    def test_alb_reconciler_detection_sees_the_known_calls(self):
+        source = (STACK / "functions/alb_alarm_reconciler.py").read_text()
+        actions = called_actions(source)
+        for expected in (
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeTargetGroups",
+            "cloudwatch:DescribeAlarms",
+            "cloudwatch:PutMetricAlarm",
+            "cloudwatch:DeleteAlarms",
+        ):
+            self.assertIn(expected, actions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Follow-up to #6919. Its reconciler-side deletion never ran because **the reconciler has been crashing on every tick since 2026-08-06**:

```
[ERROR] ClientError: An error occurred (AccessDenied) when calling the DescribeTargetGroups operation:
User: arn:aws:sts::935064898258:assumed-role/KortixEc2CpuAlarmReconciler/kortix-alb-alarm-reconciler
is not authorized to perform: elasticloadbalancing:DescribeTargetGroups
```

`fcf779ffb3` added per-target-group alarms (`describe_target_groups`) without the IAM grant. Schedule ENABLED, function Active, applies green — 20 days of silent failure in 3 regions. Nothing monitored the monitor.

## Change

- `ec2-cpu-reconciler.tf`: `elasticloadbalancing:DescribeTargetGroups` in the discovery statement.
- `reconciler-health.tf`: `AWS/Lambda Errors ≥ 1 / 5 min` alarm per reconciler function (`kortix-alb-alarm-reconciler` ×3 regions, `kortix-ec2-cpu-alarm-reconciler` ×2) → regional alert topic, with `ok_actions`.
- `infra/terraform/scripts/test_reconciler_iam_coverage.py` + terraform-ci step: parses every boto3 call in `functions/*_reconciler.py` and asserts the IAM policy names the action. **Fails on `origin/main`** (`DescribeTargetGroups` missing), passes here.
- `learnings` rule.

## Verified

- `python3 infra/terraform/scripts/test_reconciler_iam_coverage.py` → `Ran 2 tests … OK` (and `FAILED` when run against the pre-change policy).
- `functions/`: `Ran 10 tests … OK`; `terraform fmt -check` clean; `terraform validate` → `Success!`.
- Dry run of the merged reconciler against real AWS (MFA session, `put_metric_alarm`/`delete_alarms` stubbed):
  - us-west-2: 7 ALBs, put=12, **delete=37**
  - eu-west-2: 3 ALBs, put=4, **delete=18**
  - us-east-2: 2 ALBs, put=4, **delete=2**
  Deletes = 13 retired `kortix-alb-*-target-response-time` + 44 legacy `compliance-*` ALB alarms (27 of them on EKS ALBs that no longer exist). Puts = `unhealthy-hosts` re-keyed per target group + the `zero-healthy-hosts` alarms that were never created.

## After merge

`Terraform Apply Global` → within one 5-min tick each region logs `deleted_alarms: [...]`; `describe-alarms --alarm-name-prefix compliance-` returns only `*-cpu-high`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790347049&installation_model_id=434224&pr_number=6921&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6921&signature=f26c1adc9ab6fa7a00fae9eb4aee71f3c1df26538b65d4e6d719e9fb5d5b5ddd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->