### PR TITLE
release(staging): quarantine CONN-26 in the release gate

### DIFF
--- a/tests/src/flows/run-session-backlog.flow.ts
+++ b/tests/src/flows/run-session-backlog.flow.ts
@@ -374,6 +374,19 @@ flow(
     requires: ['funded', 'daytona', 'managedGit'],
     serial: true,
     timeoutMs: 720_000,
+    // Added in 5b070ebb18 (2026-08-24, direct push) and never run on a
+    // deployed gate before the v0.13.6 release (run 32992496089, api shard
+    // 1), where it failed after 392s: `Timed out waiting for Composio Gmail
+    // authorization request from agent session ses_fc0decd80ffeYPyIR1B5efRcz3`.
+    // CONN-25 passed in the same run (real connect.composio.dev link in 7.4s),
+    // so staging holds a working COMPOSIO_API_KEY — the unproven part is the
+    // live gpt-5.6-luna turn calling `add_connector` inside the 300s wait, and
+    // the harness dumps no transcript on that timeout. Quarantined until it
+    // passes a staging dry run of tests-release.yml with the transcript
+    // captured on failure; un-quarantine ONLY in the PR that carries that
+    // green run.
+    quarantine:
+      'real-agent Composio selection: gpt-5.6-luna turn produced no add_connector call / connect.composio.dev link within 300s on staging (gate run 32992496089, api shard 1) — unproven flow, quarantined 2026-08-26 pending a green staging dry run',
     routes: [
       'POST /v1/projects/:projectId/sessions',
       'POST /v1/projects/:projectId/sessions/:sessionId/start',


### PR DESCRIPTION
Targeted release-candidate hotfix: cherry-pick of 40c5a26f594705243c793592054981df11c40038 (PR to main opened separately). Test-only change. CONN-26 failed the v0.13.6 gate (run 32992496089, api shard 1) after 392s waiting for the agent's Composio authorization link; it was added in 5b070ebb18 and has never passed a deployed gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790358314&installation_model_id=434224&pr_number=6930&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6930&signature=73d6f3dc0097329dd7fb22a969cdba169abbfb814405940f17614d00f08624f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->