### PR TITLE
fix(tests): keep the Vercel bypass storage state (_vercel_jwt) out of uploaded CI artifacts

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -434,7 +434,9 @@ jobs:
         if: always()
         with:
           name: preview-results-pr-${{ needs.authorize.outputs.pr_number }}-${{ needs.authorize.outputs.sha }}
-          path: tests/test-results/**
+          path: |
+            tests/test-results/**
+            !tests/test-results/deployment-bypass-state.json
           if-no-files-found: warn
           retention-days: 14
       - name: Fail when deployment or tests failed

--- a/.github/workflows/tests-browser-nightly.yml
+++ b/.github/workflows/tests-browser-nightly.yml
@@ -103,6 +103,8 @@ jobs:
         if: always()
         with:
           name: tests-browser-nightly-quarantine
-          path: tests/test-results/**
+          path: |
+            tests/test-results/**
+            !tests/test-results/deployment-bypass-state.json
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -252,7 +252,9 @@ jobs:
         if: always()
         with:
           name: tests-release-api-shard-${{ matrix.shard }}
-          path: tests/test-results/**
+          path: |
+            tests/test-results/**
+            !tests/test-results/deployment-bypass-state.json
           if-no-files-found: warn
           retention-days: 90
 
@@ -346,7 +348,9 @@ jobs:
         if: always()
         with:
           name: tests-release-browser-shard-${{ matrix.shard }}
-          path: tests/test-results/**
+          path: |
+            tests/test-results/**
+            !tests/test-results/deployment-bypass-state.json
           if-no-files-found: warn
           retention-days: 90
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,8 @@ jobs:
         if: always() && (inputs.mode == 'full' || inputs.mode == matrix.mode)
         with:
           name: ${{ inputs.artifact-name }}-${{ matrix.lane }}
-          path: tests/test-results/**
+          path: |
+            tests/test-results/**
+            !tests/test-results/deployment-bypass-state.json
           if-no-files-found: warn
           retention-days: ${{ inputs.retention-days }}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 test-results/
+.state/
 contract/pacts/*.json
 *.log
 .env

--- a/tests/e2e/helpers/deployment-bypass.ts
+++ b/tests/e2e/helpers/deployment-bypass.ts
@@ -50,7 +50,15 @@ import type { BrowserContext, Cookie } from '@playwright/test';
 export const DEPLOYMENT_BYPASS_STATE_PATH = join(
   dirname(dirname(fileURLToPath(import.meta.url))),
   '..',
-  'test-results',
+  // NOT under `test-results/`: that directory is uploaded verbatim as a CI
+  // artifact (`tests/test-results/**`) on a PUBLIC repo, and this file holds
+  // the live `_vercel_jwt` deployment-protection cookie (7-day lifetime).
+  // Every release-gate run from 2026-08-20 to 2026-08-26 published it; the
+  // artifact-secret guard only started running for real on 2026-08-25 (grep
+  // instead of a missing rg) and caught it in the v0.13.6 gate. `.state/` is
+  // gitignored and never listed in any upload path. The workflows also
+  // exclude `deployment-bypass-state.json` by name as a second guard.
+  '.state',
   'deployment-bypass-state.json',
 );
 

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -237,6 +237,33 @@ describe('web ECS migration', () => {
     expect(existsSync(resolve(root, 'tests/e2e/examples/playwright.config.ts'))).toBe(false);
   });
 
+  it('the deployment-bypass storage state is never written under an uploaded artifact path', () => {
+    // tests/test-results/** is uploaded verbatim on a public repo; the state
+    // file holds the live _vercel_jwt cookie. Both guards must hold: the file
+    // lives outside test-results, AND every upload of test-results excludes
+    // it by name (belt and braces — see deployment-bypass.ts).
+    const helper = read('tests/e2e/helpers/deployment-bypass.ts');
+    expect(helper).not.toMatch(/'test-results',\s*\n\s*'deployment-bypass-state\.json'/);
+    expect(helper).toContain("'.state',");
+    expect(read('tests/.gitignore')).toContain('.state/');
+    for (const wf of [
+      '.github/workflows/tests-release.yml',
+      '.github/workflows/tests-browser-nightly.yml',
+      '.github/workflows/tests.yml',
+      '.github/workflows/deploy-preview.yml',
+    ]) {
+      const uploads = read(wf).split('upload-artifact@').slice(1);
+      let seen = 0;
+      for (const block of uploads) {
+        const head = block.slice(0, 600);
+        if (!head.includes('tests/test-results/**')) continue;
+        seen += 1;
+        expect(head, wf).toContain('!tests/test-results/deployment-bypass-state.json');
+      }
+      expect(seen, wf).toBeGreaterThan(0);
+    }
+  });
+
   /**
    * The bypass secret must never ride on `use.extraHTTPHeaders`.
    *


### PR DESCRIPTION
`tests/e2e/helpers/deployment-bypass.ts` wrote the Playwright storage state —
which holds the live `_vercel_jwt` deployment-protection cookie for
staging.kortix.com (7-day lifetime, `aud: staging.kortix.com`) — to
`tests/test-results/deployment-bypass-state.json`. Every deployed browser job
uploads `tests/test-results/**` as a workflow artifact, and this repository
is public. Every release-gate run from 2026-08-20 (when #6632 introduced the
cookie exchange) to 2026-08-26 published that cookie; the "Guard test
artifacts against secrets" step never caught it because it invoked `rg`,
which GitHub's images do not ship, under `2>/dev/null` — it only started
running for real on Blacksmith (grep, 2026-08-25) and failed all three
browser shards of the v0.13.6 gate (run 32998656515) on exactly this file.
78 unexpired `tests-release-browser-shard-*` artifacts were deleted by hand
on 2026-08-26.

Two guards, both pinned by `web-ecs-workflow.test.ts`:
- the state file now lives in `tests/.state/` (gitignored, never an upload
  path);
- every `tests/test-results/**` upload (tests-release, tests-browser-nightly,
  tests, deploy-preview) excludes `deployment-bypass-state.json` by name.

The artifact-secret guard stays as the third line.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360835&installation_model_id=434224&pr_number=6933&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6933&signature=852f7e565cd434867436c725d2407bcd673880a08c7f36620d921c2998ae2d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->