### PR TITLE
release(staging): quarantine the Composio Gmail Connect-Link browser journey

### DIFF
--- a/tests/e2e/specs/23-composio-connector.spec.ts
+++ b/tests/e2e/specs/23-composio-connector.spec.ts
@@ -262,7 +262,18 @@ test.describe("23 — Composio managed connector", () => {
     expect(pageErrors, `client errors: ${pageErrors.join(" | ")}`).toEqual([]);
   });
 
-  test("a fresh Gmail Connect Link uses Composio managed auth and Google serves sign-in", async ({
+  // @quarantine: this journey calls `test.skip(!providers.includes("composio"))`
+  // when the live `/connectors/connect-status` does not report composio. Under
+  // the strict browser reporter (E2E_REQUIRE_ALL_BROWSER=1) any runtime skip
+  // other than the tagged 17-oauth journey fails the whole shard — so this
+  // deployment-conditional skip red-lit browser shard 3 of the v0.13.6 gate
+  // (run 33002502228) even though its four siblings passed. It is the browser
+  // twin of CONN-26 (both added 2026-08-24, 5b070ebb18) and, like CONN-26, has
+  // never cleared a deployed gate. Tag it so the gate EXCLUDES it (an
+  // authorized outcome) instead of counting a runtime skip as unauthorized.
+  // Un-quarantine only in the PR whose staging dry run of tests-release.yml is
+  // green with this journey enabled.
+  test("a fresh Gmail Connect Link uses Composio managed auth and Google serves sign-in", { tag: "@quarantine" }, async ({
     page,
     request,
   }) => {


### PR DESCRIPTION
Targeted release-candidate hotfix: cherry-pick of e1f696075724afc2def64cb8c9ac3f596be3fb31 (PR to main opened separately). Test-only. The journey's deployment-conditional test.skip failed browser shard 3 of the v0.13.6 gate (runs 32998656515, 33002502228) under the strict reporter; it is the browser twin of CONN-26 and has never cleared a deployed gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363402&installation_model_id=434224&pr_number=6937&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6937&signature=f137706ff0333447345f9557c6144ddb5fef6cf1e4296deb6c9e5f469fd6b5d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->