### PR TITLE
ci(release-gate): pin pnpm/action-setup@v4 in the browser shard (v6 on Blacksmith runs pnpm on bundled Node 18.5.0)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,36 @@ linked, not inlined.
 
 ## Register
 
+### A runner migration re-tests every setup action; one job on a different major is a latent break (2026-08-26)
+
+**When:** moving a workflow to a different runner image (Blacksmith), or
+bumping a setup action (`pnpm/action-setup`, `setup-node`) in ONE job of a
+multi-job workflow. `tests-release.yml` ran `pnpm/action-setup@v4` in three
+jobs and `@v6` in the `deployed browser shard` only (dependabot #6343 bumped
+one). On GitHub's `ubuntu-latest` no pnpm is preinstalled, so both majors
+behaved the same and the v0.13.5 gate was green. The Blacksmith image ships
+pnpm v11.19.0 at `PNPM_HOME`; `@v6`'s self-installer took its "Switching pnpm
+from v11.19.0 to v8.11.0" path, warned `Failed to create bin ... @pnpm/exe ...
+ENOENT`, and left a standalone `@pnpm/exe` on PATH. That binary runs on its
+own bundled Node (18.5.0), so `pnpm install --frozen-lockfile` failed
+`engine-strict` against `eslint@9.39.4` (`Got: v18.5.0`) although
+`setup-node` had put 22.22.0 on PATH one step earlier. All three browser
+shards of the v0.13.6 gate died in ~60 s; the api shards on the SAME runner
+label passed on `@v4`.
+Rules: (1) every job in a workflow uses one major of each setup action — a
+dependabot bump that touches one `uses:` line of four is a review reject;
+(2) after a runner-image migration, run the release gate as a dry run
+(`gh workflow run tests-release.yml --ref staging -f expected_sha=<sha>`)
+BEFORE the next promote — Blacksmith (#6906) moved the gate on 2026-08-25 and
+the first real run was the release; (3) a whole-shard failure in well under
+the usual runtime is a setup failure — read the install step, not the tests
+(same class as the 2026-08-18 lockfile entry).
+*Incident:* v0.13.6 release PR #6923, gate run 32992496089; fixed by #6925 /
+#6926 (pin `@v4`); ~1 h of release delay on top of the GitHub Actions outage.
+*Enforcer:* none — a lint that every `pnpm/action-setup@` in a workflow file
+shares one major is the TODO.
+
+
 ### A row lock held to COMMIT makes batch size a blast radius, and a 500 turns backpressure into a livelock (2026-08-26)
 
 **When:** writing anything that inserts into `kortix.audit_events`, sizing an

--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.11.0
       - uses: actions/setup-node@v7

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -309,7 +309,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.11.0
       - uses: actions/setup-node@v7


### PR DESCRIPTION
The `deployed browser shard` job of tests-release.yml was the only job on
pnpm/action-setup@v6 (dependabot #6343); the api shards, sweep and quality
jobs stayed on @v4. On GitHub's ubuntu-latest no pnpm is preinstalled, so
the two behaved the same. On the Blacksmith image (tests-release moved there
in #6906) pnpm v11.19.0 is preinstalled at PNPM_HOME, and @v6's self-installer
takes its "Switching pnpm from v11.19.0 to v8.11.0" path, warns
`Failed to create bin ... @pnpm/exe/8.11.0 ... ENOENT`, and leaves a
standalone @pnpm/exe on PATH. That binary runs on its own bundled Node, so
`pnpm install --frozen-lockfile` fails engine-strict before the first
package:

  ERR_PNPM_UNSUPPORTED_ENGINE  Your Node version is incompatible with "/eslint/9.39.4".
  Expected version: ^18.18.0 || ^20.9.0 || >=21.1.0
  Got: v18.5.0

while actions/setup-node had already put 22.22.0 on PATH. All three browser
shards of the v0.13.6 gate (run 32992496089) died in ~60 s on this line.

Pin the browser shard (and tests-browser-nightly.yml, same shape) to @v4 like
every other job in the file.

Evidence: gate run https://github.com/kortix-ai/suna/actions/runs/32992496089 (release PR #6923), browser shard job 98255504956 vs api shard job 98255505082 (identical runner label, @v4, passed install).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356906&installation_model_id=434224&pr_number=6925&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6925&signature=a0360df1666aaa7f1c0ed6451acb5896d1251f837a179658a24431669d949084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->