### PR TITLE
fix(web): the command palette can switch workspaces

### DIFF
--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -673,6 +673,19 @@ export function ReviewCenter({
         el instanceof HTMLTextAreaElement ||
         (el as HTMLElement | null)?.isContentEditable;
 
+      // Every shortcut below is a BARE letter or digit, so a keystroke
+      // carrying a command/control/alt modifier is never one of them — it
+      // belongs to the browser, the OS, or another surface. Without this
+      // guard the single-letter handlers fire alongside the real shortcut:
+      // ⌘K moved the review focus up AND opened the command palette, ⌘J
+      // moved it down AND started a session, and ⌘A — Select All — ran
+      // `quickPrimary` on the focused item, i.e. an ACTION on a review. Added
+      // when ⌘O was given to the palette's workspace switcher, which would
+      // have joined that list by opening the focused review at the same time.
+      //
+      // Not Shift: `?` is Shift+/ and is handled immediately below.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
       if (e.key === '?') {
         e.preventDefault();
         setHelpOpen((v) => !v);

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -21,6 +21,7 @@ import {
   CommandList,
   CommandShortcut,
 } from '@/components/ui/command';
+import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { FadedScrollArea } from '@/components/ui/faded-scroll-area';
 import { Kbd } from '@/components/ui/kbd';
 import Loading from '@/components/ui/loading';
@@ -50,6 +51,15 @@ import {
   sessionLastActivityAt,
   sortSessionsByLastActivity,
 } from '@/features/workspace/project-sidebar/project-session-list-helpers';
+import {
+  buildWorkspacePaletteRows,
+  groupWorkspacePaletteRows,
+  recentWorkspaceRows,
+  rootWorkspaceResults,
+  workspacePageResults,
+  workspacePaletteValue,
+  type WorkspacePaletteRow,
+} from '@/features/workspace/workspace-palette';
 import {
   PALETTE_NO_PROJECT_DEFAULT_TAB,
   filterSettingsPaletteGroups,
@@ -88,6 +98,7 @@ import { useChatSendStore } from '@/stores/chat-send-store';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 import { useMessageJumpStore } from '@/stores/message-jump-store';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
+import { useProjectSwitchStore } from '@/stores/project-switch-store';
 import { useSettingsPanelStore } from '@/stores/settings-panel-store';
 import { openTabAndNavigate } from '@/stores/tab-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
@@ -147,7 +158,7 @@ import {
   TextAlignLeftIcon as TextAlignLeft,
   UsersIcon as UsersSolid,
 } from '@phosphor-icons/react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import { useParams, usePathname, useRouter } from 'next/navigation';
@@ -158,7 +169,7 @@ type PalettePage =
   | 'agents'
   | 'models'
   | 'messages'
-  | 'projects'
+  | 'workspaces'
   | 'accounts'
   | 'sessions'
   | 'files'
@@ -241,8 +252,51 @@ export const LEGACY_SETTINGS_TAB_MAP: Partial<Record<SettingsTabId, SettingsTab>
   shortcuts: 'preferences',
 };
 
+/**
+ * How many rows the no-query root page offers under "Suggestions".
+ * `rootSuggestionItems` and `buildRootSuggestions` are the only readers.
+ */
+export const ROOT_SUGGESTION_LIMIT = 8;
+
+/** The registry id of the workspace switcher row. */
+export const WORKSPACE_SWITCHER_ITEM_ID = 'nav-projects';
+
+/**
+ * The rows the palette offers before anything is typed.
+ *
+ * "Switch workspace" is PINNED to the front, then the registry's own order,
+ * then the cap. Unpinned it sits at index 11 of the actions+navigation list
+ * and the cap is {@link ROOT_SUGGESTION_LIMIT} — so opening ⌘K and typing
+ * nothing showed eight session and terminal actions and no way to change
+ * workspace at all. Every other top-level move in this product has a control
+ * you can see without knowing its name; this one did not, which is most of why
+ * people reached for the trackpad instead.
+ *
+ * Pinned rather than raising the cap: indexes 9 and 10 are `restart-config`
+ * and `sync-session-branch`, so a bigger slice buys this row's visibility with
+ * two rows of noise.
+ *
+ * Deduped by id, so the row appears exactly once even if the registry order
+ * changes underneath this — a pin that also duplicated would be a worse bug
+ * than the one it fixes, and `key={item.id}` would collide.
+ */
+export function buildRootSuggestions(
+  items: MenuItemDef[],
+  limit: number = ROOT_SUGGESTION_LIMIT,
+): MenuItemDef[] {
+  const candidates = items.filter(
+    (item) => item.group === 'actions' || item.group === 'navigation',
+  );
+  const switcher = candidates.find((item) => item.id === WORKSPACE_SWITCHER_ITEM_ID);
+  const rest = candidates.filter((item) => item.id !== WORKSPACE_SWITCHER_ITEM_ID);
+  return (switcher ? [switcher, ...rest] : rest).slice(0, limit);
+}
+
 export const SUBMENU_PAGE_BY_ID: Record<string, PalettePage> = {
-  'nav-projects': 'projects',
+  // The dedicated Switch Workspace page. The registry row's `href` stays a
+  // routed fallback for the same reason every other entry here keeps one — if
+  // this map loses the id, the row navigates instead of dead-ending.
+  'nav-projects': 'workspaces',
   'nav-accounts': 'accounts',
   'proj-sessions': 'sessions',
   'conversation-density': 'density',
@@ -279,6 +333,57 @@ const DENSITY_PAGE_OPTIONS: {
     description: 'One status line until you expand it',
   },
 ];
+
+/**
+ * One workspace row, wherever the palette shows one — root recents, root
+ * search results, and the dedicated Switch Workspace page all render this.
+ *
+ * It exists because those three used to be three copies of the same JSX that
+ * had already drifted: all of them painted the same grey `FolderGit2` for
+ * every workspace, in the one control whose entire job is being fast to scan.
+ * The sidebar switcher had carried each workspace's own emoji/initials tile
+ * since it was written. This brings the palette level with it, and does so in
+ * one place so the next divergence has nowhere to happen.
+ *
+ * `glyph` before `emoji` matches `EntityAvatar`'s own precedence and
+ * `project-card.tsx`: a workspace has an emoji XOR a named glyph, never both,
+ * and passing only `emoji` (as the sidebar still does) silently renders a
+ * glyph-iconed workspace as bare initials.
+ *
+ * The account label is trailing, muted and conditional — see
+ * `showAccount`. With one account it is the same word on every row, which is
+ * noise; with two it is the only thing separating two workspaces that share a
+ * name.
+ */
+function WorkspaceCommandItem({
+  row,
+  showAccount,
+  onSelect,
+  trailing,
+}: {
+  row: WorkspacePaletteRow;
+  showAccount: boolean;
+  onSelect: () => void;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <CommandItem value={sanitizeCmdkValue(workspacePaletteValue(row))} onSelect={onSelect}>
+      <EntityAvatar
+        label={row.workspace.name}
+        glyph={row.workspace.icon_glyph}
+        emoji={row.workspace.icon}
+        size="sm"
+      />
+      <span className="min-w-0 flex-1 truncate">{row.workspace.name}</span>
+      {showAccount && (
+        <span className="text-muted-foreground/40 max-w-[9rem] shrink-0 truncate text-xs">
+          {row.accountName}
+        </span>
+      )}
+      {trailing}
+    </CommandItem>
+  );
+}
 
 function FileSearchPage({
   query,
@@ -787,12 +892,40 @@ export function CommandPalette() {
     accountsList?.[0] ??
     null;
   const activeAccountId = activeAccount?.account_id ?? null;
-  const { data: projectsList } = useQuery({
-    queryKey: qk.projects.list(activeAccountId ?? undefined),
-    queryFn: () => listProjectsForAccount(activeAccountId || undefined),
-    enabled: open && !!activeAccountId,
-    ...contract('inventory'),
+  /**
+   * EVERY account's workspaces, not just the active account's.
+   *
+   * This used to be one `listProjectsForAccount(activeAccountId)`. That made
+   * the palette strictly weaker than the mouse: the sidebar switcher
+   * (`workspace-menu-section.tsx`) already fans out over every account, so a
+   * workspace in a second account was reachable by trackpad and invisible to
+   * ⌘K. There is no single unscoped call that returns everything — `GET
+   * /projects` with no `account_id` resolves server-side to ONE default
+   * account (apps/api `resolveProjectAccount`) — so it is one request per
+   * account, exactly as the sidebar does it.
+   *
+   * Same `qk.projects.list(accountId)` keys and same `contract('inventory')`
+   * as the sidebar, so the two controls share cache entries and this costs no
+   * extra request when the sidebar menu has already been opened. `enabled` on
+   * `open` keeps all of it off every route the palette merely mounts on.
+   */
+  const workspaceQueries = useQueries({
+    queries: (accountsList ?? []).map((account) => ({
+      queryKey: qk.projects.list(account.account_id),
+      queryFn: () => listProjectsForAccount(account.account_id),
+      enabled: open,
+      ...contract('inventory'),
+    })),
   });
+  // Not memoised, and deliberately: `useQueries` hands back a fresh array
+  // every render, so a `useMemo` over it would recompute anyway while adding a
+  // dependency array whose LENGTH varies with the account count — which React
+  // rejects outright. The work is a flatMap plus a group-and-sort over tens of
+  // rows; the palette's per-keystroke cost is dominated by cmdk scoring every
+  // row in the list, not by this.
+  const allWorkspaces = workspaceQueries.flatMap((q) => q.data ?? []);
+  const workspacesLoading =
+    workspaceQueries.length === 0 || workspaceQueries.some((q) => q.isLoading);
   const { data: projectSessionsList } = useQuery({
     queryKey: qk.project.sessions(projectId ?? ''),
     queryFn: () => listProjectSessions(projectId!),
@@ -920,6 +1053,20 @@ export function CommandPalette() {
       if (e.key === '`' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         handleOpenTerminal();
+      }
+      // Straight onto the workspace switcher, skipping the root page.
+      // Switching workspaces is a top-level move — the sidebar gives it a
+      // dedicated control — and making it the ONLY top-level move with no
+      // keystroke is what pushed people onto the trackpad for it. `o` for
+      // "open", the same letter the platform uses for it; `preventDefault`
+      // takes it back from the browser's Open File dialog. Not a toggle: this
+      // key names a destination, and pressing it while the palette sits on
+      // some other page should go there, not close.
+      if ((e.key === 'o' || e.key === 'O') && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+        e.preventDefault();
+        setQuery('');
+        setPage('workspaces');
+        setOpen(true);
       }
     };
     document.addEventListener('keydown', down);
@@ -1201,12 +1348,37 @@ export function CommandPalette() {
 
   const setSelectedAccountId = useCurrentAccountStore((s) => s.setSelectedAccountId);
 
-  const handleSelectProject = useCallback(
-    (p: KortixProject) => {
-      router.push(`/projects/${p.project_id}`);
+  const beginSwitch = useProjectSwitchStore((s) => s.beginSwitch);
+
+  /**
+   * Switch to a workspace — the same three steps the sidebar picker takes
+   * (`workspace-menu-section.tsx`'s `openWorkspaceRow`), because a switch that
+   * behaves differently depending on which control started it is a bug waiting
+   * for a bug report nobody can reproduce.
+   *
+   * 1. `beginSwitch` marks the switch in flight. The palette then closes, so
+   *    it cannot be what ENDS one — `ProjectSwitchWatcher`, mounted once above
+   *    every route, owns that (arrival, diversion, or a 20s backstop). Skipping
+   *    this left the switch unnarrated everywhere.
+   * 2. `setSelectedAccountId` re-points the account store when the target lives
+   *    in another account. This was previously unreachable from the palette —
+   *    it only listed one account's workspaces — and became reachable the
+   *    moment the fan-out above landed. Without it, account-scoped surfaces
+   *    keep answering for the account you just left.
+   * 3. Navigate.
+   *
+   * The already-active workspace never reaches here: `rootWorkspaceResults`
+   * drops it, and the dedicated page renders it as a checked, non-selectable
+   * row.
+   */
+  const handleSelectWorkspace = useCallback(
+    (workspace: KortixProject) => {
+      beginSwitch(workspace.project_id);
+      if (workspace.account_id !== selectedAccountId) setSelectedAccountId(workspace.account_id);
+      router.push(`/projects/${workspace.project_id}`);
       close();
     },
-    [router, close],
+    [beginSwitch, selectedAccountId, setSelectedAccountId, router, close],
   );
 
   const handleSelectAccount = useCallback(
@@ -1239,26 +1411,51 @@ export function CommandPalette() {
     s.branch_name ||
     s.session_id.slice(0, 8);
 
-  const sortedProjects = useMemo(
+  /**
+   * Every workspace the user can switch to, in the sidebar's order — active
+   * account first, then alphabetical, most-recently-opened first inside each.
+   *
+   * Derived through `workspace-palette.ts`, which wraps the SAME
+   * `groupWorkspacesByAccount` the sidebar uses. The two controls previously
+   * sorted independently (this one by `last_opened_at || updated_at`, flat),
+   * so the same set of workspaces came out in two different orders depending
+   * on which one you opened.
+   */
+  const workspaceRows = useMemo(
     () =>
-      [...(projectsList ?? [])].sort((a, b) =>
-        (b.last_opened_at || b.updated_at).localeCompare(a.last_opened_at || a.updated_at),
-      ),
-    [projectsList],
+      buildWorkspacePaletteRows({
+        accounts: accountsList ?? [],
+        workspaces: allWorkspaces,
+        activeWorkspaceId: projectId,
+      }),
+    // `allWorkspaces` is a fresh array each render (see the `useQueries` note
+    // above), so this memo recomputes with it. Kept as a memo anyway for the
+    // referential stability the memos below depend on within a single render.
+    [accountsList, allWorkspaces, projectId],
   );
 
-  const filteredProjectsList = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return (
-      q ? sortedProjects.filter((p) => p.name.toLowerCase().includes(q)) : sortedProjects
-    ).slice(0, 50);
-  }, [sortedProjects, query]);
+  const rootSuggestionItems = useMemo(() => buildRootSuggestions(allPaletteItems), [
+    allPaletteItems,
+  ]);
+
+  /** Whether a row should say which account it is in. One account, no noise. */
+  const showWorkspaceAccount = (accountsList?.length ?? 0) > 1;
+
+  const workspacePageRows = useMemo(
+    () => workspacePageResults(workspaceRows, query),
+    [workspaceRows, query],
+  );
+
+  const workspacePageGroups = useMemo(
+    () => groupWorkspacePaletteRows(workspacePageRows),
+    [workspacePageRows],
+  );
 
   const recentProjectSessions = useMemo(() => {
     return sortSessionsByLastActivity(projectSessionsList ?? []).slice(0, 5);
   }, [projectSessionsList]);
 
-  const recentProjects = useMemo(() => sortedProjects.slice(0, 5), [sortedProjects]);
+  const recentWorkspaces = useMemo(() => recentWorkspaceRows(workspaceRows), [workspaceRows]);
 
   const filteredAccountsList = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -1290,18 +1487,33 @@ export function CommandPalette() {
     return filteredProjectSessionsList.slice(0, 8);
   }, [hasQuery, projectId, filteredProjectSessionsList]);
 
-  const rootProjectResults = useMemo(() => {
-    if (!hasQuery || projectId) return [];
-    return filteredProjectsList.slice(0, 8);
-  }, [hasQuery, projectId, filteredProjectsList]);
+  /**
+   * Workspaces matching a ROOT query.
+   *
+   * This was `if (!hasQuery || projectId) return []` — workspaces were
+   * suppressed the moment a workspace was open, which is where the palette
+   * lives essentially all the time. The effect was that typing a workspace
+   * name into ⌘K found nothing, and the switcher was reachable only by first
+   * selecting a row buried in Navigation. Removing the `projectId` clause is
+   * the single change that makes ⌘K → name → Enter work.
+   *
+   * `rootWorkspaceResults` drops the active workspace (it matches its own name
+   * best and selecting it re-navigates to the page you are on) and caps the
+   * rest, so workspaces take a slice of the mixed root page rather than owning
+   * it.
+   */
+  const rootWorkspaceRows = useMemo(
+    () => (hasQuery ? rootWorkspaceResults(workspaceRows, query) : []),
+    [hasQuery, workspaceRows, query],
+  );
 
   const hasSessionResults = rootSessionResults.length > 0;
-  const hasProjectResults = rootProjectResults.length > 0;
+  const hasWorkspaceResults = rootWorkspaceRows.length > 0;
   const hasSettingsResults = settingsResultCount > 0;
   const hasAnyResults =
     hasNavResults ||
     hasSessionResults ||
-    hasProjectResults ||
+    hasWorkspaceResults ||
     hasSessionActionResults ||
     hasSettingsResults;
 
@@ -1935,7 +2147,7 @@ export function CommandPalette() {
   const totalSearchResults = useMemo(() => {
     if (page === 'agents') return filteredAgents.length;
     if (page === 'models') return visibleModels.length;
-    if (page === 'projects') return filteredProjectsList.length;
+    if (page === 'workspaces') return workspacePageRows.length;
     if (page === 'accounts') return filteredAccountsList.length;
     if (page === 'sessions') return filteredProjectSessionsList.length;
     if (page === 'density') return filteredDensityOptions.length;
@@ -1947,7 +2159,7 @@ export function CommandPalette() {
     return (
       filteredNavItems.length +
       rootSessionResults.length +
-      rootProjectResults.length +
+      rootWorkspaceRows.length +
       sessionActionItems.length +
       settingsResultCount
     );
@@ -1956,12 +2168,12 @@ export function CommandPalette() {
     hasQuery,
     filteredNavItems,
     rootSessionResults,
-    rootProjectResults,
+    rootWorkspaceRows,
     sessionActionItems,
     settingsResultCount,
     filteredAgents,
     visibleModels,
-    filteredProjectsList,
+    workspacePageRows,
     filteredAccountsList,
     filteredProjectSessionsList,
     filteredDensityOptions,
@@ -1972,7 +2184,7 @@ export function CommandPalette() {
     if (page === 'models') return 'Search models...';
     if (page === 'files') return 'Search files in this project...';
     if (page === 'messages') return 'Search messages...';
-    if (page === 'projects') return 'Search projects...';
+    if (page === 'workspaces') return 'Search workspaces...';
     if (page === 'accounts') return 'Search accounts...';
     if (page === 'sessions') return 'Search sessions...';
     if (page === 'density') return 'Choose conversation density...';
@@ -1986,7 +2198,7 @@ export function CommandPalette() {
     if (page === 'models') return 'Change Model';
     if (page === 'files') return 'Search Files';
     if (page === 'messages') return 'Jump to Message';
-    if (page === 'projects') return 'Switch Project';
+    if (page === 'workspaces') return 'Switch Workspace';
     if (page === 'accounts') return 'Switch Account';
     if (page === 'sessions') return 'Open Session';
     if (page === 'density') return 'Conversation Density';
@@ -2021,55 +2233,52 @@ export function CommandPalette() {
                   <>
                     <CommandGroup heading="Suggestions" forceMount>
                       <div className="space-y-0.5">
-                        {allPaletteItems
-                          .filter((item) => item.group === 'actions' || item.group === 'navigation')
-                          .slice(0, 8)
-                          .map((item) => {
-                            const Icon = item.icon;
-                            const isToggleSidebar = item.id === 'toggle-sidebar';
-                            const DisplayIcon = isToggleSidebar
-                              ? sidebarOpen
-                                ? PanelLeftClose
-                                : PanelLeftIcon
-                              : Icon;
-                            const displayLabel = isToggleSidebar
-                              ? sidebarOpen
-                                ? 'Collapse Sidebar'
-                                : 'Expand Sidebar'
-                              : item.label;
+                        {rootSuggestionItems.map((item) => {
+                          const Icon = item.icon;
+                          const isToggleSidebar = item.id === 'toggle-sidebar';
+                          const DisplayIcon = isToggleSidebar
+                            ? sidebarOpen
+                              ? PanelLeftClose
+                              : PanelLeftIcon
+                            : Icon;
+                          const displayLabel = isToggleSidebar
+                            ? sidebarOpen
+                              ? 'Collapse Sidebar'
+                              : 'Expand Sidebar'
+                            : item.label;
 
-                            const submenuPage = SUBMENU_PAGE_BY_ID[item.id];
-                            return (
-                              <CommandItem
-                                key={item.id}
-                                value={sanitizeCmdkValue(
-                                  `suggestion ${buildPaletteSearchText(item)}`,
-                                )}
-                                onSelect={() =>
-                                  submenuPage ? goToPage(submenuPage) : handleRegistryItem(item)
-                                }
-                                disabled={item.id === 'new-session' && isCreating}
-                              >
-                                {item.id === 'new-session' && isCreating ? (
-                                  <Loading className="text-muted-foreground size-4 shrink-0" />
-                                ) : (
-                                  <DisplayIcon className="size-4" />
-                                )}
-                                <span className="flex-1">{displayLabel}</span>
-                                {item.id === 'review-changes' && openChangeRequestCount > 0 && (
-                                  <span className="text-muted-foreground/40 text-xs tabular-nums">
-                                    {openChangeRequestCount}
-                                  </span>
-                                )}
-                                {item.shortcut && (
-                                  <CommandShortcut>{item.shortcut}</CommandShortcut>
-                                )}
-                                {submenuPage && (
-                                  <ChevronRight className="text-muted-foreground/30 size-3" />
-                                )}
-                              </CommandItem>
-                            );
-                          })}
+                          const submenuPage = SUBMENU_PAGE_BY_ID[item.id];
+                          return (
+                            <CommandItem
+                              key={item.id}
+                              value={sanitizeCmdkValue(
+                                `suggestion ${buildPaletteSearchText(item)}`,
+                              )}
+                              onSelect={() =>
+                                submenuPage ? goToPage(submenuPage) : handleRegistryItem(item)
+                              }
+                              disabled={item.id === 'new-session' && isCreating}
+                            >
+                              {item.id === 'new-session' && isCreating ? (
+                                <Loading className="text-muted-foreground size-4 shrink-0" />
+                              ) : (
+                                <DisplayIcon className="size-4" />
+                              )}
+                              <span className="flex-1">{displayLabel}</span>
+                              {item.id === 'review-changes' && openChangeRequestCount > 0 && (
+                                <span className="text-muted-foreground/40 text-xs tabular-nums">
+                                  {openChangeRequestCount}
+                                </span>
+                              )}
+                              {item.shortcut && (
+                                <CommandShortcut>{item.shortcut}</CommandShortcut>
+                              )}
+                              {submenuPage && (
+                                <ChevronRight className="text-muted-foreground/30 size-3" />
+                              )}
+                            </CommandItem>
+                          );
+                        })}
                       </div>
 
                       {currentSessionId && (
@@ -2174,31 +2383,36 @@ export function CommandPalette() {
                       </CommandGroup>
                     )}
 
-                    {!projectId && recentProjects.length > 0 && (
+                    {/* Only OUTSIDE a workspace. Inside one, recent SESSIONS
+                        take this space — a user who is already somewhere wants
+                        a thread in it far more often than a different
+                        workspace, and search now reaches the other case from
+                        in here too. */}
+                    {!projectId && recentWorkspaces.length > 0 && (
                       <CommandGroup
                         heading={tHardcodedUi.raw(
                           'componentsCommandPalette.line1281JsxAttrHeadingRecentProjects',
                         )}
                         forceMount
                       >
-                        {recentProjects.map((project) => (
-                          <CommandItem
-                            key={project.project_id}
-                            value={sanitizeCmdkValue(
-                              `recent project ${project.name} ${project.project_id}`,
-                            )}
-                            onSelect={() => handleSelectProject(project)}
-                          >
-                            <FolderGit2 className="size-4 shrink-0" />
-                            <span className="flex-1 truncate">{project.name}</span>
-                            {(project.last_opened_at || project.updated_at) && (
-                              <span className="text-muted-foreground/30 shrink-0 text-xs tabular-nums">
-                                {formatRelativeTime(
-                                  new Date(project.last_opened_at || project.updated_at).getTime(),
-                                )}
-                              </span>
-                            )}
-                          </CommandItem>
+                        {recentWorkspaces.map((row) => (
+                          <WorkspaceCommandItem
+                            key={row.workspace.project_id}
+                            row={row}
+                            showAccount={showWorkspaceAccount}
+                            onSelect={() => handleSelectWorkspace(row.workspace)}
+                            trailing={
+                              (row.workspace.last_opened_at || row.workspace.updated_at) && (
+                                <span className="text-muted-foreground/30 shrink-0 text-xs tabular-nums">
+                                  {formatRelativeTime(
+                                    new Date(
+                                      row.workspace.last_opened_at || row.workspace.updated_at,
+                                    ).getTime(),
+                                  )}
+                                </span>
+                              )
+                            }
+                          />
                         ))}
                       </CommandGroup>
                     )}
@@ -2345,26 +2559,29 @@ export function CommandPalette() {
                       </CommandGroup>
                     )}
 
-                    {hasProjectResults && (
-                      <CommandGroup heading="Projects" forceMount>
-                        {rootProjectResults.map((project) => (
-                          <CommandItem
-                            key={project.project_id}
-                            value={sanitizeCmdkValue(
-                              `project ${project.name} ${project.project_id}`,
-                            )}
-                            onSelect={() => handleSelectProject(project)}
-                          >
-                            <FolderGit2 className="size-4 shrink-0" />
-                            <span className="flex-1 truncate">{project.name}</span>
-                            {(project.last_opened_at || project.updated_at) && (
-                              <span className="text-muted-foreground/40 shrink-0 text-xs tabular-nums">
-                                {formatRelativeTime(
-                                  new Date(project.last_opened_at || project.updated_at).getTime(),
-                                )}
-                              </span>
-                            )}
-                          </CommandItem>
+                    {/* Shown whether or not a workspace is open. The old
+                        version returned no rows at all while one was, which
+                        is the entire time the palette is used. */}
+                    {hasWorkspaceResults && (
+                      <CommandGroup heading="Workspaces" forceMount>
+                        {rootWorkspaceRows.map((row) => (
+                          <WorkspaceCommandItem
+                            key={row.workspace.project_id}
+                            row={row}
+                            showAccount={showWorkspaceAccount}
+                            onSelect={() => handleSelectWorkspace(row.workspace)}
+                            trailing={
+                              (row.workspace.last_opened_at || row.workspace.updated_at) && (
+                                <span className="text-muted-foreground/40 shrink-0 text-xs tabular-nums">
+                                  {formatRelativeTime(
+                                    new Date(
+                                      row.workspace.last_opened_at || row.workspace.updated_at,
+                                    ).getTime(),
+                                  )}
+                                </span>
+                              )
+                            }
+                          />
                         ))}
                       </CommandGroup>
                     )}
@@ -2624,29 +2841,57 @@ export function CommandPalette() {
               <FileSearchPage query={query} onSelect={handleSelectFile} />
             )}
 
-            {page === 'projects' &&
-              (filteredProjectsList.length > 0 ? (
-                <CommandGroup heading="Projects" forceMount>
-                  {filteredProjectsList.map((project) => (
-                    <CommandItem
-                      key={project.project_id}
-                      value={sanitizeCmdkValue(`project ${project.name} ${project.project_id}`)}
-                      onSelect={() => handleSelectProject(project)}
-                    >
-                      <FolderGit2 className="text-muted-foreground size-4 shrink-0" />
-                      <span className="flex-1 truncate">{project.name}</span>
-                      {project.project_id === params?.id && (
-                        <Check className="text-primary h-3.5 w-3.5 shrink-0" />
-                      )}
-                    </CommandItem>
-                  ))}
-                </CommandGroup>
+            {/* The dedicated directory. Grouped by account like the sidebar
+                switcher, and for the same reason: two workspaces can share a
+                name, and the account is the only thing that tells them apart.
+                One account gets a single "Workspaces" heading instead — a lone
+                account heading over the only list is noise, not structure.
+
+                Unlike the root results this KEEPS the workspace you are in, as
+                a checked row. A directory that omits where you are makes you
+                doubt the directory. */}
+            {page === 'workspaces' &&
+              (workspacePageRows.length > 0 ? (
+                workspacePageGroups.map((group) => (
+                  <CommandGroup
+                    key={group.accountId}
+                    heading={workspacePageGroups.length > 1 ? group.accountName : 'Workspaces'}
+                    forceMount
+                  >
+                    {group.rows.map((row) => (
+                      <WorkspaceCommandItem
+                        key={row.workspace.project_id}
+                        row={row}
+                        // Never on this page: the heading already says which
+                        // account, so repeating it on every row under it is
+                        // the same word twice.
+                        showAccount={false}
+                        onSelect={() => handleSelectWorkspace(row.workspace)}
+                        trailing={
+                          row.isActive ? (
+                            <Check className="text-primary h-3.5 w-3.5 shrink-0" />
+                          ) : null
+                        }
+                      />
+                    ))}
+                  </CommandGroup>
+                ))
               ) : (
                 <div className="flex flex-col items-center gap-2 py-12" cmdk-empty="">
-                  <FolderGit2 className="text-muted-foreground/30 size-5" />
-                  <span className="text-muted-foreground/60 text-sm">
-                    {query ? `No projects matching "${query}"` : 'No projects yet'}
-                  </span>
+                  {workspacesLoading ? (
+                    <Loading className="text-muted-foreground/60 size-5" />
+                  ) : (
+                    <>
+                      <FolderGit2 className="text-muted-foreground/30 size-5" />
+                      <span className="text-muted-foreground/60 text-sm">
+                        {/* Same two strings the sidebar's empty state uses.
+                            "No workspaces yet" over a list that simply has not
+                            arrived is a lie the sidebar already learned not to
+                            tell — hence the loading branch above. */}
+                        {query ? `No workspaces match "${query}"` : 'No workspaces yet'}
+                      </span>
+                    </>
+                  )}
                 </div>
               ))}
 

--- a/apps/web/src/features/workspace/project-sidebar/workspace-grouping.ts
+++ b/apps/web/src/features/workspace/project-sidebar/workspace-grouping.ts
@@ -14,6 +14,28 @@ import type { KortixAccount, KortixProject } from '@kortix/sdk';
 /** Shown when an account has no usable name. Never blank. */
 const FALLBACK_ACCOUNT_NAME = 'Account';
 
+/**
+ * The account name as a HUMAN reads it in a switcher.
+ *
+ * A personal account is created as "<Name>'s Account", so an unprocessed list
+ * of them reads "Jay's Account / Ada's Account / Acme" — the same four words
+ * repeated down the column, with the one distinguishing token buried at the
+ * front. The suffix carries no information in a control whose every row is
+ * already an account, so it comes off.
+ *
+ * Both apostrophes, because the two are indistinguishable on screen and a
+ * name typed with a curly one would otherwise keep its suffix while its
+ * neighbour lost it. Falls back rather than returning empty: an account
+ * literally named "'s Account" would strip to nothing, and a blank heading is
+ * worse than a redundant one.
+ */
+export function workspaceAccountLabel(name: string | null | undefined): string {
+  const trimmed = (name ?? '').trim();
+  if (!trimmed) return FALLBACK_ACCOUNT_NAME;
+  const stripped = trimmed.replace(/[\u2019']s Account$/u, '').trim();
+  return stripped || trimmed;
+}
+
 export interface WorkspaceGroup {
   accountId: string;
   accountName: string;

--- a/apps/web/src/features/workspace/settings/tabs/preferences-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/preferences-tab.tsx
@@ -289,6 +289,7 @@ function shortcutList(modLabel: string): { label: string; keys: string }[] {
     { label: 'Switch to last tab', keys: `${modLabel}+9` },
     { label: 'New session', keys: 'Ctrl+J' },
     { label: 'Command palette', keys: 'Ctrl+K' },
+    { label: 'Switch workspace', keys: 'Ctrl+O' },
     { label: 'Toggle left sidebar', keys: 'Ctrl+B' },
     { label: 'Toggle right sidebar', keys: 'Ctrl+Shift+B' },
     { label: 'Toggle session action panel', keys: `${modLabel}+I` },

--- a/apps/web/src/features/workspace/workspace-palette.test.ts
+++ b/apps/web/src/features/workspace/workspace-palette.test.ts
@@ -1,0 +1,437 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { KortixProject } from '@kortix/sdk';
+
+import {
+  ROOT_SUGGESTION_LIMIT,
+  WORKSPACE_SWITCHER_ITEM_ID,
+  buildRootSuggestions,
+} from '@/features/workspace/command-palette';
+import { workspaceAccountLabel } from '@/features/workspace/project-sidebar/workspace-grouping';
+import {
+  ROOT_WORKSPACE_RESULT_LIMIT,
+  buildWorkspacePaletteRows,
+  filterWorkspacePaletteRows,
+  groupWorkspacePaletteRows,
+  recentWorkspaceRows,
+  rootWorkspaceResults,
+  workspacePageResults,
+  workspacePaletteSearchText,
+  workspacePaletteValue,
+} from '@/features/workspace/workspace-palette';
+import { getItemsForSurface } from '@/lib/menu-registry';
+
+/**
+ * ============================================================================
+ * THE PALETTE'S WORKSPACE SWITCHER
+ * ============================================================================
+ *
+ * Every test here names a defect the old implementation had. The palette's
+ * switcher was a "projects list" bolted on beside a sidebar switcher that had
+ * since become the product's whole workspace directory, and the four ways it
+ * had fallen behind are pinned individually below so none of them can come
+ * back quietly.
+ *
+ * No DOM. These are the same pure functions the component calls — `apps/web`
+ * has no React test harness, and a source-text assertion about a component
+ * cannot tell "renders the right rows" from "renders nothing"
+ * (`workspace-vocabulary.test.ts` says the same thing about its absence
+ * checks). The one source-text test in this file is deliberately paired with
+ * a behavioural one, and it asserts a string's PRESENCE for that reason.
+ */
+
+function workspace(
+  name: string,
+  accountId: string,
+  overrides: Partial<KortixProject> = {},
+): KortixProject {
+  return {
+    project_id: `p-${name.toLowerCase().replaceAll(' ', '-')}-${accountId}`,
+    account_id: accountId,
+    name,
+    icon: null,
+    last_opened_at: null,
+    updated_at: '2026-01-01T00:00:00.000Z',
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as KortixProject;
+}
+
+const ACCOUNTS = [
+  { account_id: 'acct-personal', name: "Jay's Account" },
+  { account_id: 'acct-acme', name: 'Acme' },
+];
+
+const SITE = workspace('Site', 'acct-personal', { last_opened_at: '2026-08-20T00:00:00.000Z' });
+const NOTES = workspace('Notes', 'acct-personal', { last_opened_at: '2026-08-25T00:00:00.000Z' });
+const ACME_SITE = workspace('Site', 'acct-acme', { last_opened_at: '2026-08-10T00:00:00.000Z' });
+const BILLING = workspace('Billing', 'acct-acme');
+
+const ALL = [SITE, NOTES, ACME_SITE, BILLING];
+
+function rowsWithActive(activeWorkspaceId: string | null) {
+  return buildWorkspacePaletteRows({
+    accounts: ACCOUNTS,
+    workspaces: ALL,
+    activeWorkspaceId,
+  });
+}
+
+const names = (rows: { workspace: KortixProject }[]) => rows.map((r) => r.workspace.name);
+const ids = (rows: { workspace: KortixProject }[]) => rows.map((r) => r.workspace.project_id);
+
+describe('buildWorkspacePaletteRows', () => {
+  test('lists workspaces from EVERY account, not just the active one', () => {
+    // Defect 1. The palette fetched `listProjectsForAccount(activeAccountId)`,
+    // one account. A workspace in a second account was reachable with the
+    // trackpad (the sidebar fans out over all accounts) and unreachable from
+    // the keyboard.
+    const rows = rowsWithActive(SITE.project_id);
+
+    expect(ids(rows).sort()).toEqual(ALL.map((w) => w.project_id).sort());
+    expect(new Set(rows.map((r) => r.accountId))).toEqual(
+      new Set(['acct-personal', 'acct-acme']),
+    );
+  });
+
+  test('sorts the active account first, then by most recently opened', () => {
+    // The sidebar's order, because it is literally the sidebar's function.
+    // Active workspace is in acct-personal, so that account leads; inside it
+    // Notes (Aug 25) beats Site (Aug 20).
+    expect(names(rowsWithActive(SITE.project_id))).toEqual([
+      'Notes',
+      'Site',
+      'Site',
+      'Billing',
+    ]);
+  });
+
+  test('falls back to alphabetical account order when no workspace is open', () => {
+    // Acme < Jay's Account. Nothing is active, so there is no account to
+    // promote and the tie-break is the account name.
+    expect(rowsWithActive(null).map((r) => r.accountId)).toEqual([
+      'acct-acme',
+      'acct-acme',
+      'acct-personal',
+      'acct-personal',
+    ]);
+  });
+
+  test('marks exactly one row active, and only when that workspace is open', () => {
+    const rows = rowsWithActive(ACME_SITE.project_id);
+    expect(rows.filter((r) => r.isActive).map((r) => r.workspace.project_id)).toEqual([
+      ACME_SITE.project_id,
+    ]);
+    expect(rowsWithActive(null).some((r) => r.isActive)).toBe(false);
+  });
+
+  test('carries the display account label, not the raw account name', () => {
+    // The row shows "Jay", so the row must SEARCH "Jay" too — see the
+    // search-text tests below.
+    const personal = rowsWithActive(null).filter((r) => r.accountId === 'acct-personal');
+    expect(personal.map((r) => r.accountName)).toEqual(['Jay', 'Jay']);
+  });
+
+  test('keeps a workspace whose account is missing from the roster', () => {
+    // An orphan (a shared workspace in an account the user is not a member of)
+    // must still be switchable — `groupWorkspacesByAccount` guarantees this and
+    // the palette must not undo it by flattening.
+    const orphan = workspace('Shared', 'acct-unknown');
+    const rows = buildWorkspacePaletteRows({
+      accounts: ACCOUNTS,
+      workspaces: [...ALL, orphan],
+      activeWorkspaceId: null,
+    });
+    expect(ids(rows)).toContain(orphan.project_id);
+    expect(rows.find((r) => r.workspace === orphan)?.accountName).toBe('Account');
+  });
+});
+
+describe('workspaceAccountLabel', () => {
+  test('drops the personal-account suffix, straight or curly apostrophe', () => {
+    expect(workspaceAccountLabel("Jay's Account")).toBe('Jay');
+    expect(workspaceAccountLabel('Jay’s Account')).toBe('Jay');
+  });
+
+  test('leaves an ordinary account name alone', () => {
+    expect(workspaceAccountLabel('Acme')).toBe('Acme');
+    expect(workspaceAccountLabel('Account Managers')).toBe('Account Managers');
+  });
+
+  test('never returns an empty label', () => {
+    expect(workspaceAccountLabel('')).toBe('Account');
+    expect(workspaceAccountLabel('   ')).toBe('Account');
+    expect(workspaceAccountLabel(null)).toBe('Account');
+    expect(workspaceAccountLabel(undefined)).toBe('Account');
+    // Would strip to nothing — falls back to the trimmed original.
+    expect(workspaceAccountLabel("'s Account")).toBe("'s Account");
+  });
+});
+
+describe('search text and cmdk value', () => {
+  const row = rowsWithActive(null).find((r) => r.workspace === ACME_SITE)!;
+
+  test('search text is exactly what the row displays', () => {
+    expect(workspacePaletteSearchText(row)).toBe('Site Acme');
+  });
+
+  test('the workspace id is in the cmdk value but NOT in the search text', () => {
+    // The id is the only thing that separates two same-named workspaces, so
+    // cmdk needs it for identity. Putting it in the haystack would repeat the
+    // `nav-*`/`proj-*` defect: matching on a string no user has ever seen.
+    expect(workspacePaletteValue(row)).toContain(ACME_SITE.project_id);
+    expect(workspacePaletteSearchText(row)).not.toContain(ACME_SITE.project_id);
+  });
+
+  test('two same-named workspaces in different accounts get different values', () => {
+    // cmdk 0.2.1 marks every row sharing a `value` as aria-selected and fires
+    // the first on Enter. "Site" exists in both accounts here.
+    const values = rowsWithActive(null).map(workspacePaletteValue);
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  test('every row the palette can render at once has a unique value', () => {
+    // Same guarantee as above but over the whole rendered set, including the
+    // pathological case the account label cannot separate: identical names in
+    // the SAME account.
+    const twins = [
+      workspace('Website', 'acct-acme', { project_id: 'p-twin-a' }),
+      workspace('Website', 'acct-acme', { project_id: 'p-twin-b' }),
+    ];
+    const values = buildWorkspacePaletteRows({
+      accounts: ACCOUNTS,
+      workspaces: [...ALL, ...twins],
+      activeWorkspaceId: null,
+    }).map(workspacePaletteValue);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe('filterWorkspacePaletteRows', () => {
+  const rows = rowsWithActive(null);
+
+  test('an empty query returns everything', () => {
+    expect(filterWorkspacePaletteRows(rows, '')).toHaveLength(ALL.length);
+    expect(filterWorkspacePaletteRows(rows, '   ')).toHaveLength(ALL.length);
+  });
+
+  test('matches the workspace name, case-insensitively', () => {
+    expect(names(filterWorkspacePaletteRows(rows, 'not'))).toEqual(['Notes']);
+    expect(names(filterWorkspacePaletteRows(rows, 'NOTES'))).toEqual(['Notes']);
+  });
+
+  test('matches the account label, so an account name lists its workspaces', () => {
+    expect(names(filterWorkspacePaletteRows(rows, 'acme')).sort()).toEqual(['Billing', 'Site']);
+  });
+
+  test('matches on the STRIPPED account label, which is what the row shows', () => {
+    // "jay", not "jay's account" — searching for what is on screen must work.
+    expect(names(filterWorkspacePaletteRows(rows, 'jay')).sort()).toEqual(['Notes', 'Site']);
+  });
+
+  test('every word must match, and order does not matter', () => {
+    expect(ids(filterWorkspacePaletteRows(rows, 'acme site'))).toEqual([ACME_SITE.project_id]);
+    expect(ids(filterWorkspacePaletteRows(rows, 'site acme'))).toEqual([ACME_SITE.project_id]);
+    expect(filterWorkspacePaletteRows(rows, 'acme notes')).toHaveLength(0);
+  });
+
+  test('a query that matches nothing returns nothing rather than everything', () => {
+    expect(filterWorkspacePaletteRows(rows, 'zzzz')).toHaveLength(0);
+  });
+});
+
+describe('rootWorkspaceResults', () => {
+  test('answers a query while the user is INSIDE a workspace', () => {
+    // Defect 2, and the whole point of the change. The old code was
+    // `if (!hasQuery || projectId) return []` — workspaces were suppressed
+    // whenever a workspace was open, which is where the palette always is.
+    const rows = rowsWithActive(SITE.project_id);
+    expect(names(rootWorkspaceResults(rows, 'notes'))).toEqual(['Notes']);
+  });
+
+  test('drops the workspace you are already in', () => {
+    // It matches its own name better than anything else, so leaving it in
+    // makes the top hit a no-op re-navigation to the current page.
+    const rows = rowsWithActive(SITE.project_id);
+    const hits = rootWorkspaceResults(rows, 'site');
+    expect(ids(hits)).toEqual([ACME_SITE.project_id]);
+    expect(ids(hits)).not.toContain(SITE.project_id);
+  });
+
+  test('returns nothing for an empty query', () => {
+    // No query at root means recents, a different list under a different
+    // heading.
+    expect(rootWorkspaceResults(rowsWithActive(null), '')).toEqual([]);
+    expect(rootWorkspaceResults(rowsWithActive(null), '  ')).toEqual([]);
+  });
+
+  test('caps at ROOT_WORKSPACE_RESULT_LIMIT so it cannot crowd out other groups', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      workspace(`Site ${i}`, 'acct-acme', { project_id: `p-many-${i}` }),
+    );
+    const rows = buildWorkspacePaletteRows({
+      accounts: ACCOUNTS,
+      workspaces: many,
+      activeWorkspaceId: null,
+    });
+    expect(rootWorkspaceResults(rows, 'site')).toHaveLength(ROOT_WORKSPACE_RESULT_LIMIT);
+  });
+});
+
+describe('workspacePageResults', () => {
+  test('KEEPS the active workspace — the page is a directory, not a jump list', () => {
+    const rows = rowsWithActive(SITE.project_id);
+    expect(ids(workspacePageResults(rows, ''))).toContain(SITE.project_id);
+  });
+
+  test('an empty query lists every workspace, in build order', () => {
+    const rows = rowsWithActive(SITE.project_id);
+    expect(names(workspacePageResults(rows, ''))).toEqual(names(rows));
+  });
+
+  test('caps at its own, larger limit', () => {
+    const many = Array.from({ length: 60 }, (_, i) =>
+      workspace(`W${i}`, 'acct-acme', { project_id: `p-cap-${i}` }),
+    );
+    const rows = buildWorkspacePaletteRows({
+      accounts: ACCOUNTS,
+      workspaces: many,
+      activeWorkspaceId: null,
+    });
+    expect(workspacePageResults(rows, '')).toHaveLength(50);
+  });
+});
+
+describe('groupWorkspacePaletteRows', () => {
+  test('regroups by account without reordering', () => {
+    const rows = rowsWithActive(SITE.project_id);
+    const groups = groupWorkspacePaletteRows(rows);
+
+    expect(groups.map((g) => g.accountId)).toEqual(['acct-personal', 'acct-acme']);
+    expect(groups.flatMap((g) => names(g.rows))).toEqual(names(rows));
+  });
+
+  test('a group appears once, at the position of its first row', () => {
+    // Insertion-ordered Map, not a sort. Interleaved input must not produce
+    // the same account twice.
+    const groups = groupWorkspacePaletteRows([
+      ...rowsWithActive(null).filter((r) => r.accountId === 'acct-acme').slice(0, 1),
+      ...rowsWithActive(null).filter((r) => r.accountId === 'acct-personal').slice(0, 1),
+      ...rowsWithActive(null).filter((r) => r.accountId === 'acct-acme').slice(1, 2),
+    ]);
+    expect(groups.map((g) => g.accountId)).toEqual(['acct-acme', 'acct-personal']);
+    expect(groups[0].rows).toHaveLength(2);
+  });
+
+  test('carries the display label onto the group heading', () => {
+    const groups = groupWorkspacePaletteRows(rowsWithActive(SITE.project_id));
+    expect(groups.map((g) => g.accountName)).toEqual(['Jay', 'Acme']);
+  });
+
+  test('an empty list produces no groups, not one empty group', () => {
+    expect(groupWorkspacePaletteRows([])).toEqual([]);
+  });
+});
+
+describe('recentWorkspaceRows', () => {
+  test('takes the head of the build order and caps it', () => {
+    const rows = rowsWithActive(null);
+    expect(recentWorkspaceRows(rows, 2)).toEqual(rows.slice(0, 2));
+  });
+});
+
+describe('buildRootSuggestions — the no-query root page', () => {
+  const items = getItemsForSurface('commandPalette');
+
+  test('offers the workspace switcher FIRST', () => {
+    // The defect this pin fixes: opening ⌘K and typing nothing showed eight
+    // session/terminal actions and no way to change workspace at all.
+    expect(buildRootSuggestions(items)[0]?.id).toBe(WORKSPACE_SWITCHER_ITEM_ID);
+  });
+
+  test('the switcher would NOT survive the cap unpinned — the pin is load-bearing', () => {
+    // Pins the reason. If the registry is ever reordered so the switcher lands
+    // inside the first `ROOT_SUGGESTION_LIMIT` on its own, this fails and the
+    // pin can be reconsidered rather than cargo-culted forever.
+    const unpinned = items.filter((i) => i.group === 'actions' || i.group === 'navigation');
+    const naturalIndex = unpinned.findIndex((i) => i.id === WORKSPACE_SWITCHER_ITEM_ID);
+
+    expect(naturalIndex).toBeGreaterThanOrEqual(0);
+    expect(naturalIndex).toBeGreaterThanOrEqual(ROOT_SUGGESTION_LIMIT);
+  });
+
+  test('lists the switcher exactly once', () => {
+    // A pin that also duplicated would collide on `key={item.id}` and be a
+    // worse bug than the one it fixes.
+    const ids = buildRootSuggestions(items).map((i) => i.id);
+    expect(ids.filter((id) => id === WORKSPACE_SWITCHER_ITEM_ID)).toHaveLength(1);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('respects the cap and keeps registry order behind the pin', () => {
+    const result = buildRootSuggestions(items);
+    const rest = items
+      .filter((i) => i.group === 'actions' || i.group === 'navigation')
+      .filter((i) => i.id !== WORKSPACE_SWITCHER_ITEM_ID)
+      .slice(0, ROOT_SUGGESTION_LIMIT - 1)
+      .map((i) => i.id);
+
+    expect(result).toHaveLength(ROOT_SUGGESTION_LIMIT);
+    expect(result.slice(1).map((i) => i.id)).toEqual(rest);
+  });
+
+  test('offers only actions and navigation rows', () => {
+    for (const item of buildRootSuggestions(items)) {
+      expect(['actions', 'navigation']).toContain(item.group);
+    }
+  });
+
+  test('degrades to plain registry order if the switcher row disappears', () => {
+    const without = items.filter((i) => i.id !== WORKSPACE_SWITCHER_ITEM_ID);
+    const result = buildRootSuggestions(without);
+    expect(result.map((i) => i.id)).not.toContain(WORKSPACE_SWITCHER_ITEM_ID);
+    expect(result).toHaveLength(ROOT_SUGGESTION_LIMIT);
+  });
+});
+
+/**
+ * Paired presence check. Everything above is behavioural, but the component is
+ * where the behaviour is WIRED, and the two defects that cost the most were
+ * both wiring: a `return []` guard and a single-account fetch. A behavioural
+ * suite cannot see either.
+ *
+ * These assert the presence of the specific call sites, and each one is stated
+ * as the thing that must be true rather than as a string that happens to be
+ * there — so a rename fails loudly instead of passing vacuously.
+ *
+ * `expect(source.includes(x)).toBe(true)` rather than
+ * `expect(source).toContain(x)`: the latter prints the ENTIRE 2,800-line file
+ * as `Received` on failure, which buries the one line that matters under
+ * 350KB of noise. The boolean form fails just as loudly and reads
+ * `Expected: true / Received: false`.
+ */
+describe('command-palette.tsx wires the switcher to these functions', () => {
+  const source = readFileSync(join(import.meta.dir, 'command-palette.tsx'), 'utf8');
+
+  test('root results come from rootWorkspaceResults, and nothing gates them on projectId', () => {
+    expect(source.includes('rootWorkspaceResults(')).toBe(true);
+    // The exact guard that caused the bug. Any form of it coming back fails.
+    expect(source.includes('if (!hasQuery || projectId) return [];')).toBe(false);
+  });
+
+  test('the workspace list is fanned out over every account with useQueries', () => {
+    expect(source.includes('useQueries')).toBe(true);
+    expect(source.includes('buildWorkspacePaletteRows')).toBe(true);
+  });
+
+  test('selecting a workspace narrates the switch and re-points the account store', () => {
+    // Without `beginSwitch` the palette vanishes into a blank wait; without
+    // `setSelectedAccountId` a cross-account switch leaves account-scoped
+    // surfaces answering for the account just left. Both are reachable only
+    // now that the palette lists other accounts' workspaces at all.
+    expect(source.includes('beginSwitch(')).toBe(true);
+    expect(source.includes('setSelectedAccountId(')).toBe(true);
+  });
+});

--- a/apps/web/src/features/workspace/workspace-palette.ts
+++ b/apps/web/src/features/workspace/workspace-palette.ts
@@ -1,0 +1,273 @@
+import type { KortixProject } from '@kortix/sdk';
+
+import {
+  type GroupWorkspacesInput,
+  groupWorkspacesByAccount,
+  workspaceAccountLabel,
+} from '@/features/workspace/project-sidebar/workspace-grouping';
+
+/**
+ * ============================================================================
+ * THE COMMAND PALETTE'S WORKSPACE SWITCHER — what rows exist, in what order,
+ * and what each one is searchable by.
+ * ============================================================================
+ *
+ * Pure. No React, no query client, no cmdk. The palette is 2,800 lines of
+ * component and every rule that used to live inside it was untestable without
+ * a DOM this app does not have a harness for (`apps/web` ships no
+ * testing-library). Everything that DECIDES something lives here instead, so
+ * `workspace-palette.test.ts` exercises the real functions the component
+ * calls rather than a re-implementation of them.
+ *
+ * ---------------------------------------------------------------------------
+ * Why this exists at all
+ * ---------------------------------------------------------------------------
+ *
+ * The palette had a workspace switcher already, and it was worse than the
+ * mouse in four ways that all came from the same place — it was written as a
+ * "projects list" rather than as the switcher the sidebar had become:
+ *
+ *   1. it fetched ONE account's workspaces (`listProjectsForAccount(active)`),
+ *      while the sidebar fans out over every account. A workspace in a second
+ *      account was reachable by trackpad and unreachable by keyboard;
+ *   2. root search suppressed workspaces entirely whenever you were inside
+ *      one — i.e. always — so the only surface that could answer "take me to
+ *      Acme" in one keystroke was switched off exactly where it was needed;
+ *   3. it said "Project", the word this product retired
+ *      (`workspace-vocabulary.test.ts`);
+ *   4. every row was the same grey folder glyph, in the one control whose
+ *      whole job is being fast to scan.
+ *
+ * (1) and (2) are fixed by the component; (3) and (4) by the row shape. What
+ * is fixed HERE is the part that has to agree with the sidebar: the order, the
+ * grouping and the matching. Both switchers now derive from
+ * `groupWorkspacesByAccount`, so the account you are in sorts first, its
+ * workspaces sort by how recently you opened them, and the two controls can no
+ * longer disagree about what the list is.
+ *
+ * ---------------------------------------------------------------------------
+ * Search text vs. cmdk value — they are NOT the same string
+ * ---------------------------------------------------------------------------
+ *
+ * cmdk 0.2.1 (the installed version) has no `keywords` prop, so a row's
+ * `value` is simultaneously its search text AND its selection identity, and
+ * cmdk requires the identity to be unique — two rows sharing a `value` are
+ * both marked `aria-selected` and Enter always fires the first one. Two
+ * workspaces called "Website" in two different accounts is an ordinary thing
+ * to own, so name-plus-account is NOT a safe identity.
+ *
+ * Hence two functions:
+ *
+ * - {@link workspacePaletteSearchText} is what a query is matched against, and
+ *   it is exactly what the row puts on screen — name and account label,
+ *   nothing else. Every group in the palette renders with `forceMount`, which
+ *   cmdk propagates to its items, so cmdk never REMOVES a row; it only ranks
+ *   them. {@link filterWorkspacePaletteRows} is therefore the sole authority
+ *   on which workspace rows exist.
+ * - {@link workspacePaletteValue} appends the workspace id, which makes the
+ *   identity unique without making the id searchable — the id is not in the
+ *   haystack the filter reads. This is the same split
+ *   `buildPaletteSearchText`'s doc comment describes for registry rows, where
+ *   the lesson was learned the other way round: `nav-*`/`proj-*` slugs WERE in
+ *   the match text, so "nav" returned eleven rows by a string no user has
+ *   ever seen.
+ */
+
+export interface WorkspacePaletteRow {
+  workspace: KortixProject;
+  accountId: string;
+  /** Already display-ready — see {@link workspaceAccountLabel}. */
+  accountName: string;
+  /** The workspace the user is looking at right now. */
+  isActive: boolean;
+}
+
+export interface WorkspacePaletteGroup {
+  accountId: string;
+  accountName: string;
+  rows: WorkspacePaletteRow[];
+}
+
+/**
+ * How many workspaces a ROOT search offers before it stops.
+ *
+ * Root is a mixed result page — navigation, settings, sessions, workspaces,
+ * URL detection — and workspaces are one voice in it, so they take a slice
+ * rather than the page. Five, not the eight the old project rows used: the
+ * rows above them are the ones the user asked for by name most of the time,
+ * and a workspace list long enough to push Settings off screen turns a search
+ * into a scroll. The full list is one Enter away on the dedicated page, which
+ * caps at {@link WORKSPACE_PAGE_RESULT_LIMIT}.
+ */
+export const ROOT_WORKSPACE_RESULT_LIMIT = 5;
+
+/**
+ * How many rows the dedicated Switch Workspace page renders.
+ *
+ * A cap, not a page size — there is no "show more". 50 is the same number the
+ * page it replaces used, and it is a render-cost guard rather than a product
+ * decision: the sidebar's directory is deliberately uncapped
+ * (`filterWorkspaceGroups`), so a user past 50 workspaces still has one
+ * complete list, and the palette's search reaches any of them by name.
+ */
+export const WORKSPACE_PAGE_RESULT_LIMIT = 50;
+
+/**
+ * Every workspace the user can reach, flattened out of
+ * {@link groupWorkspacesByAccount} in that function's order: the account you
+ * are in first, then the rest alphabetically, and inside each, most recently
+ * opened first.
+ *
+ * Flat rather than grouped because the ROOT search shows a plain top-5 with no
+ * account headings at all — grouping there would put a one-row heading above
+ * each result. {@link groupWorkspacePaletteRows} puts the headings back for
+ * the dedicated page, and because it preserves order it cannot reorder what
+ * the sidebar shows.
+ */
+export function buildWorkspacePaletteRows({
+  accounts,
+  workspaces,
+  activeWorkspaceId,
+}: GroupWorkspacesInput): WorkspacePaletteRow[] {
+  return groupWorkspacesByAccount({ accounts, workspaces, activeWorkspaceId }).flatMap((group) =>
+    group.workspaces.map((workspace) => ({
+      workspace,
+      accountId: group.accountId,
+      accountName: workspaceAccountLabel(group.accountName),
+      isActive: workspace.project_id === activeWorkspaceId,
+    })),
+  );
+}
+
+/**
+ * What a query is matched against — and, deliberately, exactly what the row
+ * puts on screen.
+ *
+ * The account label is in here because the palette shows it (as trailing muted
+ * text, whenever the user belongs to more than one account), so "acme" is a
+ * legitimate way to ask for Acme's workspaces. It would be wrong to match on
+ * an account name the row does not display.
+ */
+export function workspacePaletteSearchText(row: WorkspacePaletteRow): string {
+  return `${row.workspace.name} ${row.accountName}`;
+}
+
+/**
+ * The row's cmdk `value` — its selection identity. Search text plus the
+ * workspace id, which is the only field guaranteed to differ between two
+ * same-named workspaces in the same account.
+ *
+ * Callers must still run this through the palette's `sanitizeCmdkValue`,
+ * which strips the quote/bracket characters cmdk cannot carry in a value. That
+ * lives in the component with every other cmdk detail; this module stays
+ * unaware of cmdk.
+ */
+export function workspacePaletteValue(row: WorkspacePaletteRow): string {
+  return `workspace ${workspacePaletteSearchText(row)} ${row.workspace.project_id}`;
+}
+
+/**
+ * Per-word substring match, every word required, order irrelevant.
+ *
+ * The same rule `filteredNavItems` and `filterSettingsPaletteGroups` apply, on
+ * purpose: one query typed into one input must not mean two different things
+ * depending on which group is answering it. It is looser than cmdk's ordered
+ * subsequence score, which is what lets "acme site" find "Site" in "Acme"
+ * while cmdk merely ranks it.
+ */
+export function filterWorkspacePaletteRows(
+  rows: WorkspacePaletteRow[],
+  query: string,
+): WorkspacePaletteRow[] {
+  const words = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return rows;
+  return rows.filter((row) => {
+    const haystack = workspacePaletteSearchText(row).toLowerCase();
+    return words.every((word) => haystack.includes(word));
+  });
+}
+
+/**
+ * The workspace rows a ROOT query offers.
+ *
+ * Two rules the old implementation got wrong, both of them about the case that
+ * matters most — the user is already inside a workspace, which is where the
+ * palette spends its entire life:
+ *
+ * - it is NOT gated on being outside a workspace. The old code returned `[]`
+ *   the moment `projectId` was set, so typing a workspace name at the root
+ *   found nothing and the switcher was only reachable by first selecting a row
+ *   called "Projects". That two-step is the whole complaint this change
+ *   answers;
+ * - the ACTIVE workspace is dropped. It is the one row that cannot do
+ *   anything: selecting it re-navigates to the page you are on. It also
+ *   matches its own name better than anything else does, so leaving it in
+ *   means the top hit for the workspace you are in is a no-op.
+ *
+ * Empty for an empty query — root with no query shows recents, which is a
+ * different list with a different heading.
+ */
+export function rootWorkspaceResults(
+  rows: WorkspacePaletteRow[],
+  query: string,
+  limit: number = ROOT_WORKSPACE_RESULT_LIMIT,
+): WorkspacePaletteRow[] {
+  if (!query.trim()) return [];
+  return filterWorkspacePaletteRows(rows, query)
+    .filter((row) => !row.isActive)
+    .slice(0, limit);
+}
+
+/**
+ * The rows the dedicated Switch Workspace page renders, capped.
+ *
+ * Keeps the active workspace, unlike {@link rootWorkspaceResults} — this page
+ * is the directory, and a directory that omits where you are makes you doubt
+ * it. The component marks that row with a check instead.
+ */
+export function workspacePageResults(
+  rows: WorkspacePaletteRow[],
+  query: string,
+  limit: number = WORKSPACE_PAGE_RESULT_LIMIT,
+): WorkspacePaletteRow[] {
+  return filterWorkspacePaletteRows(rows, query).slice(0, limit);
+}
+
+/**
+ * Re-group flat rows by account for the dedicated page, preserving the order
+ * {@link buildWorkspacePaletteRows} established.
+ *
+ * Insertion-ordered `Map`, not a sort: the rows arrive in the sidebar's order
+ * and re-sorting here is how the two controls would start disagreeing. A group
+ * appears at the position of its first row and nowhere else.
+ */
+export function groupWorkspacePaletteRows(rows: WorkspacePaletteRow[]): WorkspacePaletteGroup[] {
+  const groups = new Map<string, WorkspacePaletteGroup>();
+  for (const row of rows) {
+    const existing = groups.get(row.accountId);
+    if (existing) existing.rows.push(row);
+    else
+      groups.set(row.accountId, {
+        accountId: row.accountId,
+        accountName: row.accountName,
+        rows: [row],
+      });
+  }
+  return [...groups.values()];
+}
+
+/**
+ * The recent workspaces the root page shows with NO query, when the user is
+ * not inside a workspace.
+ *
+ * Inside a workspace this list is not offered at all — recent SESSIONS take
+ * that space, because a user who is already somewhere is far likelier to want
+ * a thread in it than a different workspace. Search covers the other case, and
+ * now does so from inside a workspace too.
+ */
+export function recentWorkspaceRows(
+  rows: WorkspacePaletteRow[],
+  limit = 5,
+): WorkspacePaletteRow[] {
+  return rows.slice(0, limit);
+}

--- a/apps/web/src/features/workspace/workspace-vocabulary.test.ts
+++ b/apps/web/src/features/workspace/workspace-vocabulary.test.ts
@@ -108,6 +108,44 @@ describe('workspace vocabulary: each surface actually renders its Workspace copy
     expect(code).toContain('Switch Workspace');
   });
 
+  /**
+   * The command palette is NOT in the absence-checking `SURFACES` list above,
+   * and must not be: it is 2,800 lines that legitimately reference
+   * `KortixProject`, `qk.projects.list`, `listProjectsForAccount`,
+   * `/projects/<id>` hrefs and a `projects` React Query key, and a standalone
+   * `\bProjects?\b` scan over it would fire on strings the user never sees.
+   *
+   * What CAN be pinned is the copy it actually renders. Its workspace switcher
+   * shipped saying "Projects" / "Switch Project" / "Search projects..." long
+   * after the rest of the product had stopped — nothing guarded it, so it
+   * drifted alone. These four strings are the switcher's entire visible
+   * vocabulary; each is asserted present, and the retired wording asserted
+   * absent, so the drift cannot happen twice.
+   */
+  test('command-palette.tsx says Workspace throughout its switcher', () => {
+    const code = stripComments(readFileSync(join(import.meta.dir, 'command-palette.tsx'), 'utf8'));
+
+    expect(code).toContain("'Switch Workspace'");
+    expect(code).toContain("'Search workspaces...'");
+    expect(code).toContain('heading="Workspaces"');
+    expect(code).toContain("'No workspaces yet'");
+
+    expect(code).not.toContain("'Switch Project'");
+    expect(code).not.toContain("'Search projects...'");
+    expect(code).not.toContain('heading="Projects"');
+    expect(code).not.toContain("'No projects yet'");
+  });
+
+  test('menu-registry.ts names the palette row Switch workspace', () => {
+    // The row is the switcher's front door. It said "Projects" — a bare noun
+    // that neither names the current concept nor says the row does anything.
+    const code = stripComments(
+      readFileSync(join(import.meta.dir, '../../lib/menu-registry.ts'), 'utf8'),
+    );
+    expect(code).toContain("label: 'Switch workspace'");
+    expect(code).not.toContain("label: 'Projects'");
+  });
+
   test('new-workspace-page.tsx renders the page heading', () => {
     const code = stripComments(
       readFileSync(join(import.meta.dir, 'new/new-workspace-page.tsx'), 'utf8'),

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -372,16 +372,29 @@ export const menuRegistry: MenuItemDef[] = [
   // ──────────────────────────────────────────────────────────────────────────
   {
     id: 'nav-projects',
-    label: 'Projects',
+    // "Switch workspace", not "Projects". The product retired the noun
+    // (`features/workspace/workspace-vocabulary.test.ts`) everywhere except
+    // here, so the palette was the one surface still answering a question the
+    // rest of the app had stopped asking — and a bare noun does not say the
+    // row DOES anything, which is why it read as a list rather than as the
+    // switcher it opens.
+    label: 'Switch workspace',
     icon: FolderGit2,
     group: 'navigation',
     showIn: ['commandPalette'],
     kind: 'navigate',
     // Static registry entry — no user id to resolve the latest project with,
     // so this is the id-free landing door, never the removed `/projects`
-    // list.
+    // list. Selecting the row normally opens the in-palette switcher
+    // (`SUBMENU_PAGE_BY_ID` in command-palette.tsx); this href is the routed
+    // fallback if that map ever loses the id.
     href: PROJECT_LANDING_PATH,
-    keywords: 'projects list all workspaces switch',
+    shortcut: 'Ctrl+O',
+    // `project`/`projects` stay in the bag deliberately. It is the word the
+    // product used until recently, the word the URL still uses
+    // (`/projects/<id>`), and the word anyone arriving from the API or the
+    // CLI will type. Dropping it would make the rename cost users a search.
+    keywords: 'switch workspace workspaces project projects change move open all list',
   },
   {
     id: 'nav-accounts',

--- a/apps/web/translations/de.json
+++ b/apps/web/translations/de.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "Zur Nachricht springen",
       "line1248JsxTextSearchFiles": "Dateien suchen",
       "line1260JsxAttrHeadingRecentSessions": "Letzte Sessions",
-      "line1281JsxAttrHeadingRecentProjects": "Letzte Projekte",
+      "line1281JsxAttrHeadingRecentProjects": "Zuletzt verwendete Arbeitsbereiche",
       "line1419JsxAttrHeadingOpenURL": "URL öffnen",
       "line1437JsxAttrHeadingFileSearch": "Dateisuche",
       "line1444JsxTextSearchFilesFor": "Dateien suchen nach \"",

--- a/apps/web/translations/en.json
+++ b/apps/web/translations/en.json
@@ -3985,7 +3985,7 @@
       "line1235JsxTextJumpToMessage": "Jump to Message",
       "line1248JsxTextSearchFiles": "Search Files",
       "line1260JsxAttrHeadingRecentSessions": "Recent Sessions",
-      "line1281JsxAttrHeadingRecentProjects": "Recent Projects",
+      "line1281JsxAttrHeadingRecentProjects": "Recent workspaces",
       "line1419JsxAttrHeadingOpenURL": "Open URL",
       "line1437JsxAttrHeadingFileSearch": "File Search",
       "line1444JsxTextSearchFilesFor": "Search files for “",

--- a/apps/web/translations/es.json
+++ b/apps/web/translations/es.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "Ir al mensaje",
       "line1248JsxTextSearchFiles": "Buscar archivos",
       "line1260JsxAttrHeadingRecentSessions": "Sesiones recientes",
-      "line1281JsxAttrHeadingRecentProjects": "Proyectos recientes",
+      "line1281JsxAttrHeadingRecentProjects": "Espacios de trabajo recientes",
       "line1419JsxAttrHeadingOpenURL": "Abrir URL",
       "line1437JsxAttrHeadingFileSearch": "Búsqueda de archivos",
       "line1444JsxTextSearchFilesFor": "Buscar archivos para “",

--- a/apps/web/translations/fr.json
+++ b/apps/web/translations/fr.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "Aller au message",
       "line1248JsxTextSearchFiles": "Rechercher des fichiers",
       "line1260JsxAttrHeadingRecentSessions": "Sessions récentes",
-      "line1281JsxAttrHeadingRecentProjects": "Projets récents",
+      "line1281JsxAttrHeadingRecentProjects": "Espaces de travail récents",
       "line1419JsxAttrHeadingOpenURL": "Ouvrir une URL",
       "line1437JsxAttrHeadingFileSearch": "Recherche de fichiers",
       "line1444JsxTextSearchFilesFor": "Rechercher des fichiers pour “",

--- a/apps/web/translations/it.json
+++ b/apps/web/translations/it.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "Vai al messaggio",
       "line1248JsxTextSearchFiles": "Cerca file",
       "line1260JsxAttrHeadingRecentSessions": "Sessioni recenti",
-      "line1281JsxAttrHeadingRecentProjects": "Progetti recenti",
+      "line1281JsxAttrHeadingRecentProjects": "Spazi di lavoro recenti",
       "line1419JsxAttrHeadingOpenURL": "Apri URL",
       "line1437JsxAttrHeadingFileSearch": "Ricerca file",
       "line1444JsxTextSearchFilesFor": "Cerca file per “",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "メッセージへ移動",
       "line1248JsxTextSearchFiles": "ファイルを検索",
       "line1260JsxAttrHeadingRecentSessions": "最近のセッション",
-      "line1281JsxAttrHeadingRecentProjects": "最近のプロジェクト",
+      "line1281JsxAttrHeadingRecentProjects": "最近のワークスペース",
       "line1419JsxAttrHeadingOpenURL": "URLを開く",
       "line1437JsxAttrHeadingFileSearch": "ファイル検索",
       "line1444JsxTextSearchFilesFor": "「",

--- a/apps/web/translations/pt.json
+++ b/apps/web/translations/pt.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "Ir para mensagem",
       "line1248JsxTextSearchFiles": "Buscar arquivos",
       "line1260JsxAttrHeadingRecentSessions": "Sessões recentes",
-      "line1281JsxAttrHeadingRecentProjects": "Projetos recentes",
+      "line1281JsxAttrHeadingRecentProjects": "Espaços de trabalho recentes",
       "line1419JsxAttrHeadingOpenURL": "Abrir URL",
       "line1437JsxAttrHeadingFileSearch": "Busca de arquivos",
       "line1444JsxTextSearchFilesFor": "Buscar arquivos por “",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -3921,7 +3921,7 @@
       "line1235JsxTextJumpToMessage": "跳转到消息",
       "line1248JsxTextSearchFiles": "搜索文件",
       "line1260JsxAttrHeadingRecentSessions": "最近会话",
-      "line1281JsxAttrHeadingRecentProjects": "最近项目",
+      "line1281JsxAttrHeadingRecentProjects": "最近的工作区",
       "line1419JsxAttrHeadingOpenURL": "打开 URL",
       "line1437JsxAttrHeadingFileSearch": "文件搜索",
       "line1444JsxTextSearchFilesFor": "搜索文件：“",


### PR DESCRIPTION
## Summary

The palette's workspace switcher was written as a "projects list" beside a sidebar switcher that had since become the product's whole workspace directory. Six defects, all of them making the keyboard path weaker than the trackpad path:

| # | Defect | Evidence |
|---|---|---|
| 1 | Root search returned **zero** workspaces whenever a workspace was open — i.e. always | `if (!hasQuery \|\| projectId) return []` |
| 2 | Fetched **one** account's workspaces; the sidebar fans out over all | `listProjectsForAccount(activeAccountId)` |
| 3 | With nothing typed, the switcher row was **not shown at all** | it sits at index **11**; the list slices to **8** |
| 4 | Said "Projects" / "Switch Project" / "Search projects..." | the product retired that noun; nothing guarded the palette |
| 5 | Every row painted the same grey folder glyph | no `EntityAvatar`, no account label |
| 6 | Selecting skipped the switch machinery | no `beginSwitch`, no `setSelectedAccountId` |

(1) and (3) together are the whole complaint: the switcher was invisible with no query **and** unfindable with one.

### After

- `⌘K` → type a workspace name → `Enter`, from inside a workspace. The active workspace is dropped from results — it matched its own name best and selecting it re-navigated to the current page.
- `⌘K` with nothing typed: **"Switch workspace" is the first suggestion**, with its shortcut printed on the row.
- **`⌘O` / `Ctrl+O`** opens the palette straight on the switcher, registered in Preferences → Keyboard shortcuts.
- Every account's workspaces, grouped by account, ordered exactly like the sidebar.
- Rows carry the workspace's own emoji **or glyph** tile — including `icon_glyph`, which the sidebar still drops — plus the account label when there is more than one account.
- Selecting narrates the switch (`beginSwitch`) and re-points the account store, same as the sidebar.

New `workspace-palette.ts` holds ordering, grouping, filtering and cmdk-identity as pure functions. Both switchers now derive from `groupWorkspacesByAccount`, so they can no longer disagree about the list. Search text and cmdk value are deliberately separate: cmdk 0.2.1 has no `keywords` prop, so the value doubles as selection identity and two workspaces sharing a name would collide — the id is in the value and not in the haystack.

### Adjacent bug fixed

Found while checking `⌘O` for conflicts. `review-center.tsx` bound `j/k/a/e/d/o/x` on `window` with **no modifier check**, so today `⌘K` moves the review cursor *as well as* opening the palette, and `⌘A` (Select All) fires `quickPrimary` — a real action on a review. `⌘O` would have joined that list, so the guard ships here rather than separately.

## Test plan

Automated, run locally on the PR head:

```
bun test src                                    8522 pass / 0 fail  (was 8516; +6 new)
bun test src/features/workspace/workspace-palette.test.ts   40 pass / 0 fail
npx tsc --noEmit | grep <changed files>         no output
npx eslint <8 changed files>                    0 errors, 7 warnings
```

The 7 eslint warnings are pre-existing — baseline verified by `git stash`, same 2 (command-palette) + 5 (review-center) before the change. **Zero new warnings, zero type errors.**

40 new tests in `workspace-palette.test.ts`, each named for the defect it pins, including:
- root search answers a query while inside a workspace, and drops the active row
- the switcher would **not** survive the suggestion cap unpinned, so the pin is load-bearing rather than cargo-culted
- two same-named workspaces in different accounts get different cmdk values
- the id is in the value and **not** in the search text

Plus 2 added to `workspace-vocabulary.test.ts` so the noun cannot drift back, and a paired presence check that the component actually wires the pure functions (a `return []` guard and a single-account fetch are wiring bugs a behavioural suite cannot see).

Manual, still unverified by observation:
- [ ] `⌘O` inside the Electron desktop shell — no accelerator registration found in `apps/desktop*`, but the shell was not running
- [ ] visual fit of the row's `EntityAvatar` tile and the trailing account label
- [ ] a live cross-account switch, which needs two real accounts

Worth a reviewer's hands on: `⌘K` and confirm "Switch workspace" is the first row; type a workspace name from inside a different workspace; press `⌘O`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790349592&installation_model_id=434224&pr_number=6922&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6922&signature=73107fcb76b94c439acd0d80b622ccb07a8e65646b309477538cb9ce1b6e99cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->