### PR TITLE
docs(learnings): a never-fired guard is untested; an artifact upload path is a publish path

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,35 @@ linked, not inlined.
 
 ## Register
 
+### A guard that has never fired has never been tested; and an artifact upload path is a publish path (2026-08-26)
+
+**When:** writing any secret guard in CI (`if grep …; then exit 1`), or
+uploading a directory as a workflow artifact on a public repository.
+Two facts, one incident. (1) The "Guard test artifacts against secrets" step
+in `tests-release.yml` invoked `rg` under `2>/dev/null`; GitHub's ubuntu
+images do not ship `rg`, so from its first run (2026-08-19) until the
+Blacksmith move (2026-08-25, `grep`) it passed on nothing, every time. A
+guard is only evidence after it has been SEEN to fail on a planted value —
+plant one in a dry run before trusting it. (2) The moment it ran for real it
+found `tests/test-results/deployment-bypass-state.json`: the Playwright
+storage state from #6632's bypass exchange, holding the live `_vercel_jwt`
+cookie for `staging.kortix.com` (HS256, `aud: staging.kortix.com`, 7-day
+expiry). `tests/test-results/**` is uploaded verbatim by every deployed
+browser job, and `kortix-ai/suna` is public — so every release-gate run from
+2026-08-20 to 2026-08-26 published a valid deployment-protection bypass
+cookie; 78 unexpired `tests-release-browser-shard-*` artifacts held one.
+Rules: never write a credential-bearing file under a directory that any
+workflow uploads (`tests/.state/` now; `web-ecs-workflow.test.ts` pins the
+helper path AND a by-name exclusion on all four `tests/test-results/**`
+uploads); treat `path: <dir>/**` as "publish everything here"; and when a
+new guard first goes red, assume it is telling the truth before assuming it
+is noise. Fixed in #6933/#6934; artifacts deleted by hand the same day.
+*Incident:* v0.13.6 gate run 32998656515 — all 3 browser shards failed on
+the guard after their journeys had passed. No known exploitation; the
+cookies themselves cannot be revoked by us — rotating the Vercel
+"Protection Bypass for Automation" secret is the operator follow-up.
+*Enforcer:* the unit pin above + the (now real) artifact guard.
+
 ### A release-gate flow is added or un-quarantined only in the PR that carries its green deployed run (2026-08-26)
 
 **When:** adding a flow with `requires: ['daytona']` (it never runs in local


### PR DESCRIPTION
Register entry for the _vercel_jwt-in-artifacts finding (v0.13.6 gate run 32998656515; fix #6933/#6934). Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790360989&installation_model_id=434224&pr_number=6935&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6935&signature=66e223d70564793e89f09083b74820d776d4e98cee120b78e93c3ef6046b768b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->