### PR TITLE
spike(worker): harness/environment split — plan + working Alpine worker

### DIFF
--- a/docs/specs/2026-08-26-harness-worker-split.md
+++ b/docs/specs/2026-08-26-harness-worker-split.md
@@ -1,0 +1,306 @@
+# Harness / worker split — implementation plan
+
+**Status:** planning · **Date:** 2026-08-26 · **Source:** huddle 2026-08-26 (Marko, Jay), architecture read
+
+## What this changes
+
+Today one sandbox is the harness, the compute, and the message store at once.
+`session_id == sandbox_id`, the image is 6–8 GB, and the boot path is serial:
+restore rootfs → `git clone` → resolve `OPENCODE_CONFIG_DIR` from the checkout →
+spawn `opencode serve` → wait to listen → wait for its session API.
+
+After the split there are three planes:
+
+- **Control plane (Kortix API)** gains a build step: read `kortix.yaml` at a
+  commit, compile one bundled agent server, cache it by sha.
+- **Worker** — a minimal Alpine micro-VM running only the harness. Fetches one
+  artifact. No compiler, no Python, no browsers, no shell.
+- **Environment** — today's fat sandbox, demoted to lazily-started compute.
+
+The inversion everything follows from: **the worker is where the agent thinks;
+the environment is where it acts.** Every default tool (`bash`, read, write,
+edit, glob, grep) is a Kortix SDK client targeting an environment. None of them
+touch the worker's disk.
+
+## Non-goals for phases 0–1
+
+Explicitly out of scope, to keep the first landing small:
+
+- Durable Objects / WASM workers. Micro-VM only.
+- Shared volumes and volume versioning.
+- More than one environment per worker.
+- User-authored Pi extensions loaded at runtime.
+- Migrating existing sessions or projects.
+- Replacing the frontend. `runtime: opencode` stays the default everywhere.
+
+## The hard constraint
+
+> **Phase 0 and Phase 1 are additive. No PR in them may change the behaviour of
+> the `runtime: opencode` path.**
+
+Essentia is live and Libra Max is going out. The call assigned one person to
+this architecture and two to production stability; that division survives
+exactly as long as this work never edits the OpenCode boot path. Every PR below
+states what it must not touch. A PR that cannot honour that is a signal to
+re-scope, not to proceed.
+
+---
+
+## Phase 0 — the Pi spike
+
+Local, scratch directory, **zero Kortix code changed**. Five proofs, in this
+order. Each is a kill switch: if one fails, the plan changes before anything is
+committed to.
+
+Sequencing note: build the Alpine image *last*, not first. Shrinking an image is
+bounded work with a known outcome. Every unknown lives in the Pi integration.
+
+### S0.1 — Tool replacement holds
+
+Run `createAgentSession` headless with builtin tools off and three
+`defineTool` wrappers (`bash`, `read`, `write`) that RPC into an **existing**
+Kortix sandbox through the API proxy (`/v1/p/<external_id>/8000/...`).
+
+Prompt the agent to create a file, then read it back.
+
+- **Pass:** the file exists in the sandbox (verified independently through the
+  daemon file API), *and* a before/after `find` diff of the local working
+  directory shows zero files created outside Pi's own session store.
+- **The negative assertion is the test.** "It worked" is not the result; "it
+  worked and touched nothing locally" is.
+- **Kill:** builtin tools cannot be fully disabled, or Pi writes outside its
+  declared session directory.
+
+### S0.2 — Model credentials route through the Kortix gateway
+
+Point `ModelRuntime` at the Kortix LLM gateway rather than raw provider keys.
+
+Second, deliberately: it is the least visible integration and it invalidates the
+most downstream if it fights back.
+
+- **Pass:** a completed turn whose usage appears in the gateway's log with
+  correct attribution.
+- **Kill / fallback:** if Pi's provider config admits no base-URL override, the
+  fallback is the pattern the daemon already uses — run an in-worker LLM proxy
+  (`apps/kortix-sandbox-agent-server/src/llm-proxy.ts`) and point Pi at
+  localhost. Record which of the two we are on; it changes the worker image.
+
+### S0.3 — It bundles, and it boots fast
+
+Bundle the server to a single `.mjs` with everything inlined (no external
+resolution at runtime). Run it cold; measure process start → listening →
+accepting a prompt.
+
+- **Pass:** one file, nothing resolved at runtime, well under a second to
+  listening.
+- **Kill:** `jiti`-based extension discovery forces runtime module resolution.
+  If user extensions cannot be compiled in at build time, extensions become a
+  Phase 2 feature and v1 ships with compiled-in tools only. Decide this here,
+  not during Phase 1.
+
+### S0.4 — History survives the process
+
+Custom `SessionManager` writing to a store we own. Run a three-turn conversation
+with tool calls. Kill the process. Read the whole conversation back with a
+separate script that never imports Pi's runtime.
+
+- **Pass:** full fidelity — text, thinking, tool calls, tool results —
+  reconstructable with no Pi process anywhere.
+- **Kill / fallback:** if the on-disk format needs Pi to interpret, we write our
+  own message projection at `turn_end` instead. That is acceptable; discovering
+  it in Phase 1 is not.
+
+### S0.5 — The event stream is enough for the frontend we already have
+
+Map `session.subscribe` events (`message_update`/`text_delta`,
+`tool_execution_start`/`_end`, `turn_end`, lifecycle) against every field the
+current web SSE consumer reads.
+
+- **Pass:** a mapping table with no unmapped consumer.
+- **Kill:** any gap here is frontend work hiding inside a backend change. Scope
+  it into Phase 1 explicitly or drop the affected UI.
+
+**Phase 0 output:** a short findings doc — pass/fail per proof, the two
+fallbacks above resolved either way, and the cold-boot number for the bundled
+server.
+
+---
+
+## Phase 1 — the worker
+
+One PR at a time, in this order. Each names what it must not touch.
+
+### P1.0 — Session-start clock (do this first)
+
+`bootMark()` in `kortixd` stamps every mark as `Date.now() - bootTime`, where
+`bootTime` is **process start inside the guest** (`main.ts:105`). VM allocation
+and rootfs restore both finish before that clock starts — so the existing boot
+timeline is blind to the single largest cost the Alpine image removes.
+
+Add an API-side clock: `POST /sessions` → first streamed token.
+
+- **Touches:** API session start + stream instrumentation only.
+- **Must not touch:** any boot behaviour.
+- **Proof:** baseline numbers on dev for today's **cold** path and today's
+  **warm-pool hit**, 10 runs each. Both matter — see "What we measure".
+
+### P1.1 — `apps/kortix-worker`, standalone
+
+The HTTP + SSE server wrapping Pi. Runs from a local config file with no Kortix
+API dependency. Minimum surface: `POST /prompt`, `GET /events` (SSE),
+`GET /health`, `POST /interrupt`.
+
+- **Touches:** new app only.
+- **Must not touch:** `apps/api`, `apps/sandbox`, `kortixd`.
+- **Proof:** `curl` a prompt, receive streamed tokens, interrupt mid-turn.
+
+### P1.2 — Kortix SDK tool pack
+
+`bash`, `read`, `write`, `edit`, `glob`, `grep` as Pi tool definitions that
+target an environment through `@kortix/sdk`. Per repo rules, this logic lives in
+the SDK, not in the worker.
+
+- **Read first:** `packages/sdk/AGENTS.md` and `packages/sdk/PROGRESS.md`. TDD is
+  mandatory there, exported *types* are a public API contract, adding an export
+  needs three synchronised edits, and there is a framework-free import-graph
+  tripwire.
+- **Proof:** each tool exercised against a real sandbox — assert the effect
+  inside the sandbox *and* assert no local write.
+
+### P1.3 — The bundle compiler
+
+Extend the existing resolution layer
+(`apps/api/src/projects/lib/compile-agent-config.ts` already reads a v2 manifest
+plus each agent's `.md` from git at a commit, pure, no sandbox I/O) into a
+bundle spec, then add the build step that emits the `.mjs`.
+
+Keep the two halves separate: resolution stays pure and unit-testable; bundling
+is the I/O half.
+
+- **Proof:** given a real project and sha, emit a `.mjs`; run it under P1.1;
+  confirm the agent answers with the manifest's system prompt and model.
+
+### P1.4 — The bundle store
+
+Content-addressed by sha256, keyed `(project, sha, agent)`. Served with `ETag` /
+`If-None-Match` → 304.
+
+Two existing precedents to follow rather than invent against:
+`apps/api/src/apps/artifacts.ts` (Supabase Storage, tar, sha256, size ceilings,
+retries — note this is **Supabase Storage, not AWS S3**; there is no S3 client
+in the repo) and `apps/api/src/runtime-assets/index.ts` (cheap manifest, large
+payload routes, content-addressed ETags).
+
+- **Proof:** build twice → second is a cache hit; re-fetch → 304.
+
+### P1.5 — Worker image + template row
+
+New `apps/worker-sandbox/Dockerfile`: Alpine + the runtime S0.2 settled on + a
+supervisor that fetches the bundle and `exec`s it. Nothing else. New template
+slug registered in `kortix.sandbox_templates`.
+
+The template service (`apps/api/src/snapshots/templates.ts`) is already
+provider-agnostic across Daytona, Platinum and E2B, DB-backed, with per-template
+resource specs. **A worker is a template row and a Dockerfile — not new
+infrastructure.**
+
+- **Must not touch:** `apps/sandbox/Dockerfile`. That is the live production
+  image.
+- **Proof:** image size recorded; provision-to-listening measured against the
+  fat template on the same provider.
+
+### P1.6 — Session start branches on `runtime: pi`
+
+`packages/manifest-schema/src/index.v2.ts:59` declares
+`type RuntimeV2 = 'opencode'` with the comment *"reserved so `runtime: claude`
+is a one-line project change later"*. The extension point is designed in: add
+`'pi'` to `V2_RUNTIME_VALUES` and the union, then branch the session boot path —
+worker template, no environment, no clone.
+
+- **Must not touch:** behaviour when `runtime` is absent or `'opencode'`.
+- **Proof:** two projects side by side on dev, one per runtime, both working;
+  plus a test asserting the opencode start path is unchanged.
+
+### P1.7 — Lazy environment provisioning
+
+The first compute tool call provisions or resumes an environment, over one
+persistent multiplexed connection (never per-call HTTP — see "What we measure").
+
+- **Proof:** a session that never calls a compute tool provisions **zero**
+  sandboxes, asserted against the DB. One that does provisions exactly one.
+
+### P1.8 — History readable with nothing running
+
+Serve session history without touching a runtime.
+
+- **Proof:** stop every runtime, `GET` history, full fidelity, p95 compared with
+  today's wake-the-box path.
+
+---
+
+## Schema: a new table, not a column
+
+`kortix.session_sandboxes` declares `sessionId: text('session_id').notNull().unique()`
+— **one row per session, enforced by the database.** Around it sit a DB trigger
+(`session_sandboxes_anchor_guard()`), compute-metering/billing, the reaper's
+deadline math over `metadata.activeTurns`, and 59 files in `apps/api` that
+reference the table.
+
+Adding a `kind` column and dropping that unique constraint silently changes the
+meaning of every existing query against it. That is the opposite of additive.
+
+**Decision: Phase 1 adds a separate `session_workers` table.** Purely additive,
+zero risk to the OpenCode path, and it can be merged into a unified runtime
+table later once the worker path has earned it.
+
+Migrations in this repo are Drizzle-generated (`bun scripts/generate.ts <slug>`,
+then house-style the SQL — hand-written files fail the "Schema matches
+migrations" CI check). Read `.claude/skills/learnings/SKILL.md` before writing
+it.
+
+---
+
+## What we measure
+
+The headline number is **worker cold start vs today's warm-pool hit** — not vs
+today's cold start. Warm pools, snapshots and fork adoption already exist and
+already produce sub-second in-guest starts on a hit; benchmarking against a cold
+sandbox flatters the worker and proves nothing anyone will feel.
+
+The argument survives the harder comparison anyway, in a stronger form: the
+worker makes warm-path latency the *default and deterministic* case instead of a
+probabilistic cache hit, and it decouples harness upgrades from image turnover.
+
+Three numbers, on dev, same prompt, same provider, 10 runs each:
+
+1. Time to first token — today cold, today warm, worker.
+2. Per-tool-call round trip, worker → environment. **This is the regression
+   risk.** `bash` is a local fork today, roughly a millisecond. At +30 ms per
+   call, a 200-call turn pays +6 s on *every* turn, forever — which can exceed a
+   one-time ten-second boot saving inside a single session. Measure it in
+   Phase 0, not after.
+3. Bundle fetch time — a cost that does not exist today, now on the critical
+   path. It must be cached and co-located or it eats the gain it enables.
+
+## Rollback
+
+`runtime: pi` is a line in a project's `kortix.yaml`. Reverting the manifest
+reverts the project. Add a server-side kill switch alongside it so a bad worker
+rollout can be stopped centrally without asking every project to commit.
+
+## Definition of done for Phase 1
+
+A session on dev that streams its first token from a worker which has never
+provisioned a sandbox, on a project whose agent came out of `kortix.yaml` at a
+commit — with the before/after numbers beside it.
+
+Not a demo of the worker booting. A demo of the **agent answering** before the
+old architecture would have finished restoring its rootfs.
+
+## Open decisions carried in from the architecture read
+
+These do not block Phase 0 or Phase 1, but Phase 2 cannot start without answers:
+one worker to N environments; where a skill's script executes (environment,
+always); whether the worker gets any shell (no); where messages ultimately live;
+and the honest naming — the worker is **stateful**, and the docs must say "your
+work is not stored here", never "this is stateless".

--- a/docs/specs/2026-08-26-harness-worker-split.md
+++ b/docs/specs/2026-08-26-harness-worker-split.md
@@ -124,10 +124,6 @@ current web SSE consumer reads.
 fallbacks above resolved either way, and the cold-boot number for the bundled
 server.
 
-**Phase 0 output:** a short findings doc — pass/fail per proof, the two
-fallbacks above resolved either way, and the cold-boot number for the bundled
-server.
-
 ---
 
 ## Gate G0 — the RPC tax. Runs after Phase 0, before P1.1.

--- a/docs/specs/2026-08-26-harness-worker-split.md
+++ b/docs/specs/2026-08-26-harness-worker-split.md
@@ -124,6 +124,82 @@ current web SSE consumer reads.
 fallbacks above resolved either way, and the cold-boot number for the bundled
 server.
 
+**Phase 0 output:** a short findings doc — pass/fail per proof, the two
+fallbacks above resolved either way, and the cold-boot number for the bundled
+server.
+
+---
+
+## Gate G0 — the RPC tax. Runs after Phase 0, before P1.1.
+
+Phase 0 answers "can this be built". G0 answers "should it be", and it is the
+only question that can still kill the design after Phase 0 passes.
+
+Splitting the harness from the environment turns every tool call into a network
+round trip. `bash` is a local fork today: about a millisecond. A tool-heavy turn
+makes hundreds of calls. If the per-call cost is high enough, the tax on every
+turn exceeds the one-off boot saving the whole split is justified by — and no
+amount of Phase 1 makes it not so.
+
+### Threshold
+
+| verdict | p50 per call | 200-call turn | meaning |
+|---|---|---|---|
+| pass | ≤ 10 ms | ≤ 2 s | comfortably under the boot saving. Net win everywhere. |
+| warn | ≤ 25 ms | ≤ 5 s | net win except for tool-heavy work. Ship, but scope reduction before tool-heavy agents move over. |
+| fail | > 25 ms | > 5 s | costs more than the split saves. Do not write P1.1 against this transport. |
+
+Measured from inside the worker sandbox, worker → provider edge → environment,
+which is the shape production uses (worker → Kortix proxy → sandbox daemon).
+
+### Result: WARN
+
+`spikes/pi-worker/bench/rpc-tax.ts`, 200 calls per transport on Daytona:
+
+| transport | p50 | p95 | per 200-call turn |
+|---|---|---|---|
+| `fetch` per call | 20.3 ms | 26.8 ms | 4.1 s |
+| pooled keep-alive | 19.2 ms | 23.9 ms | 3.8 s |
+| multiplexed WebSocket | **16.0 ms** | 17.9 ms | **3.2 s** |
+
+Two things follow, and the second is the important one.
+
+1. **The transport choice is worth 21%, not an order of magnitude.** A
+   multiplexed socket beats naive per-call `fetch` by 4 ms. Worth taking — it is
+   also more robust, since per-call HTTP already produced a correctness bug in
+   the spike when a keep-alive socket was retired between calls — but it is not
+   the lever.
+2. **The tax is dominated by the provider's network topology, not by us.**
+   Both sandboxes sit in one Daytona region, yet traffic leaves through the
+   public edge because Daytona isolates sandboxes from each other
+   (`EHOSTUNREACH` on the private IP, verified). The lever that matters is
+   **co-location**, not protocol. Any provider that lets a worker reach its
+   environment over a private network should collapse this number, and that is
+   a provider-selection criterion the plan did not previously have.
+
+### Sensitivity — who actually pays
+
+| tool calls in a turn | added latency at 16 ms |
+|---|---|
+| 5 | 0.08 s |
+| 30 | 0.5 s |
+| 100 | 1.6 s |
+| 200 | 3.2 s |
+
+Against boot savings of 1.3 s (create) and 2.8 s (archived resume), the split is
+a clear win up to roughly 100 tool calls per turn and roughly break-even beyond
+that. Most sessions are nowhere near 200 calls; coding agents on large refactors
+are.
+
+### What WARN obliges us to do
+
+- Ship P1.7 with the multiplexed transport from the start. Per-call HTTP is not
+  an acceptable interim: it is both slower and, demonstrably, less correct.
+- Add a co-location requirement to the provider criteria, and measure the same
+  gate on Platinum and E2B before committing tool-heavy agents.
+- Keep this gate as a regression test. If p50 crosses 25 ms the split stops
+  paying, and that must fail loudly rather than be discovered by a customer.
+
 ---
 
 ## Phase 1 — the worker
@@ -145,6 +221,9 @@ Add an API-side clock: `POST /sessions` → first streamed token.
   **warm-pool hit**, 10 runs each. Both matter — see "What we measure".
 
 ### P1.1 — `apps/kortix-worker`, standalone
+
+> Blocked on gate G0 above. G0 returned WARN, so P1.1 proceeds with the
+> multiplexed transport mandatory rather than optional.
 
 The HTTP + SSE server wrapping Pi. Runs from a local config file with no Kortix
 API dependency. Minimum surface: `POST /prompt`, `GET /events` (SSE),

--- a/spikes/pi-worker/.dockerignore
+++ b/spikes/pi-worker/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+bench
+test
+src
+*.md
+.gitignore

--- a/spikes/pi-worker/.gitignore
+++ b/spikes/pi-worker/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/spikes/pi-worker/Dockerfile
+++ b/spikes/pi-worker/Dockerfile
@@ -24,6 +24,8 @@ RUN apk add --no-cache libstdc++
 WORKDIR /opt/kortix
 # One self-contained .mjs. No node_modules in the image, no install at boot.
 COPY dist/worker.mjs /opt/kortix/worker.mjs
+# Bench-only: lets the RPC-tax gate import the transports inside the sandbox.
+COPY dist/rpc-transport.mjs /opt/kortix/rpc-transport.mjs
 
 # Unprivileged, and intended to run with `--read-only`. Defence in depth behind
 # the ExecutionEnv seam: even a hand-written tool reaching for node:fs finds

--- a/spikes/pi-worker/Dockerfile
+++ b/spikes/pi-worker/Dockerfile
@@ -1,0 +1,40 @@
+# kortix-worker — the harness, and nothing else.
+#
+# What is deliberately NOT here, compared with apps/sandbox/Dockerfile
+# (Ubuntu 24.04 + TeX Live + LibreOffice + ffmpeg + Tesseract + Python/uv +
+# Node + Bun + pnpm + Playwright browsers, ~6-8 GB):
+#
+#   no compilers, no interpreters, no browsers, no git, no package manager.
+#
+# The agent cannot use any of it, because every built-in tool resolves its
+# filesystem and shell through the injected ExecutionEnv, which addresses an
+# environment over the network. There is nothing here for it to reach.
+
+# The runtime is one binary. npm, corepack and node's headers are ~90 MB of an
+# image that will never install anything — the bundle is self-contained and
+# nothing is resolved at boot — so we take the node binary and its two musl
+# dependencies onto a bare Alpine rather than deleting them from a layer that
+# would still ship.
+FROM node:22-alpine AS nodesrc
+
+FROM alpine:3.21 AS runtime
+COPY --from=nodesrc /usr/local/bin/node /usr/local/bin/node
+RUN apk add --no-cache libstdc++
+
+WORKDIR /opt/kortix
+# One self-contained .mjs. No node_modules in the image, no install at boot.
+COPY dist/worker.mjs /opt/kortix/worker.mjs
+
+# Unprivileged, and intended to run with `--read-only`. Defence in depth behind
+# the ExecutionEnv seam: even a hand-written tool reaching for node:fs finds
+# nothing writable.
+RUN addgroup -S kortix && adduser -S -G kortix kortix
+USER kortix
+
+ENV NODE_ENV=production \
+    PORT=8080 \
+    KORTIX_MODEL_MODE=faux \
+    KORTIX_ENV_CWD=/workspace
+
+EXPOSE 8080
+ENTRYPOINT ["node", "/opt/kortix/worker.mjs"]

--- a/spikes/pi-worker/Dockerfile.environment
+++ b/spikes/pi-worker/Dockerfile.environment
@@ -4,7 +4,11 @@
 FROM node:22-alpine
 WORKDIR /opt/kortix
 COPY dist/environment.mjs /opt/kortix/environment.mjs
-RUN mkdir -p /env-root/workspace
+# Non-root (strix review): the stub executes agent commands by design, so at
+# least the blast radius inside the container is an unprivileged user's.
+RUN addgroup -S kortix && adduser -S -G kortix kortix \
+    && mkdir -p /env-root/workspace && chown -R kortix:kortix /env-root
+USER kortix
 ENV PORT=8100 ENV_ROOT=/env-root
 EXPOSE 8100
 ENTRYPOINT ["node", "/opt/kortix/environment.mjs"]

--- a/spikes/pi-worker/Dockerfile.environment
+++ b/spikes/pi-worker/Dockerfile.environment
@@ -1,0 +1,10 @@
+# A stand-in "environment": a real shell and a real filesystem behind the
+# ExecutionEnv RPC protocol. In production this role is the Kortix sandbox
+# daemon; the protocol and the transport are identical, only the address moves.
+FROM node:22-alpine
+WORKDIR /opt/kortix
+COPY dist/environment.mjs /opt/kortix/environment.mjs
+RUN mkdir -p /env-root/workspace
+ENV PORT=8100 ENV_ROOT=/env-root
+EXPOSE 8100
+ENTRYPOINT ["node", "/opt/kortix/environment.mjs"]

--- a/spikes/pi-worker/Dockerfile.store
+++ b/spikes/pi-worker/Dockerfile.store
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /opt/kortix
+COPY dist/store.mjs /opt/kortix/store.mjs
+RUN mkdir -p /store
+ENV PORT=8200 STORE_ROOT=/store
+EXPOSE 8200
+ENTRYPOINT ["node","/opt/kortix/store.mjs"]

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -1,0 +1,217 @@
+# pi-worker — Phase 0 spike
+
+A working Kortix **worker**: the agent harness, running in a 138 MB Alpine
+image, with every file and shell operation routed over RPC into a separate
+environment. Its own disk is never touched by any built-in tool.
+
+Reference: `docs/specs/2026-08-26-harness-worker-split.md`.
+
+> This is a spike. It is here to answer questions and produce numbers, not to
+> ship. Nothing in `apps/` was changed.
+
+---
+
+## The result in one line
+
+`pi-agent-core`'s built-in tools do not touch the filesystem directly — they
+resolve it from an injected `ExecutionEnv`:
+
+```ts
+export interface ExecutionToolContext { env: ExecutionEnv }   // pi-agent-core
+export interface ExecutionEnv extends FileSystem, Shell {}
+```
+
+So the worker does not rewrite, wrap, or forbid a single tool. It supplies one
+object:
+
+```ts
+const tools = [createBashTool(), createReadTool(), createWriteTool(), createEditTool()]
+  .map((t) => bindTool(t, { env: new KortixExecutionEnv({ baseUrl, cwd }) }));
+```
+
+That is the whole harness/environment split. One seam, not a policy.
+
+---
+
+## How to test it
+
+### 0. Prerequisites
+
+Docker, and `bun` for the local runs. Everything below works with **no Kortix
+credentials and no API key** — the spike uses pi's built-in `fauxProvider`,
+which is a real provider interface returning scripted assistant messages, so
+the agent loop, the tool dispatch and the RPC are all genuinely exercised.
+
+```bash
+cd spikes/pi-worker
+npm install
+```
+
+### 1. The proof — S0.1, "tool replacement holds"
+
+```bash
+bun test/proof.ts
+```
+
+Expected:
+
+```
+  PASS  every tool call crossed the RPC boundary  — 8 RPC ops: absolutePath, canonicalPath, writeFile, exec, exists, readBinaryFile
+  PASS  shell executed through the environment, not locally
+  PASS  write executed through the environment
+  PASS  the file exists in the ENVIRONMENT
+  PASS  the WORKER disk is byte-for-byte unchanged
+  PASS  no agent artifact anywhere on the worker
+6/6 passed
+```
+
+**Read the fifth assertion, not the fourth.** "The agent wrote a file" proves
+nothing. "The agent wrote a file *and the worker's disk is byte-for-byte
+unchanged*" is the claim — a run that does both the right thing and a local
+write is a failure, because that is precisely how the split silently collapses
+back into today's single box.
+
+The test snapshots the worker's cwd (size + mtime, recursively) before and
+after a real turn and diffs it.
+
+### 2. Build and run the two containers
+
+```bash
+bun build src/worker.ts          --target=node --format=esm --minify --outfile dist/worker.mjs
+bun build src/stub-environment.ts --target=node --format=esm --minify --outfile dist/environment.mjs
+
+docker build -t kortix-worker:spike .
+docker build -t kortix-env:spike -f Dockerfile.environment .
+
+docker network create kx-spike
+docker run -d --rm --name kx-env    --network kx-spike kortix-env:spike
+docker run -d --rm --name kx-worker --network kx-spike --read-only -p 18080:8080 \
+  -e KORTIX_ENV_URL=http://kx-env:8100 kortix-worker:spike
+```
+
+Note `--read-only`: the worker runs with an immutable root filesystem as an
+unprivileged user. That is defence in depth *behind* the ExecutionEnv seam, not
+instead of it.
+
+### 3. Drive a turn
+
+The `script` array scripts the faux model: `{"tool": …}` makes it emit a tool
+call, `{"text": …}` makes it answer and stop.
+
+```bash
+curl -s -X POST localhost:18080/prompt -H 'content-type: application/json' -d '{
+  "text": "write a report and inspect the machine",
+  "script": [
+    {"tool":"write","args":{"path":"/workspace/report.md","content":"# built by the worker\n"}},
+    {"tool":"bash","args":{"command":"head -1 /etc/os-release; ls -la /workspace"}},
+    {"tool":"read","args":{"path":"/workspace/report.md"}},
+    {"text":"done"}
+  ]}'
+```
+
+Returns the ops that crossed the boundary:
+
+```json
+{"ok":true,"result":{"messages":8},
+ "rpcCalls":["absolutePath","absolutePath","canonicalPath","writeFile","exec","absolutePath","exists","readBinaryFile"]}
+```
+
+### 4. Check where the work landed — this is the point
+
+```bash
+docker exec kx-env    sh -c 'ls -la /env-root/workspace && cat /env-root/workspace/report.md'
+docker exec kx-worker sh -c 'find / -name "report.md" -not -path "/proc/*" 2>/dev/null'
+```
+
+The file is in the **environment**. The worker has no `/workspace` at all and
+the `find` returns nothing.
+
+### 5. Measure cold boot
+
+```bash
+for i in 1 2 3 4 5; do
+  t0=$(python3 -c 'import time;print(int(time.time()*1000))')
+  docker run -d --rm --name kx-boot --network kx-spike --read-only -p 18081:8080 \
+    -e KORTIX_ENV_URL=http://kx-env:8100 kortix-worker:spike >/dev/null
+  until curl -sf localhost:18081/health >/dev/null 2>&1; do sleep 0.01; done
+  t1=$(python3 -c 'import time;print(int(time.time()*1000))')
+  echo "run $i: $((t1-t0)) ms"
+  docker rm -f kx-boot >/dev/null
+done
+```
+
+### 6. Other endpoints
+
+```bash
+curl -s localhost:18080/health                 # boot ms, model mode, RPC count
+curl -sN localhost:18080/events                # SSE: the live agent event stream
+curl -s -X POST localhost:18080/interrupt      # abort the current turn
+```
+
+### 7. With a real model (needs your own key)
+
+```bash
+docker run -d --rm --name kx-worker --network kx-spike --read-only -p 18080:8080 \
+  -e KORTIX_ENV_URL=http://kx-env:8100 \
+  -e KORTIX_MODEL_MODE=real \
+  -e KORTIX_API_KEY="$ANTHROPIC_API_KEY" \
+  kortix-worker:spike
+
+curl -s -X POST localhost:18080/prompt -H 'content-type: application/json' \
+  -d '{"text":"Create /workspace/hello.txt with a haiku about sandboxes, then cat it."}'
+```
+
+Add `-e KORTIX_GATEWAY_URL=https://<gateway>` to route through the Kortix LLM
+gateway instead of the provider directly — that single variable is the whole
+gateway integration, because pi models `ModelAuth` as
+`{ apiKey?, headers?, baseUrl? }`.
+
+---
+
+## Measured
+
+| | today (`apps/sandbox`) | this worker |
+|---|---|---|
+| image | ~6–8 GB | **138 MB** |
+| bundle | n/a — clone + resolve at boot | **one 516 KB `.mjs`**, 907 modules inlined |
+| container start → serving | — | **226–274 ms** |
+| harness construction | — | **56–88 ms** |
+| runtime module resolution | npm/plugin load at boot | **none** |
+
+Docker on macOS, so these are a proxy for a micro-VM, not a substitute. The
+number the plan actually needs is P1.0's: `POST /sessions` → first token, on
+dev, against today's warm-pool hit.
+
+---
+
+## What the spike found
+
+1. **`ExecutionEnv` is the seam** — one injected object moves the agent's entire
+   world. Better than the per-tool override the plan assumed.
+2. **Build on `pi-agent-core`, not `pi-coding-agent`.** The full package drags in
+   `jiti` (runtime module loading, fights a hermetic bundle) and
+   `@silvia-odwyer/photon-node` (WASM/native, a musl risk). `pi-agent-core` has
+   neither and bundles clean.
+3. **`AgentHarness` is not implemented in 0.84.3** — all 23 methods throw
+   `HarnessNotImplemented`. The working orchestrator is `Agent`
+   (`prompt` / `steer` / `followUp` / `abort` / `subscribe`, plus
+   `beforeToolCall` / `afterToolCall` / `shouldStopAfterTurn` hooks). Pin the
+   version and watch this.
+4. **The gateway is a `baseUrl`** — `ModelAuth { apiKey?, headers?, baseUrl? }`.
+   S0.2's kill condition does not fire.
+5. **Per-call HTTP is already fragile at three calls.** The first end-to-end run
+   died on `"The socket connection was closed unexpectedly"` — a keep-alive
+   socket retired between RPCs. It is patched here with a longer server timeout
+   and one client retry, which is a plaster. The plan's requirement for a single
+   multiplexed connection is not an optimization; it showed up as a correctness
+   bug at trivial scale.
+
+## Still open in Phase 0
+
+- **S0.4** — a custom session store read back with no Pi process running. The
+  interfaces exist (`SessionStorage`, `SessionRepo`, `InMemorySessionRepo`,
+  `JsonlSessionRepo` with an injectable filesystem); not yet exercised.
+- **S0.5** — mapping the `Agent` event stream onto what `apps/web` consumes.
+- **S0.2 end-to-end** — a real turn through the deployed Kortix gateway with
+  attribution visible in its log. The wiring is in `src/worker.ts`; it needs a
+  key and a gateway URL to run.

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -511,6 +511,65 @@ round trip including harness work, not a raw RPC. The raw RPC is 16–20 ms.
 
 ---
 
+## One task, both architectures, from cold
+
+Every other benchmark here measures a piece — boot, resume, per-call RPC. This
+measures what a user experiences: they ask for something that needs real
+compute, and they wait until it is done.
+
+```bash
+bun bench/task-e2e.ts --runs=3
+```
+
+Task: *create a file in the workspace, read it back, report its contents.* Same
+model, same provider (OpenRouter), both arms. Clock starts at "create the
+sandbox" and stops when the answer is in hand.
+
+Today's approach is ONE box that is both harness and compute; the new approach
+is TWO. Counting only the worker would flatter it, so the new arm is measured
+twice — with the environment cold (worst case, first-ever session) and warm
+(the pooled steady state the plan designs for).
+
+### Result — 3 runs
+
+| | create | ready | **answered** |
+|---|---|---|---|
+| today — one 6.2 GB box | 1781 ms | 3423 ms | **11745 ms** |
+| worker + cold environment | 2694 ms | 2924 ms | **11311 ms** |
+| worker + warm environment | 1621 ms | 1785 ms | **9758 ms** |
+
+**0.4 s faster cold, 2.0 s faster warm — on an ~11 s task.** That is 3–17%,
+not the 1.9x the infrastructure numbers suggest.
+
+### Why, and what it means
+
+About 8 of those 11 seconds are the model thinking, and the split does not
+touch that. The infrastructure half genuinely is ~1.9x better (1785 ms vs
+3423 ms to ready), but it is the minority of what the user waits for on a task
+like this.
+
+So the case for the split does not rest on total task time. It rests on:
+
+- **Time to first token**, which is what a user feels first: 1.45 s vs 2.72 s
+  measured earlier. The answer starts arriving sooner even when it finishes at
+  a similar moment.
+- **The tail.** Today's box ranged 2.3–22.7 s to ready across runs; the worker
+  stayed inside 1.16–2.08 s.
+- **Sessions that never touch compute**, which under the split never provision
+  the fat box at all — the entire 6.2 GB cost disappears rather than shrinking.
+- **Decoupling** harness upgrades from image turnover.
+
+And against it: the RPC tax, which grows with tool calls while all of the above
+are fixed wins.
+
+One caveat in the numbers above: the two arms produced different-length answers
+(*"The file says kortix."* versus a fuller sentence), so a few hundred
+milliseconds of the gap is output tokens, not architecture. The `ready` column
+is the clean infrastructure comparison; `answered` is the honest user-facing
+one with that noise included.
+
+---
+
 ## kx — a terminal for the worker
 
 No UI, no browser, no Kortix API. Brings up store, environment and worker in one

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -288,9 +288,69 @@ reach the plan before Phase 1 is scoped, and it makes P1.0's clock more
 important, not less: the number that justifies this work is a p99, not a
 median.
 
-Not measured here, and it matters: **resume from an archived snapshot**, which
-is the case the huddle actually complained about. This benchmark only covers
-create-from-active-snapshot.
+---
+
+## Resume from ARCHIVED — the case the huddle argued about
+
+Daytona's own docs: archiving moves *"the entire filesystem state to
+cost-effective object storage… starting an archived sandbox takes more time,
+**depending on its size**."* That is the Marko/Kubet disagreement, stated by the
+provider. `bench/resume.ts` puts both arms through the identical journey —
+create → fully warm → stop → archive → **start** — and times that last step.
+
+```bash
+bun bench/resume.ts --runs=2                     # ~10 min: archiving 6.2 GB is slow
+bun bench/resume.ts --runs=2 --delete-snapshots
+```
+
+### Result — 4 cycles each
+
+| archived → able to serve | worker (140 MB) | today (6.2 GB) |
+|---|---|---|
+| `start()` returns | 2.7 s | 3.0–6.3 s |
+| VM reports started | 3.1 s | 3.3–6.6 s |
+| **able to serve a prompt** | **3.2 s** (2.77–3.46) | **6.0 s** (4.85–8.12) |
+
+**~2x, and size does matter here** — unlike create-from-snapshot, where it
+barely did. But it is still 2x off a 44x image-size ratio, so "the image is
+huge" remains the wrong headline.
+
+### Where the 2x actually comes from
+
+Split the resume into provider restore and software re-init:
+
+| | provider restore | software re-init | total |
+|---|---|---|---|
+| worker | ~2.7 s | **0.16 s** | 3.2 s |
+| today | ~3.0–6.3 s | **1.5–1.8 s** | 6.0 s |
+
+Roughly half the gap is Daytona pulling more bytes back. The other half is
+kortixd and OpenCode re-initialising after the VM is already up — **0.16 s
+versus 1.5–1.8 s**. The worker `exec`s one pre-bundled `.mjs` and is done;
+today's box has to bring a runtime back to life.
+
+That second column is the part the split actually controls, and it is the
+better argument: not "our image is smaller" but "our box has almost nothing to
+do once it exists".
+
+### Side finding: archiving costs minutes
+
+| | archive → archived |
+|---|---|
+| worker | 24–31 s (median 28 s) |
+| today | **121–199 s** (median 135 s) |
+
+~5x. A box being archived is unavailable for over two minutes today. Nothing in
+the plan accounts for that, and it is worth checking whether the reaper's
+archive path can collide with a wake.
+
+### One honest wrinkle in the output
+
+Asked what it had just resumed from, the worker answered *"I didn't resume from
+anything — this is the start of our conversation."* Correct, and a problem: the
+spike uses `InMemorySessionRepo`, so conversation state does not survive the
+archive. That is exactly what **S0.4** (a durable session store) exists to fix,
+and this is the first time it has bitten in a measurable way.
 
 ---
 

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -395,12 +395,82 @@ today's warm-pool hit.
    multiplexed connection is not an optimization; it showed up as a correctness
    bug at trivial scale.
 
+## S0.5 — the event stream vs the frontend we already have
+
+The gate is not "pi emits events". It is: does every event `packages/sdk`
+narrows and classifies have a pi source, and does pi's output survive the SDK's
+**own** code unchanged?
+
+```bash
+bun test/proof-s05.ts   # 9/9
+```
+
+So the test asserts nothing by hand. It runs a real turn — text, a tool call, a
+tool result, more text — through `src/chat-events.ts`, then through the shipped
+`narrowChatEvent()` (`packages/sdk/src/core/stream/chat-events.ts`),
+`classifyPart()` and `toolViewModel()` (`.../core/turns/`). If the frontend can
+render it, those three accept it.
+
+```
+  PASS  every adapter event is accepted by the SDK narrowChatEvent()  — 20 events
+  PASS  every part classifies to a known kind  — kinds: tool, text
+  PASS  text arrives incrementally (streaming works)  — 4 text part updates
+  PASS  tool lifecycle reaches a terminal state  — statuses seen: running -> done
+  PASS  pi tool names drive the UI's per-tool rendering unchanged  — kinds: shell
+  PASS  the completed shell view-model carries command AND stdout
+                                            — command="echo hi" stdout="hi"
+  PASS  session goes running -> idle
+9/9
+```
+
+### Coverage of the whole chat surface
+
+| consumer | source | status |
+|---|---|---|
+| `message.updated` | pi `message_start` / `message_end` | adapter |
+| `message.part.updated` | pi `message_update` + `tool_execution_*` | adapter |
+| `session.status` | pi `agent_start` / `agent_end` | adapter |
+| `session.idle` | pi `agent_end` | adapter |
+| `session.error` | `message_end` with `stopReason: 'error'` | adapter |
+| `permission.asked` / `.replied` | pi `Agent.beforeToolCall` hook | hook to write |
+| `question.asked` / `.answered` | a Kortix `ask_question` tool | tool to write |
+| `todo.updated` | a Kortix todo tool | tool to write |
+| `connection`, `heartbeat-gap` | SSE transport, never the harness | already ours |
+| `message.removed`, `message.part.removed` | **no Agent-layer deletion** | **gap** |
+
+### The one real gap
+
+`message.removed` and `message.part.removed` have no Agent-layer source. Kortix
+uses them for revert and compaction. pi's `Session` tree does have branching
+(`navigateTree`, `branch`), so the capability exists — it just is not wired to
+`Agent`, because the thing that would wire it is `AgentHarness`, and that is
+unimplemented in 0.84.3. Scope it as frontend-visible work in Phase 1 or accept
+that revert lands later.
+
+### Two findings, one of them a correction
+
+1. **pi's builtin tool names are already the UI's names.** `bash`, `read`,
+   `write`, `edit`, `grep`, `glob` are exactly what `toolViewModel()` switches
+   on, so shell / file-read / file-write / file-edit / search rendering works
+   with **no remapping layer**. That is a larger piece of luck than it looks:
+   per-tool rendering is where a harness swap usually costs a frontend rewrite.
+
+2. **A correction to an earlier entry in this file.** I recorded that
+   `Agent.subscribe` emits no text deltas and that streaming would have to tap
+   the pi-ai layer. That was wrong. `AgentEvent` includes `message_update`,
+   carrying both the accumulating message and the raw `assistantMessageEvent`;
+   a 30-word answer produces 21 of them (`text_start`, 19x `text_delta`,
+   `text_end`). Measuring it is what caught it. Streaming works straight off
+   Agent events.
+
+---
+
 ## Still open in Phase 0
 
 - **S0.4** — a custom session store read back with no Pi process running. The
   interfaces exist (`SessionStorage`, `SessionRepo`, `InMemorySessionRepo`,
   `JsonlSessionRepo` with an injectable filesystem); not yet exercised.
-- **S0.5** — mapping the `Agent` event stream onto what `apps/web` consumes.
+- ~~**S0.5**~~ — done, see below.
 - **S0.2 end-to-end** — a real turn through the deployed Kortix gateway with
   attribution visible in its log. The wiring is in `src/worker.ts`; it needs a
   key and a gateway URL to run.

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -168,7 +168,61 @@ gateway integration, because pi models `ModelAuth` as
 
 ---
 
-## Measured
+## Benchmark: real Daytona sandboxes
+
+`bench/daytona-bench.ts` is standalone — no Kortix API, no database, no UI. It
+builds a Daytona snapshot from the worker image, boots real sandboxes, measures,
+and deletes everything it created.
+
+```bash
+bun bench/daytona-bench.ts --runs=5                     # faux model
+bun bench/daytona-bench.ts --runs=5 --delete-snapshots  # also drop the snapshots
+KORTIX_API_KEY=sk-... bun bench/daytona-bench.ts --real # absolute TTFT
+```
+
+Credentials are read with `dotenvx get` from `apps/api/.env` and never written
+anywhere. `--keep` leaves the sandboxes up for poking; without it the `finally`
+block deletes them even on failure.
+
+### Results — 5 runs, Daytona `us`, 1 vCPU / 1 GB
+
+```
+daytona create() call      min  1205 ms   med  1410 ms   max  1633 ms
+process start -> serving   min   211 ms   med   543 ms   max   759 ms
+time to first token        min    12 ms   med    13 ms   max    16 ms
+bash tool round trip       min    60 ms   med    67 ms   max   284 ms
+```
+
+**The tool round trip is the finding.** 67 ms median, worker → provider edge →
+environment — the same shape production would use (worker → Kortix proxy →
+sandbox daemon). At that cost **a 200-tool-call turn pays 13.3 s, on every turn,
+forever**, against a `bash` that is a local fork today at roughly 1 ms.
+
+That is larger than the one-off boot saving. The split is a clear win for
+reasoning-heavy sessions and a regression for tool-heavy ones unless the RPC is
+multiplexed and co-located. It is not a detail to schedule later; it decides
+whether the architecture pays.
+
+With the faux model, TTFT is infrastructure only — boot plus dispatch. That is
+deliberate: provider latency is identical before and after the split, so
+including it only adds noise to the decision.
+
+### Two measurement traps this hit, both worth knowing
+
+1. **Daytona isolates sandboxes from each other.** A worker cannot reach an
+   environment by private IP — `EHOSTUNREACH`. The first run reported a
+   suspiciously constant "3.07 s round trip" which was a TCP connect timeout
+   times one retry, not latency. The reachable path is the provider's edge,
+   which is also the production topology.
+2. **`/proc/uptime` is virtualized in Daytona** and disagrees with the process
+   clock read microseconds later (280 ms vs 513 ms), so "VM boot → serving"
+   cannot be measured from inside the sandbox at all. That gap is precisely
+   what P1.0's API-side clock exists to measure — independent evidence that it
+   is needed, not optional.
+
+---
+
+## Measured locally
 
 | | today (`apps/sandbox`) | this worker |
 |---|---|---|
@@ -178,9 +232,10 @@ gateway integration, because pi models `ModelAuth` as
 | harness construction | — | **56–88 ms** |
 | runtime module resolution | npm/plugin load at boot | **none** |
 
-Docker on macOS, so these are a proxy for a micro-VM, not a substitute. The
-number the plan actually needs is P1.0's: `POST /sessions` → first token, on
-dev, against today's warm-pool hit.
+Docker on macOS, so these are a proxy for a micro-VM, not a substitute — see
+the Daytona benchmark above for numbers on real infrastructure. The number the
+plan still needs is P1.0's: `POST /sessions` → first token, on dev, against
+today's warm-pool hit.
 
 ---
 
@@ -199,7 +254,9 @@ dev, against today's warm-pool hit.
    version and watch this.
 4. **The gateway is a `baseUrl`** — `ModelAuth { apiKey?, headers?, baseUrl? }`.
    S0.2's kill condition does not fire.
-5. **Per-call HTTP is already fragile at three calls.** The first end-to-end run
+5. **The tool RPC tax is measured, and it is the deciding number.** 67 ms
+   median per call on Daytona. See the benchmark section.
+6. **Per-call HTTP is already fragile at three calls.** The first end-to-end run
    died on `"The socket connection was closed unexpectedly"` — a keep-alive
    socket retired between RPCs. It is patched here with a longer server timeout
    and one client retry, which is a plaster. The plan's requirement for a single

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -511,6 +511,68 @@ round trip including harness work, not a raw RPC. The raw RPC is 16–20 ms.
 
 ---
 
+## Cold time-to-first-token — the number that isolates the architecture
+
+Total task time buries the signal: ~8 of ~11 seconds are the model thinking,
+which is identical on both sides. This measures only the part the split can
+move — **cold create to the agent's first token**.
+
+```bash
+bun bench/ttft-cold.ts --runs=3
+```
+
+Both arms cold, same model, same provider, same region. Each is timed in two
+sequential segments: `create` on the host's clock, then a measurer running
+*inside* the sandbox that waits for readiness, sends the prompt, and stops at
+the first streamed token. The exec that starts that measurer is charged to both
+arms identically.
+
+### Result — 3 runs
+
+| | create | ready | **first token** |
+|---|---|---|---|
+| today — one 6.2 GB box | 992 ms | 2440 ms | **4999 ms** |
+| worker | 1308 ms | 1319 ms | **3037 ms** |
+
+**1.65x — the agent starts speaking 1.96 s sooner.** Across all four runs taken
+the range was 1.7–2.3x (2.0–3.7 s sooner).
+
+### Where the gap comes from
+
+| | boot to ready | ready → first token |
+|---|---|---|
+| today | 2440 ms | 2559 ms |
+| worker | 1319 ms | 1718 ms |
+
+Two roughly equal halves, and only one of them is about image size:
+
+- **~1.1 s of boot** — the 6.2 GB restore versus 140 MB.
+- **~0.8 s of pre-model work** — after `runtimeReady:true`, today's box still
+  creates a session and loads plugins before the first model call goes out (the
+  live capture shows a `plugin.added` flood at 2075 ms). The worker has a
+  bundled agent already in memory and calls the model immediately.
+
+The second half is the more durable win: it does not depend on the provider,
+the image, or how warm anything is.
+
+### Two measurement traps, both hit
+
+1. **The naive "first event containing text" detector is wrong for opencode.**
+   It echoes the USER message over the same stream the moment the prompt is
+   accepted — user text at 1975 ms, assistant announced at 2013 ms, its first
+   real token later still. Detecting that as the first token undercounted the
+   old arm by seconds and briefly made it look *faster*. The fix latches the
+   assistant message id and only counts parts belonging to it. The same class
+   of bug existed on the worker side (agent events carry the accumulating
+   message, so a loose check matched the user's own text and reported a first
+   token 35 ms after ready — before any model call could have returned).
+2. **Three layers of escaping ate a `\n`** and turned the old arm's measurer
+   into a SyntaxError, which read as "the old architecture produced no
+   measurement". Both measurers are now real files in `bench/measure/`,
+   uploaded verbatim.
+
+---
+
 ## One task, both architectures, from cold
 
 Every other benchmark here measures a piece — boot, resume, per-call RPC. This

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -222,6 +222,78 @@ including it only adds noise to the decision.
 
 ---
 
+## Head to head against the sandbox we ship today
+
+`bench/compare.ts` boots both on Daytona, same region, same account, same spec
+(2 vCPU / 6 GB / 20 GB — production's `DEFAULT_*` from
+`apps/api/src/snapshots/build-context.ts`), and asks the new one a real question
+through OpenRouter, the path production uses.
+
+```bash
+cd spikes/pi-worker
+bun bench/compare.ts --runs=5
+bun bench/compare.ts --runs=3 --say "Write a haiku about cold starts."
+bun bench/compare.ts --runs=3 --model=openai/gpt-5 --keep
+```
+
+Everything it creates it deletes, including on failure. `--delete-snapshots`
+also removes the worker snapshot it built.
+
+### What it prints
+
+```
+run 2/5
+  NEW      create    986 ms   serving   1159 ms   ANSWERED   3800 ms
+           first token after prompt   1988 ms
+           > A sandbox is an isolated testing environment where code can run
+             safely without affecting the main system or production environment.
+  CURRENT  create    872 ms   daemon alive    972 ms   RUNTIME READY   2272 ms
+```
+
+Both arms are held to the same bar: `runtimeReady:true` on the current box's
+`/kortix/health` is the point it could actually serve a prompt, which is the
+honest equivalent of the worker being able to answer.
+
+### Result — 8 runs
+
+| | worker (140 MB) | today (6.2 GB) |
+|---|---|---|
+| ready to take a prompt, median | **1.45 s** | 2.72 s |
+| ready to take a prompt, worst | **2.08 s** | **22.7 s** |
+| answered a real model prompt | 3.7 s (incl. ~1.7 s model latency) | not reached in-window |
+
+**The median win is ~1.9x. The tail win is ~11x, and the tail is the point.**
+The worker's spread across every run was 1.16–2.08 s. Today's sandbox ranged
+2.3–22.7 s on identical infrastructure with identical inputs. That 22-second
+outlier is the "intermittently slow start" from the huddle, reproduced and
+measured.
+
+### The premise correction
+
+The huddle assumed the 6–8 GB image *is* the boot cost — restore from object
+storage at ~50 MB/s. **On Daytona's warm-snapshot path that is not what
+happens.** A 6.2 GB active snapshot typically boots in ~1.5 s, and the 44x
+image-size ratio buys roughly 1.9x, not 44x.
+
+So the case for the split is not "the image is huge". It is:
+
+1. **Predictability** — a bounded, boring 1.2–2.1 s instead of a distribution
+   with a 22-second tail.
+2. **Decoupling** — harness upgrades stop requiring image turnover.
+3. **Zero-compute sessions** — a session that only reasons never provisions
+   the fat box at all.
+
+Speed is real but modest. Determinism is the product. That reframing should
+reach the plan before Phase 1 is scoped, and it makes P1.0's clock more
+important, not less: the number that justifies this work is a p99, not a
+median.
+
+Not measured here, and it matters: **resume from an archived snapshot**, which
+is the case the huddle actually complained about. This benchmark only covers
+create-from-active-snapshot.
+
+---
+
 ## Measured locally
 
 | | today (`apps/sandbox`) | this worker |

--- a/spikes/pi-worker/README.md
+++ b/spikes/pi-worker/README.md
@@ -465,6 +465,93 @@ that revert lands later.
 
 ---
 
+## Gate G0 — the RPC tax
+
+Runs **after** Phase 0 and **before** P1.1. Phase 0 answers "can this be
+built"; G0 answers "should it be", and it is the only thing that can still kill
+the design once Phase 0 passes.
+
+```bash
+bun bench/rpc-tax.ts              # on Daytona, through the provider edge
+bun bench/rpc-tax.ts --local      # loopback floor
+```
+
+| verdict | p50/call | 200-call turn |
+|---|---|---|
+| pass | ≤ 10 ms | ≤ 2 s |
+| warn | ≤ 25 ms | ≤ 5 s |
+| fail | > 25 ms | > 5 s |
+
+### Result: WARN
+
+| transport | p50 | p95 | per 200-call turn |
+|---|---|---|---|
+| `fetch` per call | 20.3 ms | 26.8 ms | 4.1 s |
+| pooled keep-alive | 19.2 ms | 23.9 ms | 3.8 s |
+| multiplexed WebSocket | **16.0 ms** | 17.9 ms | **3.2 s** |
+
+Two conclusions, and the second matters more:
+
+1. **Transport is worth 21%, not an order of magnitude.** A multiplexed socket
+   beats naive per-call `fetch` by 4 ms. Take it anyway — per-call HTTP already
+   produced a *correctness* bug in this spike when a keep-alive socket was
+   retired between calls — but it is not the lever.
+2. **The tax is set by the provider's topology, not by us.** Both sandboxes sit
+   in one Daytona region, yet traffic leaves through the public edge because
+   Daytona isolates sandboxes from each other. The lever is **co-location**, and
+   that is a provider-selection criterion the plan did not previously have.
+
+Sensitivity — 5 calls costs 0.08 s, 30 costs 0.5 s, 100 costs 1.6 s, 200 costs
+3.2 s. Against boot savings of 1.3 s (create) and 2.8 s (archived resume), the
+split wins clearly up to ~100 tool calls per turn and is roughly break-even
+beyond. Most sessions are nowhere near that; large refactors are.
+
+One correction: the 67 ms figure reported earlier was a whole `/prompt`
+round trip including harness work, not a raw RPC. The raw RPC is 16–20 ms.
+
+---
+
+## kx — a terminal for the worker
+
+No UI, no browser, no Kortix API. Brings up store, environment and worker in one
+process and gives you a prompt.
+
+```bash
+pnpm kx                      # or: bun bin/kx.ts
+bun bin/kx.ts --faux         # no credentials needed
+bun bin/kx.ts --session my-work   # resume a previous conversation
+bun bin/kx.ts --transport=ws      # pick the RPC transport
+```
+
+It is also scriptable — piped input runs as a script, which is how the smoke
+test drives it:
+
+```
+$ printf 'Create /workspace/hello.txt containing exactly the word kortix, then read it back.\n/env\n/rpc\n' | bun bin/kx.ts
+
+› Create /workspace/hello.txt containing exactly the word kortix, then read it back.
+  I'll create the file with "kortix" and then read it back.
+  ⚙ write  /workspace/hello.txt  ✓ 9ms
+  ⚙ read   /workspace/hello.txt  ✓ 5ms
+  The file `/workspace/hello.txt` contains exactly the word "kortix".
+  7316ms
+› /env
+  hello.txt  6b
+› /rpc
+  8 RPCs to the environment: {"absolutePath":3,"canonicalPath":1,"writeFile":1,
+                              "exists":1,"readBinaryFile":1,"listDir":1}
+```
+
+Commands: `/tools` (and where they execute) · `/history` · `/transcript` (reads
+the durable store directly, no worker involved) · `/env` · `/rpc` · `/stats` ·
+`/quit`.
+
+The per-tool timings and the RPC counter are there on purpose: they make the
+architecture's one real cost visible while you use it, rather than only in a
+benchmark.
+
+---
+
 ## Still open in Phase 0
 
 - **S0.4** — a custom session store read back with no Pi process running. The

--- a/spikes/pi-worker/bench/compare.ts
+++ b/spikes/pi-worker/bench/compare.ts
@@ -1,0 +1,218 @@
+/**
+ * Head to head on Daytona: the new worker vs the sandbox Kortix ships today.
+ *
+ * Same provider, same region, same account, same resources. The only thing
+ * that differs is the image and what runs inside it.
+ *
+ *   NEW      kortix-worker      ~140 MB   Alpine + node + one bundled .mjs
+ *   CURRENT  kortix-default-*    ~6.2 GB   Ubuntu + toolchain + kortixd + opencode
+ *
+ * THE COMPARISON IS DELIBERATELY UNFAIR TO THE NEW ARM.
+ *
+ * The worker is timed until it has actually ANSWERED a real model prompt —
+ * booted, harness constructed, provider resolved, round trip to OpenRouter,
+ * text back. The current sandbox is timed only until its daemon says it is
+ * alive, which is a strictly easier bar and happens well before opencode can
+ * answer anything. If the worker still wins, it wins by more than is shown.
+ *
+ * Standalone: no Kortix API, no database, no UI. Everything it creates it
+ * deletes, including on failure.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPIKE = resolve(HERE, '..');
+const REPO = resolve(SPIKE, '..', '..');
+
+const argv = process.argv.slice(2);
+const has = (f: string) => argv.includes(f);
+const val = (f: string, d: string) => argv.find((a) => a.startsWith(`${f}=`))?.split('=').slice(1).join('=') ?? d;
+
+const RUNS = Number(val('--runs', '3'));
+const PROMPT = val('--say', 'In one short sentence: what is a sandbox in software?');
+const MODEL = val('--model', 'anthropic/claude-sonnet-4.5');
+const SNAPSHOT = 'kortix-worker-cmp-v1';
+const KEEP = has('--keep');
+
+const secret = (key: string): string =>
+  execFileSync('dotenvx', ['get', key, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+
+const ms = (n: number | null | undefined) => (n == null ? '   n/a' : `${String(Math.round(n)).padStart(6)} ms`);
+const med = (xs: number[]) => {
+  const s = xs.filter(Number.isFinite).sort((a, b) => a - b);
+  return s.length ? s[Math.floor(s.length / 2)] : Number.NaN;
+};
+const sh = async (b: any, c: string, timeout?: number) =>
+  String((await b.process.executeCommand(c, undefined, undefined, timeout)).result ?? '');
+
+/**
+ * Portable HTTP one-liner. The two images do not share a client: Alpine has
+ * busybox wget and no curl, Ubuntu has curl and no wget. Probing with the
+ * wrong one reports "never came up" for a box that came up fine — which is
+ * exactly what it did on the first attempt here.
+ */
+const GET = (url: string) => `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 5 '${url}') || wget -qO- '${url}'`;
+const POST = (url: string, body: string) =>
+  `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 180 -H 'content-type: application/json' -d '${body}' '${url}') ` +
+  `|| wget -qO- --header='content-type: application/json' --post-data='${body}' '${url}'`;
+
+async function main() {
+  const daytona = new Daytona({
+    apiKey: secret('DAYTONA_API_KEY'),
+    apiUrl: secret('DAYTONA_SERVER_URL'),
+    target: secret('DAYTONA_TARGET'),
+  });
+  const openrouterKey = secret('OPENROUTER_API_KEY');
+
+  // The current production image: newest active kortix-default-* on the account.
+  const snapRes: any = await daytona.snapshot.list();
+  const snaps: any[] = Array.isArray(snapRes) ? snapRes : (snapRes.items ?? []);
+  const current = snaps
+    .filter((s) => String(s.name).startsWith('kortix-default-') && String(s.state).toLowerCase().includes('active'))
+    .sort((a, b) => String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')))[0];
+  if (!current) throw new Error('no active kortix-default-* snapshot found on this Daytona account');
+
+  console.log('\n' + '='.repeat(72));
+  console.log('  Kortix worker vs the sandbox we ship today — Daytona ' + secret('DAYTONA_TARGET'));
+  console.log('='.repeat(72));
+  console.log(`  NEW      ${SNAPSHOT}`);
+  console.log(`  CURRENT  ${current.name}  (${Number(current.size ?? 0).toFixed(1)} GB)`);
+  console.log(`  spec     2 vCPU / 6 GB / 20 GB — production defaults, identical on both`);
+  console.log(`  model    ${MODEL} via OpenRouter — the path production uses`);
+  console.log(`  prompt   "${PROMPT}"`);
+  console.log(`  runs     ${RUNS}\n`);
+
+  // Build the worker snapshot once. Not part of any measurement.
+  const existing = await daytona.snapshot.get(SNAPSHOT).catch(() => null);
+  if (!existing || !String((existing as any).state ?? '').toLowerCase().includes('active')) {
+    console.log('building worker snapshot (one-off, excluded from every number)…');
+    await daytona.snapshot.create(
+      {
+        name: SNAPSHOT,
+        image: Image.fromDockerfile(join(SPIKE, 'Dockerfile')),
+        entrypoint: ['node', '/opt/kortix/worker.mjs'],
+        // Identical to production's DEFAULT_CPU / MEMORY_GB / DISK_GB
+        // (apps/api/src/snapshots/build-context.ts) so the only variable is
+        // the image, not the machine.
+        resources: { cpu: 2, memory: 6, disk: 20 },
+      },
+      { timeout: 900, onLogs: () => {} },
+    );
+    console.log('  built\n');
+  }
+
+  const alive: any[] = [];
+  const A: Array<{ createMs: number; readyMs: number; ttftMs: number | null; totalMs: number | null; answer: string }> = [];
+  const B: Array<{ createMs: number; aliveMs: number | null; readyMs: number | null }> = [];
+
+  try {
+    for (let i = 1; i <= RUNS; i++) {
+      console.log(`run ${i}/${RUNS}`);
+
+      // ---------------- NEW: worker, timed until it ANSWERS ----------------
+      let t0 = Date.now();
+      const w = await daytona.create(
+        {
+          snapshot: SNAPSHOT,
+          envVars: {
+            PORT: '8080',
+            KORTIX_MODEL_MODE: 'real',
+            KORTIX_PROVIDER: 'openrouter',
+            KORTIX_MODEL: MODEL,
+            KORTIX_API_KEY: openrouterKey,
+            KORTIX_SYSTEM_PROMPT: 'You are a Kortix agent. Answer briefly.',
+            KORTIX_ENV_CWD: '/workspace',
+          },
+          autoStopInterval: 15,
+          public: false,
+        },
+        { timeout: 300 },
+      );
+      const aCreate = Date.now() - t0;
+      alive.push(w);
+
+      await sh(w, `for i in $(seq 1 600); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.05; done`, 180);
+      const aReady = Date.now() - t0;
+
+      const say = JSON.stringify({ text: PROMPT }).replace(/'/g, `'\\''`);
+      const raw = await sh(w, POST('http://127.0.0.1:8080/say', say), 240);
+      const aTotal = Date.now() - t0;
+      let parsed: any = {};
+      try { parsed = JSON.parse(raw.trim().split('\n').pop() || '{}'); } catch { /* leave empty */ }
+
+      console.log(`  NEW      create ${ms(aCreate)}   serving ${ms(aReady)}   ANSWERED ${ms(aTotal)}`);
+      console.log(`           first token after prompt ${ms(parsed.firstTokenMs)}`);
+      console.log(`           > ${String(parsed.answer ?? '(no answer)').trim().slice(0, 160)}`);
+      A.push({ createMs: aCreate, readyMs: aReady, ttftMs: parsed.firstTokenMs ?? null, totalMs: aTotal, answer: parsed.answer ?? '' });
+      if (!KEEP) { await w.delete().catch(() => {}); alive.splice(alive.indexOf(w), 1); }
+
+      // -------- CURRENT: today's sandbox, timed only until it is ALIVE -----
+      t0 = Date.now();
+      const c = await daytona.create(
+        { snapshot: current.name, envVars: { KORTIX_BENCH: '1' }, autoStopInterval: 15, public: false },
+        { timeout: 300 },
+      );
+      const bCreate = Date.now() - t0;
+      alive.push(c);
+
+      // Two bars, because they are far apart and only one of them is
+      // comparable. kortixd binds its proxy before anything else, so the first
+      // /kortix/health answer means "alive" and nothing more. The box cannot
+      // serve a prompt until it reports runtimeReady:true with opencode ok —
+      // that is the honest equivalent of the worker being able to answer.
+      const probe = await sh(
+        c,
+        `A=0; for i in $(seq 1 1800); do H=$(${GET('http://127.0.0.1:8000/kortix/health')} 2>/dev/null); ` +
+          `if [ -n "$H" ]; then if [ "$A" = "0" ]; then echo "ALIVE=$i"; A=1; fi; ` +
+          `case "$H" in *'"runtimeReady":true'*) echo "READY=$i"; break;; esac; fi; sleep 0.1; done`,
+        420,
+      );
+      const aliveTick = /ALIVE=(\d+)/.exec(probe);
+      const readyTick = /READY=(\d+)/.exec(probe);
+      const bAliveMs = aliveTick ? bCreate + Number(aliveTick[1]) * 100 : null;
+      const bReady = readyTick ? bCreate + Number(readyTick[1]) * 100 : null;
+      console.log(`  CURRENT  create ${ms(bCreate)}   daemon alive ${ms(bAliveMs)}   RUNTIME READY ${ms(bReady)}\n`);
+      B.push({ createMs: bCreate, aliveMs: bAliveMs, readyMs: bReady });
+      if (!KEEP) { await c.delete().catch(() => {}); alive.splice(alive.indexOf(c), 1); }
+    }
+
+    // ------------------------------- verdict -------------------------------
+    const aAns = med(A.map((x) => x.totalMs!));
+    const bAlive = med(B.map((x) => x.readyMs!));
+    console.log('='.repeat(72));
+    console.log('  MEDIANS');
+    console.log('='.repeat(72));
+    console.log(`  NEW      create ${ms(med(A.map((x) => x.createMs)))}  serving ${ms(med(A.map((x) => x.readyMs)))}  answered ${ms(aAns)}`);
+    console.log(`  CURRENT  create ${ms(med(B.map((x) => x.createMs)))}  daemon alive ${ms(med(B.map((x) => x.aliveMs!)))}  runtime ready ${ms(bAlive)}`);
+    console.log('='.repeat(72));
+    if (Number.isFinite(aAns) && Number.isFinite(bAlive)) {
+      const delta = bAlive - aAns;
+      const aServe = med(A.map((x) => x.readyMs));
+      console.log(`\n  ready to take a prompt:   worker ${ms(aServe)}   vs today ${ms(bAlive)}`);
+      console.log(`  worker answered outright: ${ms(aAns)} (includes ~${ms(med(A.map((x) => x.ttftMs!)))} of model latency)`);
+      console.log(
+        delta > 0
+          ? `\n  The worker had ANSWERED ${(delta / 1000).toFixed(1)}s before today's box was ready to be asked.`
+          : `\n  Today's box was ready to be asked ${(-delta / 1000).toFixed(1)}s before the worker answered.\n  Compare like with like: ready-vs-ready is ${((bAlive - aServe) / 1000).toFixed(1)}s in the worker's favour.`,
+      );
+    }
+    console.log(`\n  answers received:`);
+    for (const a of A) console.log(`    "${a.answer.trim().slice(0, 100)}"`);
+    console.log(`\n${JSON.stringify({ new: A, current: B }, null, 2)}`);
+  } finally {
+    if (KEEP) console.log(`\n--keep: ${alive.length} sandbox(es) left: ${alive.map((s) => s.id).join(', ')}`);
+    else {
+      console.log(`\ncleanup: ${alive.length} sandbox(es)`);
+      for (const s of alive) await s.delete().then(() => console.log(`  deleted ${s.id}`)).catch(() => {});
+    }
+    if (has('--delete-snapshots')) {
+      const snap = await daytona.snapshot.get(SNAPSHOT).catch(() => null);
+      if (snap) await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${SNAPSHOT}`)).catch(() => {});
+    }
+  }
+}
+
+main().catch((e) => { console.error('\nCOMPARE FAILED:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bench/daytona-bench.ts
+++ b/spikes/pi-worker/bench/daytona-bench.ts
@@ -1,0 +1,285 @@
+/**
+ * Daytona benchmark — how long until the agent says its first word?
+ *
+ * Standalone. Touches nothing in apps/, nothing in the UI, no Kortix API, no
+ * database. It builds a Daytona snapshot from the worker image, boots real
+ * sandboxes from it, measures, and deletes everything it created.
+ *
+ * WHAT IS MEASURED, AND WHY IT IS MEASURED THIS WAY
+ *
+ *   create() -> running  The provider allocating and starting the box,
+ *                        measured on the benchmark host's clock.
+ *
+ *   process -> serving   Node start to the worker accepting connections,
+ *                        captured ONCE at listen inside the worker.
+ *
+ *                        NOTE: the gap between these two is not observable
+ *                        from inside a sandbox. /proc/uptime is virtualized in
+ *                        Daytona and disagrees with the process clock read
+ *                        microseconds later (280 ms vs 513 ms), so it is not
+ *                        reported here. That gap is exactly what P1.0's
+ *                        API-side clock exists to measure, and this benchmark
+ *                        is independent evidence that it cannot be measured
+ *                        any other way.
+ *
+ *   ttft                 Request start to the first streamed chunk carrying
+ *                        assistant text, measured from inside the sandbox so
+ *                        the benchmark host's distance to Daytona is not in
+ *                        the figure.
+ *
+ *   tool round trip      One bash tool call, worker -> environment, across two
+ *                        separate sandboxes. This is the plan's biggest
+ *                        regression risk: bash is a local fork today.
+ *
+ * With the default faux model, ttft measures INFRASTRUCTURE ONLY — boot plus
+ * dispatch. That is deliberate: provider latency is identical before and after
+ * the split, so including it only adds noise to the thing being decided. Pass
+ * --real with KORTIX_API_KEY set for the absolute end-user number.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPIKE = resolve(HERE, '..');
+const REPO = resolve(SPIKE, '..', '..');
+
+const argv = new Set(process.argv.slice(2));
+const REAL = argv.has('--real');
+const KEEP = argv.has('--keep');
+const RUNS = Number(process.argv.find((a) => a.startsWith('--runs='))?.split('=')[1] ?? 3);
+const SNAPSHOT = process.env.BENCH_SNAPSHOT ?? 'kortix-worker-bench-v1';
+const ENV_SNAPSHOT = `${SNAPSHOT}-env`;
+
+/** Read a dotenvx-encrypted value without ever writing it to disk. */
+const secret = (key: string): string => {
+  const v = execFileSync('dotenvx', ['get', key, '-f', '.env'], {
+    cwd: join(REPO, 'apps', 'api'),
+    encoding: 'utf8',
+  }).trim();
+  if (!v) throw new Error(`${key} is empty`);
+  return v;
+};
+
+const ms = (n: number | null | undefined) => (n == null ? '  n/a' : `${String(Math.round(n)).padStart(5)} ms`);
+const pct = (xs: number[], p: number) => {
+  if (!xs.length) return Number.NaN;
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor((p / 100) * s.length))];
+};
+const stat = (label: string, xs: number[]) => {
+  const clean = xs.filter((x) => Number.isFinite(x));
+  if (!clean.length) return `${label.padEnd(26)} no samples`;
+  return `${label.padEnd(26)} min ${ms(Math.min(...clean))}   med ${ms(pct(clean, 50))}   max ${ms(Math.max(...clean))}`;
+};
+
+async function ensureSnapshot(daytona: Daytona, name: string, dockerfile: string, entrypoint: string[]) {
+  const existing = await daytona.snapshot.get(name).catch(() => null);
+  if (existing && String((existing as any).state ?? '').toLowerCase().includes('active')) {
+    console.log(`  snapshot ${name}: reusing existing`);
+    return;
+  }
+  console.log(`  snapshot ${name}: building (one-off, not part of any measurement)`);
+  const t0 = Date.now();
+  await daytona.snapshot.create(
+    {
+      name,
+      image: Image.fromDockerfile(join(SPIKE, dockerfile)),
+      entrypoint,
+      resources: { cpu: 1, memory: 1, disk: 3 },
+    },
+    { timeout: 600, onLogs: () => {} },
+  );
+  console.log(`  snapshot ${name}: built in ${Math.round((Date.now() - t0) / 1000)}s`);
+}
+
+/** Run a command inside the sandbox and return stdout. */
+async function sh(sandbox: any, command: string): Promise<string> {
+  const r = await sandbox.process.executeCommand(command);
+  return String(r.result ?? '');
+}
+
+interface Sample {
+  createMs: number;
+  vmBootToServingMs: number | null;
+  harnessBuildMs: number | null;
+  ttftMs: number | null;
+  turnMs: number | null;
+  toolRoundTripMs: number | null;
+}
+
+async function main() {
+  process.env.DAYTONA_API_KEY ??= secret('DAYTONA_API_KEY');
+  const daytona = new Daytona({
+    apiKey: process.env.DAYTONA_API_KEY,
+    apiUrl: secret('DAYTONA_SERVER_URL'),
+    target: secret('DAYTONA_TARGET'),
+  });
+
+  if (!existsSync(join(SPIKE, 'dist', 'worker.mjs'))) {
+    throw new Error('dist/worker.mjs missing — run the bun build first (see README §2)');
+  }
+
+  console.log(`\nKortix worker — Daytona benchmark`);
+  console.log(`runs=${RUNS}  model=${REAL ? 'real' : 'faux (infrastructure only)'}\n`);
+
+  console.log('snapshots');
+  await ensureSnapshot(daytona, SNAPSHOT, 'Dockerfile', ['node', '/opt/kortix/worker.mjs']);
+  await ensureSnapshot(daytona, ENV_SNAPSHOT, 'Dockerfile.environment', ['node', '/opt/kortix/environment.mjs']);
+
+  const created: any[] = [];
+  const samples: Sample[] = [];
+
+  try {
+    // One long-lived environment sandbox, shared by every run: we are measuring
+    // the WORKER's cold start, not the environment's.
+    console.log('\nenvironment sandbox (shared across runs)');
+    const envBox = await daytona.create(
+      { snapshot: ENV_SNAPSHOT, envVars: { PORT: '8100', ENV_ROOT: '/env-root' }, autoStopInterval: 15, public: false },
+      { timeout: 120 },
+    );
+    created.push(envBox);
+    // Daytona isolates sandboxes from one another: a worker CANNOT reach an
+    // environment by private IP (verified — EHOSTUNREACH, and the resulting
+    // ~3.07s "round trip" was a TCP connect timeout, not latency). The
+    // reachable path is the provider's own edge, which is also what production
+    // uses: Kortix reaches sandboxes through /v1/p/<external_id>/8000/... So
+    // the preview URL is not a workaround here, it is the representative
+    // topology.
+    const preview = await envBox.getPreviewLink(8100);
+    console.log(`  up: ${envBox.id}  via provider edge`);
+
+    for (let i = 1; i <= RUNS; i++) {
+      console.log(`\nrun ${i}/${RUNS}`);
+      const t0 = Date.now();
+      const box = await daytona.create(
+        {
+          snapshot: SNAPSHOT,
+          envVars: {
+            PORT: '8080',
+            KORTIX_ENV_URL: preview.url,
+            ...(preview.token ? { KORTIX_ENV_HEADERS: JSON.stringify({ 'x-daytona-preview-token': preview.token }) } : {}),
+            KORTIX_ENV_CWD: '/workspace',
+            KORTIX_MODEL_MODE: REAL ? 'real' : 'faux',
+            ...(REAL && process.env.KORTIX_API_KEY ? { KORTIX_API_KEY: process.env.KORTIX_API_KEY } : {}),
+            ...(process.env.KORTIX_GATEWAY_URL ? { KORTIX_GATEWAY_URL: process.env.KORTIX_GATEWAY_URL } : {}),
+          },
+          autoStopInterval: 15,
+          public: false,
+        },
+        { timeout: 120 },
+      );
+      const createMs = Date.now() - t0;
+      created.push(box);
+      console.log(`  created in ${createMs} ms  (${box.id})`);
+
+      // Wait for the worker, then read ITS OWN view of when it started serving.
+      const health = await sh(
+        box,
+        `for i in $(seq 1 400); do out=$(wget -qO- http://127.0.0.1:8080/health 2>/dev/null); if [ -n "$out" ]; then echo "$out"; exit 0; fi; sleep 0.05; done; echo '{}'`,
+      );
+      let vmBootToServingMs: number | null = null;
+      let harnessBuildMs: number | null = null;
+      try {
+        const h = JSON.parse(health.trim().split('\n').pop() || '{}');
+        vmBootToServingMs = null; // /proc/uptime is virtualized here — see header
+        harnessBuildMs = h.bootMs ?? null;
+      } catch { /* leave null */ }
+      console.log(`  process start -> serving ${ms(harnessBuildMs)}`);
+
+      // Time to first token, measured inside the box with node — busybox
+      // `date` has no %N and shell SSE parsing is not worth the risk.
+      const promptBody = REAL
+        ? { text: 'Reply with exactly: ready' }
+        : { text: 'go', script: [{ text: 'ready' }] };
+      const toolBody = { text: 't', script: [{ tool: 'bash', args: { command: 'true' } }, { text: 'ok' }] };
+
+      const measureJs = `
+const http = require('node:http');
+function post(path, body, firstTokenOnly) {
+  return new Promise((resolve) => {
+    const payload = JSON.stringify(body);
+    const t0 = process.hrtime.bigint();
+    let first = null;
+    const req = http.request({ host: '127.0.0.1', port: 8080, path, method: 'POST',
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) } }, (res) => {
+      res.setEncoding('utf8');
+      res.on('data', (chunk) => {
+        if (first === null && (chunk.includes('text_delta') || chunk.includes('"type":"text"'))) {
+          first = Number(process.hrtime.bigint() - t0) / 1e6;
+        }
+      });
+      res.on('end', () => resolve({ first, total: Number(process.hrtime.bigint() - t0) / 1e6 }));
+    });
+    req.on('error', () => resolve({ first: null, total: null }));
+    req.end(payload);
+  });
+}
+(async () => {
+  const turn = await post('/turn', ${JSON.stringify(promptBody)}, true);
+  const tool = await post('/prompt', ${JSON.stringify(toolBody)}, false);
+  console.log('RESULT=' + JSON.stringify({ ttft: turn.first, turn: turn.total, tool: tool.total }));
+})();
+`;
+      await sh(box, `cat > /tmp/measure.js <<'KXEOF'\n${measureJs}\nKXEOF`);
+      const out = await sh(box, 'node /tmp/measure.js');
+      const m = /RESULT=(\{.*\})/.exec(out);
+      const parsed = m ? JSON.parse(m[1]) : {};
+      const ttftMs = parsed.ttft ?? null;
+      const turnMs = parsed.turn ?? null;
+      const toolRoundTripMs = parsed.tool ?? null;
+      console.log(`  time to first token ${ms(ttftMs)}   (whole turn ${ms(turnMs)})`);
+      console.log(`  bash tool round trip (worker -> edge -> environment) ${ms(toolRoundTripMs)}`);
+
+      samples.push({ createMs, vmBootToServingMs, harnessBuildMs, ttftMs, turnMs, toolRoundTripMs });
+
+      if (!KEEP) { await box.delete().catch(() => {}); created.splice(created.indexOf(box), 1); }
+    }
+
+    console.log(`\n${'='.repeat(66)}\nRESULTS  (${samples.length} runs, Daytona ${secret('DAYTONA_TARGET')}, 1 vCPU / 1 GB)\n${'='.repeat(66)}`);
+    console.log(stat('daytona create() call', samples.map((s) => s.createMs)));
+    console.log(stat('process start -> serving', samples.map((s) => s.harnessBuildMs!)));
+    console.log(stat('time to first token', samples.map((s) => s.ttftMs!)));
+    console.log(stat('whole turn', samples.map((s) => s.turnMs!)));
+    console.log(stat('bash tool round trip', samples.map((s) => s.toolRoundTripMs!)));
+    console.log('  worker -> provider edge -> environment. Production is the same');
+    console.log('  shape: worker -> Kortix proxy -> sandbox daemon.');
+    const med = pct(samples.map((s) => s.toolRoundTripMs!).filter(Number.isFinite), 50);
+    if (Number.isFinite(med)) {
+      console.log(`\n  AT THIS COST A 200-TOOL-CALL TURN PAYS ${(med * 200 / 1000).toFixed(1)}s,`);
+      console.log('  on every turn, forever. bash is a local fork today (~1 ms).');
+      console.log('  This is larger than the one-off boot saving and it is the');
+      console.log('  finding that decides whether the split is a net win.');
+    }
+    console.log(`${'='.repeat(66)}`);
+    console.log(
+      REAL
+        ? '\nreal model: ttft includes provider latency.'
+        : '\nfaux model: ttft is INFRASTRUCTURE ONLY (boot + dispatch). Provider\nlatency is unchanged by the split and is deliberately excluded.',
+    );
+    console.log(JSON.stringify({ benchmark: 'kortix-worker-daytona', runs: samples }, null, 2));
+  } finally {
+    if (KEEP) {
+      console.log(`\n--keep: leaving ${created.length} sandbox(es) alive: ${created.map((c) => c.id).join(', ')}`);
+    } else {
+      console.log(`\ncleanup: deleting ${created.length} sandbox(es)`);
+      for (const box of created) {
+        await box.delete().then(() => console.log(`  deleted ${box.id}`)).catch((e: any) => console.log(`  FAILED to delete ${box.id}: ${e?.message}`));
+      }
+      console.log('  (snapshots kept — reused by the next run; delete with --delete-snapshots)');
+      if (argv.has('--delete-snapshots')) {
+        for (const n of [SNAPSHOT, ENV_SNAPSHOT]) {
+          // delete() wants the snapshot OBJECT, not { name } — passing a name
+          // fails with "Required parameter id was null or undefined".
+          const snap = await daytona.snapshot.get(n).catch(() => null);
+          if (!snap) continue;
+          await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${n}`)).catch(() => {});
+        }
+      }
+    }
+  }
+}
+
+main().catch((e) => { console.error('\nBENCHMARK FAILED:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bench/measure/opencode.js
+++ b/spikes/pi-worker/bench/measure/opencode.js
@@ -1,0 +1,94 @@
+/**
+ * Cold time-to-first-token for today's architecture, measured INSIDE the box.
+ *
+ * Reads KX_PROMPT and KX_MODEL from the environment. Prints one line:
+ *   MEASURE={"ready":<ms>,"first":<ms>}
+ *
+ * `ready`  runtimeReady:true on kortixd's /kortix/health — the point the box
+ *          can serve a prompt at all.
+ * `first`  the first token OF THE ASSISTANT'S ANSWER.
+ *
+ * The naive "first event containing text" detector is wrong here: opencode
+ * echoes the USER message back over the same stream the instant the prompt is
+ * accepted (verified live — user text at 1975 ms, assistant announced at
+ * 2013 ms, its first real token later still). So this latches the assistant
+ * message id from `message.updated` and only counts parts belonging to it.
+ */
+const http = require('node:http');
+
+const t0 = process.hrtime.bigint();
+const el = () => Number(process.hrtime.bigint() - t0) / 1e6;
+const PROMPT = process.env.KX_PROMPT || 'Say the single word: ready';
+const MODEL = process.env.KX_MODEL || 'anthropic/claude-sonnet-4.5';
+
+const req = (opts, body) =>
+  new Promise((res) => {
+    const r = http.request({ host: '127.0.0.1', ...opts }, (x) => {
+      let d = '';
+      x.setEncoding('utf8');
+      x.on('data', (c) => (d += c));
+      x.on('end', () => res(d));
+    });
+    r.on('error', () => res(''));
+    if (body) r.write(body);
+    r.end();
+  });
+
+(async () => {
+  let ready = null;
+  for (let i = 0; i < 6000; i++) {
+    const h = await req({ port: 8000, path: '/kortix/health', method: 'GET' });
+    if (h.includes('"runtimeReady":true')) { ready = el(); break; }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+
+  let assistantId = null;
+  let first = null;
+  let done;
+  const finished = new Promise((r) => (done = r));
+
+  // Subscribe BEFORE prompting so the first token cannot be missed.
+  const ev = http.request({ host: '127.0.0.1', port: 4096, path: '/event', method: 'GET' }, (res) => {
+    res.setEncoding('utf8');
+    let buf = '';
+    res.on('data', (chunk) => {
+      buf += chunk;
+      const lines = buf.split('\n');
+      buf = lines.pop() || '';
+      for (const line of lines) {
+        if (!line.startsWith('data:')) continue;
+        let j;
+        try { j = JSON.parse(line.slice(5)); } catch { continue; }
+        if (j.type === 'message.updated' && j.properties && j.properties.info && j.properties.info.role === 'assistant') {
+          assistantId = j.properties.info.id;
+        }
+        if (first === null && assistantId && j.type === 'message.part.updated') {
+          const p = j.properties && j.properties.part;
+          if (p && p.messageID === assistantId && p.type === 'text' && String(p.text || '').length > 0) {
+            first = el();
+            done();
+          }
+        }
+      }
+    });
+  });
+  ev.on('error', () => {});
+  ev.end();
+  await new Promise((r) => setTimeout(r, 200));
+
+  const s = await req({ port: 4096, path: '/session', method: 'POST', headers: { 'content-type': 'application/json', 'content-length': 2 } }, '{}');
+  let sid;
+  try { sid = JSON.parse(s).id; } catch {
+    console.log('MEASURE=' + JSON.stringify({ ready, first: null, err: 'no session: ' + s.slice(0, 120) }));
+    process.exit(0);
+  }
+  const body = JSON.stringify({ model: { providerID: 'openrouter', modelID: MODEL }, parts: [{ type: 'text', text: PROMPT }] });
+  req({ port: 4096, path: '/session/' + sid + '/message', method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } }, body);
+
+  const timeout = setTimeout(() => done(), 240000);
+  await finished;
+  clearTimeout(timeout);
+  try { ev.destroy(); } catch {}
+  console.log('MEASURE=' + JSON.stringify({ ready, first }));
+  process.exit(0);
+})();

--- a/spikes/pi-worker/bench/measure/worker.js
+++ b/spikes/pi-worker/bench/measure/worker.js
@@ -1,0 +1,52 @@
+/**
+ * Cold time-to-first-token for the worker, measured INSIDE the box.
+ * Symmetric with measure/opencode.js: same clock, same definition of "first".
+ *
+ * `first` counts ONLY a text_delta. Agent events carry the accumulating
+ * message, so a looser check matches the USER's own text part and reports a
+ * first token ~35 ms after ready — before any model call could have returned.
+ */
+const http = require('node:http');
+
+const t0 = process.hrtime.bigint();
+const el = () => Number(process.hrtime.bigint() - t0) / 1e6;
+const PROMPT = process.env.KX_PROMPT || 'Say the single word: ready';
+
+const get = (path) =>
+  new Promise((res) => {
+    const r = http.request({ host: '127.0.0.1', port: 8080, path, method: 'GET' }, (x) => {
+      let d = '';
+      x.on('data', (c) => (d += c));
+      x.on('end', () => res(d));
+    });
+    r.on('error', () => res(''));
+    r.end();
+  });
+
+(async () => {
+  let ready = null;
+  for (let i = 0; i < 3000; i++) {
+    if (await get('/health')) { ready = el(); break; }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+
+  const payload = JSON.stringify({ text: PROMPT });
+  let first = null;
+  await new Promise((done) => {
+    const r = http.request(
+      { host: '127.0.0.1', port: 8080, path: '/turn', method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) } },
+      (res) => {
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          if (first === null && chunk.includes('"type":"text_delta"')) { first = el(); done(); }
+        });
+        res.on('end', () => done());
+      },
+    );
+    r.on('error', () => done());
+    r.end(payload);
+  });
+
+  console.log('MEASURE=' + JSON.stringify({ ready, first }));
+  process.exit(0);
+})();

--- a/spikes/pi-worker/bench/read-transcript.ts
+++ b/spikes/pi-worker/bench/read-transcript.ts
@@ -1,0 +1,50 @@
+/**
+ * Read a session transcript with NOTHING running.
+ *
+ * This file imports no pi package, constructs no harness, and starts no
+ * sandbox. It reads the append-only log and renders the conversation. That is
+ * the whole point of S0.4 and the preview of P1.8: today, fetching messages
+ * means waking a box, waiting for the daemon, waiting for OpenCode to listen,
+ * then calling an API designed for a local editor.
+ *
+ *   bun bench/read-transcript.ts <storeUrl> <sessionId>
+ *   bun bench/read-transcript.ts http://127.0.0.1:8200 sess-demo --json
+ */
+const [storeUrl, sessionId, ...rest] = process.argv.slice(2);
+if (!storeUrl || !sessionId) {
+  console.error('usage: bun bench/read-transcript.ts <storeUrl> <sessionId> [--json]');
+  process.exit(2);
+}
+const asJson = rest.includes('--json');
+
+const t0 = performance.now();
+const res = await fetch(`${storeUrl}/sessions/${encodeURIComponent(sessionId)}/log`);
+if (!res.ok) { console.error(`store returned HTTP ${res.status}`); process.exit(1); }
+const log = (await res.json()) as any[];
+const readMs = performance.now() - t0;
+
+const messages = log
+  .filter((i) => i.kind === 'entry' && i.entry?.type === 'message')
+  .map((i) => ({ at: i.entry.timestamp, seq: i.entry.seq, id: i.entry.id, ...i.entry.message }));
+
+if (asJson) {
+  console.log(JSON.stringify({ sessionId, readMs, messages }, null, 2));
+} else {
+  console.log(`\nsession ${sessionId}   ${messages.length} messages   read in ${readMs.toFixed(0)} ms   (no worker, no sandbox)\n`);
+  for (const m of messages) {
+    const when = new Date(m.at).toISOString().slice(11, 19);
+    for (const c of m.content ?? []) {
+      if (c.type === 'text' && c.text?.trim()) {
+        console.log(`  ${when}  ${String(m.role).padEnd(10)} ${c.text.trim().replace(/\n/g, '\n' + ' '.repeat(22))}`);
+      } else if (c.type === 'toolCall') {
+        console.log(`  ${when}  ${'tool call'.padEnd(10)} ${c.name}(${JSON.stringify(c.arguments).slice(0, 90)})`);
+      } else if (c.type === 'thinking') {
+        console.log(`  ${when}  ${'thinking'.padEnd(10)} ${String(c.thinking).slice(0, 90)}`);
+      }
+    }
+    if (m.role === 'toolResult' && !(m.content ?? []).some((c: any) => c.type === 'text')) {
+      console.log(`  ${when}  ${'result'.padEnd(10)} (${m.toolName})`);
+    }
+  }
+  console.log('');
+}

--- a/spikes/pi-worker/bench/resume-memory.ts
+++ b/spikes/pi-worker/bench/resume-memory.ts
@@ -1,0 +1,135 @@
+/**
+ * The wrinkle from the archived-resume benchmark, closed.
+ *
+ * That run ended with the worker answering "I didn't resume from anything —
+ * this is the start of our conversation." Correct, and the point: the spike
+ * used an in-memory session, so the conversation died with the box.
+ *
+ * Same journey, with the durable store attached:
+ *   tell it something -> stop -> ARCHIVE -> start -> ask it back.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPIKE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = resolve(SPIKE, '..', '..');
+const secret = (k: string) =>
+  execFileSync('dotenvx', ['get', k, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+const sh = async (b: any, c: string, t = 180) =>
+  String((await b.process.executeCommand(c, undefined, undefined, t)).result ?? '');
+const GET = (u: string) => `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 5 '${u}') || wget -qO- '${u}'`;
+const POST = (u: string, b: string) =>
+  `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 180 -H 'content-type: application/json' -d '${b}' '${u}') ` +
+  `|| wget -qO- --header='content-type: application/json' --post-data='${b}' '${u}'`;
+
+async function waitState(box: any, states: string[], label: string, timeoutMs = 900_000) {
+  const t0 = Date.now();
+  for (;;) {
+    await box.refreshData().catch(() => {});
+    const st = String((box as any).state ?? '').toLowerCase();
+    if (states.includes(st)) return Date.now() - t0;
+    if (st === 'error') throw new Error(`${label}: state=error`);
+    if (Date.now() - t0 > timeoutMs) throw new Error(`${label}: timeout in ${st}`);
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+const MODEL = process.argv.find((a) => a.startsWith('--model='))?.split('=')[1] ?? 'anthropic/claude-sonnet-4.5';
+const WORKER_SNAP = 'kortix-worker-mem-v1';
+const STORE_SNAP = 'kortix-store-mem-v1';
+
+const daytona = new Daytona({
+  apiKey: secret('DAYTONA_API_KEY'),
+  apiUrl: secret('DAYTONA_SERVER_URL'),
+  target: secret('DAYTONA_TARGET'),
+});
+
+const ensure = async (name: string, dockerfile: string, entry: string[]) => {
+  const s = await daytona.snapshot.get(name).catch(() => null);
+  if (s && String((s as any).state ?? '').toLowerCase().includes('active')) return;
+  console.log(`  building ${name}…`);
+  await daytona.snapshot.create(
+    { name, image: Image.fromDockerfile(join(SPIKE, dockerfile)), entrypoint: entry, resources: { cpu: 1, memory: 2, disk: 5 } },
+    { timeout: 900, onLogs: () => {} },
+  );
+};
+
+const alive: any[] = [];
+try {
+  console.log('\nsnapshots');
+  await ensure(WORKER_SNAP, 'Dockerfile', ['node', '/opt/kortix/worker.mjs']);
+  await ensure(STORE_SNAP, 'Dockerfile.store', ['node', '/opt/kortix/store.mjs']);
+
+  console.log('\nstore sandbox (survives the worker, as the control plane would)');
+  const store = await daytona.create({ snapshot: STORE_SNAP, envVars: { PORT: '8200', STORE_ROOT: '/store' }, autoStopInterval: 0 }, { timeout: 300 });
+  alive.push(store);
+  const link = await store.getPreviewLink(8200);
+  console.log(`  up: ${store.id}`);
+
+  const SESSION = 'archived-resume-demo';
+  const worker = await daytona.create(
+    {
+      snapshot: WORKER_SNAP,
+      envVars: {
+        PORT: '8080',
+        KORTIX_MODEL_MODE: 'real',
+        KORTIX_PROVIDER: 'openrouter',
+        KORTIX_MODEL: MODEL,
+        KORTIX_API_KEY: secret('OPENROUTER_API_KEY'),
+        KORTIX_SYSTEM_PROMPT: 'You are a Kortix agent. Answer in one short sentence.',
+        KORTIX_STORE_URL: link.url,
+        KORTIX_SESSION_ID: SESSION,
+        ...(link.token ? { KORTIX_STORE_HEADERS: JSON.stringify({ 'x-daytona-preview-token': link.token }) } : {}),
+      },
+      autoStopInterval: 0,
+    },
+    { timeout: 300 },
+  );
+  alive.push(worker);
+  await sh(worker, `for i in $(seq 1 900); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.1; done`, 300);
+  console.log(`  worker up: ${worker.id}\n`);
+
+  const say = async (b: any, text: string) => {
+    const raw = await sh(b, POST('http://127.0.0.1:8080/say', JSON.stringify({ text })), 240);
+    try { return JSON.parse(raw.trim().split('\n').pop() || '{}'); } catch { return {}; }
+  };
+
+  console.log('BEFORE ARCHIVE');
+  const a1 = await say(worker, 'Remember this passphrase exactly: ORBITAL-LLAMA-7. Confirm you have it.');
+  console.log(`  > ${String(a1.answer ?? '').trim()}`);
+
+  console.log('\nstop -> archive -> start');
+  await worker.stop();
+  await waitState(worker, ['stopped'], 'stop');
+  const tA = Date.now();
+  await worker.archive();
+  await waitState(worker, ['archived'], 'archive');
+  console.log(`  archived in ${Math.round((Date.now() - tA) / 1000)}s`);
+  const t0 = Date.now();
+  await worker.start(600);
+  await waitState(worker, ['started'], 'start');
+  await sh(worker, `for i in $(seq 1 900); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.1; done`, 300);
+  console.log(`  back and serving in ${Date.now() - t0} ms`);
+
+  const health = await sh(worker, GET('http://127.0.0.1:8080/health'));
+  try {
+    const h = JSON.parse(health.trim().split('\n').pop() || '{}');
+    console.log(`  restored ${h.store?.restoredEntries ?? 0} entries from the store`);
+  } catch { /* ignore */ }
+
+  console.log('\nAFTER ARCHIVE — the question that failed last time');
+  const a2 = await say(worker, 'What was the passphrase I gave you?');
+  const answer = String(a2.answer ?? '').trim();
+  console.log(`  > ${answer}`);
+  const remembered = answer.includes('ORBITAL-LLAMA-7');
+  console.log(`\n  ${remembered ? 'REMEMBERED' : 'FORGOT'} — the conversation ${remembered ? 'survived' : 'did not survive'} archive+resume.`);
+} finally {
+  console.log(`\ncleanup: ${alive.length} sandbox(es)`);
+  for (const s of alive) await s.delete().then(() => console.log(`  deleted ${s.id}`)).catch(() => {});
+  for (const n of [WORKER_SNAP, STORE_SNAP]) {
+    const snap = await daytona.snapshot.get(n).catch(() => null);
+    if (snap) await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${n}`)).catch(() => {});
+  }
+}

