### PR TITLE
release(staging): pin pnpm/action-setup@v4 in the release-gate browser shard

### DIFF
--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.11.0
       - uses: actions/setup-node@v7

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -309,7 +309,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v4
         with:
           version: 8.11.0
       - uses: actions/setup-node@v7


### PR DESCRIPTION
Targeted release-candidate hotfix: cherry-pick of 7d9cc0b97ef315ce3667585119f4baf721af6bcd (PR #6925 to main). Workflow-only change; no app code differs from staging cf91212b6a. Unblocks the v0.13.6 gate, whose 3 browser shards failed in ~60 s with ERR_PNPM_UNSUPPORTED_ENGINE (Got: v18.5.0) on Blacksmith — see release PR #6923 / run 32992496089.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790356932&installation_model_id=434224&pr_number=6926&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6926&signature=a93b8a234182e6b5ef261b45b4a74716f730c8ea78e20d4d4249f2a564e772ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->