### PR TITLE
test(ke2e): re-quarantine SESS-23 — stop→wake still 503s on the first post-wake read (gate run 32992496089)

### DIFF
--- a/tests/src/flows/session-thread-reliability.flow.ts
+++ b/tests/src/flows/session-thread-reliability.flow.ts
@@ -468,9 +468,19 @@ flow(
   {
     domain: 'sessions',
     requires: ['funded', 'daytona'],
-    // This used to be quarantined after repeated true-origin failures during
-    // stop→wake. Keep it in the normal release gate now: the stop-time abort
-    // and boot-time orphan finalizer must prove the contract on every run.
+    // Un-quarantined in 09aa887a55 (2026-08-24) on the expectation that the
+    // stop-time abort + boot-time orphan finalizer had closed the wake path.
+    // Its first release-gate run since (v0.13.6, run 32992496089, api shard 2)
+    // failed again at 168.7s: `status in [200] — expected [200], got 503` on
+    // the first OpenCode read through the preview proxy right after `/start`
+    // reported ready — the box was still waking (the "503 = waking state"
+    // class), i.e. the same pre-existing stop→wake defect the earlier
+    // quarantine documented (#6638 investigation). Re-quarantined until the
+    // wake path is proven on a staging dry run
+    // (`gh workflow run tests-release.yml --ref staging -f expected_sha=<sha>`);
+    // un-quarantine ONLY in the PR that carries that green run.
+    quarantine:
+      'stop→wake: first post-wake OpenCode read through the preview proxy answers 503 while the box is still waking after /start reports ready — pre-existing wake-path defect, re-quarantined 2026-08-26 (gate run 32992496089)',
     // 420_000 was smaller than the sum of the bounds this flow itself contains:
     // boot readiness 300_000 + OpenCode readiness 120_000 + stop-settle 60_000
     // + wake readiness (below) + assistant marker 240_000. The two readiness


### PR DESCRIPTION
09aa887a55 removed the SESS-23 quarantine on 2026-08-24 without a passing
release gate behind it. The first gate run since (v0.13.6, run 32992496089,
api shard 2) failed the flow again at 168.7s:

  ✗ [48/81] FAIL SESS-23 168.7s — status in [200] — expected [200], got 503

`waitForSessionReady` returned inside its 180s budget, and the very next
call — `listOcMessages` through the preview proxy — got 503: the sandbox was
still waking after `/start` reported ready. That is the pre-existing
stop→wake defect the previous quarantine text documented (#6638), not
something this release candidate introduced or fixed. The other 80 flows in
the shard passed.

Restore the quarantine (a named quarantine is a legitimate --require-all
outcome, #6643) with today's evidence. Un-quarantine only in the PR that
carries a green staging dry run of tests-release.yml.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790357722&installation_model_id=434224&pr_number=6927&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6927&signature=69fb03358b906da1d6b6005c76aebbd1a81b456a0525d9e8fdc48118e2ebb5a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->