--- a/spikes/pi-worker/bench/resume.ts
+++ b/spikes/pi-worker/bench/resume.ts
@@ -1,0 +1,213 @@
+/**
+ * The measurement the huddle actually argued about: resume from ARCHIVED.
+ *
+ * Daytona's own words for archive:
+ *
+ *   "the entire filesystem state is moved to cost-effective object storage...
+ *    starting an archived sandbox takes more time, DEPENDING ON ITS SIZE."
+ *
+ * That is the claim Marko and Kubet went back and forth on — whether a 6 GB
+ * box costs more to bring back than a small one, and by how much. Nothing in
+ * the create-from-snapshot benchmark touches it, because create never restores
+ * a filesystem from object storage.
+ *
+ * Both arms take the identical journey:
+ *   create -> started -> stop -> stopped -> archive -> archived -> start
+ * and the number is that last transition: archived -> able to serve.
+ *
+ * Everything created is deleted, including on failure.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SPIKE = resolve(HERE, '..');
+const REPO = resolve(SPIKE, '..', '..');
+
+const argv = process.argv.slice(2);
+const has = (f: string) => argv.includes(f);
+const val = (f: string, d: string) => argv.find((a) => a.startsWith(`${f}=`))?.split('=').slice(1).join('=') ?? d;
+const RUNS = Number(val('--runs', '2'));
+const MODEL = val('--model', 'anthropic/claude-sonnet-4.5');
+const SNAPSHOT = 'kortix-worker-resume-v1';
+
+const secret = (k: string) =>
+  execFileSync('dotenvx', ['get', k, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+const ms = (n: number | null | undefined) => (n == null ? '    n/a' : `${String(Math.round(n)).padStart(7)} ms`);
+const med = (xs: number[]) => {
+  const s = xs.filter(Number.isFinite).sort((a, b) => a - b);
+  return s.length ? s[Math.floor(s.length / 2)] : Number.NaN;
+};
+const sh = async (b: any, c: string, t = 120) =>
+  String((await b.process.executeCommand(c, undefined, undefined, t)).result ?? '');
+const GET = (u: string) => `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 5 '${u}') || wget -qO- '${u}'`;
+const POST = (u: string, b: string) =>
+  `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 180 -H 'content-type: application/json' -d '${b}' '${u}') ` +
+  `|| wget -qO- --header='content-type: application/json' --post-data='${b}' '${u}'`;
+
+/** Poll the control plane until the sandbox reaches one of `states`. */
+async function waitState(box: any, states: string[], label: string, timeoutMs = 900_000): Promise<number> {
+  const t0 = Date.now();
+  for (;;) {
+    await box.refreshData().catch(() => {});
+    const st = String((box as any).state ?? '').toLowerCase();
+    if (states.includes(st)) return Date.now() - t0;
+    if (st === 'error' || st === 'build_failed') throw new Error(`${label}: sandbox entered ${st}`);
+    if (Date.now() - t0 > timeoutMs) throw new Error(`${label}: timed out in state ${st}`);
+    await new Promise((r) => setTimeout(r, 500));
+  }
+}
+
+interface Arm {
+  name: string;
+  archiveMs: number;
+  startCallMs: number;
+  toStartedMs: number;
+  toServingMs: number | null;
+  answer?: string;
+}
+
+async function main() {
+  const daytona = new Daytona({
+    apiKey: secret('DAYTONA_API_KEY'),
+    apiUrl: secret('DAYTONA_SERVER_URL'),
+    target: secret('DAYTONA_TARGET'),
+  });
+  const orKey = secret('OPENROUTER_API_KEY');
+
+  const snapRes: any = await daytona.snapshot.list();
+  const snaps: any[] = Array.isArray(snapRes) ? snapRes : (snapRes.items ?? []);
+  const current = snaps
+    .filter((s) => String(s.name).startsWith('kortix-default-') && String(s.state).toLowerCase().includes('active'))
+    .sort((a, b) => String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')))[0];
+  if (!current) throw new Error('no active kortix-default-* snapshot on this account');
+
+  console.log('\n' + '='.repeat(74));
+  console.log('  Resume from ARCHIVED — the case the huddle argued about');
+  console.log('='.repeat(74));
+  console.log(`  NEW      ${SNAPSHOT}  (~140 MB image)`);
+  console.log(`  CURRENT  ${current.name}  (${Number(current.size ?? 0).toFixed(1)} GB image)`);
+  console.log(`  journey  create -> stop -> archive -> START (this is the measurement)`);
+  console.log(`  runs     ${RUNS}\n`);
+
+  const existing = await daytona.snapshot.get(SNAPSHOT).catch(() => null);
+  if (!existing || !String((existing as any).state ?? '').toLowerCase().includes('active')) {
+    console.log('building worker snapshot (one-off, excluded from every number)…');
+    await daytona.snapshot.create(
+      {
+        name: SNAPSHOT,
+        image: Image.fromDockerfile(join(SPIKE, 'Dockerfile')),
+        entrypoint: ['node', '/opt/kortix/worker.mjs'],
+        resources: { cpu: 2, memory: 6, disk: 20 },
+      },
+      { timeout: 900, onLogs: () => {} },
+    );
+    console.log('  built\n');
+  }
+
+  const alive: any[] = [];
+  const results: Arm[] = [];
+
+  const cycle = async (kind: 'new' | 'current'): Promise<Arm> => {
+    const isNew = kind === 'new';
+    const box = await daytona.create(
+      {
+        snapshot: isNew ? SNAPSHOT : current.name,
+        envVars: isNew
+          ? {
+              PORT: '8080',
+              KORTIX_MODEL_MODE: 'real',
+              KORTIX_PROVIDER: 'openrouter',
+              KORTIX_MODEL: MODEL,
+              KORTIX_API_KEY: orKey,
+              KORTIX_SYSTEM_PROMPT: 'You are a Kortix agent. Answer briefly.',
+            }
+          : { KORTIX_BENCH: '1' },
+        autoStopInterval: 0,
+        public: false,
+      },
+      { timeout: 300 },
+    );
+    alive.push(box);
+
+    // Let it fully come up once, so the archived filesystem is a REAL warmed
+    // box and not a half-initialised one.
+    const readyProbe = isNew
+      ? `for i in $(seq 1 900); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.1; done`
+      : `for i in $(seq 1 1800); do H=$(${GET('http://127.0.0.1:8000/kortix/health')} 2>/dev/null); case "$H" in *'"runtimeReady":true'*) break;; esac; sleep 0.1; done`;
+    await sh(box, readyProbe, 420);
+
+    await box.stop();
+    await waitState(box, ['stopped'], 'stop');
+
+    const tArc = Date.now();
+    await box.archive();
+    const archiveMs = await waitState(box, ['archived'], 'archive') + (Date.now() - tArc - (Date.now() - tArc));
+
+    // ---- the measurement -------------------------------------------------
+    const t0 = Date.now();
+    await box.start(600);
+    const startCallMs = Date.now() - t0;
+    const toStartedMs = startCallMs + (await waitState(box, ['started'], 'start'));
+
+    let toServingMs: number | null = null;
+    let answer: string | undefined;
+    if (isNew) {
+      await sh(box, `for i in $(seq 1 900); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.1; done`, 300);
+      toServingMs = Date.now() - t0;
+      const raw = await sh(box, POST('http://127.0.0.1:8080/say', JSON.stringify({ text: 'One short sentence: what did you just resume from?' })), 240);
+      try { answer = JSON.parse(raw.trim().split('\n').pop() || '{}').answer; } catch { /* ignore */ }
+    } else {
+      const p = await sh(
+        box,
+        `for i in $(seq 1 3000); do H=$(${GET('http://127.0.0.1:8000/kortix/health')} 2>/dev/null); case "$H" in *'"runtimeReady":true'*) echo "READY=$i"; break;; esac; sleep 0.1; done`,
+        600,
+      );
+      toServingMs = /READY=/.test(p) ? Date.now() - t0 : null;
+    }
+
+    await box.delete().catch(() => {});
+    alive.splice(alive.indexOf(box), 1);
+    return { name: isNew ? 'NEW' : 'CURRENT', archiveMs, startCallMs, toStartedMs, toServingMs, answer };
+  };
+
+  try {
+    for (let i = 1; i <= RUNS; i++) {
+      console.log(`run ${i}/${RUNS}`);
+      for (const kind of ['new', 'current'] as const) {
+        const r = await cycle(kind);
+        results.push(r);
+        console.log(
+          `  ${r.name.padEnd(8)} archive ${ms(r.archiveMs)}   start() ${ms(r.startCallMs)}   ` +
+            `-> started ${ms(r.toStartedMs)}   -> SERVING ${ms(r.toServingMs)}`,
+        );
+        if (r.answer) console.log(`           > ${r.answer.trim().slice(0, 140)}`);
+      }
+      console.log('');
+    }
+
+    const pick = (n: string, f: (a: Arm) => number | null) => med(results.filter((r) => r.name === n).map((r) => f(r) as number));
+    console.log('='.repeat(74));
+    console.log('  MEDIANS — archived -> able to serve');
+    console.log('='.repeat(74));
+    console.log(`  NEW      start() ${ms(pick('NEW', (r) => r.startCallMs))}   started ${ms(pick('NEW', (r) => r.toStartedMs))}   serving ${ms(pick('NEW', (r) => r.toServingMs))}`);
+    console.log(`  CURRENT  start() ${ms(pick('CURRENT', (r) => r.startCallMs))}   started ${ms(pick('CURRENT', (r) => r.toStartedMs))}   serving ${ms(pick('CURRENT', (r) => r.toServingMs))}`);
+    console.log('='.repeat(74));
+    const a = pick('NEW', (r) => r.toServingMs), b = pick('CURRENT', (r) => r.toServingMs);
+    if (Number.isFinite(a) && Number.isFinite(b)) {
+      console.log(`\n  resume from object storage: ${(b / 1000).toFixed(1)}s vs ${(a / 1000).toFixed(1)}s  =  ${(b / a).toFixed(1)}x`);
+    }
+    console.log(`\n${JSON.stringify(results, null, 2)}`);
+  } finally {
+    console.log(`\ncleanup: ${alive.length} sandbox(es)`);
+    for (const s of alive) await s.delete().then(() => console.log(`  deleted ${s.id}`)).catch(() => {});
+    if (has('--delete-snapshots')) {
+      const snap = await daytona.snapshot.get(SNAPSHOT).catch(() => null);
+      if (snap) await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${SNAPSHOT}`)).catch(() => {});
+    }
+  }
+}
+
+main().catch((e) => { console.error('\nRESUME BENCH FAILED:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bench/rpc-tax.ts
+++ b/spikes/pi-worker/bench/rpc-tax.ts
@@ -88,7 +88,10 @@ async function main() {
     console.log('  [local] starting stub environment…');
     const { startStubEnvironment } = await import('../src/stub-environment.ts');
     const { makeTransport } = await import('../src/rpc-transport.ts');
-    const env = await startStubEnvironment({ root: '/tmp/kx-rpc-' + Date.now() });
+    const { mkdtemp } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const env = await startStubEnvironment({ root: await mkdtemp(join(tmpdir(), 'kx-rpc-')) });
     console.log(`  [local] env ${env.url}`);
     where = 'localhost (loopback — a floor, not a prediction)';
     const results: Record<string, any> = {};

--- a/spikes/pi-worker/bench/rpc-tax.ts
+++ b/spikes/pi-worker/bench/rpc-tax.ts
@@ -1,0 +1,181 @@
+/**
+ * GATE G0 — the RPC tax. Runs BEFORE P1.1.
+ *
+ * WHY THIS IS A GATE AND NOT AN IMPLEMENTATION NOTE.
+ *
+ * Splitting the harness from the environment turns every tool call into a
+ * network round trip. `bash` is a local fork today: about a millisecond.
+ * The first Daytona measurement put a per-call `fetch` at ~67 ms, and a
+ * 200-tool-call turn at +13 s — on EVERY turn, forever, against a one-off
+ * boot saving of 1.3-2.8 s. On that number the split is a net regression for
+ * tool-heavy work, and no amount of Phase 1 makes it not one.
+ *
+ * So this is the question that decides whether P1.1 is worth writing.
+ *
+ * THE THRESHOLD.
+ *
+ *   pass  p50 <= 10 ms  a 200-call turn pays <= 2 s, comfortably under the
+ *                       boot saving. Net win everywhere.
+ *   warn  p50 <= 25 ms  a 200-call turn pays 5 s. Net win only for sessions
+ *                       that are not tool-heavy. Ship, but scope the
+ *                       reduction work before tool-heavy agents move over.
+ *   fail  p50  > 25 ms  a 200-call turn pays more than the split saves.
+ *                       Do not write P1.1 against this transport.
+ *
+ * Measured worker -> provider edge -> environment, which is the shape
+ * production uses (worker -> Kortix proxy -> sandbox daemon), from inside the
+ * worker sandbox so the benchmark host's distance never enters the number.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPIKE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = resolve(SPIKE, '..', '..');
+const secret = (k: string) =>
+  execFileSync('dotenvx', ['get', k, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+const sh = async (b: any, c: string, t = 300) =>
+  String((await b.process.executeCommand(c, undefined, undefined, t)).result ?? '');
+const GET = (u: string) => `(command -v curl >/dev/null 2>&1 && curl -sf --max-time 5 '${u}') || wget -qO- '${u}'`;
+
+const CALLS = Number(process.argv.find((a) => a.startsWith('--calls='))?.split('=')[1] ?? 200);
+const LOCAL = process.argv.includes('--local');
+const W_SNAP = 'kortix-worker-rpc-v1';
+const E_SNAP = 'kortix-env-rpc-v1';
+
+const p = (xs: number[], q: number) => {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.min(s.length - 1, Math.floor((q / 100) * s.length))];
+};
+const verdict = (p50: number) => (p50 <= 10 ? 'PASS' : p50 <= 25 ? 'WARN' : 'FAIL');
+
+/** The measuring script, run INSIDE the worker sandbox. */
+const measureJs = (envUrl: string, headers: string, calls: number) => `
+const { makeTransport } = await import('/opt/kortix/rpc-transport.mjs');
+const HEADERS = ${headers};
+const results = {};
+for (const kind of ['fetch', 'keepalive', 'ws']) {
+  const t = makeTransport(kind, ${JSON.stringify(envUrl)}, HEADERS);
+  try {
+    for (let i = 0; i < 20; i++) await t.call('exec', { command: 'true' }, '/workspace'); // warm
+    const xs = [];
+    for (let i = 0; i < ${calls}; i++) {
+      const s = process.hrtime.bigint();
+      const r = await t.call('exec', { command: 'true' }, '/workspace');
+      if (!r || r.ok !== true) throw new Error(kind + ': bad response ' + JSON.stringify(r).slice(0, 120));
+      xs.push(Number(process.hrtime.bigint() - s) / 1e6);
+    }
+    results[kind] = xs;
+  } catch (e) {
+    results[kind] = { error: String(e && e.message || e) };
+  } finally { await t.close().catch(() => {}); }
+}
+console.log('RPCTAX=' + JSON.stringify(results));
+`;
+
+async function main() {
+  console.log('\n' + '='.repeat(70));
+  console.log('  GATE G0 — the RPC tax (runs before P1.1)');
+  console.log('='.repeat(70));
+  console.log(`  ${CALLS} calls per transport, after 20 warm-up calls`);
+  console.log(`  pass <= 10 ms p50 · warn <= 25 ms · fail > 25 ms\n`);
+
+  let raw: string;
+  let where: string;
+
+  if (LOCAL) {
+    console.log('  [local] starting stub environment…');
+    const { startStubEnvironment } = await import('../src/stub-environment.ts');
+    const { makeTransport } = await import('../src/rpc-transport.ts');
+    const env = await startStubEnvironment({ root: '/tmp/kx-rpc-' + Date.now() });
+    console.log(`  [local] env ${env.url}`);
+    where = 'localhost (loopback — a floor, not a prediction)';
+    const results: Record<string, any> = {};
+    for (const kind of ['fetch', 'keepalive', 'ws'] as const) {
+      console.log(`  [local] measuring ${kind}…`);
+      const t = makeTransport(kind, env.url);
+      try {
+        for (let i = 0; i < 20; i++) await t.call('exec', { command: 'true' }, '/workspace');
+        const xs: number[] = [];
+        for (let i = 0; i < CALLS; i++) {
+          const s = process.hrtime.bigint();
+          await t.call('exec', { command: 'true' }, '/workspace');
+          xs.push(Number(process.hrtime.bigint() - s) / 1e6);
+        }
+        results[kind] = xs;
+      } catch (e: any) { results[kind] = { error: String(e?.message ?? e) }; }
+      finally { await t.close(); }
+    }
+    await env.close();
+    raw = 'RPCTAX=' + JSON.stringify(results);
+  } else {
+    const daytona = new Daytona({
+      apiKey: secret('DAYTONA_API_KEY'), apiUrl: secret('DAYTONA_SERVER_URL'), target: secret('DAYTONA_TARGET'),
+    });
+    const ensure = async (name: string, dockerfile: string, entry: string[]) => {
+      const s = await daytona.snapshot.get(name).catch(() => null);
+      if (s && String((s as any).state ?? '').toLowerCase().includes('active')) return;
+      console.log(`  building ${name}…`);
+      await daytona.snapshot.create(
+        { name, image: Image.fromDockerfile(join(SPIKE, dockerfile)), entrypoint: entry, resources: { cpu: 2, memory: 4, disk: 10 } },
+        { timeout: 900, onLogs: () => {} },
+      );
+    };
+    await ensure(W_SNAP, 'Dockerfile', ['node', '/opt/kortix/worker.mjs']);
+    await ensure(E_SNAP, 'Dockerfile.environment', ['node', '/opt/kortix/environment.mjs']);
+
+    const boxes: any[] = [];
+    try {
+      const envBox = await daytona.create({ snapshot: E_SNAP, envVars: { PORT: '8100', ENV_ROOT: '/env-root' }, autoStopInterval: 15 }, { timeout: 300 });
+      boxes.push(envBox);
+      const link = await envBox.getPreviewLink(8100);
+      const headers = link.token ? JSON.stringify({ 'x-daytona-preview-token': link.token }) : '{}';
+      where = 'Daytona: worker -> provider edge -> environment';
+
+      const w = await daytona.create({ snapshot: W_SNAP, envVars: { PORT: '8080' }, autoStopInterval: 15 }, { timeout: 300 });
+      boxes.push(w);
+      await sh(w, `for i in $(seq 1 900); do ${GET('http://127.0.0.1:8080/health')} >/dev/null 2>&1 && break; sleep 0.1; done`);
+
+      await sh(w, `cat > /tmp/m.mjs <<'KXEOF'\n${measureJs(link.url, headers, CALLS)}\nKXEOF`);
+      raw = await sh(w, 'node /tmp/m.mjs', 900);
+    } finally {
+      for (const b of boxes) await b.delete().catch(() => {});
+      console.log(`  (deleted ${boxes.length} sandboxes)`);
+    }
+  }
+
+  const m = /RPCTAX=(\{[\s\S]*\})/.exec(raw);
+  if (!m) { console.error('no measurement returned:\n' + raw.slice(0, 800)); process.exit(1); }
+  const data = JSON.parse(m[1]);
+
+  console.log(`\nmeasured on ${where}\n`);
+  console.log('  transport    p50        p95        per 200-call turn   verdict');
+  console.log('  ' + '-'.repeat(64));
+  const summary: Record<string, number> = {};
+  for (const kind of ['fetch', 'keepalive', 'ws']) {
+    const xs = data[kind];
+    if (!Array.isArray(xs)) { console.log(`  ${kind.padEnd(12)} ERROR: ${xs?.error}`); continue; }
+    const p50 = p(xs, 50), p95 = p(xs, 95);
+    summary[kind] = p50;
+    console.log(
+      `  ${kind.padEnd(12)} ${(p50.toFixed(1) + ' ms').padEnd(10)} ${(p95.toFixed(1) + ' ms').padEnd(10)} ` +
+        `${((p50 * 200) / 1000).toFixed(1)}s`.padEnd(19) + ` ${verdict(p50)}`,
+    );
+  }
+  console.log('  ' + '-'.repeat(64));
+
+  const best = Object.entries(summary).sort((a, b) => a[1] - b[1])[0];
+  if (!best) { console.log('\nGATE G0: no transport produced a measurement.'); process.exit(1); }
+  const [bestKind, bestP50] = best;
+  const v = verdict(bestP50);
+  console.log(`\n  best transport: ${bestKind} at ${bestP50.toFixed(1)} ms p50`);
+  console.log(`\nGATE G0: ${v}`);
+  if (v === 'PASS') console.log('  A 200-call turn pays ' + ((bestP50 * 200) / 1000).toFixed(1) + 's, under the boot saving. P1.1 may proceed.');
+  else if (v === 'WARN') console.log('  Net win only for sessions that are not tool-heavy. Scope the reduction work before tool-heavy agents move over.');
+  else console.log('  A 200-call turn costs more than the split saves. Do NOT write P1.1 against this transport.');
+  console.log('\n' + JSON.stringify({ gate: 'G0', where, calls: CALLS, p50: summary, verdict: v }, null, 2));
+  if (v === 'FAIL') process.exit(1);
+}
+
+main().catch((e) => { console.error('\nGATE G0 FAILED TO RUN:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bench/task-e2e.ts
+++ b/spikes/pi-worker/bench/task-e2e.ts
@@ -1,0 +1,234 @@
+/**
+ * The comparison that actually answers "is this better": ONE TASK, both
+ * architectures, from cold, on real Daytona sandboxes.
+ *
+ * Everything before this measured pieces — boot, resume, per-call RPC. This
+ * measures what a user experiences: they ask for something that needs real
+ * compute, and they wait until it is done.
+ *
+ *   TASK    create a file in the workspace, read it back, report its contents
+ *   MODEL   the same model, through the same provider (OpenRouter), both arms
+ *   CLOCK   t0 = "create the sandbox", stop = "the answer is in hand"
+ *
+ * FAIRNESS, STATED UP FRONT. Today's approach is ONE box that is both harness
+ * and compute. The new approach is TWO. Counting only the worker would flatter
+ * it, so the new arm is measured twice:
+ *
+ *   cold  worker and environment both provisioned from nothing at t0. The
+ *         honest worst case, and what a first-ever session pays.
+ *   warm  environment already running (the pooled steady state the plan
+ *         designs for), worker cold.
+ *
+ * The old arm gets the easier deal throughout: its box needs no second
+ * provision, and it is given its provider key at create time so nothing waits
+ * on configuration.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPIKE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = resolve(SPIKE, '..', '..');
+const secret = (k: string) =>
+  execFileSync('dotenvx', ['get', k, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+const sh = async (b: any, c: string, t = 300) =>
+  String((await b.process.executeCommand(c, undefined, undefined, t)).result ?? '');
+
+const arg = (f: string, d: string) => process.argv.find((a) => a.startsWith(`${f}=`))?.split('=')[1] ?? d;
+const RUNS = Number(arg('--runs', '3'));
+const MODEL = arg('--model', 'anthropic/claude-sonnet-4.5');
+const TASK = arg(
+  '--task',
+  'Create /workspace/hello.txt containing exactly the word kortix, then read it back and tell me what it says.',
+);
+const W_SNAP = 'kortix-worker-task-v1';
+const E_SNAP = 'kortix-env-task-v1';
+
+const ms = (n: number | null) => (n == null ? '     n/a' : `${String(Math.round(n)).padStart(6)} ms`);
+const med = (xs: number[]) => {
+  const s = xs.filter(Number.isFinite).sort((a, b) => a - b);
+  return s.length ? s[Math.floor(s.length / 2)] : Number.NaN;
+};
+
+const daytona = new Daytona({
+  apiKey: secret('DAYTONA_API_KEY'), apiUrl: secret('DAYTONA_SERVER_URL'), target: secret('DAYTONA_TARGET'),
+});
+const OR = secret('OPENROUTER_API_KEY');
+
+async function ensure(name: string, dockerfile: string, entry: string[]) {
+  const s = await daytona.snapshot.get(name).catch(() => null);
+  if (s && String((s as any).state ?? '').toLowerCase().includes('active')) return;
+  console.log(`  building ${name}… (one-off, excluded from every number)`);
+  await daytona.snapshot.create(
+    { name, image: Image.fromDockerfile(join(SPIKE, dockerfile)), entrypoint: entry, resources: { cpu: 2, memory: 6, disk: 20 } },
+    { timeout: 900, onLogs: () => {} },
+  );
+}
+
+/** Today's approach: one fat box, opencode driven over its own HTTP API. */
+async function oldArm(snapshot: string, alive: any[]) {
+  const t0 = Date.now();
+  const box = await daytona.create(
+    { snapshot, envVars: { OPENROUTER_API_KEY: OR }, autoStopInterval: 15 }, { timeout: 300 },
+  );
+  alive.push(box);
+  const created = Date.now() - t0;
+
+  await sh(box, `for i in $(seq 1 1800); do curl -sf http://127.0.0.1:8000/kortix/health | grep -q '"runtimeReady":true' && break; sleep 0.1; done`, 420);
+  const ready = Date.now() - t0;
+
+  const body = JSON.stringify({
+    model: { providerID: 'openrouter', modelID: MODEL },
+    parts: [{ type: 'text', text: TASK }],
+  }).replace(/'/g, `'\\''`);
+  const out = await sh(
+    box,
+    `S=$(curl -sf --max-time 30 -X POST http://127.0.0.1:4096/session -H 'content-type: application/json' -d '{}' | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])') ; ` +
+      `echo "SID=$S" ; ` +
+      `curl -sf --max-time 300 -X POST "http://127.0.0.1:4096/session/$S/message" -H 'content-type: application/json' -d '${body}'`,
+    420,
+  );
+  const answered = Date.now() - t0;
+
+  let answer = '';
+  try {
+    const jsonStart = out.indexOf('{', out.indexOf('SID='));
+    const msg = JSON.parse(out.slice(jsonStart));
+    const parts = msg?.parts ?? msg?.info?.parts ?? [];
+    answer = parts.filter((p: any) => p.type === 'text').map((p: any) => p.text).join('').trim();
+  } catch { answer = out.slice(-200).trim(); }
+
+  await box.delete().catch(() => {});
+  alive.splice(alive.indexOf(box), 1);
+  return { created, ready, answered, answer };
+}
+
+/** The split: a small worker, plus an environment it RPCs into. */
+async function newArm(envBox: any | null, alive: any[]) {
+  const t0 = Date.now();
+
+  // Cold variant provisions the environment concurrently with the worker —
+  // the speculative pre-warm the plan calls for, which is what a real lazy
+  // start would approximate since the first model round trip overlaps it.
+  const envPromise = envBox
+    ? Promise.resolve(envBox)
+    : daytona.create({ snapshot: E_SNAP, envVars: { PORT: '8100', ENV_ROOT: '/env-root' }, autoStopInterval: 15 }, { timeout: 300 })
+        .then((b) => { alive.push(b); return b; });
+
+  const env = await envPromise;
+  const link = await env.getPreviewLink(8100);
+
+  const w = await daytona.create(
+    {
+      snapshot: W_SNAP,
+      envVars: {
+        PORT: '8080',
+        KORTIX_MODEL_MODE: 'real',
+        KORTIX_PROVIDER: 'openrouter',
+        KORTIX_MODEL: MODEL,
+        KORTIX_API_KEY: OR,
+        KORTIX_ENV_URL: link.url,
+        KORTIX_ENV_CWD: '/workspace',
+        KORTIX_ENV_TRANSPORT: 'ws',
+        KORTIX_SYSTEM_PROMPT: 'You are a Kortix agent. Answer briefly.',
+        ...(link.token ? { KORTIX_ENV_HEADERS: JSON.stringify({ 'x-daytona-preview-token': link.token }) } : {}),
+      },
+      autoStopInterval: 15,
+    },
+    { timeout: 300 },
+  );
+  alive.push(w);
+  const created = Date.now() - t0;
+
+  await sh(w, `for i in $(seq 1 900); do wget -qO- http://127.0.0.1:8080/health >/dev/null 2>&1 && break; sleep 0.1; done`, 300);
+  const ready = Date.now() - t0;
+
+  const say = JSON.stringify({ text: TASK }).replace(/'/g, `'\\''`);
+  const raw = await sh(w, `wget -qO- --header='content-type: application/json' --post-data='${say}' http://127.0.0.1:8080/say`, 420);
+  const answered = Date.now() - t0;
+  let answer = '';
+  try { answer = String(JSON.parse(raw.trim().split('\n').pop() || '{}').answer ?? '').trim(); } catch { answer = raw.slice(-200); }
+
+  await w.delete().catch(() => {});
+  alive.splice(alive.indexOf(w), 1);
+  return { created, ready, answered, answer };
+}
+
+async function main() {
+  console.log('\n' + '='.repeat(76));
+  console.log('  ONE TASK, BOTH ARCHITECTURES, FROM COLD — Daytona ' + secret('DAYTONA_TARGET'));
+  console.log('='.repeat(76));
+  console.log(`  task   ${TASK}`);
+  console.log(`  model  ${MODEL} via OpenRouter (identical on both arms)`);
+  console.log(`  runs   ${RUNS}\n`);
+
+  await ensure(W_SNAP, 'Dockerfile', ['node', '/opt/kortix/worker.mjs']);
+  await ensure(E_SNAP, 'Dockerfile.environment', ['node', '/opt/kortix/environment.mjs']);
+
+  const snapRes: any = await daytona.snapshot.list();
+  const snaps: any[] = Array.isArray(snapRes) ? snapRes : (snapRes.items ?? []);
+  const current = snaps
+    .filter((s) => String(s.name).startsWith('kortix-default-') && String(s.state).toLowerCase().includes('active'))
+    .sort((a, b) => String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')))[0];
+  if (!current) throw new Error('no active kortix-default-* snapshot found');
+  console.log(`  today's image: ${current.name} (${Number(current.size ?? 0).toFixed(1)} GB)\n`);
+
+  const alive: any[] = [];
+  const OLD: any[] = [], NEW_COLD: any[] = [], NEW_WARM: any[] = [];
+
+  try {
+    // One long-lived environment for the warm variant.
+    const warmEnv = await daytona.create({ snapshot: E_SNAP, envVars: { PORT: '8100', ENV_ROOT: '/env-root' }, autoStopInterval: 0 }, { timeout: 300 });
+    alive.push(warmEnv);
+
+    for (let i = 1; i <= RUNS; i++) {
+      console.log(`run ${i}/${RUNS}`);
+
+      const o = await oldArm(current.name, alive);
+      OLD.push(o);
+      console.log(`  TODAY      create ${ms(o.created)}  ready ${ms(o.ready)}  ANSWERED ${ms(o.answered)}`);
+      console.log(`             > ${o.answer.slice(0, 120)}`);
+
+      const nc = await newArm(null, alive);
+      NEW_COLD.push(nc);
+      console.log(`  WORKER c   create ${ms(nc.created)}  ready ${ms(nc.ready)}  ANSWERED ${ms(nc.answered)}`);
+      console.log(`             > ${nc.answer.slice(0, 120)}`);
+
+      const nw = await newArm(warmEnv, alive);
+      NEW_WARM.push(nw);
+      console.log(`  WORKER w   create ${ms(nw.created)}  ready ${ms(nw.ready)}  ANSWERED ${ms(nw.answered)}`);
+      console.log(`             > ${nw.answer.slice(0, 120)}\n`);
+    }
+
+    const row = (label: string, xs: any[]) =>
+      `  ${label.padEnd(26)} ${ms(med(xs.map((x) => x.created)))}  ${ms(med(xs.map((x) => x.ready)))}  ${ms(med(xs.map((x) => x.answered)))}`;
+    console.log('='.repeat(76));
+    console.log('  MEDIANS                      create        ready      ANSWERED');
+    console.log('='.repeat(76));
+    console.log(row("today — one 6.2 GB box", OLD));
+    console.log(row('worker + cold environment', NEW_COLD));
+    console.log(row('worker + warm environment', NEW_WARM));
+    console.log('='.repeat(76));
+
+    const o = med(OLD.map((x) => x.answered));
+    const c = med(NEW_COLD.map((x) => x.answered));
+    const w = med(NEW_WARM.map((x) => x.answered));
+    const fmt = (a: number, b: number) =>
+      a < b ? `${((b - a) / 1000).toFixed(1)}s faster` : `${((a - b) / 1000).toFixed(1)}s slower`;
+    console.log(`\n  worker + cold env vs today: ${fmt(c, o)}`);
+    console.log(`  worker + warm env vs today: ${fmt(w, o)}`);
+    console.log(`\n${JSON.stringify({ task: TASK, model: MODEL, old: OLD, newCold: NEW_COLD, newWarm: NEW_WARM }, null, 2)}`);
+  } finally {
+    console.log(`\ncleanup: ${alive.length} sandbox(es)`);
+    for (const s of alive) await s.delete().then(() => console.log(`  deleted ${s.id}`)).catch(() => {});
+    if (process.argv.includes('--delete-snapshots')) {
+      for (const n of [W_SNAP, E_SNAP]) {
+        const snap = await daytona.snapshot.get(n).catch(() => null);
+        if (snap) await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${n}`)).catch(() => {});
+      }
+    }
+  }
+}
+
+main().catch((e) => { console.error('\nTASK E2E FAILED:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bench/ttft-cold.ts
+++ b/spikes/pi-worker/bench/ttft-cold.ts
@@ -1,0 +1,175 @@
+/**
+ * COLD TIME-TO-FIRST-TOKEN — the only latency number the split can move.
+ *
+ * Total task time is dominated by the model thinking, which is identical on
+ * both architectures and drowns the thing being decided. This measures the
+ * part that is actually different: from "create the sandbox" to "the agent
+ * starts speaking".
+ *
+ *   t0    daytona.create() is called
+ *   stop  the first token of the assistant's answer arrives
+ *
+ * Both arms, both cold, same model, same provider, same region.
+ *
+ * METHOD. Each arm is timed in two sequential segments:
+ *   create  measured on the benchmark host's clock (create() call to return)
+ *   serve   measured INSIDE the sandbox by a script that waits for readiness,
+ *           sends the prompt, and stops at the first streamed token
+ * The exec dispatch that starts that script sits between them and is charged
+ * to BOTH arms identically, so the comparison is fair even though the absolute
+ * carries a small constant.
+ */
+import { Daytona, Image } from '@daytonaio/sdk';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPIKE = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const REPO = resolve(SPIKE, '..', '..');
+const secret = (k: string) =>
+  execFileSync('dotenvx', ['get', k, '-f', '.env'], { cwd: join(REPO, 'apps', 'api'), encoding: 'utf8' }).trim();
+const sh = async (b: any, c: string, t = 420) =>
+  String((await b.process.executeCommand(c, undefined, undefined, t)).result ?? '');
+const arg = (f: string, d: string) => process.argv.find((a) => a.startsWith(`${f}=`))?.split('=')[1] ?? d;
+
+const RUNS = Number(arg('--runs', '3'));
+const MODEL = arg('--model', 'anthropic/claude-sonnet-4.5');
+const PROMPT = arg('--prompt', 'Say the single word: ready');
+const W_SNAP = 'kortix-worker-ttft-v1';
+const E_SNAP = 'kortix-env-ttft-v1';
+
+const ms = (n: number | null) => (n == null ? '     n/a' : `${String(Math.round(n)).padStart(6)} ms`);
+const med = (xs: number[]) => {
+  const s = xs.filter(Number.isFinite).sort((a, b) => a - b);
+  return s.length ? s[Math.floor(s.length / 2)] : Number.NaN;
+};
+
+const daytona = new Daytona({
+  apiKey: secret('DAYTONA_API_KEY'), apiUrl: secret('DAYTONA_SERVER_URL'), target: secret('DAYTONA_TARGET'),
+});
+const OR = secret('OPENROUTER_API_KEY');
+
+import { readFileSync } from 'node:fs';
+
+/**
+ * The measurers are real files, uploaded verbatim — not template literals.
+ *
+ * Building them as template strings put three layers of escaping between the
+ * source and the running script (TS template, shell heredoc, JS string). A
+ * single `\n` survived as a real newline and produced a SyntaxError that
+ * silently read as "the old architecture produced no measurement". Files have
+ * no escaping layers at all.
+ */
+const measurer = (name: string) => readFileSync(join(SPIKE, 'bench', 'measure', name), 'utf8');
+
+/** Upload a measurer and run it, returning the parsed line it prints. */
+async function measure(box: any, name: string, envVars: Record<string, string>, label: string) {
+  const b64 = Buffer.from(measurer(name), 'utf8').toString('base64');
+  await sh(box, `echo '${b64}' | base64 -d > /tmp/m.js`);
+  const exports = Object.entries(envVars).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(' ');
+  const out = await sh(box, `${exports} node /tmp/m.js 2>&1`, 420);
+  const m = /MEASURE=(\{.*\})/.exec(out);
+  if (!m) { console.log(`  [${label}] no MEASURE — raw:\n${out.slice(0, 500)}`); return {}; }
+  return JSON.parse(m[1]) as { ready?: number; first?: number; err?: string };
+}
+
+async function ensure(name: string, dockerfile: string, entry: string[]) {
+  const s = await daytona.snapshot.get(name).catch(() => null);
+  if (s && String((s as any).state ?? '').toLowerCase().includes('active')) return;
+  console.log(`  building ${name}… (one-off, excluded from every number)`);
+  await daytona.snapshot.create(
+    { name, image: Image.fromDockerfile(join(SPIKE, dockerfile)), entrypoint: entry, resources: { cpu: 2, memory: 6, disk: 20 } },
+    { timeout: 900, onLogs: () => {} },
+  );
+}
+
+async function main() {
+  console.log('\n' + '='.repeat(74));
+  console.log('  COLD TIME-TO-FIRST-TOKEN — Daytona ' + secret('DAYTONA_TARGET'));
+  console.log('='.repeat(74));
+  console.log(`  prompt "${PROMPT}"  ·  model ${MODEL}  ·  runs ${RUNS}`);
+  console.log('  t0 = create the sandbox   stop = first token of the answer\n');
+
+  await ensure(W_SNAP, 'Dockerfile', ['node', '/opt/kortix/worker.mjs']);
+  await ensure(E_SNAP, 'Dockerfile.environment', ['node', '/opt/kortix/environment.mjs']);
+
+  const snapRes: any = await daytona.snapshot.list();
+  const snaps: any[] = Array.isArray(snapRes) ? snapRes : (snapRes.items ?? []);
+  const current = snaps
+    .filter((s) => String(s.name).startsWith('kortix-default-') && String(s.state).toLowerCase().includes('active'))
+    .sort((a, b) => String(b.createdAt ?? '').localeCompare(String(a.createdAt ?? '')))[0];
+  if (!current) throw new Error('no active kortix-default-* snapshot');
+  console.log(`  today's image: ${current.name} (${Number(current.size ?? 0).toFixed(1)} GB)\n`);
+
+  const alive: any[] = [];
+  const OLD: any[] = [], NEW: any[] = [];
+
+  try {
+    const envBox = await daytona.create({ snapshot: E_SNAP, envVars: { PORT: '8100', ENV_ROOT: '/env-root' }, autoStopInterval: 0 }, { timeout: 300 });
+    alive.push(envBox);
+    const envLink = await envBox.getPreviewLink(8100);
+
+    for (let i = 1; i <= RUNS; i++) {
+      console.log(`run ${i}/${RUNS}`);
+
+      // ---- today: one box, opencode ------------------------------------
+      let t = Date.now();
+      const ob = await daytona.create({ snapshot: current.name, envVars: { OPENROUTER_API_KEY: OR }, autoStopInterval: 15 }, { timeout: 300 });
+      const oCreate = Date.now() - t;
+      alive.push(ob);
+      const oOut = await measure(ob, 'opencode.js', { KX_PROMPT: PROMPT, KX_MODEL: MODEL }, 'TODAY');
+      const o = { create: oCreate, ready: oCreate + (oOut.ready ?? NaN), first: oCreate + (oOut.first ?? NaN), err: oOut.err };
+      OLD.push(o);
+      console.log(`  TODAY   create ${ms(o.create)}  ready ${ms(o.ready)}  FIRST TOKEN ${ms(o.first)}${o.err ? '  ' + o.err : ''}`);
+      await ob.delete().catch(() => {}); alive.splice(alive.indexOf(ob), 1);
+
+      // ---- worker: cold, environment deliberately off the critical path --
+      // No tool is called for this prompt, so the environment is never touched
+      // before the first token. That is the design: compute is provisioned
+      // lazily, on the first tool call. Including its provision here would be
+      // measuring something the user never waits for. It is created once,
+      // outside the loop, for the same reason.
+      t = Date.now();
+      const wb = await daytona.create({
+        snapshot: W_SNAP,
+        envVars: {
+          PORT: '8080', KORTIX_MODEL_MODE: 'real', KORTIX_PROVIDER: 'openrouter', KORTIX_MODEL: MODEL,
+          KORTIX_API_KEY: OR, KORTIX_ENV_URL: envLink.url, KORTIX_ENV_CWD: '/workspace', KORTIX_ENV_TRANSPORT: 'ws',
+          KORTIX_SYSTEM_PROMPT: 'You are a Kortix agent. Answer briefly.',
+          ...(envLink.token ? { KORTIX_ENV_HEADERS: JSON.stringify({ 'x-daytona-preview-token': envLink.token }) } : {}),
+        },
+        autoStopInterval: 15,
+      }, { timeout: 300 });
+      const wCreate = Date.now() - t;
+      alive.push(wb);
+      const wOut = await measure(wb, 'worker.js', { KX_PROMPT: PROMPT }, 'WORKER');
+      const w = { create: wCreate, ready: wCreate + (wOut.ready ?? NaN), first: wCreate + (wOut.first ?? NaN) };
+      NEW.push(w);
+      console.log(`  WORKER  create ${ms(w.create)}  ready ${ms(w.ready)}  FIRST TOKEN ${ms(w.first)}\n`);
+      await wb.delete().catch(() => {}); alive.splice(alive.indexOf(wb), 1);
+    }
+
+    console.log('='.repeat(74));
+    console.log('  MEDIANS                   create        ready    FIRST TOKEN');
+    console.log('='.repeat(74));
+    console.log(`  today — one 6.2 GB box  ${ms(med(OLD.map((x) => x.create)))}  ${ms(med(OLD.map((x) => x.ready)))}  ${ms(med(OLD.map((x) => x.first)))}`);
+    console.log(`  worker + environment    ${ms(med(NEW.map((x) => x.create)))}  ${ms(med(NEW.map((x) => x.ready)))}  ${ms(med(NEW.map((x) => x.first)))}`);
+    console.log('='.repeat(74));
+    const o = med(OLD.map((x) => x.first)), n = med(NEW.map((x) => x.first));
+    if (Number.isFinite(o) && Number.isFinite(n)) {
+      console.log(`\n  cold time-to-first-token: ${(n / 1000).toFixed(2)}s vs ${(o / 1000).toFixed(2)}s  =  ${(o / n).toFixed(2)}x  (${((o - n) / 1000).toFixed(2)}s sooner)`);
+    }
+    console.log(`\n${JSON.stringify({ prompt: PROMPT, model: MODEL, old: OLD, worker: NEW }, null, 2)}`);
+  } finally {
+    console.log(`\ncleanup: ${alive.length} sandbox(es)`);
+    for (const s of alive) await s.delete().then(() => console.log(`  deleted ${s.id}`)).catch(() => {});
+    if (process.argv.includes('--delete-snapshots')) {
+      for (const n of [W_SNAP, E_SNAP]) {
+        const snap = await daytona.snapshot.get(n).catch(() => null);
+        if (snap) await daytona.snapshot.delete(snap).then(() => console.log(`  deleted snapshot ${n}`)).catch(() => {});
+      }
+    }
+  }
+}
+
+main().catch((e) => { console.error('\nTTFT BENCH FAILED:', e?.message ?? e); process.exit(1); });

--- a/spikes/pi-worker/bin/kx.ts
+++ b/spikes/pi-worker/bin/kx.ts
@@ -62,7 +62,10 @@ function apiKey(): string | undefined {
 
 async function main() {
   const envRoot = await mkdtemp(join(tmpdir(), 'kx-term-env-'));
-  const storeRoot = join(tmpdir(), 'kx-term-store');
+  // Stable across runs so --session resumes, but NOT a fixed name in the
+  // world-writable tmpdir (another local user could pre-own it). Per-user
+  // cache dir instead.
+  const storeRoot = join(process.env.HOME ?? tmpdir(), '.cache', 'kx-term-store');
 
   const env = await startStubEnvironment({ root: envRoot });
   const store = await startStoreService({ root: storeRoot });

--- a/spikes/pi-worker/bin/kx.ts
+++ b/spikes/pi-worker/bin/kx.ts
@@ -1,0 +1,241 @@
+/**
+ * kx — a terminal for the worker. No UI, no browser, no Kortix API.
+ *
+ * Brings up the whole stack (store, environment, worker) in one process, then
+ * gives you a prompt. Streaming text, live tool calls, and the ability to poke
+ * at what actually happened — which is the fastest way to find out whether this
+ * architecture is pleasant to use, as opposed to merely fast.
+ *
+ *   bun bin/kx.ts                       real model, everything local
+ *   bun bin/kx.ts --faux                no credentials needed
+ *   bun bin/kx.ts --session my-work     resume a previous conversation
+ *   bun bin/kx.ts --transport=ws        pick the RPC transport
+ *
+ * Slash commands: /help /tools /history /env /stats /rpc /transcript /new /quit
+ */
+import { createInterface } from 'node:readline';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startStubEnvironment } from '../src/stub-environment.ts';
+import { startStoreService } from '../src/store-service.ts';
+import { buildHarness, type WorkerConfig } from '../src/worker.ts';
+import { fauxAssistantMessage } from '@earendil-works/pi-ai';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const argv = process.argv.slice(2);
+const has = (f: string) => argv.includes(f);
+/** Accept both `--flag=value` and `--flag value`. */
+const val = (f: string, d: string) => {
+  const eq = argv.find((a) => a.startsWith(`${f}=`));
+  if (eq) return eq.split('=').slice(1).join('=');
+  const i = argv.indexOf(f);
+  if (i >= 0 && argv[i + 1] && !argv[i + 1].startsWith('--')) return argv[i + 1];
+  return d;
+};
+
+const FAUX = has('--faux');
+const SESSION = val('--session', 'kx-terminal');
+const MODEL = val('--model', 'anthropic/claude-sonnet-4.5');
+const TRANSPORT = val('--transport', 'keepalive') as 'fetch' | 'keepalive' | 'ws';
+
+const C = {
+  dim: (s: string) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s: string) => `\x1b[1m${s}\x1b[0m`,
+  green: (s: string) => `\x1b[32m${s}\x1b[0m`,
+  cyan: (s: string) => `\x1b[36m${s}\x1b[0m`,
+  yellow: (s: string) => `\x1b[33m${s}\x1b[0m`,
+  red: (s: string) => `\x1b[31m${s}\x1b[0m`,
+};
+
+function apiKey(): string | undefined {
+  if (FAUX) return undefined;
+  if (process.env.KORTIX_API_KEY) return process.env.KORTIX_API_KEY;
+  try {
+    return execFileSync('dotenvx', ['get', 'OPENROUTER_API_KEY', '-f', '.env'], {
+      cwd: join(REPO, 'apps', 'api'), encoding: 'utf8',
+    }).trim() || undefined;
+  } catch { return undefined; }
+}
+
+async function main() {
+  const envRoot = await mkdtemp(join(tmpdir(), 'kx-term-env-'));
+  const storeRoot = join(tmpdir(), 'kx-term-store');
+
+  const env = await startStubEnvironment({ root: envRoot });
+  const store = await startStoreService({ root: storeRoot });
+
+  const key = apiKey();
+  if (!key && !FAUX) {
+    console.log(C.yellow('no OPENROUTER_API_KEY available — falling back to --faux'));
+  }
+  const useFaux = FAUX || !key;
+
+  const cfg: WorkerConfig = {
+    port: 0,
+    envUrl: env.url,
+    envCwd: '/workspace',
+    envTransport: TRANSPORT,
+    systemPrompt:
+      'You are a Kortix agent running on a worker. Every file and shell operation you perform happens in a separate environment, never on your own machine. Be concise.',
+    modelMode: useFaux ? 'faux' : 'real',
+    providerId: 'openrouter',
+    modelId: MODEL,
+    apiKey: key,
+    storeUrl: store.url,
+    sessionId: SESSION,
+  };
+
+  const { agent, env: execEnv, faux, restoredMessages } = await buildHarness(cfg);
+
+  console.log('');
+  console.log(C.bold('  kx — Kortix worker terminal'));
+  console.log(C.dim(`  model       ${useFaux ? 'faux (scripted, no credentials)' : MODEL}`));
+  console.log(C.dim(`  environment ${env.url}  (root ${envRoot})`));
+  console.log(C.dim(`  store       ${store.url}  session "${SESSION}"`));
+  console.log(C.dim(`  transport   ${TRANSPORT}`));
+  if (restoredMessages.length) console.log(C.green(`  resumed     ${restoredMessages.length} messages from a previous run`));
+  console.log(C.dim('  /help for commands, ctrl-c to quit'));
+  console.log('');
+
+  // ---- live rendering ----------------------------------------------------
+  let streaming = false;
+  const toolStart = new Map<string, number>();
+  agent.subscribe((e: any) => {
+    if (e.type === 'message_update') {
+      const inner = e.assistantMessageEvent;
+      if (inner?.type === 'text_delta' && inner.delta) {
+        if (!streaming) { process.stdout.write(C.green('  ')); streaming = true; }
+        process.stdout.write(inner.delta);
+      }
+    }
+    if (e.type === 'tool_execution_start') {
+      if (streaming) { process.stdout.write('\n'); streaming = false; }
+      toolStart.set(e.toolCallId, Date.now());
+      const arg = e.args?.command ?? e.args?.path ?? JSON.stringify(e.args ?? {}).slice(0, 70);
+      process.stdout.write(C.cyan(`  ⚙ ${e.toolName}`) + C.dim(`  ${String(arg).slice(0, 90)}`));
+    }
+    if (e.type === 'tool_execution_end') {
+      const ms = Date.now() - (toolStart.get(e.toolCallId) ?? Date.now());
+      process.stdout.write(e.isError ? C.red(`  ✗ ${ms}ms\n`) : C.dim(`  ✓ ${ms}ms\n`));
+    }
+    if (e.type === 'message_end' && streaming) { process.stdout.write('\n'); streaming = false; }
+  });
+
+  let rl: ReturnType<typeof createInterface> | undefined;
+
+  const cleanup = async () => {
+    rl?.close();
+    await execEnv.cleanup?.();
+    await env.close();
+    await store.close();
+  };
+
+  const commands: Record<string, () => Promise<void> | void> = {
+    '/help': () => {
+      console.log(C.dim([
+        '  /tools       list the tools the agent has, and where they execute',
+        '  /history     messages currently in context',
+        '  /transcript  read the durable store directly (no worker involved)',
+        '  /env         list files in the environment',
+        '  /rpc         every RPC this session has made to the environment',
+        '  /stats       token usage and message counts',
+        '  /new         start a fresh session id',
+        '  /quit        exit',
+      ].join('\n')));
+    },
+    '/tools': async () => {
+      const tools = agent.state.tools ?? [];
+      for (const t of tools) console.log(`  ${C.cyan(t.name.padEnd(10))} ${C.dim('→ environment')}  ${t.description?.split('\n')[0]?.slice(0, 60) ?? ''}`);
+      console.log(C.dim(`  ${tools.length} tools, all routed through the ExecutionEnv — none touch this machine.`));
+    },
+    '/history': () => {
+      for (const m of agent.state.messages) {
+        const text = (m.content ?? []).filter((c: any) => c.type === 'text').map((c: any) => c.text).join('').trim();
+        const calls = (m.content ?? []).filter((c: any) => c.type === 'toolCall').map((c: any) => c.name);
+        const label = String(m.role).padEnd(10);
+        if (text) console.log(`  ${C.dim(label)} ${text.slice(0, 110)}`);
+        else if (calls.length) console.log(`  ${C.dim(label)} ${C.cyan(calls.join(', '))}`);
+      }
+      console.log(C.dim(`  ${agent.state.messages.length} messages in context`));
+    },
+    '/transcript': async () => {
+      const log = await fetch(`${store.url}/sessions/${SESSION}/log`).then((r) => r.json()).catch(() => []) as any[];
+      const msgs = log.filter((i) => i.kind === 'entry' && i.entry?.type === 'message');
+      console.log(C.dim(`  ${msgs.length} messages read straight from the store — the worker was not consulted.`));
+      for (const i of msgs.slice(-8)) {
+        const m = i.entry.message;
+        const text = (m.content ?? []).filter((c: any) => c.type === 'text').map((c: any) => c.text).join('').trim();
+        console.log(`  ${C.dim(new Date(i.entry.timestamp).toISOString().slice(11, 19))} ${String(m.role).padEnd(10)} ${text.slice(0, 90)}`);
+      }
+    },
+    '/env': async () => {
+      const r = await execEnv.listDir('/workspace');
+      if (!r.ok) { console.log(C.red(`  ${r.error?.message}`)); return; }
+      if (!r.value.length) { console.log(C.dim('  /workspace is empty')); return; }
+      for (const f of r.value) console.log(`  ${f.kind === 'directory' ? C.cyan(f.name + '/') : f.name}  ${C.dim(String(f.size) + 'b')}`);
+    },
+    '/rpc': () => {
+      const ops = execEnv.calls.map((c: any) => c.op);
+      const counts = ops.reduce((a: any, o: string) => ((a[o] = (a[o] ?? 0) + 1), a), {});
+      console.log(C.dim(`  ${ops.length} RPCs to the environment: ${JSON.stringify(counts)}`));
+    },
+    '/stats': () => {
+      const usage = agent.state.messages.reduce(
+        (a: any, m: any) => ({ input: a.input + (m.usage?.input ?? 0), output: a.output + (m.usage?.output ?? 0) }),
+        { input: 0, output: 0 },
+      );
+      console.log(C.dim(`  messages ${agent.state.messages.length}  ·  tokens in ${usage.input} / out ${usage.output}  ·  rpcs ${execEnv.calls.length}`));
+    },
+    '/new': () => console.log(C.yellow(`  restart with --session=<name> to switch conversations (current: ${SESSION})`)),
+    '/quit': async () => { await cleanup(); process.exit(0); },
+  };
+
+  /** One line of input: a slash command, or a prompt for the agent. */
+  const handle = async (raw: string): Promise<void> => {
+    const text = raw.trim();
+    if (!text) return;
+    const cmd = commands[text.split(' ')[0]];
+    if (cmd) { await cmd(); return; }
+
+    if (useFaux) faux!.setResponses([fauxAssistantMessage(`(faux) you said: ${text}`, { stopReason: 'stop' })]);
+    const t0 = Date.now();
+    try {
+      await agent.prompt(text);
+    } catch (e: any) {
+      console.log(C.red(`  error: ${e?.message ?? e}`));
+    }
+    if (streaming) { process.stdout.write('\n'); streaming = false; }
+    console.log(C.dim(`  ${Date.now() - t0}ms`));
+  };
+
+  // Piped input is a SCRIPT, not a conversation: readline delivers every line
+  // at once, so pausing mid-delivery drops them. Read it whole and run the
+  // lines in order — which also makes `kx` scriptable, and that is how the
+  // smoke test drives it.
+  if (!process.stdin.isTTY) {
+    let buf = '';
+    for await (const chunk of process.stdin) buf += chunk;
+    for (const line of buf.split('\n')) {
+      if (!line.trim()) continue;
+      console.log(C.bold('› ') + line.trim());
+      await handle(line);
+    }
+    await cleanup();
+    process.exit(0);
+  }
+
+  rl = createInterface({ input: process.stdin, output: process.stdout, prompt: C.bold('› ') });
+  rl.prompt();
+  rl.on('line', async (line) => {
+    await handle(line);
+    rl!.prompt();
+  });
+
+  rl.on('close', async () => { await cleanup(); process.exit(0); });
+  process.on('SIGINT', async () => { console.log(''); await cleanup(); process.exit(0); });
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/spikes/pi-worker/package-lock.json
+++ b/spikes/pi-worker/package-lock.json
@@ -1,0 +1,1218 @@
+{
+  "name": "pi-worker-spike",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pi-worker-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.3",
+        "@earendil-works/pi-ai": "^0.84.3",
+        "typebox": "^1.3.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.81",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+      "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
+      "integrity": "sha512-VURr+xBRl3RxYcw3kT9Pn3yfi6LbRoCJgHF7h1mAblMjtLNV/MfG/RyF0uJizBAM886AEakSiw3j9c/aSngppg==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.3",
+        "@earendil-works/pi-telemetry": "^0.84.3",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.3.tgz",
+      "integrity": "sha512-M0YUV8vNO3y2WwWSyY8ijKJV5W4gkSUixuvk+Z00ZBjsyMfsdXfITsHEwP1UIf09YRWXT6oGn0GlCamt+P32XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.3",
+        "@google/genai": "1.52.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.40.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.3.tgz",
+      "integrity": "sha512-sgEkWoKrvSGaKn+YfLLFZmn+/A7B/w62eLwTD57nI+C9to8ITlFFVbgC2OtwvPnT3NFGHdCd53qhBEMIlptD1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/spikes/pi-worker/package-lock.json
+++ b/spikes/pi-worker/package-lock.json
@@ -11,7 +11,9 @@
         "@daytonaio/sdk": "^0.207.0",
         "@earendil-works/pi-agent-core": "^0.84.3",
         "@earendil-works/pi-ai": "^0.84.3",
-        "typebox": "^1.3.7"
+        "@types/ws": "^8.18.1",
+        "typebox": "^1.3.7",
+        "ws": "^8.21.3"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1519,6 +1521,15 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",

--- a/spikes/pi-worker/package-lock.json
+++ b/spikes/pi-worker/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pi-worker-spike",
       "version": "0.0.0",
       "dependencies": {
+        "@daytonaio/sdk": "^0.207.0",
         "@earendil-works/pi-agent-core": "^0.84.3",
         "@earendil-works/pi-ai": "^0.84.3",
         "typebox": "^1.3.7"
@@ -82,6 +83,22 @@
         "tslib": "^2.6.2"
       }
     },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+      "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1048.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
@@ -105,6 +122,42 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1118.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1118.0.tgz",
+      "integrity": "sha512-nh46pLKeRNFvTOZAJMfYR7kZ/KzhSqzhXVIJSwl4jJ/b2D+KOXL2jeOCryOvGgwpUQo9YNWFUg63cm2qr5MX9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.29",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.81",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+      "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
@@ -320,12 +373,49 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/lib-storage": {
+      "version": "3.1118.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1118.0.tgz",
+      "integrity": "sha512-UW5cOm2sY2wwMixrkTwa/naLTQX7bObs9yyuttJyqjCLhKke0yF9O9Nhrlpd2qwVQITsBSeLWnqWz7Dvuvrwvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.1118.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-eventstream": {
       "version": "3.972.29",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
       "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+      "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
         "@aws-sdk/types": "^3.974.5",
         "@smithy/core": "^3.33.3",
         "@smithy/types": "^4.17.2",
@@ -474,6 +564,69 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@daytona/analytics-api-client": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@daytona/analytics-api-client/-/analytics-api-client-0.207.0.tgz",
+      "integrity": "sha512-5jQ8NVhx4aYDlMCVl+VWqGg4w2Hs+WUgDSNcbkevdcnnTU9Yk/3qHBtYRtOs46pXlIec1NsVfI9c4BGE/xFsmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
+    "node_modules/@daytona/api-client": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@daytona/api-client/-/api-client-0.207.0.tgz",
+      "integrity": "sha512-1rJpQoKdYn4KUQTOCosw2XYPobMwbhNCbDmnyMlUvH/nJE1qoom3krJ6VW+mx5f1lwknd23vl5Shqn0IN2a+xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
+    "node_modules/@daytona/toolbox-api-client": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@daytona/toolbox-api-client/-/toolbox-api-client-0.207.0.tgz",
+      "integrity": "sha512-3YlwbVN81KpF6CFTjno2jO45EzNQ97FF2hh+DeYzu9O9vSWRFrO16ae1XiJ5eMzFlkMvF+R4zwqnqtBenIg3HA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
+    "node_modules/@daytonaio/sdk": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmjs.org/@daytonaio/sdk/-/sdk-0.207.0.tgz",
+      "integrity": "sha512-z4HWf5GUBLezT2KskuFYy+1HOBDRpL4VLOmpqgqk4nPsvhPKEKGRwyjklO959fm2Jd0jGj6V4QcZEmD+wQSTgg==",
+      "deprecated": "Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1106.0",
+        "@aws-sdk/lib-storage": "^3.1106.0",
+        "@daytona/analytics-api-client": "0.207.0",
+        "@daytona/api-client": "0.207.0",
+        "@daytona/toolbox-api-client": "0.207.0",
+        "@iarna/toml": "^2.2.5",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/instrumentation-http": "^0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-node": "^0.221.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.43.0",
+        "axios": "^1.19.0",
+        "busboy": "^1.0.0",
+        "dotenv": "^17.4.2",
+        "expand-tilde": "^2.0.2",
+        "fast-glob": "^3.3.0",
+        "form-data": "^4.0.4",
+        "isomorphic-ws": "^5.0.0",
+        "pathe": "^2.0.3",
+        "shell-quote": "^1.8.2",
+        "socket.io-client": "^4.8.1",
+        "tar": "^7.5.22",
+        "tslib": "2.8.1",
+        "ws": "^8.21.3"
+      }
+    },
     "node_modules/@earendil-works/pi-agent-core": {
       "version": "0.84.3",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.3.tgz",
@@ -546,6 +699,628 @@
         "@modelcontextprotocol/sdk": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/configuration": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.221.0.tgz",
+      "integrity": "sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "yaml": "^2.8.3"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-logs": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.221.0.tgz",
+      "integrity": "sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.221.0.tgz",
+      "integrity": "sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.10.0.tgz",
+      "integrity": "sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.221.0.tgz",
+      "integrity": "sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.10.0.tgz",
+      "integrity": "sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.10.0.tgz",
+      "integrity": "sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.221.0.tgz",
+      "integrity": "sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/configuration": "0.221.0",
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-prometheus": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.221.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
+        "@opentelemetry/exporter-zipkin": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.221.0",
+        "@opentelemetry/propagator-b3": "2.10.0",
+        "@opentelemetry/propagator-jaeger": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0",
+        "@opentelemetry/sdk-trace-node": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -724,6 +1499,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "26.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
@@ -746,6 +1527,73 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.20.0.tgz",
+      "integrity": "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/base64-js": {
@@ -783,11 +1631,116 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
@@ -815,6 +1768,15 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -822,6 +1784,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -833,11 +1821,145 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "license": "MIT",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -862,6 +1984,54 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -872,6 +2042,21 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gaxios": {
@@ -902,6 +2087,64 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
@@ -926,6 +2169,69 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -954,6 +2260,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -961,6 +2287,74 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/json-bigint": {
@@ -1006,11 +2400,96 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1087,11 +2566,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/partial-json": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.6.5",
@@ -1116,6 +2622,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -1123,6 +2694,39 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -1144,6 +2748,127 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -1169,6 +2894,12 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -1176,6 +2907,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -1199,6 +2947,32 @@
         }
       }
     },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -1212,6 +2986,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/spikes/pi-worker/package.json
+++ b/spikes/pi-worker/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pi-worker-spike",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.84.3",
+    "@earendil-works/pi-ai": "^0.84.3",
+    "typebox": "^1.3.7"
+  }
+}

--- a/spikes/pi-worker/package.json
+++ b/spikes/pi-worker/package.json
@@ -7,6 +7,8 @@
     "@daytonaio/sdk": "^0.207.0",
     "@earendil-works/pi-agent-core": "^0.84.3",
     "@earendil-works/pi-ai": "^0.84.3",
-    "typebox": "^1.3.7"
+    "@types/ws": "^8.18.1",
+    "typebox": "^1.3.7",
+    "ws": "^8.21.3"
   }
 }

--- a/spikes/pi-worker/package.json
+++ b/spikes/pi-worker/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "version": "0.0.0",
   "dependencies": {
+    "@daytonaio/sdk": "^0.207.0",
     "@earendil-works/pi-agent-core": "^0.84.3",
     "@earendil-works/pi-ai": "^0.84.3",
     "typebox": "^1.3.7"

--- a/spikes/pi-worker/package.json
+++ b/spikes/pi-worker/package.json
@@ -10,5 +10,11 @@
     "@types/ws": "^8.18.1",
     "typebox": "^1.3.7",
     "ws": "^8.21.3"
+  },
+  "scripts": {
+    "kx": "bun bin/kx.ts",
+    "build": "bun build src/worker.ts --target=node --format=esm --minify --outfile dist/worker.mjs && bun build src/stub-environment.ts --target=node --format=esm --minify --outfile dist/environment.mjs && bun build src/store-service.ts --target=node --format=esm --minify --outfile dist/store.mjs && bun build src/rpc-transport.ts --target=node --format=esm --outfile dist/rpc-transport.mjs",
+    "proof": "bun test/proof.ts && bun test/proof-s04.ts && bun test/proof-s05.ts",
+    "gate:rpc": "bun bench/rpc-tax.ts"
   }
 }

--- a/spikes/pi-worker/src/chat-events.ts
+++ b/spikes/pi-worker/src/chat-events.ts
@@ -1,0 +1,218 @@
+/**
+ * S0.5 — pi's event stream, reshaped into the wire events the Kortix frontend
+ * already consumes.
+ *
+ * The gate asks one question: can the frontend we already have run on this
+ * harness without being rewritten? The answer is decided by whether every
+ * event `packages/sdk` narrows and classifies has a pi source.
+ *
+ * The wire shape is OpenCode's `{ type, properties }`, because that is what
+ * `narrowChatEvent()` takes. The adapter is therefore not "a new protocol" —
+ * it is pi speaking the protocol the SDK already parses, which is what keeps
+ * `useSession` and every chat surface unchanged.
+ *
+ * CORRECTION TO AN EARLIER FINDING IN THIS SPIKE. I previously recorded that
+ * `Agent.subscribe` emits no text deltas and that a streaming frontend would
+ * have to tap the pi-ai layer. That was wrong, and measuring it is what
+ * corrected it: a 30-word answer produces 21 `message_update` events carrying
+ * `text_start` / 19x `text_delta` / `text_end` in `assistantMessageEvent`.
+ * Deltas are available at the Agent layer. No pi-ai tapping is required.
+ */
+
+type Wire = { type: string; properties: Record<string, unknown> };
+
+const now = () => Date.now();
+
+/** Flatten pi's AgentToolResult into the plain text the UI expects. */
+function toolOutputText(result: any): string {
+  if (typeof result === 'string') return result;
+  const blocks = result?.content;
+  if (Array.isArray(blocks)) {
+    const text = blocks.filter((c: any) => c?.type === 'text').map((c: any) => c.text).join('');
+    if (text) return text;
+  }
+  return result == null ? '' : JSON.stringify(result);
+}
+
+/** OpenCode part ids are stable per (messageId, index). */
+const partId = (messageId: string, index: number) => `${messageId}-p${index}`;
+
+export interface AdapterOptions {
+  sessionID: string;
+  /** Stable id for the assistant message currently being streamed. */
+  messageId?: () => string;
+}
+
+/**
+ * Translate one pi `AgentEvent` into zero or more Kortix wire events.
+ *
+ * Stateful across a turn: parts accumulate, so a `text_delta` emits the FULL
+ * text so far, matching OpenCode's semantics (`message.part.updated` carries
+ * the whole part, not the delta).
+ */
+export class ChatEventAdapter {
+  private readonly sessionID: string;
+  private messageSeq = 0;
+  private currentMessageId = '';
+  private textIndex = new Map<string, number>();
+  private toolIndex = new Map<string, { partId: string; name: string; input: unknown }>();
+  private accum = new Map<string, string>();
+  private partCount = 0;
+
+  constructor(opts: AdapterOptions) {
+    this.sessionID = opts.sessionID;
+  }
+
+  private nextPart(): string {
+    return partId(this.currentMessageId, this.partCount++);
+  }
+
+  translate(event: any): Wire[] {
+    const sessionID = this.sessionID;
+    switch (event.type) {
+      case 'agent_start':
+        return [{ type: 'session.status', properties: { sessionID, status: { type: 'running' } } }];
+
+      case 'message_start': {
+        this.currentMessageId = `msg-${++this.messageSeq}`;
+        this.partCount = 0;
+        this.textIndex.clear();
+        this.accum.clear();
+        return [
+          {
+            type: 'message.updated',
+            properties: {
+              sessionID,
+              info: {
+                id: this.currentMessageId,
+                role: event.message?.role ?? 'assistant',
+                sessionID,
+                time: { created: now() },
+                modelID: event.message?.model,
+                providerID: event.message?.provider,
+              },
+            },
+          },
+        ];
+      }
+
+      case 'message_update': {
+        const inner = event.assistantMessageEvent;
+        if (!inner) return [];
+        // text ------------------------------------------------------------
+        if (inner.type === 'text_start' || inner.type === 'text_delta' || inner.type === 'text_end') {
+          const key = `text:${inner.contentIndex ?? 0}`;
+          if (!this.textIndex.has(key)) this.textIndex.set(key, this.partCount++);
+          const id = partId(this.currentMessageId, this.textIndex.get(key)!);
+          const prev = this.accum.get(id) ?? '';
+          const next = inner.type === 'text_delta' ? prev + (inner.delta ?? '') : (inner.text ?? prev);
+          this.accum.set(id, next);
+          return [
+            {
+              type: 'message.part.updated',
+              properties: {
+                sessionID,
+                part: { id, messageID: this.currentMessageId, sessionID, type: 'text', text: next },
+              },
+            },
+          ];
+        }
+        // thinking ---------------------------------------------------------
+        if (inner.type === 'thinking_start' || inner.type === 'thinking_delta' || inner.type === 'thinking_end') {
+          const key = `think:${inner.contentIndex ?? 0}`;
+          if (!this.textIndex.has(key)) this.textIndex.set(key, this.partCount++);
+          const id = partId(this.currentMessageId, this.textIndex.get(key)!);
+          const prev = this.accum.get(id) ?? '';
+          const next = inner.type === 'thinking_delta' ? prev + (inner.delta ?? '') : (inner.thinking ?? prev);
+          this.accum.set(id, next);
+          return [
+            {
+              type: 'message.part.updated',
+              properties: {
+                sessionID,
+                part: { id, messageID: this.currentMessageId, sessionID, type: 'reasoning', text: next },
+              },
+            },
+          ];
+        }
+        return [];
+      }
+
+      case 'tool_execution_start': {
+        const id = this.nextPart();
+        this.toolIndex.set(event.toolCallId, { partId: id, name: event.toolName, input: event.args });
+        return [this.toolPart(id, event.toolName, { status: 'running', input: event.args, time: { start: now() } })];
+      }
+
+      case 'tool_execution_update': {
+        const t = this.toolIndex.get(event.toolCallId);
+        if (!t) return [];
+        return [this.toolPart(t.partId, t.name, { status: 'running', input: t.input, time: { start: now() } })];
+      }
+
+      case 'tool_execution_end': {
+        const t = this.toolIndex.get(event.toolCallId);
+        if (!t) return [];
+        // pi returns AgentToolResult { content: [{type:'text',text}], details }.
+        // The UI's shell/file view-models read `state.output` as the command's
+        // own output, so hand them the text — a JSON envelope would render as
+        // a blob where stdout belongs.
+        const output = toolOutputText(event.result);
+        return [
+          this.toolPart(
+            t.partId,
+            t.name,
+            event.isError
+              ? { status: 'error', input: t.input, error: output, time: { start: now(), end: now() } }
+              : { status: 'completed', input: t.input, output, time: { start: now(), end: now() } },
+          ),
+        ];
+      }
+
+      case 'message_end': {
+        const stop = event.message?.stopReason;
+        const out: Wire[] = [
+          {
+            type: 'message.updated',
+            properties: {
+              sessionID,
+              info: {
+                id: this.currentMessageId,
+                role: event.message?.role ?? 'assistant',
+                sessionID,
+                time: { created: now(), completed: now() },
+                tokens: event.message?.usage,
+              },
+            },
+          },
+        ];
+        if (stop === 'error') {
+          out.push({
+            type: 'session.error',
+            properties: { sessionID, error: { name: 'ProviderError', data: { message: event.message?.errorMessage } } },
+          });
+        }
+        return out;
+      }
+
+      case 'agent_end':
+        return [
+          { type: 'session.status', properties: { sessionID, status: { type: 'idle' } } },
+          { type: 'session.idle', properties: { sessionID } },
+        ];
+
+      default:
+        return [];
+    }
+  }
+
+  private toolPart(id: string, tool: string, state: Record<string, unknown>): Wire {
+    return {
+      type: 'message.part.updated',
+      properties: {
+        sessionID: this.sessionID,
+        part: { id, messageID: this.currentMessageId, sessionID: this.sessionID, type: 'tool', tool, callID: id, state },
+      },
+    };
+  }
+}

--- a/spikes/pi-worker/src/kortix-env.ts
+++ b/spikes/pi-worker/src/kortix-env.ts
@@ -17,6 +17,8 @@
  * `Result.err` rather than letting them escape.
  */
 
+import { makeTransport, type RpcTransport } from './rpc-transport.ts';
+
 type Ok<T> = { ok: true; value: T };
 type Err<E> = { ok: false; error: E };
 type Result<T, E> = Ok<T> | Err<E>;
@@ -45,6 +47,8 @@ class ExecutionErrorLike extends Error {
   }
 }
 
+export type TransportKind = 'fetch' | 'keepalive' | 'ws';
+
 export interface KortixEnvOptions {
   /** Base URL of the environment's RPC endpoint. In production this is the Kortix sandbox proxy. */
   baseUrl: string;
@@ -56,6 +60,8 @@ export interface KortixEnvOptions {
   headers?: Record<string, string>;
   /** Per-call timeout. */
   timeoutMs?: number;
+  /** Which transport carries the RPC. See src/rpc-transport.ts and the gate. */
+  transport?: TransportKind;
 }
 
 export class KortixExecutionEnv {
@@ -63,6 +69,7 @@ export class KortixExecutionEnv {
   private readonly baseUrl: string;
   private readonly token?: string;
   private readonly headers: Record<string, string>;
+  private readonly transport: RpcTransport;
   private readonly timeoutMs: number;
 
   /** Every RPC that crossed the boundary. The proof harness reads this. */
@@ -73,6 +80,9 @@ export class KortixExecutionEnv {
     this.cwd = opts.cwd;
     this.token = opts.token;
     this.headers = opts.headers ?? {};
+    // Default to keepalive: one pooled connection, handshake paid once per
+    // session rather than once per tool call. See the RPC-tax gate.
+    this.transport = makeTransport(opts.transport ?? 'keepalive', this.baseUrl, this.headers);
     this.timeoutMs = opts.timeoutMs ?? 120_000;
   }
 
@@ -96,31 +106,16 @@ export class KortixExecutionEnv {
   }
 
   private async rpcOnce<T>(op: string, args: Record<string, unknown>): Promise<Result<T, any>> {
-    const ctl = new AbortController();
-    const timer = setTimeout(() => ctl.abort(), this.timeoutMs);
+    const timer = new Promise<never>((_, rej) =>
+      setTimeout(() => rej(new Error('rpc timeout')), this.timeoutMs).unref?.(),
+    );
     try {
-      const res = await fetch(`${this.baseUrl}/rpc`, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
-          ...this.headers,
-        },
-        body: JSON.stringify({ op, args, cwd: this.cwd }),
-        signal: ctl.signal,
-      });
-      if (!res.ok) {
-        return err(new FileErrorLike('unknown', `environment returned HTTP ${res.status}`));
-      }
-      const body: any = await res.json();
-      if (body.ok) return ok(body.value as T);
-      return err(new FileErrorLike(body.error?.code ?? 'unknown', body.error?.message ?? 'environment error', body.error?.path));
+      const body: any = await Promise.race([this.transport.call(op, args, this.cwd), timer]);
+      if (body?.ok) return ok(body.value as T);
+      return err(new FileErrorLike(body?.error?.code ?? 'unknown', body?.error?.message ?? 'environment error', body?.error?.path));
     } catch (e: any) {
       // Never throw. A dead environment is a Result, not an exception.
-      const aborted = e?.name === 'AbortError';
-      return err(new FileErrorLike(aborted ? 'aborted' : 'unknown', String(e?.message ?? e)));
-    } finally {
-      clearTimeout(timer);
+      return err(new FileErrorLike('unknown', String(e?.message ?? e)));
     }
   }
 

--- a/spikes/pi-worker/src/kortix-env.ts
+++ b/spikes/pi-worker/src/kortix-env.ts
@@ -52,6 +52,8 @@ export interface KortixEnvOptions {
   cwd: string;
   /** Bearer token for the environment. Optional for the local stub. */
   token?: string;
+  /** Extra headers sent with every RPC (provider preview tokens, tracing). */
+  headers?: Record<string, string>;
   /** Per-call timeout. */
   timeoutMs?: number;
 }
@@ -60,6 +62,7 @@ export class KortixExecutionEnv {
   readonly cwd: string;
   private readonly baseUrl: string;
   private readonly token?: string;
+  private readonly headers: Record<string, string>;
   private readonly timeoutMs: number;
 
   /** Every RPC that crossed the boundary. The proof harness reads this. */
@@ -69,6 +72,7 @@ export class KortixExecutionEnv {
     this.baseUrl = opts.baseUrl.replace(/\/$/, '');
     this.cwd = opts.cwd;
     this.token = opts.token;
+    this.headers = opts.headers ?? {};
     this.timeoutMs = opts.timeoutMs ?? 120_000;
   }
 
@@ -100,6 +104,7 @@ export class KortixExecutionEnv {
         headers: {
           'content-type': 'application/json',
           ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+          ...this.headers,
         },
         body: JSON.stringify({ op, args, cwd: this.cwd }),
         signal: ctl.signal,

--- a/spikes/pi-worker/src/kortix-env.ts
+++ b/spikes/pi-worker/src/kortix-env.ts
@@ -1,0 +1,185 @@
+/**
+ * KortixExecutionEnv — the whole harness/environment split, in one object.
+ *
+ * pi-agent-core's built-in tools (bash, read, write, edit) do not touch the
+ * filesystem directly. They take an `ExecutionEnv` out of their tool context
+ * (`ExecutionToolContext { env }`) and go through it for every operation. So
+ * the worker does not need to reimplement or override a single tool: it
+ * supplies THIS object instead of `NodeExecutionEnv`, and every file read,
+ * every write, and every shell command lands in the Kortix environment
+ * instead of on the worker's own disk.
+ *
+ * Contract from pi-agent-core's own docs, and it matters:
+ *   "Operation methods must never throw or reject. All filesystem failures,
+ *    including unexpected backend failures, must be encoded in the returned
+ *    Result."
+ * Every method below honours that — `rpc()` converts transport failures into
+ * `Result.err` rather than letting them escape.
+ */
+
+type Ok<T> = { ok: true; value: T };
+type Err<E> = { ok: false; error: E };
+type Result<T, E> = Ok<T> | Err<E>;
+
+const ok = <T,>(value: T): Ok<T> => ({ ok: true, value });
+const err = <E,>(error: E): Err<E> => ({ ok: false, error });
+
+/** Mirrors pi's FileError shape without importing it, so this file stays dependency-light. */
+class FileErrorLike extends Error {
+  code: string;
+  path?: string;
+  constructor(code: string, message: string, path?: string) {
+    super(message);
+    this.name = 'FileError';
+    this.code = code;
+    this.path = path;
+  }
+}
+
+class ExecutionErrorLike extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'ExecutionError';
+    this.code = code;
+  }
+}
+
+export interface KortixEnvOptions {
+  /** Base URL of the environment's RPC endpoint. In production this is the Kortix sandbox proxy. */
+  baseUrl: string;
+  /** Working directory inside the environment. */
+  cwd: string;
+  /** Bearer token for the environment. Optional for the local stub. */
+  token?: string;
+  /** Per-call timeout. */
+  timeoutMs?: number;
+}
+
+export class KortixExecutionEnv {
+  readonly cwd: string;
+  private readonly baseUrl: string;
+  private readonly token?: string;
+  private readonly timeoutMs: number;
+
+  /** Every RPC that crossed the boundary. The proof harness reads this. */
+  readonly calls: Array<{ op: string; args: unknown }> = [];
+
+  constructor(opts: KortixEnvOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/$/, '');
+    this.cwd = opts.cwd;
+    this.token = opts.token;
+    this.timeoutMs = opts.timeoutMs ?? 120_000;
+  }
+
+  /**
+   * The single boundary crossing. One persistent-friendly POST per operation.
+   *
+   * NOTE for the real implementation: this is where the per-turn RPC tax lives.
+   * A 200-tool-call turn makes 200 of these. It must become one multiplexed
+   * connection before this ships — see the latency budget in the plan.
+   */
+  private async rpc<T>(op: string, args: Record<string, unknown>): Promise<Result<T, any>> {
+    this.calls.push({ op, args });
+    // One retry: a pooled keep-alive socket retired by the peer between calls
+    // is a transport artifact, not a tool failure. See the note in
+    // stub-environment.ts — the real fix is a multiplexed connection.
+    const first = await this.rpcOnce<T>(op, args);
+    if (first.ok) return first;
+    const msg = String((first.error as any)?.message ?? '');
+    if (/socket|ECONNRESET|closed|EPIPE/i.test(msg)) return this.rpcOnce<T>(op, args);
+    return first;
+  }
+
+  private async rpcOnce<T>(op: string, args: Record<string, unknown>): Promise<Result<T, any>> {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${this.baseUrl}/rpc`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          ...(this.token ? { authorization: `Bearer ${this.token}` } : {}),
+        },
+        body: JSON.stringify({ op, args, cwd: this.cwd }),
+        signal: ctl.signal,
+      });
+      if (!res.ok) {
+        return err(new FileErrorLike('unknown', `environment returned HTTP ${res.status}`));
+      }
+      const body: any = await res.json();
+      if (body.ok) return ok(body.value as T);
+      return err(new FileErrorLike(body.error?.code ?? 'unknown', body.error?.message ?? 'environment error', body.error?.path));
+    } catch (e: any) {
+      // Never throw. A dead environment is a Result, not an exception.
+      const aborted = e?.name === 'AbortError';
+      return err(new FileErrorLike(aborted ? 'aborted' : 'unknown', String(e?.message ?? e)));
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // ---- FileSystem ---------------------------------------------------------
+  absolutePath(path: string) { return this.rpc<string>('absolutePath', { path }); }
+  joinPath(parts: string[]) { return this.rpc<string>('joinPath', { parts }); }
+  readTextFile(path: string) { return this.rpc<string>('readTextFile', { path }); }
+  readTextLines(path: string, options?: { maxLines?: number }) {
+    return this.rpc<string[]>('readTextLines', { path, maxLines: options?.maxLines });
+  }
+  async readBinaryFile(path: string): Promise<Result<Uint8Array, any>> {
+    const r = await this.rpc<string>('readBinaryFile', { path });
+    if (!r.ok) return r;
+    return ok(Uint8Array.from(Buffer.from(r.value, 'base64')));
+  }
+  writeFile(path: string, content: string | Uint8Array) {
+    const isBin = typeof content !== 'string';
+    return this.rpc<void>('writeFile', {
+      path,
+      content: isBin ? Buffer.from(content as Uint8Array).toString('base64') : content,
+      encoding: isBin ? 'base64' : 'utf8',
+    });
+  }
+  appendFile(path: string, content: string | Uint8Array) {
+    const isBin = typeof content !== 'string';
+    return this.rpc<void>('appendFile', {
+      path,
+      content: isBin ? Buffer.from(content as Uint8Array).toString('base64') : content,
+      encoding: isBin ? 'base64' : 'utf8',
+    });
+  }
+  renameFile(sourcePath: string, destinationPath: string) {
+    return this.rpc<void>('renameFile', { sourcePath, destinationPath });
+  }
+  fileInfo(path: string) { return this.rpc<any>('fileInfo', { path }); }
+  listDir(path: string) { return this.rpc<any[]>('listDir', { path }); }
+  canonicalPath(path: string) { return this.rpc<string>('canonicalPath', { path }); }
+  exists(path: string) { return this.rpc<boolean>('exists', { path }); }
+  createDir(path: string, options?: { recursive?: boolean }) {
+    return this.rpc<void>('createDir', { path, recursive: options?.recursive ?? true });
+  }
+  remove(path: string, options?: { recursive?: boolean; force?: boolean }) {
+    return this.rpc<void>('remove', { path, recursive: !!options?.recursive, force: !!options?.force });
+  }
+  createTempDir(prefix?: string) { return this.rpc<string>('createTempDir', { prefix: prefix ?? 'tmp-' }); }
+  createTempFile(options?: { prefix?: string; suffix?: string }) {
+    return this.rpc<string>('createTempFile', { prefix: options?.prefix ?? '', suffix: options?.suffix ?? '' });
+  }
+
+  // ---- Shell --------------------------------------------------------------
+  async exec(command: string, options?: any): Promise<Result<{ stdout: string; stderr: string; exitCode: number }, any>> {
+    const r = await this.rpc<{ stdout: string; stderr: string; exitCode: number }>('exec', {
+      command,
+      cwd: options?.cwd,
+      env: options?.env,
+      timeout: options?.timeout,
+    });
+    if (!r.ok) return err(new ExecutionErrorLike((r.error as any)?.code ?? 'unknown', String((r.error as any)?.message)));
+    // Streaming callbacks are honoured after the fact for the spike; the real
+    // implementation streams these over the multiplexed connection.
+    if (options?.onStdout && r.value.stdout) options.onStdout(r.value.stdout);
+    if (options?.onStderr && r.value.stderr) options.onStderr(r.value.stderr);
+    return r;
+  }
+
+  async cleanup(): Promise<void> { /* nothing local to release — that is the point */ }
+}

--- a/spikes/pi-worker/src/rpc-transport.ts
+++ b/spikes/pi-worker/src/rpc-transport.ts
@@ -1,0 +1,138 @@
+/**
+ * The transport under the ExecutionEnv — and the subject of the RPC-tax gate.
+ *
+ * Every tool call the agent makes crosses this boundary. `bash` is a local
+ * fork today, roughly a millisecond. Measured on Daytona, per-call `fetch`
+ * costs ~67 ms, which at 200 tool calls is +13 s on EVERY turn, forever —
+ * larger than the one-off boot saving the whole split is justified by.
+ *
+ * Three implementations, so the gate compares like with like:
+ *
+ *   fetch      one `fetch` per call. What the spike shipped. Whatever pooling
+ *              the runtime does, we do not control it.
+ *   keepalive  `http.request` over one explicitly-pooled agent: a single TCP
+ *              connection, handshake paid once.
+ *   ws         one WebSocket, request/response multiplexed by id. No HTTP
+ *              framing per call, and the server can push.
+ */
+import { Agent, request as httpRequest } from 'node:http';
+import { Agent as HttpsAgent } from 'node:https';
+import WebSocket from 'ws';
+
+export interface RpcTransport {
+  call(op: string, args: Record<string, unknown>, cwd: string): Promise<any>;
+  close(): Promise<void>;
+  readonly kind: string;
+}
+
+export class FetchTransport implements RpcTransport {
+  readonly kind = 'fetch';
+  constructor(private readonly baseUrl: string, private readonly headers: Record<string, string> = {}) {}
+  async call(op: string, args: Record<string, unknown>, cwd: string) {
+    const res = await fetch(`${this.baseUrl}/rpc`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...this.headers },
+      body: JSON.stringify({ op, args, cwd }),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+  async close() {}
+}
+
+/** One pooled connection. The handshake is paid once per session, not per call. */
+export class KeepAliveTransport implements RpcTransport {
+  readonly kind = 'keepalive';
+  private readonly agent: Agent | HttpsAgent;
+  private readonly url: URL;
+  constructor(baseUrl: string, private readonly headers: Record<string, string> = {}) {
+    this.url = new URL(`${baseUrl.replace(/\/$/, '')}/rpc`);
+    const opts = { keepAlive: true, maxSockets: 1, keepAliveMsecs: 30_000 };
+    this.agent = this.url.protocol === 'https:' ? new HttpsAgent(opts) : new Agent(opts);
+  }
+  call(op: string, args: Record<string, unknown>, cwd: string): Promise<any> {
+    const payload = JSON.stringify({ op, args, cwd });
+    return new Promise((resolve, reject) => {
+      const req = httpRequest(
+        {
+          protocol: this.url.protocol,
+          hostname: this.url.hostname,
+          port: this.url.port || (this.url.protocol === 'https:' ? 443 : 80),
+          path: this.url.pathname,
+          method: 'POST',
+          agent: this.agent as any,
+          headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload), ...this.headers },
+        },
+        (res) => {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', (c) => (body += c));
+          res.on('end', () => {
+            try { resolve(JSON.parse(body)); } catch (e) { reject(e); }
+          });
+        },
+      );
+      req.on('error', reject);
+      req.end(payload);
+    });
+  }
+  async close() { (this.agent as any).destroy?.(); }
+}
+
+/** One socket, many in-flight calls, correlated by id. */
+export class WebSocketTransport implements RpcTransport {
+  readonly kind = 'ws';
+  private ws?: WebSocket;
+  private ready?: Promise<void>;
+  private seq = 0;
+  private readonly pending = new Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>();
+
+  constructor(private readonly baseUrl: string, private readonly headers: Record<string, string> = {}) {}
+
+  private connect(): Promise<void> {
+    if (this.ready) return this.ready;
+    this.ready = new Promise((resolve, reject) => {
+      const url = this.baseUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/rpc-ws';
+      const ws = new WebSocket(url, { headers: this.headers });
+      this.ws = ws;
+      ws.on('open', () => resolve());
+      ws.on('error', (e) => reject(e));
+      ws.on('message', (data) => {
+        let msg: any;
+        try { msg = JSON.parse(String(data)); } catch { return; }
+        const p = this.pending.get(msg.id);
+        if (!p) return;
+        this.pending.delete(msg.id);
+        p.resolve(msg.body);
+      });
+      ws.on('close', () => {
+        for (const [, p] of this.pending) p.reject(new Error('rpc socket closed'));
+        this.pending.clear();
+        this.ready = undefined;
+      });
+    });
+    return this.ready;
+  }
+
+  async call(op: string, args: Record<string, unknown>, cwd: string): Promise<any> {
+    await this.connect();
+    const id = ++this.seq;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws!.send(JSON.stringify({ id, op, args, cwd }));
+    });
+  }
+
+  async close() {
+    this.ws?.close();
+    this.ready = undefined;
+  }
+}
+
+export function makeTransport(kind: string, baseUrl: string, headers: Record<string, string> = {}): RpcTransport {
+  switch (kind) {
+    case 'ws': return new WebSocketTransport(baseUrl, headers);
+    case 'fetch': return new FetchTransport(baseUrl, headers);
+    default: return new KeepAliveTransport(baseUrl, headers);
+  }
+}

--- a/spikes/pi-worker/src/session-store.ts
+++ b/spikes/pi-worker/src/session-store.ts
@@ -1,0 +1,152 @@
+/**
+ * S0.4 — a durable session store the worker does not own.
+ *
+ * THE REQUIREMENT, from the plan: history must be readable when nothing is
+ * running. Today fetching messages means waking a box, waiting for the daemon,
+ * waiting for OpenCode to listen, then calling an API built for a local editor.
+ * That is the "session looks stopped, then a huge delay" class of bug.
+ *
+ * THE SHAPE. pi-agent-core's `SessionStorage` is a 20-method interface with
+ * lane pointers, branch queries and open-operation recovery. Reimplementing
+ * that against a network store would be reimplementing pi's tree semantics,
+ * badly. So this decorates the in-memory implementation instead:
+ *
+ *   - every mutation is written through to an append-only remote log;
+ *   - `restore()` replays that log into a fresh in-memory storage.
+ *
+ * pi keeps owning the tree. We own durability. The log is plain JSON entries,
+ * so the control plane can render a transcript without pi in the picture at
+ * all — which is P1.8, previewed.
+ *
+ * FIDELITY, STATED EXACTLY. The log is the source of truth and is byte-exact:
+ * ids, order, message content, tool calls, tool results and original
+ * timestamps all survive. Replay rebuilds the tree with the SAME ids in the
+ * SAME order; `seq`/`parentId` are recomputed identically because the sequence
+ * is identical, and `timestamp` is re-stamped because `appendEntry` owns it.
+ * A reader that wants original timestamps reads the log, not the replayed
+ * tree. Nothing about a conversation is lost; one derived field is refreshed.
+ */
+import { InMemorySessionStorage } from '@earendil-works/pi-agent-core';
+
+type LogItem =
+  | { kind: 'entry'; lane: string; entry: any }
+  | { kind: 'record'; record: any }
+  | { kind: 'lane_create'; lane: string; at: string | null }
+  | { kind: 'lane_move'; lane: string; to: string | null }
+  | { kind: 'name'; name: string | undefined }
+  | { kind: 'label'; id: string; label: string | undefined };
+
+export interface SessionLog {
+  append(item: LogItem): Promise<void>;
+  read(): Promise<LogItem[]>;
+}
+
+/** Append-only log over HTTP. Stands in for the Kortix control plane. */
+export class RemoteSessionLog implements SessionLog {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly sessionId: string,
+    private readonly headers: Record<string, string> = {},
+  ) {}
+
+  async append(item: LogItem): Promise<void> {
+    // Fire-and-await: a lost append is a lost message, which is the one thing
+    // this exists to prevent. Failures propagate rather than being swallowed.
+    const res = await fetch(`${this.baseUrl}/sessions/${this.sessionId}/log`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...this.headers },
+      body: JSON.stringify(item),
+    });
+    if (!res.ok) throw new Error(`session log append failed: HTTP ${res.status}`);
+  }
+
+  async read(): Promise<LogItem[]> {
+    const res = await fetch(`${this.baseUrl}/sessions/${this.sessionId}/log`, { headers: this.headers });
+    if (res.status === 404) return [];
+    if (!res.ok) throw new Error(`session log read failed: HTTP ${res.status}`);
+    return (await res.json()) as LogItem[];
+  }
+}
+
+/**
+ * Write-through decorator over InMemorySessionStorage.
+ *
+ * Reads are served entirely from memory — the remote store is never on the
+ * read path of a running turn. Only mutations cross the network.
+ */
+export class DurableSessionStorage {
+  private constructor(
+    private readonly inner: InMemorySessionStorage,
+    private readonly log: SessionLog,
+    /** Suppressed while replaying, so restore does not re-write the log. */
+    private replaying = false,
+  ) {}
+
+  static async open(metadata: any, log: SessionLog): Promise<{ storage: DurableSessionStorage; restoredEntries: number }> {
+    const inner = new InMemorySessionStorage(metadata);
+    const durable = new DurableSessionStorage(inner, log, true);
+    const items = await log.read();
+    for (const item of items) {
+      switch (item.kind) {
+        case 'lane_create': await inner.createLane(item.lane, item.at); break;
+        case 'lane_move': await inner.moveLane(item.lane, item.to); break;
+        case 'entry': {
+          // Strip the storage-owned fields; the id is ours and is preserved.
+          const { parentId: _p, seq: _s, timestamp: _t, ...provisioned } = item.entry;
+          await inner.appendEntry(provisioned as any, item.lane);
+          break;
+        }
+        case 'record': await inner.appendRecord(item.record); break;
+        case 'name': await inner.setName(item.name); break;
+        case 'label': await inner.setLabel(item.id, item.label); break;
+      }
+    }
+    durable.replaying = false;
+    return { storage: durable, restoredEntries: items.filter((i) => i.kind === 'entry').length };
+  }
+
+  private async write(item: LogItem): Promise<void> {
+    if (!this.replaying) await this.log.append(item);
+  }
+
+  // ---- mutations: write through -------------------------------------------
+  async appendEntry(entry: any, lane: string) {
+    const stored = await this.inner.appendEntry(entry, lane);
+    await this.write({ kind: 'entry', lane, entry: stored });
+    return stored;
+  }
+  async appendRecord(record: any) {
+    const stored = await this.inner.appendRecord(record);
+    await this.write({ kind: 'record', record: stored });
+    return stored;
+  }
+  async createLane(lane: string, at: string | null) {
+    await this.inner.createLane(lane, at);
+    await this.write({ kind: 'lane_create', lane, at });
+  }
+  async moveLane(lane: string, to: string | null) {
+    await this.inner.moveLane(lane, to);
+    await this.write({ kind: 'lane_move', lane, to });
+  }
+  async setName(name: string | undefined) {
+    await this.inner.setName(name);
+    await this.write({ kind: 'name', name });
+  }
+  async setLabel(id: string, label: string | undefined) {
+    await this.inner.setLabel(id, label);
+    await this.write({ kind: 'label', id, label });
+  }
+
+  // ---- reads: straight through, never touch the network --------------------
+  getMetadata() { return this.inner.getMetadata(); }
+  getLanes() { return this.inner.getLanes(); }
+  getEntry(id: string) { return this.inner.getEntry(id); }
+  findEntries(q?: any) { return this.inner.findEntries(q); }
+  findEntriesOnBranch(q: any) { return this.inner.findEntriesOnBranch(q); }
+  findRecords(q?: any) { return (this.inner as any).findRecords(q); }
+  findOpenOperations(lane: string, o?: any) { return this.inner.findOpenOperations(lane, o); }
+  getLog(o?: any) { return this.inner.getLog(o); }
+  getName() { return this.inner.getName(); }
+  getLabel(id: string) { return this.inner.getLabel(id); }
+  getStats() { return this.inner.getStats(); }
+}

--- a/spikes/pi-worker/src/store-service.ts
+++ b/spikes/pi-worker/src/store-service.ts
@@ -1,0 +1,66 @@
+/**
+ * Stand-in for the Kortix control plane's session store.
+ *
+ * Append-only JSONL per session, over HTTP. Two routes:
+ *   POST /sessions/:id/log   append one item
+ *   GET  /sessions/:id/log   read the whole log
+ *
+ * In production this is the Kortix API backed by Postgres or object storage.
+ * The point of it being a separate process here is that it OUTLIVES the
+ * worker: killing the worker must not take the conversation with it.
+ */
+import { createServer } from 'node:http';
+import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export async function startStoreService(opts: { root: string; port?: number }) {
+  const root = resolve(opts.root);
+  await mkdir(root, { recursive: true });
+  const fileFor = (id: string) => join(root, `${id.replace(/[^a-zA-Z0-9_-]/g, '_')}.jsonl`);
+
+  const server = createServer((req, res) => {
+    const m = /^\/sessions\/([^/]+)\/log$/.exec(req.url ?? '');
+    if (!m) { res.writeHead(404).end(); return; }
+    const file = fileFor(decodeURIComponent(m[1]));
+
+    if (req.method === 'GET') {
+      if (!existsSync(file)) { res.writeHead(404).end('[]'); return; }
+      readFile(file, 'utf8').then((text) => {
+        const items = text.split('\n').filter(Boolean).map((l) => JSON.parse(l));
+        const payload = JSON.stringify(items);
+        res.writeHead(200, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) }).end(payload);
+      });
+      return;
+    }
+
+    if (req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', async () => {
+        try {
+          JSON.parse(body); // reject malformed before it reaches the log
+          await appendFile(file, body.replace(/\n/g, ' ') + '\n');
+          res.writeHead(200, { 'content-type': 'application/json' }).end('{"ok":true}');
+        } catch (e: any) {
+          res.writeHead(400, { 'content-type': 'application/json' })
+             .end(JSON.stringify({ ok: false, error: String(e?.message ?? e) }));
+        }
+      });
+      return;
+    }
+    res.writeHead(405).end();
+  });
+
+  server.keepAliveTimeout = 120_000;
+  server.headersTimeout = 125_000;
+  await new Promise<void>((r) => server.listen(opts.port ?? 0, '0.0.0.0', r));
+  const port = (server.address() as any).port;
+  return { port, root, url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  startStoreService({ root: process.env.STORE_ROOT ?? join(tmpdir(), 'kortix-session-store'), port: Number(process.env.PORT ?? 8200) })
+    .then((s) => console.log(`[store-service] ${s.url}  root=${s.root}`));
+}

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -14,7 +14,6 @@ import { createServer } from 'node:http';
 import { WebSocketServer } from 'ws';
 import { exec as execCb } from 'node:child_process';
 import { promisify } from 'node:util';
-import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -11,6 +11,7 @@
  * files created by the agent land HERE and not in the worker's process cwd.
  */
 import { createServer } from 'node:http';
+import { WebSocketServer } from 'ws';
 import { exec as execCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import * as fs from 'node:fs/promises';
@@ -140,12 +141,45 @@ export async function startStubEnvironment(opts: StubEnvOptions) {
   // reusing it and the next RPC dies with "socket connection was closed".
   // The production answer is one multiplexed connection per session, not a
   // longer timeout — this is the spike making the problem visible, not solved.
+  // Multiplexed transport: one socket, many in-flight calls correlated by id.
+  // Same op table as /rpc — the transport changes, the protocol does not.
+  const wss = new WebSocketServer({ server, path: '/rpc-ws' });
+  wss.on('connection', (socket) => {
+    socket.on('message', async (raw) => {
+      let msg: any;
+      try { msg = JSON.parse(String(raw)); } catch { return; }
+      let body: unknown;
+      try {
+        const fn = ops[msg.op];
+        body = fn
+          ? { ok: true, value: await fn(msg.args ?? {}, msg.cwd ?? '/workspace') }
+          : { ok: false, error: { code: 'not_supported', message: `no op ${msg.op}` } };
+      } catch (e: any) {
+        body = { ok: false, error: { code: codeFor(e), message: String(e?.message ?? e), path: e?.path } };
+      }
+      socket.send(JSON.stringify({ id: msg.id, body }));
+    });
+  });
+
   server.keepAliveTimeout = 120_000;
   server.headersTimeout = 125_000;
 
   await new Promise<void>((r) => server.listen(opts.port ?? 0, '0.0.0.0', r));
   const port = (server.address() as any).port;
-  return { port, root, url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+  return {
+    port, root, url: `http://127.0.0.1:${port}`,
+    // Forceful on purpose: `server.close()` waits for every live connection to
+    // end, and a keep-alive socket or an open WebSocket will hold it open
+    // forever. A test that hangs on teardown looks exactly like a test that
+    // silently passed, which is worse than one that fails.
+    close: () =>
+      new Promise<void>((r) => {
+        for (const client of wss.clients) client.terminate();
+        wss.close();
+        (server as any).closeAllConnections?.();
+        server.close(() => r());
+      }),
+  };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -199,7 +199,13 @@ export async function startStubEnvironment(opts: StubEnvOptions) {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  const root = process.env.ENV_ROOT ?? path.join(os.tmpdir(), 'kortix-stub-env');
+  // A FIXED name under the shared os tmpdir was the one real instance of the
+  // insecure-temp-file pattern here: another local user could pre-create
+  // /tmp/kortix-stub-env and own everything the stub writes. mkdtemp gives the
+  // standalone default a private, unpredictable root; tests and the Docker
+  // image always pass ENV_ROOT explicitly.
+  const root =
+    process.env.ENV_ROOT ?? (await fs.mkdtemp(path.join(os.tmpdir(), 'kortix-stub-env-')));
   startStubEnvironment({ root, port: Number(process.env.PORT ?? 8100) }).then((s) =>
     console.log(`[stub-environment] ${s.url}  root=${s.root}`),
   );

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -89,29 +89,35 @@ export async function startStubEnvironment(opts: StubEnvOptions) {
     exists: async (a, cwd) => { try { await fs.lstat(abs(a.path, cwd)); return true; } catch (e: any) { if (e.code === 'ENOENT') return false; throw e; } },
     createDir: async (a, cwd) => { await fs.mkdir(abs(a.path, cwd), { recursive: a.recursive !== false }); },
     remove: async (a, cwd) => { await fs.rm(abs(a.path, cwd), { recursive: !!a.recursive, force: !!a.force }); },
-    createTempDir: async (a, cwd) => {
-      const d = await fs.mkdtemp(path.join(abs('/tmp', cwd), a.prefix ?? 'tmp-').replace(/\/$/, ''));
+    // Temp objects live under a root-private staging area, never a shared or
+    // world-writable temp dir: fs.mkdtemp gives the crypto-random component,
+    // and the parent is inside this environment's own jail (`root`), so no
+    // other principal can pre-create or swap entries (the attack
+    // js/insecure-temporary-file exists for). Env-visible paths come back
+    // root-relative, like every other op here.
+    createTempDir: async (a, _cwd) => {
+      const staging = path.join(root, 'ephemeral');
+      await fs.mkdir(staging, { recursive: true });
+      const d = await fs.mkdtemp(path.join(staging, a.prefix ?? 'tmp-'));
       return d.slice(root.length);
     },
-    createTempFile: async (a, cwd) => {
-      const d = abs('/tmp', cwd);
-      await fs.mkdir(d, { recursive: true });
-      // Crypto-random name + exclusive create: the env root is private to this
-      // stub, but a predictable Date.now() name is still the pattern CodeQL's
-      // js/insecure-temporary-file exists to kill. 'wx' refuses to clobber.
-      const f = path.join(d, `${a.prefix ?? ''}${randomBytes(12).toString('hex')}${a.suffix ?? ''}`);
+    createTempFile: async (a, _cwd) => {
+      const staging = path.join(root, 'ephemeral');
+      await fs.mkdir(staging, { recursive: true });
+      const d = await fs.mkdtemp(path.join(staging, 'f-'));
+      const f = path.join(d, `${a.prefix ?? ''}file${a.suffix ?? ''}`);
       await fs.writeFile(f, '', { flag: 'wx' });
       return f.slice(root.length);
     },
     exec: async (a, cwd) => {
-      // codeql[js/command-line-injection] — intentional: this op IS "execute a
-      // shell command", standing in for the sandbox daemon's bash contract.
-      // Benchmark/test scaffolding only; never deployed, binds loopback in
-      // tests, and the Daytona benches run it inside a disposable sandbox.
+      // Intentional by contract: this op IS "execute a shell command" — the
+      // stub stands in for the sandbox daemon's bash tool. Test/benchmark
+      // scaffolding only; never deployed, loopback in tests, disposable
+      // sandboxes in benches. Suppressed on the call line below.
       const wd = abs(a.cwd ?? cwd, cwd);
       await fs.mkdir(wd, { recursive: true });
       try {
-        const { stdout, stderr } = await execAsync(a.command, {
+        const { stdout, stderr } = await execAsync(a.command, { // codeql[js/command-line-injection]
           cwd: wd,
           env: { ...process.env, ...(a.env ?? {}) },
           timeout: a.timeout ? a.timeout * 1000 : undefined,

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -1,0 +1,156 @@
+/**
+ * A stand-in for a Kortix environment: a plain HTTP server that executes the
+ * ExecutionEnv RPC protocol against a real filesystem and a real shell.
+ *
+ * This exists so the worker can be proven end-to-end with no Kortix
+ * credentials and no provisioned sandbox. In production this role is played by
+ * the sandbox daemon behind `/v1/p/<external_id>/8000/...`; the protocol is
+ * the same, the transport is the same, only the address changes.
+ *
+ * It deliberately runs with its own root directory so a test can assert that
+ * files created by the agent land HERE and not in the worker's process cwd.
+ */
+import { createServer } from 'node:http';
+import { exec as execCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const execAsync = promisify(execCb);
+
+export interface StubEnvOptions { root: string; port?: number }
+
+const codeFor = (e: any): string => {
+  switch (e?.code) {
+    case 'ENOENT': return 'not_found';
+    case 'EACCES': case 'EPERM': return 'permission_denied';
+    case 'ENOTDIR': return 'not_directory';
+    case 'EISDIR': return 'is_directory';
+    default: return 'unknown';
+  }
+};
+
+export async function startStubEnvironment(opts: StubEnvOptions) {
+  const root = path.resolve(opts.root);
+  await fs.mkdir(root, { recursive: true });
+
+  /** Resolve into the environment root. Nothing may address outside it. */
+  const abs = (p: string, cwd: string) => {
+    const joined = path.isAbsolute(p) ? p : path.join(cwd, p);
+    const full = path.resolve(root, '.' + (joined.startsWith('/') ? joined : '/' + joined));
+    if (!full.startsWith(root)) throw Object.assign(new Error('outside root'), { code: 'EACCES' });
+    return full;
+  };
+  const toInfo = async (full: string, shown: string) => {
+    const st = await fs.lstat(full);
+    return {
+      name: path.basename(shown),
+      path: shown,
+      kind: st.isDirectory() ? 'directory' : st.isSymbolicLink() ? 'symlink' : 'file',
+      size: st.size,
+      mtimeMs: st.mtimeMs,
+    };
+  };
+
+  const ops: Record<string, (a: any, cwd: string) => Promise<unknown>> = {
+    absolutePath: async (a, cwd) => (path.isAbsolute(a.path) ? a.path : path.posix.join(cwd, a.path)),
+    joinPath: async (a) => path.posix.join(...a.parts),
+    readTextFile: async (a, cwd) => fs.readFile(abs(a.path, cwd), 'utf8'),
+    readTextLines: async (a, cwd) => {
+      const t = await fs.readFile(abs(a.path, cwd), 'utf8');
+      const lines = t.split('\n');
+      return a.maxLines ? lines.slice(0, a.maxLines) : lines;
+    },
+    readBinaryFile: async (a, cwd) => (await fs.readFile(abs(a.path, cwd))).toString('base64'),
+    writeFile: async (a, cwd) => {
+      const f = abs(a.path, cwd);
+      await fs.mkdir(path.dirname(f), { recursive: true });
+      await fs.writeFile(f, a.encoding === 'base64' ? Buffer.from(a.content, 'base64') : a.content);
+    },
+    appendFile: async (a, cwd) => {
+      const f = abs(a.path, cwd);
+      await fs.mkdir(path.dirname(f), { recursive: true });
+      await fs.appendFile(f, a.encoding === 'base64' ? Buffer.from(a.content, 'base64') : a.content);
+    },
+    renameFile: async (a, cwd) => { await fs.rename(abs(a.sourcePath, cwd), abs(a.destinationPath, cwd)); },
+    fileInfo: async (a, cwd) => toInfo(abs(a.path, cwd), path.isAbsolute(a.path) ? a.path : path.posix.join(cwd, a.path)),
+    listDir: async (a, cwd) => {
+      const shown = path.isAbsolute(a.path) ? a.path : path.posix.join(cwd, a.path);
+      const names = await fs.readdir(abs(a.path, cwd));
+      return Promise.all(names.map((n) => toInfo(path.join(abs(a.path, cwd), n), path.posix.join(shown, n))));
+    },
+    canonicalPath: async (a, cwd) => {
+      const real = await fs.realpath(abs(a.path, cwd));
+      return real.slice(root.length) || '/';
+    },
+    exists: async (a, cwd) => { try { await fs.lstat(abs(a.path, cwd)); return true; } catch (e: any) { if (e.code === 'ENOENT') return false; throw e; } },
+    createDir: async (a, cwd) => { await fs.mkdir(abs(a.path, cwd), { recursive: a.recursive !== false }); },
+    remove: async (a, cwd) => { await fs.rm(abs(a.path, cwd), { recursive: !!a.recursive, force: !!a.force }); },
+    createTempDir: async (a, cwd) => {
+      const d = await fs.mkdtemp(path.join(abs('/tmp', cwd), a.prefix ?? 'tmp-').replace(/\/$/, ''));
+      return d.slice(root.length);
+    },
+    createTempFile: async (a, cwd) => {
+      const d = abs('/tmp', cwd);
+      await fs.mkdir(d, { recursive: true });
+      const f = path.join(d, `${a.prefix ?? ''}${Date.now()}${Math.floor(Math.random() * 1e6)}${a.suffix ?? ''}`);
+      await fs.writeFile(f, '');
+      return f.slice(root.length);
+    },
+    exec: async (a, cwd) => {
+      const wd = abs(a.cwd ?? cwd, cwd);
+      await fs.mkdir(wd, { recursive: true });
+      try {
+        const { stdout, stderr } = await execAsync(a.command, {
+          cwd: wd,
+          env: { ...process.env, ...(a.env ?? {}) },
+          timeout: a.timeout ? a.timeout * 1000 : undefined,
+          maxBuffer: 16 * 1024 * 1024,
+        });
+        return { stdout, stderr, exitCode: 0 };
+      } catch (e: any) {
+        return { stdout: e.stdout ?? '', stderr: e.stderr ?? String(e.message), exitCode: e.code ?? 1 };
+      }
+    },
+  };
+
+  const server = createServer((req, res) => {
+    if (req.method !== 'POST' || !req.url?.startsWith('/rpc')) { res.writeHead(404).end(); return; }
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', async () => {
+      let out: any;
+      try {
+        const { op, args, cwd } = JSON.parse(body);
+        const fn = ops[op];
+        if (!fn) out = { ok: false, error: { code: 'not_supported', message: `no op ${op}` } };
+        else out = { ok: true, value: await fn(args ?? {}, cwd ?? '/workspace') };
+      } catch (e: any) {
+        out = { ok: false, error: { code: codeFor(e), message: String(e?.message ?? e), path: e?.path } };
+      }
+      const payload = JSON.stringify(out);
+      res.writeHead(200, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) });
+      res.end(payload);
+    });
+  });
+
+  // Per-call HTTP is fragile precisely the way the plan predicts: without
+  // these, Node retires an idle keep-alive socket while the client is still
+  // reusing it and the next RPC dies with "socket connection was closed".
+  // The production answer is one multiplexed connection per session, not a
+  // longer timeout — this is the spike making the problem visible, not solved.
+  server.keepAliveTimeout = 120_000;
+  server.headersTimeout = 125_000;
+
+  await new Promise<void>((r) => server.listen(opts.port ?? 0, '0.0.0.0', r));
+  const port = (server.address() as any).port;
+  return { port, root, url: `http://127.0.0.1:${port}`, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const root = process.env.ENV_ROOT ?? path.join(os.tmpdir(), 'kortix-stub-env');
+  startStubEnvironment({ root, port: Number(process.env.PORT ?? 8100) }).then((s) =>
+    console.log(`[stub-environment] ${s.url}  root=${s.root}`),
+  );
+}

--- a/spikes/pi-worker/src/stub-environment.ts
+++ b/spikes/pi-worker/src/stub-environment.ts
@@ -14,6 +14,7 @@ import { createServer } from 'node:http';
 import { WebSocketServer } from 'ws';
 import { exec as execCb } from 'node:child_process';
 import { promisify } from 'node:util';
+import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -95,11 +96,18 @@ export async function startStubEnvironment(opts: StubEnvOptions) {
     createTempFile: async (a, cwd) => {
       const d = abs('/tmp', cwd);
       await fs.mkdir(d, { recursive: true });
-      const f = path.join(d, `${a.prefix ?? ''}${Date.now()}${Math.floor(Math.random() * 1e6)}${a.suffix ?? ''}`);
-      await fs.writeFile(f, '');
+      // Crypto-random name + exclusive create: the env root is private to this
+      // stub, but a predictable Date.now() name is still the pattern CodeQL's
+      // js/insecure-temporary-file exists to kill. 'wx' refuses to clobber.
+      const f = path.join(d, `${a.prefix ?? ''}${randomBytes(12).toString('hex')}${a.suffix ?? ''}`);
+      await fs.writeFile(f, '', { flag: 'wx' });
       return f.slice(root.length);
     },
     exec: async (a, cwd) => {
+      // codeql[js/command-line-injection] — intentional: this op IS "execute a
+      // shell command", standing in for the sandbox daemon's bash contract.
+      // Benchmark/test scaffolding only; never deployed, binds loopback in
+      // tests, and the Daytona benches run it inside a disposable sandbox.
       const wd = abs(a.cwd ?? cwd, cwd);
       await fs.mkdir(wd, { recursive: true });
       try {
@@ -128,7 +136,10 @@ export async function startStubEnvironment(opts: StubEnvOptions) {
         if (!fn) out = { ok: false, error: { code: 'not_supported', message: `no op ${op}` } };
         else out = { ok: true, value: await fn(args ?? {}, cwd ?? '/workspace') };
       } catch (e: any) {
-        out = { ok: false, error: { code: codeFor(e), message: String(e?.message ?? e), path: e?.path } };
+        // First line only: an Error whose message embeds a stack (some libs do)
+        // must not leak frames to the caller (js/stack-trace-exposure).
+        const msg = String(e?.message ?? e).split('\n')[0];
+        out = { ok: false, error: { code: codeFor(e), message: msg, path: e?.path } };
       }
       const payload = JSON.stringify(out);
       res.writeHead(200, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) });

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -32,7 +32,38 @@ import {
   fauxToolCall,
 } from '@earendil-works/pi-ai';
 import { AssistantMessageEventStream } from '@earendil-works/pi-ai';
+import { Session } from '@earendil-works/pi-agent-core';
 import { KortixExecutionEnv } from './kortix-env.ts';
+import { DurableSessionStorage, RemoteSessionLog } from './session-store.ts';
+
+/**
+ * pi's session layer runs `assertJsonSerializable` on every durable payload:
+ * no `undefined`, no non-finite numbers, no cycles. That is a deliberate and
+ * correct guard — it means anything accepted into a session is guaranteed
+ * persistable — but provider messages routinely carry `undefined` optional
+ * fields, so a bridge has to normalize before appending.
+ *
+ * Dropping an `undefined`-valued key is lossless: JSON has no representation
+ * for it, and a reader cannot distinguish "absent" from "present but
+ * undefined". Non-finite numbers would be a real loss, so those are surfaced
+ * rather than silently coerced.
+ */
+function toDurable<T>(value: T, path = 'message'): T {
+  if (value === null) return value;
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new Error(`non-finite number at ${path} cannot be persisted`);
+  }
+  if (Array.isArray(value)) return value.map((v, i) => toDurable(v, `${path}[${i}]`)) as unknown as T;
+  if (typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === undefined) continue;
+      out[k] = toDurable(v, `${path}.${k}`);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}
 
 /**
  * True time-to-first-token.
@@ -101,6 +132,10 @@ export interface WorkerConfig {
   modelId?: string;
   apiKey?: string;
   gatewayUrl?: string;
+  /** Durable session store. Absent = in-memory only (conversation dies with the process). */
+  storeUrl?: string;
+  storeHeaders?: Record<string, string>;
+  sessionId?: string;
 }
 
 export function configFromEnv(): WorkerConfig {
@@ -119,6 +154,9 @@ export function configFromEnv(): WorkerConfig {
     modelId: process.env.KORTIX_MODEL,
     apiKey: process.env.KORTIX_API_KEY,
     gatewayUrl: process.env.KORTIX_GATEWAY_URL,
+    storeUrl: process.env.KORTIX_STORE_URL,
+    storeHeaders: process.env.KORTIX_STORE_HEADERS ? JSON.parse(process.env.KORTIX_STORE_HEADERS) : undefined,
+    sessionId: process.env.KORTIX_SESSION_ID ?? 'session-local',
   };
 }
 
@@ -180,6 +218,23 @@ export async function buildHarness(cfg: WorkerConfig) {
   const tools = [createBashTool(), createReadTool(), createWriteTool(), createEditTool()]
     .map((t) => bindTool(t, toolContext));
 
+  // Durable transcript. The worker is a cache of it, not its owner: kill this
+  // process and the conversation is still whole in the store.
+  let session: Session | undefined;
+  let restoredEntries = 0;
+  let restoredMessages: any[] = [];
+  if (cfg.storeUrl && cfg.sessionId) {
+    const log = new RemoteSessionLog(cfg.storeUrl, cfg.sessionId, cfg.storeHeaders ?? {});
+    const opened = await DurableSessionStorage.open({ id: cfg.sessionId } as any, log);
+    restoredEntries = opened.restoredEntries;
+    session = new Session(opened.storage as any);
+    const leaf = await session.getLeafId();
+    if (leaf) {
+      const entries = await session.findEntriesOnBranch({ start: leaf } as any);
+      restoredMessages = entries.filter((e: any) => e.type === 'message').map((e: any) => e.message);
+    }
+  }
+
   const timing: { firstTokenMs: number | null } = { firstTokenMs: null };
 
   const agent = new Agent({
@@ -193,11 +248,32 @@ export async function buildHarness(cfg: WorkerConfig) {
       model,
       thinkingLevel: 'off',
       tools,
-      messages: [],
+      // Seeded from the durable store, so a restarted worker continues the
+      // same conversation rather than starting a new one.
+      messages: restoredMessages,
     } as any,
   });
 
-  return { agent, env, faux, models, timing };
+  // Bridge Agent -> Session. AgentHarness would own this natively, but every
+  // one of its 23 methods throws HarnessNotImplemented in 0.84.3, so the
+  // projection is ours — the fallback the plan named for exactly this case.
+  // The on-disk shape is still pi's own MessageEntry, so this stays compatible
+  // when AgentHarness lands.
+  if (session) {
+    let persisted = restoredMessages.length;
+    agent.subscribe(async (event: any) => {
+      if (event.type !== 'agent_end' && event.type !== 'turn_end') return;
+      const all = agent.state.messages;
+      for (let i = persisted; i < all.length; i++) {
+        await session!.appendMessage(toDurable(all[i])).catch((e) =>
+          console.error(JSON.stringify({ msg: 'session append failed', error: String(e?.message ?? e) })),
+        );
+      }
+      persisted = all.length;
+    });
+  }
+
+  return { agent, env, faux, models, timing, session, restoredEntries, restoredMessages };
 }
 
 let LISTEN_UPTIME_MS: number | null = null;
@@ -206,7 +282,7 @@ let LISTEN_UPTIME_MS: number | null = null;
 let LISTEN_MS: number | null = null;
 
 export async function startWorker(cfg = configFromEnv()) {
-  const { agent, env, faux, timing } = await buildHarness(cfg);
+  const { agent, env, faux, timing, session, restoredEntries } = await buildHarness(cfg);
   const listeners = new Set<(chunk: string) => void>();
 
   agent.subscribe((event: any) => {
@@ -226,6 +302,7 @@ export async function startWorker(cfg = configFromEnv()) {
         vmUptimeNowMs: vmUptimeMs(),
         modelMode: cfg.modelMode,
         environment: { url: cfg.envUrl, cwd: cfg.envCwd, rpcCalls: env.calls.length },
+        store: cfg.storeUrl ? { url: cfg.storeUrl, sessionId: cfg.sessionId, restoredEntries } : null,
       });
       res.writeHead(200, { 'content-type': 'application/json' }).end(body);
       return;
@@ -335,6 +412,21 @@ export async function startWorker(cfg = configFromEnv()) {
              .end(JSON.stringify({ ok: false, error: String(e?.message ?? e) }));
         }
       });
+      return;
+    }
+
+    // History straight from the durable tree. Present here for convenience;
+    // the real point is that the SAME data is readable from the store with no
+    // worker running at all — see bench/read-transcript.ts.
+    if (url.pathname === '/history') {
+      if (!session) { res.writeHead(200, { 'content-type': 'application/json' }).end('{"messages":[]}'); return; }
+      const leaf = await session.getLeafId();
+      const entries = leaf ? await session.findEntriesOnBranch({ start: leaf } as any) : [];
+      const payload = JSON.stringify({
+        restoredEntries,
+        messages: entries.filter((e: any) => e.type === 'message').map((e: any) => e.message),
+      });
+      res.writeHead(200, { 'content-type': 'application/json' }).end(payload);
       return;
     }
 

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -35,11 +35,29 @@ import { KortixExecutionEnv } from './kortix-env.ts';
 
 const BOOT_T0 = Date.now();
 
+/**
+ * Seconds since the machine booted, read at the moment we start serving.
+ *
+ * This is the number the whole project turns on. The in-guest clock the
+ * platform already has (`bootMark()` in kortixd) starts at PROCESS start, so
+ * it cannot see VM allocation or rootfs restore — the two costs the small
+ * image actually removes. Reading /proc/uptime at listen time gives
+ * machine-boot -> serving from inside the box, with no dependency on the
+ * benchmark host's clock or its latency to the provider.
+ */
+function vmUptimeMs(): number | null {
+  try {
+    const raw = require('node:fs').readFileSync('/proc/uptime', 'utf8');
+    return Math.round(Number.parseFloat(raw.split(' ')[0]) * 1000);
+  } catch { return null; }
+}
+
 export interface WorkerConfig {
   port: number;
   envUrl: string;
   envCwd: string;
   envToken?: string;
+  envHeaders?: Record<string, string>;
   systemPrompt: string;
   modelMode: 'faux' | 'real';
   providerId?: string;
@@ -55,6 +73,7 @@ export function configFromEnv(): WorkerConfig {
     envUrl: process.env.KORTIX_ENV_URL ?? 'http://127.0.0.1:8100',
     envCwd: process.env.KORTIX_ENV_CWD ?? '/workspace',
     envToken: process.env.KORTIX_ENV_TOKEN,
+    envHeaders: process.env.KORTIX_ENV_HEADERS ? JSON.parse(process.env.KORTIX_ENV_HEADERS) : undefined,
     systemPrompt:
       process.env.KORTIX_SYSTEM_PROMPT ??
       'You are a Kortix agent. All file and shell work happens in the environment, never locally.',
@@ -86,7 +105,7 @@ function bindTool(tool: any, context: object) {
 }
 
 export async function buildHarness(cfg: WorkerConfig) {
-  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken });
+  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken, headers: cfg.envHeaders });
 
   const credentials = new InMemoryCredentialStore();
   const models = createModels({ credentials });
@@ -135,6 +154,11 @@ export async function buildHarness(cfg: WorkerConfig) {
   return { agent, env, faux, models };
 }
 
+let LISTEN_UPTIME_MS: number | null = null;
+/** Process start -> listening. Captured ONCE at listen; reporting
+ *  `Date.now() - BOOT_T0` at request time measures process AGE, not boot. */
+let LISTEN_MS: number | null = null;
+
 export async function startWorker(cfg = configFromEnv()) {
   const { agent, env, faux } = await buildHarness(cfg);
   const listeners = new Set<(chunk: string) => void>();
@@ -150,7 +174,10 @@ export async function startWorker(cfg = configFromEnv()) {
     if (url.pathname === '/health') {
       const body = JSON.stringify({
         ok: true,
-        bootMs: Date.now() - BOOT_T0,
+        bootMs: LISTEN_MS,
+        processAgeMs: Date.now() - BOOT_T0,
+        vmUptimeAtListenMs: LISTEN_UPTIME_MS,
+        vmUptimeNowMs: vmUptimeMs(),
         modelMode: cfg.modelMode,
         environment: { url: cfg.envUrl, cwd: cfg.envCwd, rpcCalls: env.calls.length },
       });
@@ -196,6 +223,40 @@ export async function startWorker(cfg = configFromEnv()) {
       return;
     }
 
+    // Streaming turn. The benchmark measures time-to-first-token off the first
+    // chunk that carries assistant text, which is what a user actually waits
+    // for — not when the turn finishes.
+    if (url.pathname === '/turn' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', async () => {
+        res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
+        const { text, script } = JSON.parse(body || '{}');
+        if (faux && Array.isArray(script)) {
+          faux.setResponses(
+            script.map((step: any) =>
+              step.tool
+                ? fauxAssistantMessage([fauxToolCall(step.tool, step.args ?? {})], { stopReason: 'toolUse' })
+                : fauxAssistantMessage(String(step.text ?? ''), { stopReason: 'stop' }),
+            ),
+          );
+        }
+        const unsub = agent.subscribe((event: any) => {
+          res.write(`data: ${JSON.stringify(event)}\n\n`);
+        });
+        try {
+          await agent.prompt(String(text ?? ''));
+          res.write(`event: done\ndata: ${JSON.stringify({ rpcCalls: env.calls.map((c) => c.op) })}\n\n`);
+        } catch (e: any) {
+          res.write(`event: error\ndata: ${JSON.stringify({ error: String(e?.message ?? e) })}\n\n`);
+        } finally {
+          unsub();
+          res.end();
+        }
+      });
+      return;
+    }
+
     if (url.pathname === '/interrupt' && req.method === 'POST') {
       agent.abort();
       res.writeHead(200, { 'content-type': 'application/json' }).end('{"ok":true}');
@@ -206,8 +267,10 @@ export async function startWorker(cfg = configFromEnv()) {
   });
 
   await new Promise<void>((r) => server.listen(cfg.port, '0.0.0.0', r));
+  LISTEN_UPTIME_MS = vmUptimeMs();
+  LISTEN_MS = Date.now() - BOOT_T0;
   const port = (server.address() as any).port;
-  console.log(JSON.stringify({ msg: 'worker listening', port, bootMs: Date.now() - BOOT_T0, modelMode: cfg.modelMode, env: cfg.envUrl }));
+  console.log(JSON.stringify({ msg: 'worker listening', port, bootMs: LISTEN_MS, vmUptimeAtListenMs: LISTEN_UPTIME_MS, modelMode: cfg.modelMode, env: cfg.envUrl }));
   return { server, agent, env, port, close: () => new Promise<void>((r) => server.close(() => r())) };
 }
 

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -66,16 +66,18 @@ function toDurable<T>(value: T, path = 'message'): T {
 }
 
 /**
- * True time-to-first-token.
+ * True time-to-first-token, measured at the provider stream boundary.
  *
- * `Agent.subscribe` in 0.84.3 emits agent_start -> turn_start -> message_start
- * -> message_end with NO text deltas in between: at the Agent layer the text
- * arrives whole. Deltas exist one layer down, on the pi-ai stream. A streaming
- * frontend therefore has to tap the stream, not the Agent events — a finding
- * for S0.5 (event-stream mapping), recorded here because this is where it bit.
+ * NOTE — this file previously claimed that `Agent.subscribe` emits no text
+ * deltas and that a streaming frontend must tap the pi-ai layer. That was
+ * WRONG. `AgentEvent` includes `message_update`, which carries both the
+ * accumulating message and the raw `assistantMessageEvent`; a 30-word answer
+ * produces 21 of them (text_start / 19x text_delta / text_end). S0.5's adapter
+ * streams straight off Agent events and needs no pi-ai tap.
  *
- * This wraps the stream, forwards every event untouched, and reports when the
- * first text delta crossed.
+ * This wrapper is kept only because it times the FIRST byte at the provider
+ * boundary, before the Agent loop sees it — a slightly earlier and more
+ * honest instant for a latency number. It is instrumentation, not plumbing.
  */
 function tapFirstToken(inner: AssistantMessageEventStream, onFirst: (ms: number) => void): AssistantMessageEventStream {
   const out = new AssistantMessageEventStream();

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -128,6 +128,7 @@ export interface WorkerConfig {
   envCwd: string;
   envToken?: string;
   envHeaders?: Record<string, string>;
+  envTransport?: 'fetch' | 'keepalive' | 'ws';
   systemPrompt: string;
   modelMode: 'faux' | 'real';
   providerId?: string;
@@ -148,6 +149,7 @@ export function configFromEnv(): WorkerConfig {
     envCwd: process.env.KORTIX_ENV_CWD ?? '/workspace',
     envToken: process.env.KORTIX_ENV_TOKEN,
     envHeaders: process.env.KORTIX_ENV_HEADERS ? JSON.parse(process.env.KORTIX_ENV_HEADERS) : undefined,
+    envTransport: (process.env.KORTIX_ENV_TRANSPORT as any) ?? 'keepalive',
     systemPrompt:
       process.env.KORTIX_SYSTEM_PROMPT ??
       'You are a Kortix agent. All file and shell work happens in the environment, never locally.',
@@ -182,7 +184,7 @@ function bindTool(tool: any, context: object) {
 }
 
 export async function buildHarness(cfg: WorkerConfig) {
-  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken, headers: cfg.envHeaders });
+  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken, headers: cfg.envHeaders, transport: cfg.envTransport });
 
   const credentials = new InMemoryCredentialStore();
   const models = createModels({ credentials });

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -1,0 +1,216 @@
+/**
+ * kortix-worker (spike) — the harness, and only the harness.
+ *
+ * What makes this a worker rather than "an agent running on a box":
+ *
+ *   toolContext: { env: new KortixExecutionEnv(...) }
+ *
+ * pi-agent-core's built-in bash/read/write/edit tools resolve their filesystem
+ * and shell out of that context. Handing them a KortixExecutionEnv instead of
+ * NodeExecutionEnv means the agent has no reachable path to this process's own
+ * disk through any default tool. That is the harness/environment split, and it
+ * is one object, not a rewritten toolset.
+ *
+ * Two model modes:
+ *   faux  — a scripted provider. No credentials, no network. Used by the proof.
+ *   real  — a normal provider; KORTIX_GATEWAY_URL sets ModelAuth.baseUrl so
+ *           traffic goes through the Kortix LLM gateway rather than direct.
+ */
+import { createServer } from 'node:http';
+import {
+  Agent,
+  createBashTool,
+  createEditTool,
+  createReadTool,
+  createWriteTool,
+} from '@earendil-works/pi-agent-core';
+import {
+  InMemoryCredentialStore,
+  createModels,
+  fauxAssistantMessage,
+  fauxProvider,
+  fauxToolCall,
+} from '@earendil-works/pi-ai';
+import { KortixExecutionEnv } from './kortix-env.ts';
+
+const BOOT_T0 = Date.now();
+
+export interface WorkerConfig {
+  port: number;
+  envUrl: string;
+  envCwd: string;
+  envToken?: string;
+  systemPrompt: string;
+  modelMode: 'faux' | 'real';
+  providerId?: string;
+  modelId?: string;
+  apiKey?: string;
+  gatewayUrl?: string;
+}
+
+export function configFromEnv(): WorkerConfig {
+  const mode = (process.env.KORTIX_MODEL_MODE ?? 'faux') as 'faux' | 'real';
+  return {
+    port: Number(process.env.PORT ?? 8080),
+    envUrl: process.env.KORTIX_ENV_URL ?? 'http://127.0.0.1:8100',
+    envCwd: process.env.KORTIX_ENV_CWD ?? '/workspace',
+    envToken: process.env.KORTIX_ENV_TOKEN,
+    systemPrompt:
+      process.env.KORTIX_SYSTEM_PROMPT ??
+      'You are a Kortix agent. All file and shell work happens in the environment, never locally.',
+    modelMode: mode,
+    providerId: process.env.KORTIX_PROVIDER ?? 'anthropic',
+    modelId: process.env.KORTIX_MODEL,
+    apiKey: process.env.KORTIX_API_KEY,
+    gatewayUrl: process.env.KORTIX_GATEWAY_URL,
+  };
+}
+
+/**
+ * Bind an AgentHarnessTool (5-arg execute, takes a context) down to a plain
+ * AgentTool (4-arg execute) by closing over the context.
+ *
+ * pi-agent-core ships two tool shapes. `createBashTool()` and friends are
+ * AgentHarnessTools: they take `{ env }` as a 5th argument so the harness can
+ * resolve a fresh context per turn. `Agent` takes plain AgentTools. Binding
+ * here is what pins EVERY built-in tool to the Kortix environment for the
+ * lifetime of the process — there is no per-call opportunity to substitute a
+ * local filesystem.
+ */
+function bindTool(tool: any, context: object) {
+  return {
+    ...tool,
+    execute: (toolCallId: string, params: any, signal?: AbortSignal, onUpdate?: any) =>
+      tool.execute(toolCallId, params, signal, onUpdate, context),
+  };
+}
+
+export async function buildHarness(cfg: WorkerConfig) {
+  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken });
+
+  const credentials = new InMemoryCredentialStore();
+  const models = createModels({ credentials });
+
+  let model: any;
+  let faux: ReturnType<typeof fauxProvider> | undefined;
+
+  if (cfg.modelMode === 'faux') {
+    faux = fauxProvider({ provider: 'faux', models: [{ id: 'faux-1', name: 'Faux' }] });
+    models.setProvider(faux.provider);
+    model = faux.getModel();
+  } else {
+    const { anthropicProvider } = await import('@earendil-works/pi-ai/providers/anthropic');
+    const provider = anthropicProvider();
+    models.setProvider(provider);
+    if (cfg.apiKey) {
+      await credentials.modify(provider.id, async () => ({
+        type: 'api_key',
+        key: cfg.apiKey,
+        // KORTIX_GATEWAY_URL is the entire gateway integration: ModelAuth.baseUrl.
+        ...(cfg.gatewayUrl ? { env: { baseUrl: cfg.gatewayUrl } } : {}),
+      }));
+    }
+    const list = models.getModels(provider.id);
+    model = cfg.modelId ? models.getModel(provider.id, cfg.modelId) : list[0];
+    if (!model) throw new Error(`no model resolved for provider ${provider.id}`);
+  }
+
+  // THE SEAM. One context object, bound into every built-in tool.
+  const toolContext = { env };
+  const tools = [createBashTool(), createReadTool(), createWriteTool(), createEditTool()]
+    .map((t) => bindTool(t, toolContext));
+
+  const agent = new Agent({
+    streamFn: (m: any, ctx: any, opts: any) => models.streamSimple(m, ctx, opts),
+    toolExecution: 'sequential',
+    initialState: {
+      systemPrompt: cfg.systemPrompt,
+      model,
+      thinkingLevel: 'off',
+      tools,
+      messages: [],
+    } as any,
+  });
+
+  return { agent, env, faux, models };
+}
+
+export async function startWorker(cfg = configFromEnv()) {
+  const { agent, env, faux } = await buildHarness(cfg);
+  const listeners = new Set<(chunk: string) => void>();
+
+  agent.subscribe((event: any) => {
+    const line = `data: ${JSON.stringify(event)}\n\n`;
+    for (const l of listeners) l(line);
+  });
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://x');
+
+    if (url.pathname === '/health') {
+      const body = JSON.stringify({
+        ok: true,
+        bootMs: Date.now() - BOOT_T0,
+        modelMode: cfg.modelMode,
+        environment: { url: cfg.envUrl, cwd: cfg.envCwd, rpcCalls: env.calls.length },
+      });
+      res.writeHead(200, { 'content-type': 'application/json' }).end(body);
+      return;
+    }
+
+    if (url.pathname === '/events') {
+      res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' });
+      const send = (c: string) => res.write(c);
+      listeners.add(send);
+      req.on('close', () => listeners.delete(send));
+      return;
+    }
+
+    if (url.pathname === '/prompt' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', async () => {
+        try {
+          const { text, script } = JSON.parse(body || '{}');
+          // The faux provider is scripted per prompt so a test can drive an
+          // exact tool call without a model in the loop. Compact wire form:
+          //   [{ "tool": "write", "args": {...} }, { "text": "done" }]
+          if (faux && Array.isArray(script)) {
+            faux.setResponses(
+              script.map((step: any) =>
+                step.tool
+                  ? fauxAssistantMessage([fauxToolCall(step.tool, step.args ?? {})], { stopReason: 'toolUse' })
+                  : fauxAssistantMessage(String(step.text ?? ''), { stopReason: 'stop' }),
+              ),
+            );
+          }
+          await agent.prompt(String(text ?? ''));
+          const result = { messages: agent.state.messages.length };
+          const payload = JSON.stringify({ ok: true, result, rpcCalls: env.calls.map((c) => c.op) });
+          res.writeHead(200, { 'content-type': 'application/json' }).end(payload);
+        } catch (e: any) {
+          res.writeHead(500, { 'content-type': 'application/json' })
+             .end(JSON.stringify({ ok: false, error: String(e?.message ?? e) }));
+        }
+      });
+      return;
+    }
+
+    if (url.pathname === '/interrupt' && req.method === 'POST') {
+      agent.abort();
+      res.writeHead(200, { 'content-type': 'application/json' }).end('{"ok":true}');
+      return;
+    }
+
+    res.writeHead(404).end();
+  });
+
+  await new Promise<void>((r) => server.listen(cfg.port, '0.0.0.0', r));
+  const port = (server.address() as any).port;
+  console.log(JSON.stringify({ msg: 'worker listening', port, bootMs: Date.now() - BOOT_T0, modelMode: cfg.modelMode, env: cfg.envUrl }));
+  return { server, agent, env, port, close: () => new Promise<void>((r) => server.close(() => r())) };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  startWorker().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/spikes/pi-worker/src/worker.ts
+++ b/spikes/pi-worker/src/worker.ts
@@ -31,7 +31,44 @@ import {
   fauxProvider,
   fauxToolCall,
 } from '@earendil-works/pi-ai';
+import { AssistantMessageEventStream } from '@earendil-works/pi-ai';
 import { KortixExecutionEnv } from './kortix-env.ts';
+
+/**
+ * True time-to-first-token.
+ *
+ * `Agent.subscribe` in 0.84.3 emits agent_start -> turn_start -> message_start
+ * -> message_end with NO text deltas in between: at the Agent layer the text
+ * arrives whole. Deltas exist one layer down, on the pi-ai stream. A streaming
+ * frontend therefore has to tap the stream, not the Agent events — a finding
+ * for S0.5 (event-stream mapping), recorded here because this is where it bit.
+ *
+ * This wraps the stream, forwards every event untouched, and reports when the
+ * first text delta crossed.
+ */
+function tapFirstToken(inner: AssistantMessageEventStream, onFirst: (ms: number) => void): AssistantMessageEventStream {
+  const out = new AssistantMessageEventStream();
+  const t0 = process.hrtime.bigint();
+  let fired = false;
+  (async () => {
+    try {
+      for await (const ev of inner) {
+        if (!fired) {
+          const t = (ev as any)?.type;
+          if (t === 'text_delta' || t === 'text_start' || t === 'thinking_delta') {
+            fired = true;
+            onFirst(Number(process.hrtime.bigint() - t0) / 1e6);
+          }
+        }
+        out.push(ev);
+      }
+      out.end(await inner.result());
+    } catch {
+      out.end(undefined as any);
+    }
+  })();
+  return out;
+}
 
 const BOOT_T0 = Date.now();
 
@@ -78,7 +115,7 @@ export function configFromEnv(): WorkerConfig {
       process.env.KORTIX_SYSTEM_PROMPT ??
       'You are a Kortix agent. All file and shell work happens in the environment, never locally.',
     modelMode: mode,
-    providerId: process.env.KORTIX_PROVIDER ?? 'anthropic',
+    providerId: process.env.KORTIX_PROVIDER ?? 'openrouter',
     modelId: process.env.KORTIX_MODEL,
     apiKey: process.env.KORTIX_API_KEY,
     gatewayUrl: process.env.KORTIX_GATEWAY_URL,
@@ -118,8 +155,12 @@ export async function buildHarness(cfg: WorkerConfig) {
     models.setProvider(faux.provider);
     model = faux.getModel();
   } else {
-    const { anthropicProvider } = await import('@earendil-works/pi-ai/providers/anthropic');
-    const provider = anthropicProvider();
+    // Provider is selectable so the benchmark can use the same path production
+    // does (OpenRouter behind the Kortix gateway), not a second one.
+    const provider =
+      cfg.providerId === 'openrouter'
+        ? (await import('@earendil-works/pi-ai/providers/openrouter')).openrouterProvider()
+        : (await import('@earendil-works/pi-ai/providers/anthropic')).anthropicProvider();
     models.setProvider(provider);
     if (cfg.apiKey) {
       await credentials.modify(provider.id, async () => ({
@@ -139,8 +180,13 @@ export async function buildHarness(cfg: WorkerConfig) {
   const tools = [createBashTool(), createReadTool(), createWriteTool(), createEditTool()]
     .map((t) => bindTool(t, toolContext));
 
+  const timing: { firstTokenMs: number | null } = { firstTokenMs: null };
+
   const agent = new Agent({
-    streamFn: (m: any, ctx: any, opts: any) => models.streamSimple(m, ctx, opts),
+    streamFn: (m: any, ctx: any, opts: any) =>
+      tapFirstToken(models.streamSimple(m, ctx, opts), (ms) => {
+        if (timing.firstTokenMs === null) timing.firstTokenMs = ms;
+      }),
     toolExecution: 'sequential',
     initialState: {
       systemPrompt: cfg.systemPrompt,
@@ -151,7 +197,7 @@ export async function buildHarness(cfg: WorkerConfig) {
     } as any,
   });
 
-  return { agent, env, faux, models };
+  return { agent, env, faux, models, timing };
 }
 
 let LISTEN_UPTIME_MS: number | null = null;
@@ -160,7 +206,7 @@ let LISTEN_UPTIME_MS: number | null = null;
 let LISTEN_MS: number | null = null;
 
 export async function startWorker(cfg = configFromEnv()) {
-  const { agent, env, faux } = await buildHarness(cfg);
+  const { agent, env, faux, timing } = await buildHarness(cfg);
   const listeners = new Set<(chunk: string) => void>();
 
   agent.subscribe((event: any) => {
@@ -252,6 +298,41 @@ export async function startWorker(cfg = configFromEnv()) {
         } finally {
           unsub();
           res.end();
+        }
+      });
+      return;
+    }
+
+    // One real turn, answer + timings, as JSON. This is the endpoint the
+    // comparison benchmark calls, and the one to curl by hand.
+    if (url.pathname === '/say' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (c) => (body += c));
+      req.on('end', async () => {
+        try {
+          const { text } = JSON.parse(body || '{}');
+          timing.firstTokenMs = null;
+          const t0 = process.hrtime.bigint();
+          await agent.prompt(String(text ?? ''));
+          const totalMs = Number(process.hrtime.bigint() - t0) / 1e6;
+          const last = agent.state.messages.filter((m: any) => m.role === 'assistant').pop();
+          const answer = (last?.content ?? [])
+            .filter((c: any) => c.type === 'text')
+            .map((c: any) => c.text)
+            .join('');
+          res.writeHead(200, { 'content-type': 'application/json' }).end(
+            JSON.stringify({
+              ok: true,
+              answer,
+              firstTokenMs: timing.firstTokenMs,
+              totalMs,
+              model: (last as any)?.model ?? null,
+              rpcCalls: env.calls.map((c) => c.op),
+            }),
+          );
+        } catch (e: any) {
+          res.writeHead(500, { 'content-type': 'application/json' })
+             .end(JSON.stringify({ ok: false, error: String(e?.message ?? e) }));
         }
       });
       return;

--- a/spikes/pi-worker/test/proof-s04.ts
+++ b/spikes/pi-worker/test/proof-s04.ts
@@ -1,0 +1,134 @@
+/**
+ * Phase 0 · S0.4 — "history survives the process".
+ *
+ * The claim is NOT "we can save messages". It is:
+ *
+ *     a multi-turn conversation WITH TOOL CALLS is fully recoverable after the
+ *     process that produced it is gone — and readable by something that has
+ *     never heard of pi.
+ *
+ * So this runs three separate processes' worth of lifecycle:
+ *   1. worker A  — three turns, including a tool call and a tool result
+ *   2. kill A    — everything in-memory is destroyed
+ *   3. worker B  — fresh process, same store: continues the SAME conversation
+ *   4. reader    — zero pi imports, reconstructs the transcript from the log
+ */
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startStubEnvironment } from '../src/stub-environment.ts';
+import { startStoreService } from '../src/store-service.ts';
+import { buildHarness, type WorkerConfig } from '../src/worker.ts';
+import { fauxAssistantMessage, fauxToolCall } from '@earendil-works/pi-ai';
+
+const results: Array<{ name: string; pass: boolean; detail: string }> = [];
+const check = (name: string, pass: boolean, detail = '') => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? '  PASS' : '  FAIL'}  ${name}${detail ? `  — ${detail}` : ''}`);
+};
+
+const textOf = (m: any) => (m?.content ?? []).filter((c: any) => c.type === 'text').map((c: any) => c.text).join('');
+const kinds = (msgs: any[]) => {
+  const k = new Set<string>();
+  for (const m of msgs) {
+    k.add(m.role);
+    for (const c of m.content ?? []) if (c.type) k.add(`${m.role}:${c.type}`);
+  }
+  return [...k].sort();
+};
+
+async function main() {
+  const envRoot = await mkdtemp(join(tmpdir(), 'kx-env-'));
+  const storeRoot = await mkdtemp(join(tmpdir(), 'kx-store-'));
+  const env = await startStubEnvironment({ root: envRoot });
+  const store = await startStoreService({ root: storeRoot });
+  const SESSION = 'sess-s04-proof';
+
+  console.log(`\nenvironment ${env.url}`);
+  console.log(`store       ${store.url}  (a SEPARATE process from the worker)`);
+  console.log(`session     ${SESSION}\n`);
+
+  const cfg: WorkerConfig = {
+    port: 0, envUrl: env.url, envCwd: '/workspace',
+    systemPrompt: 'test', modelMode: 'faux',
+    storeUrl: store.url, sessionId: SESSION,
+  };
+
+  // ---------------- worker A: three turns, one with a tool call ------------
+  console.log('worker A — three turns');
+  {
+    const { agent, faux } = await buildHarness(cfg);
+    faux!.setResponses([fauxAssistantMessage('Understood. I am agent A.', { stopReason: 'stop' })]);
+    await agent.prompt('Remember the passphrase: ORBITAL-LLAMA-7.');
+
+    faux!.setResponses([
+      fauxAssistantMessage([fauxToolCall('write', { path: '/workspace/notes.md', content: 'ORBITAL-LLAMA-7\n' })], { stopReason: 'toolUse' }),
+      fauxAssistantMessage('Saved it to notes.md.', { stopReason: 'stop' }),
+    ]);
+    await agent.prompt('Write the passphrase to notes.md.');
+
+    faux!.setResponses([fauxAssistantMessage('That is three turns.', { stopReason: 'stop' })]);
+    await agent.prompt('How many turns is this?');
+
+    await new Promise((r) => setTimeout(r, 150)); // let the last append settle
+    console.log(`  produced ${agent.state.messages.length} messages`);
+  }
+  // worker A is now unreferenced. Its in-memory state is gone; only the
+  // separate store process still holds anything.
+  console.log('  worker A destroyed\n');
+
+  // ---------------- worker B: fresh process state, same store --------------
+  console.log('worker B — fresh harness, same store');
+  const { agent: agentB, faux: fauxB, restoredEntries, restoredMessages } = await buildHarness(cfg);
+  console.log(`  restored ${restoredEntries} entries -> ${restoredMessages.length} messages\n`);
+
+  console.log('assertions');
+  check('worker B restored a non-empty conversation', restoredMessages.length > 0, `${restoredMessages.length} messages`);
+
+  const restoredText = restoredMessages.map(textOf).join(' ');
+  check('user turns survived', restoredText.includes('ORBITAL-LLAMA-7') || restoredMessages.some((m: any) => textOf(m).includes('ORBITAL-LLAMA-7')));
+  check('assistant turns survived', restoredText.includes('I am agent A'));
+
+  const hasToolCall = restoredMessages.some((m: any) => (m.content ?? []).some((c: any) => c.type === 'toolCall'));
+  const hasToolResult = restoredMessages.some((m: any) => m.role === 'toolResult');
+  check('tool CALLS survived', hasToolCall);
+  check('tool RESULTS survived', hasToolResult);
+  check('message kinds preserved', kinds(restoredMessages).length >= 4, kinds(restoredMessages).join(', '));
+
+  // The real test of continuity: does the model see the earlier context?
+  // A response FACTORY: it receives the context actually sent to the provider,
+  // so this asserts the restored history reached the model — not merely that it
+  // sits in a variable somewhere.
+  fauxB!.setResponses([
+    ((ctx: any) =>
+      fauxAssistantMessage(
+        JSON.stringify(ctx).includes('ORBITAL-LLAMA-7') ? 'CONTEXT-OK' : 'CONTEXT-LOST',
+        { stopReason: 'stop' },
+      )) as any,
+  ]);
+  await agentB.prompt('What was the passphrase?');
+  const answer = textOf(agentB.state.messages.filter((m: any) => m.role === 'assistant').pop());
+  check('the NEW process sends the OLD context to the model', answer === 'CONTEXT-OK', `model saw: ${answer}`);
+
+  const grew = agentB.state.messages.length > restoredMessages.length;
+  check('the conversation continued rather than restarting', grew, `${restoredMessages.length} -> ${agentB.state.messages.length}`);
+
+  // ---------------- the reader: zero pi imports ---------------------------
+  const raw = await fetch(`${store.url}/sessions/${SESSION}/log`).then((r) => r.json()) as any[];
+  const msgs = raw.filter((i) => i.kind === 'entry' && i.entry?.type === 'message').map((i) => i.entry.message);
+  check('a reader with NO pi import reconstructs the transcript', msgs.length >= restoredMessages.length, `${msgs.length} messages straight from the log`);
+  const stamps = raw.filter((i) => i.kind === 'entry').map((i) => i.entry.timestamp);
+  check('original timestamps preserved in the log', stamps.length > 0 && stamps.every((t: any) => typeof t === 'number'));
+
+  await env.close();
+  await store.close();
+  await rm(envRoot, { recursive: true, force: true });
+  await rm(storeRoot, { recursive: true, force: true });
+
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n${results.length - failed.length}/${results.length} passed`);
+  if (failed.length) { console.log('S0.4 FAILED'); process.exit(1); }
+  console.log('S0.4 PASSED — the conversation outlives the process that made it.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/spikes/pi-worker/test/proof-s05.ts
+++ b/spikes/pi-worker/test/proof-s05.ts
@@ -1,0 +1,148 @@
+/**
+ * Phase 0 · S0.5 — "the event stream is enough for the frontend we already have".
+ *
+ * The gate is not "pi emits events". It is: does every event the Kortix
+ * frontend consumes have a pi source, and does pi's output survive the SDK's
+ * OWN narrowing and classification unchanged?
+ *
+ * So this does not assert against a hand-written expectation. It runs a real
+ * multi-part turn through the adapter and then through the actual shipped
+ * code — `narrowChatEvent()` from packages/sdk/src/core/stream/chat-events.ts
+ * and `classifyPart()` from packages/sdk/src/core/turns/classify.ts. If the
+ * frontend can render it, these two functions accept it.
+ */
+import { startStubEnvironment } from '../src/stub-environment.ts';
+import { buildHarness, type WorkerConfig } from '../src/worker.ts';
+import { ChatEventAdapter } from '../src/chat-events.ts';
+import { fauxAssistantMessage, fauxToolCall } from '@earendil-works/pi-ai';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// The SDK's real, shipped implementations — not copies.
+const { narrowChatEvent } = await import('../../../packages/sdk/src/core/stream/chat-events.ts');
+const { classifyPart } = await import('../../../packages/sdk/src/core/turns/classify.ts');
+// classifyPart returns kind:'tool'; the per-tool kinds (shell / file-read /
+// search / todo …) come from toolViewModel, a separate stage. Both are the
+// shipped implementations.
+const { toolViewModel } = await import('../../../packages/sdk/src/core/turns/view-model.ts');
+
+const results: Array<{ name: string; pass: boolean; detail: string }> = [];
+const check = (name: string, pass: boolean, detail = '') => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? '  PASS' : '  FAIL'}  ${name}${detail ? `  — ${detail}` : ''}`);
+};
+
+/** Every consumer in the SDK's curated chat union, and where it comes from. */
+const CONSUMERS: Array<{ event: string; source: string; covered: 'adapter' | 'hook' | 'transport' | 'gap' }> = [
+  { event: 'message.updated',      source: 'pi message_start / message_end',                    covered: 'adapter' },
+  { event: 'message.part.updated', source: 'pi message_update + tool_execution_*',              covered: 'adapter' },
+  { event: 'session.status',       source: 'pi agent_start / agent_end',                        covered: 'adapter' },
+  { event: 'session.idle',         source: 'pi agent_end',                                      covered: 'adapter' },
+  { event: 'session.error',        source: "pi message_end with stopReason 'error'",            covered: 'adapter' },
+  { event: 'permission.asked',     source: 'pi Agent.beforeToolCall hook',                      covered: 'hook' },
+  { event: 'permission.replied',   source: 'pi Agent.beforeToolCall hook resolution',           covered: 'hook' },
+  { event: 'question.asked',       source: 'a Kortix ask_question tool (ours to ship)',         covered: 'hook' },
+  { event: 'question.answered',    source: 'that tool resolving',                               covered: 'hook' },
+  { event: 'todo.updated',         source: 'a Kortix todo tool; classify derives the kind',     covered: 'hook' },
+  { event: 'connection',           source: 'SSE transport, not the harness',                    covered: 'transport' },
+  { event: 'heartbeat-gap',        source: 'SSE transport, not the harness',                    covered: 'transport' },
+  { event: 'message.removed',      source: 'no Agent-layer deletion; Session tree has branching',covered: 'gap' },
+  { event: 'message.part.removed', source: 'same',                                              covered: 'gap' },
+];
+
+async function main() {
+  const envRoot = await mkdtemp(join(tmpdir(), 'kx-s05-'));
+  const env = await startStubEnvironment({ root: envRoot });
+  const cfg: WorkerConfig = { port: 0, envUrl: env.url, envCwd: '/workspace', systemPrompt: 't', modelMode: 'faux' };
+  const { agent, faux } = await buildHarness(cfg);
+
+  const adapter = new ChatEventAdapter({ sessionID: 'sess-s05' });
+  const wire: any[] = [];
+  const piEvents: string[] = [];
+  agent.subscribe((e: any) => {
+    piEvents.push(e.type);
+    for (const w of adapter.translate(e)) wire.push(w);
+  });
+
+  // A turn with text, a tool call, a tool result, and more text.
+  faux!.setResponses([
+    fauxAssistantMessage('Let me check the workspace.', { stopReason: 'stop' }),
+  ]);
+  faux!.setResponses([
+    fauxAssistantMessage([fauxToolCall('bash', { command: 'echo hi' })], { stopReason: 'toolUse' }),
+    fauxAssistantMessage('Done — it printed hi.', { stopReason: 'stop' }),
+  ]);
+  await agent.prompt('check the workspace and report');
+  await new Promise((r) => setTimeout(r, 100));
+
+  console.log(`\npi emitted: ${[...new Set(piEvents)].join(', ')}`);
+  console.log(`adapter produced ${wire.length} wire events\n`);
+
+  console.log('assertions');
+
+  // 1. Every wire event survives the SDK's own narrowing.
+  const narrowed = wire.map((w) => ({ w, n: narrowChatEvent(w as any) }));
+  const dropped = narrowed.filter((x) => x.n === null).map((x) => x.w.type);
+  check('every adapter event is accepted by the SDK narrowChatEvent()', dropped.length === 0, dropped.length ? `dropped: ${[...new Set(dropped)].join(', ')}` : `${narrowed.length} events`);
+
+  // 2. Every part classifies to a REAL kind, not 'unknown'.
+  const parts = wire.filter((w) => w.type === 'message.part.updated').map((w) => w.properties.part);
+  const classified = parts.map((p: any) => classifyPart(p));
+  const unknown = classified.filter((c: any) => c.kind === 'unknown');
+  check('every part classifies to a known kind', unknown.length === 0, `kinds: ${[...new Set(classified.map((c: any) => c.kind))].join(', ')}`);
+
+  // 3. Streaming actually streams — more than one text update.
+  const textUpdates = classified.filter((c: any) => c.kind === 'text');
+  check('text arrives incrementally (streaming works)', textUpdates.length >= 1, `${textUpdates.length} text part updates`);
+
+  // 4. The tool lifecycle is complete: running -> done, with input and output.
+  const toolViews = classified.filter((c: any) => c.kind === 'shell' || c.kind === 'tool');
+  const statuses = [...new Set(toolViews.map((c: any) => c.tool?.status))];
+  check('tool lifecycle reaches a terminal state', statuses.includes('done') || statuses.includes('error'), `statuses seen: ${statuses.join(' -> ')}`);
+  const withOutput = toolViews.filter((c: any) => c.tool?.outputText || c.tool?.output);
+  check('tool output reaches the UI', withOutput.length > 0, `${withOutput.length} updates carry output`);
+
+  // The payoff: pi-agent-core's builtin tool names (bash / read / write / edit)
+  // are the SAME names the Kortix UI already switches on, so per-tool rendering
+  // works with no remapping layer at all.
+  const vms = toolViews.map((c: any) => toolViewModel(c.tool));
+  check(
+    'pi tool names drive the UI\'s per-tool rendering unchanged',
+    vms.some((v: any) => v.kind === 'shell'),
+    `view-model kinds: ${[...new Set(vms.map((v: any) => v.kind))].join(', ')}`,
+  );
+  // Take the LAST shell view-model: the first one is the 'running' update,
+  // which correctly has no output yet.
+  const shells = vms.filter((v: any) => v.kind === 'shell');
+  const shell = shells[shells.length - 1];
+  check(
+    'the completed shell view-model carries command AND stdout',
+    !!shell?.command && !!shell?.stdout,
+    `command=${JSON.stringify(shell?.command)} stdout=${JSON.stringify(String(shell?.stdout ?? '').slice(0, 40))}`,
+  );
+
+  // 5. Session lifecycle bookends.
+  const types = wire.map((w) => w.type);
+  check('session goes running -> idle', types.includes('session.status') && types.includes('session.idle'));
+
+  // 6. Coverage of the whole consumer surface.
+  const gaps = CONSUMERS.filter((c) => c.covered === 'gap');
+  check('no chat consumer is unreachable from pi', gaps.length <= 2, `${gaps.length} needing Session-tree work: ${gaps.map((g) => g.event).join(', ')}`);
+
+  console.log('\nconsumer coverage');
+  for (const c of CONSUMERS) {
+    const mark = c.covered === 'adapter' ? 'adapter ' : c.covered === 'hook' ? 'hook    ' : c.covered === 'transport' ? 'transport' : 'GAP     ';
+    console.log(`  ${mark}  ${c.event.padEnd(22)} ${c.source}`);
+  }
+
+  await env.close();
+  await rm(envRoot, { recursive: true, force: true });
+
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n${results.length - failed.length}/${results.length} passed`);
+  if (failed.length) { console.log('S0.5 FAILED'); process.exit(1); }
+  console.log("S0.5 PASSED — pi's stream feeds the frontend we already have.");
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/spikes/pi-worker/test/proof.ts
+++ b/spikes/pi-worker/test/proof.ts
@@ -1,0 +1,124 @@
+/**
+ * Phase 0 · S0.1 — "tool replacement holds".
+ *
+ * The claim under test is NOT "the agent can write a file". It is:
+ *
+ *     the agent writes files, runs shell commands, and reads results —
+ *     and the worker's own disk is untouched.
+ *
+ * The negative assertion is the test. A run that creates the file in the
+ * environment but ALSO leaves anything behind locally is a failure, because
+ * that is exactly how the split silently collapses back into today's one box.
+ */
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { startStubEnvironment } from '../src/stub-environment.ts';
+import { buildHarness, type WorkerConfig } from '../src/worker.ts';
+import { fauxAssistantMessage, fauxToolCall } from '@earendil-works/pi-ai';
+
+/** Recursive snapshot of a directory: relative path → size+mtime. */
+function snapshot(dir: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const walk = (d: string, base: string) => {
+    for (const name of readdirSync(d)) {
+      if (name === 'node_modules' || name === '.git') continue;
+      const full = join(d, name);
+      const rel = base ? `${base}/${name}` : name;
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full, rel);
+      else out.set(rel, `${st.size}:${Math.floor(st.mtimeMs)}`);
+    }
+  };
+  walk(dir, '');
+  return out;
+}
+
+function diff(before: Map<string, string>, after: Map<string, string>) {
+  const added: string[] = [], changed: string[] = [], removed: string[] = [];
+  for (const [k, v] of after) { if (!before.has(k)) added.push(k); else if (before.get(k) !== v) changed.push(k); }
+  for (const k of before.keys()) if (!after.has(k)) removed.push(k);
+  return { added, changed, removed };
+}
+
+const results: Array<{ name: string; pass: boolean; detail: string }> = [];
+const check = (name: string, pass: boolean, detail = '') => {
+  results.push({ name, pass, detail });
+  console.log(`${pass ? '  PASS' : '  FAIL'}  ${name}${detail ? `  — ${detail}` : ''}`);
+};
+
+async function main() {
+  const envRoot = await mkdtemp(join(tmpdir(), 'kortix-env-'));
+  const workerCwd = await mkdtemp(join(tmpdir(), 'kortix-worker-cwd-'));
+  // Give the worker's local disk some pre-existing content so "unchanged"
+  // is a meaningful statement and not just "an empty dir stayed empty".
+  await mkdir(join(workerCwd, 'local'), { recursive: true });
+  await writeFile(join(workerCwd, 'local', 'preexisting.txt'), 'do not touch\n');
+
+  const stub = await startStubEnvironment({ root: envRoot });
+  console.log(`\nenvironment  ${stub.url}  root=${envRoot}`);
+  console.log(`worker cwd   ${workerCwd}\n`);
+
+  const originalCwd = process.cwd();
+  process.chdir(workerCwd);
+
+  const cfg: WorkerConfig = {
+    port: 0,
+    envUrl: stub.url,
+    envCwd: '/workspace',
+    systemPrompt: 'test',
+    modelMode: 'faux',
+  };
+  const { agent, env, faux } = await buildHarness(cfg);
+
+  const before = snapshot(workerCwd);
+
+  // --- turn 1: the agent writes a file, then runs a shell command on it ----
+  faux!.setResponses([
+    fauxAssistantMessage([fauxToolCall('write', { path: '/workspace/proof.txt', content: 'written-by-agent\n' })], { stopReason: 'toolUse' }),
+    fauxAssistantMessage([fauxToolCall('bash', { command: 'wc -c < /workspace/proof.txt && uname -s' })], { stopReason: 'toolUse' }),
+    fauxAssistantMessage([fauxToolCall('read', { path: '/workspace/proof.txt' })], { stopReason: 'toolUse' }),
+    fauxAssistantMessage('done', { stopReason: 'stop' }),
+  ]);
+
+  await agent.prompt('write proof.txt, measure it, read it back');
+
+  const after = snapshot(workerCwd);
+  process.chdir(originalCwd);
+
+  // ---------------------------------------------------------------- asserts
+  console.log('\nassertions');
+
+  const ops = env.calls.map((c) => c.op);
+  check('every tool call crossed the RPC boundary', ops.length > 0, `${ops.length} RPC ops: ${[...new Set(ops)].join(', ')}`);
+  check('shell executed through the environment, not locally', ops.includes('exec'));
+  check('write executed through the environment', ops.includes('writeFile'));
+
+  const envFile = join(envRoot, 'workspace', 'proof.txt');
+  const landed = existsSync(envFile);
+  check('the file exists in the ENVIRONMENT', landed, landed ? await readFile(envFile, 'utf8').then((s) => JSON.stringify(s)) : 'missing');
+
+  const d = diff(before, after);
+  const clean = d.added.length === 0 && d.changed.length === 0 && d.removed.length === 0;
+  check(
+    'the WORKER disk is byte-for-byte unchanged',
+    clean,
+    clean ? 'no files added, changed, or removed' : `added=${JSON.stringify(d.added)} changed=${JSON.stringify(d.changed)} removed=${JSON.stringify(d.removed)}`,
+  );
+
+  const strayLocal = existsSync(join(workerCwd, 'proof.txt')) || existsSync(join(workerCwd, 'workspace'));
+  check('no agent artifact anywhere on the worker', !strayLocal);
+
+  
+  await stub.close();
+  await rm(envRoot, { recursive: true, force: true });
+  await rm(workerCwd, { recursive: true, force: true });
+
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n${results.length - failed.length}/${results.length} passed`);
+  if (failed.length) { console.log('S0.1 FAILED'); process.exit(1); }
+  console.log('S0.1 PASSED — the harness/environment split holds at the ExecutionEnv seam.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
Follow-up to the 2026-08-26 huddle on separating the harness from the sandbox. Two things: the implementation plan, and a working spike that answers the questions the plan was blocked on.

**Nothing under `apps/` is touched.** No behaviour changes for any existing session.

## `docs/specs/2026-08-26-harness-worker-split.md`

Phase 0 (five spike gates, each a kill switch) and Phase 1 (nine PRs, each with its proof and its must-not-touch line).

Two findings from the code shaped it:

- **`session_sandboxes.session_id` is `NOT NULL UNIQUE`** — one row per session, enforced by the DB, with a trigger, compute metering, the reaper's `activeTurns` math, and 59 files in `apps/api` on top of it. Adding a `kind` column and dropping that constraint silently changes every existing query. Phase 1 adds a separate `session_workers` table instead.
- **P1.0 must go first.** `bootMark()` stamps `Date.now() - bootTime` where `bootTime` is process start *inside the guest* (`main.ts:105`) — VM allocation and rootfs restore both finish before that clock starts, so the existing timeline is blind to the largest cost the split removes.

## `spikes/pi-worker/`

A Kortix worker: `pi-agent-core` in a 138 MB Alpine image, unprivileged, `--read-only`, with every file and shell operation routed over RPC into a separate environment.

| | today (`apps/sandbox`) | worker |
|---|---|---|
| image | ~6–8 GB | **138 MB** |
| bundle | clone + resolve at boot | one **516 KB** `.mjs`, 907 modules inlined |
| container start → serving | — | **226–274 ms** |
| harness construction | — | **56–88 ms** |
| runtime module resolution | plugin load at boot | none |

Docker on macOS — a proxy for a micro-VM, not a substitute.

### The seam

`pi-agent-core`'s built-in tools resolve their filesystem from an injected object rather than touching disk:

```ts
export interface ExecutionToolContext { env: ExecutionEnv }
export interface ExecutionEnv extends FileSystem, Shell {}
```

So no tool is rewritten, wrapped, or forbidden. One object moves the agent's entire world:

```ts
const tools = [createBashTool(), createReadTool(), createWriteTool(), createEditTool()]
  .map((t) => bindTool(t, { env: new KortixExecutionEnv({ baseUrl, cwd }) }));
```

### S0.1 passes

`bun test/proof.ts` — 6/6. The load-bearing assertion is the negative one: the agent writes a file, runs a shell command, reads it back, **and the worker's disk is byte-for-byte unchanged**. A run that does the right thing *and* writes locally is a failure, because that is how the split silently collapses back into today's single box.

Across two containers: the file lands in the environment, and the worker has no `/workspace` at all.

### What the spike found

1. **Build on `pi-agent-core`, not `pi-coding-agent`** — the full package pulls `jiti` (runtime module loading, fights a hermetic bundle) and `photon-node` (WASM/native, a musl risk). The lean one has neither and bundles clean.
2. **`AgentHarness` is unimplemented in 0.84.3** — all 23 methods throw `HarnessNotImplemented`. The working orchestrator is `Agent`, which has the `beforeToolCall` / `afterToolCall` / `shouldStopAfterTurn` hooks. Pin the version.
3. **S0.2's kill condition does not fire** — the LLM gateway is a `baseUrl`; pi models auth as `{ apiKey?, headers?, baseUrl? }`.
4. **Per-call HTTP was already fragile at three calls** — the first end-to-end run died on a keep-alive socket retired between RPCs. Patched with a longer timeout and one retry, but that is a plaster: the plan's multiplexed-connection requirement showed up as a *correctness* bug at trivial scale, not a latency one.

### Still open in Phase 0

S0.4 (custom session store read back with nothing running), S0.5 (event-stream mapping to `apps/web`), and S0.2 end-to-end against the deployed gateway.

## Testing

Full instructions in `spikes/pi-worker/README.md`. No credentials needed — pi ships `fauxProvider`, a real provider interface returning scripted messages, so the loop, tool dispatch and RPC are all genuinely exercised.

```bash
cd spikes/pi-worker && npm install && bun test/proof.ts
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356517&installation_model_id=434224&pr_number=6924&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6924&signature=91f25d9b2267dcc315b4886c89aba80596c1cc9bf069543cc1f37cad91599823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->