### PR TITLE
test(ke2e): quarantine CONN-26 — real-agent Composio flow never passed a deployed gate (run 32992496089)

### DIFF
--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -374,6 +374,19 @@ flow(
     requires: ['funded', 'daytona', 'managedGit'],
     serial: true,
     timeoutMs: 720_000,
+    // Added in 5b070ebb18 (2026-08-24, direct push) and never run on a
+    // deployed gate before the v0.13.6 release (run 32992496089, api shard
+    // 1), where it failed after 392s: `Timed out waiting for Composio Gmail
+    // authorization request from agent session ses_fc0decd80ffeYPyIR1B5efRcz3`.
+    // CONN-25 passed in the same run (real connect.composio.dev link in 7.4s),
+    // so staging holds a working COMPOSIO_API_KEY — the unproven part is the
+    // live gpt-5.6-luna turn calling `add_connector` inside the 300s wait, and
+    // the harness dumps no transcript on that timeout. Quarantined until it
+    // passes a staging dry run of tests-release.yml with the transcript
+    // captured on failure; un-quarantine ONLY in the PR that carries that
+    // green run.
+    quarantine:
+      'real-agent Composio selection: gpt-5.6-luna turn produced no add_connector call / connect.composio.dev link within 300s on staging (gate run 32992496089, api shard 1) — unproven flow, quarantined 2026-08-26 pending a green staging dry run',
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/start',


### PR DESCRIPTION
CONN-26 was added in 5b070ebb18 (2026-08-24, direct push to main) and first
ran on a deployed target in the v0.13.6 release gate (run 32992496089, api
shard 1), where it failed:

  ✗ [26/38] FAIL CONN-26 392.0s — Timed out waiting for Composio Gmail
    authorization request from agent session ses_fc0decd80ffeYPyIR1B5efRcz3

CONN-25 passed in the same shard (a real connect.composio.dev link in 7.4s),
so staging holds a working COMPOSIO_API_KEY; the unproven part is the live
gpt-5.6-luna turn calling `add_connector` inside the flow's 300s wait, and
the harness captures no transcript when that wait expires, so the run leaves
no evidence either way. A release gate is not the place to prove a new
LLM-behaviour flow for the first time.

Quarantine it (a named quarantine is a legitimate --require-all outcome,
#6643). Un-quarantine only in the PR that carries a green staging dry run
(`gh workflow run tests-release.yml --ref staging -f expected_sha=<sha>`)
and adds a transcript dump on timeout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790358308&installation_model_id=434224&pr_number=6929&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6929&signature=9b17a4b7b243e3341406ef5ee1d97c6d85dc846b825c7225d66662b0a44fc2dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->