### PR TITLE
fix(web): Apps gallery is a 4:5 container-query grid, no size control

### DIFF
--- a/apps/web/src/features/apps/app-preview.test.tsx
+++ b/apps/web/src/features/apps/app-preview.test.tsx
@@ -5,16 +5,13 @@ import { stripTags } from '@/test-utils/strip-tags';
 import type { App } from '@kortix/sdk';
 
 import {
-  APP_GRID_DEFAULT_DENSITY,
-  APP_GRID_DENSITY,
-  APP_GRID_DENSITY_ORDER,
-  APP_GRID_DENSITY_STORAGE_KEY,
+  APP_GRID_COLUMNS,
+  APP_GRID_CONTAINER,
   AppPreview,
   AppPreviewOverlay,
   DEPLOYMENT_COPY,
   appHost,
   deployNotice,
-  parseAppGridDensity,
   PREVIEW_SPINNER_DELAY_MS,
   PREVIEW_TILE_ASPECT,
   PREVIEW_VIEWPORT_HEIGHT,
@@ -206,17 +203,29 @@ describe('previewScale', () => {
     expect(PREVIEW_VIEWPORT_WIDTH / PREVIEW_VIEWPORT_HEIGHT).toBeCloseTo(Number(w) / Number(h), 5);
   });
 
-  test('the tile is 16:9 landscape — the shape of the page it is a picture of', () => {
-    // A 4:5 portrait tile shipped for one day. At four columns it is a 230px
-    // strip of a 1600px-tall page: the App's whole layout at 18% scale, where
-    // every card reads as the same grey rectangle. An App is a web page, and a
-    // web page is landscape.
-    expect(PREVIEW_VIEWPORT_WIDTH).toBeGreaterThan(PREVIEW_VIEWPORT_HEIGHT);
-    expect(PREVIEW_VIEWPORT_WIDTH / PREVIEW_VIEWPORT_HEIGHT).toBeCloseTo(16 / 9, 5);
-    expect(PREVIEW_TILE_ASPECT).toBe('aspect-[16/9]');
+  test('the tile is 4:5 — FINAL, chosen after five candidates', () => {
+    // Settled by Jay on 2026-08-27 over 16:9, 9:16, 3:4, 1:1 and 2:3. This is a
+    // product decision, not a derived value: it does not move without a new one.
+    expect(PREVIEW_TILE_ASPECT).toBe('aspect-[4/5]');
+    expect(PREVIEW_VIEWPORT_WIDTH).toBe(1080);
+    expect(PREVIEW_VIEWPORT_HEIGHT).toBe(1350);
+    expect(PREVIEW_VIEWPORT_WIDTH / PREVIEW_VIEWPORT_HEIGHT).toBeCloseTo(4 / 5, 5);
+  });
+
+  test('4:5 works now only because the tile is no longer 230px', () => {
+    // 4:5 shipped once (e56c580271) and was reverted (e6c4ba0b62) — paired with
+    // a `max-w-5xl` cap and a fixed four-column grid, it produced a 230px tile:
+    // the App at 18% scale, every card the same grey rectangle. The ratio was
+    // never the fault. At the current cap a four-across tile is 300px.
+    const tileAtCap = (1280 - 32 - 3 * 16) / 4;
+    expect(tileAtCap).toBeGreaterThan(230);
+    expect(tileAtCap * (5 / 4)).toBeCloseTo(375, 0);
   });
 
   test('the viewport is a desktop width — a phone width would defeat the point', () => {
+    // The tile is portrait; the VIEWPORT must not be. 1080px is still past
+    // every common desktop breakpoint, so no App answers the thumbnail with
+    // its hamburger-and-one-column layout.
     expect(PREVIEW_VIEWPORT_WIDTH).toBeGreaterThanOrEqual(1024);
   });
 });
@@ -347,54 +356,71 @@ describe('deployNotice — the header speaks only when there is news', () => {
 /**
  * The third defect: the gallery decided tile size for you, and chose wrong.
  *
- * Four columns inside a 1024px cap is a 230px tile. There is now a default that
- * is big — two per row — and a control that trades size for count. The default
- * is the part under test: a preference nobody sets has to land somewhere sane.
+ * It shipped a three-way size picker backed by `localStorage` — a preference
+ * nobody holds until they have seen the page. The grid sizes itself now, and it
+ * does so against its CONTAINER rather than the window: this page sits beside a
+ * sidebar that docks and collapses, so ~256px of the grid's width appears and
+ * disappears without the viewport moving at all.
  */
-describe('APP_GRID_DENSITY — a default size, then a choice', () => {
-  test('the default is two per row, which is what makes a tile big', () => {
-    expect(APP_GRID_DEFAULT_DENSITY).toBe('large');
-    expect(APP_GRID_DENSITY[APP_GRID_DEFAULT_DENSITY].columns).toBe(2);
-    expect(APP_GRID_DENSITY[APP_GRID_DEFAULT_DENSITY].grid).toContain('sm:grid-cols-2');
+describe('APP_GRID_COLUMNS — the grid measures the box it is in', () => {
+  /** The tile width `cols` columns leave inside a container of `width`. */
+  const tile = (width: number, cols: number) => (width - 32 - (cols - 1) * 16) / cols;
+
+  /** Which step the ladder resolves to at a given container width. */
+  const columnsAt = (width: number) =>
+    width >= 1024 ? 4 : width >= 768 ? 3 : width >= 512 ? 2 : 1;
+
+  test('every step is a CONTAINER query, never a viewport breakpoint', () => {
+    // `xl:grid-cols-4` on a 1280px viewport with the sidebar docked fires on a
+    // container that is really ~1024px wide. The window is the wrong question.
+    for (const viewportOnly of ['sm:', 'md:', 'lg:', 'xl:', '2xl:']) {
+      expect(APP_GRID_COLUMNS).not.toContain(viewportOnly);
+    }
+    expect(APP_GRID_COLUMNS.match(/@\w+\/apps:/g)).toHaveLength(3);
   });
 
-  test('the control offers every density exactly once, biggest tile first', () => {
-    expect([...APP_GRID_DENSITY_ORDER].sort()).toEqual(Object.keys(APP_GRID_DENSITY).sort());
-    const counts = APP_GRID_DENSITY_ORDER.map((key) => APP_GRID_DENSITY[key].columns);
-    expect(counts).toEqual([...counts].sort((a, b) => a - b));
-    expect(new Set(counts).size).toBe(counts.length);
-  });
-
-  test('every density starts at one column and writes its classes out in full', () => {
-    for (const key of APP_GRID_DENSITY_ORDER) {
-      const { columns, grid } = APP_GRID_DENSITY[key];
-      // A phone gets one column at every density — a 300px tile is the mobile
-      // layout this whole mechanism exists to avoid.
-      expect(grid).toContain('grid-cols-1');
-      // Tailwind scans source text, so an interpolated class never reaches the
-      // stylesheet. The widest breakpoint has to name the real column count.
-      expect(grid).toContain(`grid-cols-${columns}`);
-      expect(grid).not.toContain('${');
-      expect(APP_GRID_DENSITY[key].label.length).toBeGreaterThan(0);
+  test('the grid and its container name each other, or every step is inert', () => {
+    // A `@lg/apps:` variant with no `@container/apps` ancestor compiles and
+    // then never matches — the grid would silently stay one column forever.
+    expect(APP_GRID_CONTAINER).toBe('@container/apps');
+    const name = APP_GRID_CONTAINER.split('/')[1];
+    for (const step of APP_GRID_COLUMNS.match(/@\w+\/\w+:/g) ?? []) {
+      expect(step.split('/')[1]).toBe(`${name}:`);
     }
   });
-});
 
-describe('parseAppGridDensity — the stored value is untrusted input', () => {
-  test('accepts what this build actually renders', () => {
-    for (const key of APP_GRID_DENSITY_ORDER) expect(parseAppGridDensity(key)).toBe(key);
+  test('a docked desktop lands on four across', () => {
+    // 1440px window minus a docked sidebar is a ~1184px container; the cap is
+    // 1280px. Both are past the last step.
+    expect(columnsAt(1184)).toBe(4);
+    expect(columnsAt(1280)).toBe(4);
+    expect(APP_GRID_COLUMNS).toContain('@5xl/apps:grid-cols-4');
   });
 
-  test('rejects everything else rather than indexing into undefined', () => {
-    // `localStorage` is shared with every other tab and every past version of
-    // this page. A density this build removed, or a prototype key, would land
-    // in APP_GRID_DENSITY[value] as undefined and render a grid with no column
-    // class at all.
-    for (const bad of [null, '', 'comfortable', 'undefined', 'toString', '__proto__', 'constructor'])
-      expect(parseAppGridDensity(bad)).toBeNull();
+  test('a phone gets one column', () => {
+    // Four columns of a 375px page is a 78px tile. One column is the floor and
+    // the base class, so it needs no variant at all.
+    expect(columnsAt(375)).toBe(1);
+    expect(APP_GRID_COLUMNS.startsWith('grid-cols-1 ')).toBe(true);
   });
 
-  test('the storage key is namespaced, so it cannot collide with another page', () => {
-    expect(APP_GRID_DENSITY_STORAGE_KEY).toBe('kortix.apps.grid-density');
+  test('no step ever produces a tile too small to read the App in', () => {
+    // 230px is the width the 4:5 grid shipped at for one day: the App's whole
+    // layout at ~18% scale, where every card is the same grey rectangle.
+    for (const width of [375, 512, 640, 768, 900, 1024, 1184, 1280]) {
+      const cols = columnsAt(width);
+      if (cols === 1) continue;
+      expect(tile(width, cols)).toBeGreaterThan(230);
+    }
+  });
+
+  test('the ladder only ever widens, and names its classes in full', () => {
+    const counts = [...(APP_GRID_COLUMNS.match(/grid-cols-(\d)/g) ?? [])].map((c) =>
+      Number(c.replace('grid-cols-', '')),
+    );
+    expect(counts).toEqual([1, 2, 3, 4]);
+    // Tailwind scans source text, so an interpolated class never reaches the
+    // stylesheet.
+    expect(APP_GRID_COLUMNS).not.toContain('${');
   });
 });

--- a/apps/web/src/features/apps/apps-feature-gate.test.ts
+++ b/apps/web/src/features/apps/apps-feature-gate.test.ts
@@ -294,18 +294,25 @@ test('the Apps grid is a gallery: bordered thumbnails, captions hanging below', 
   const view = readFileSync(resolve(root, 'features/apps/apps-view.tsx'), 'utf8');
   const card = view.slice(view.indexOf('function AppCard('), view.indexOf('function AppDetailModal('));
 
-  // The grid's column count is the reader's choice now, so the gap belongs to
-  // the page and the columns come from `APP_GRID_DENSITY`. The skeleton takes
-  // the SAME class string so nothing reflows when data lands.
-  const GRID = "cn('grid gap-x-6 gap-y-8', columns)";
+  // One column ladder, used by the grid AND the skeleton, so nothing reflows
+  // when data lands. There is no size control and no stored preference.
+  const GRID = "cn('grid gap-x-4 gap-y-6', APP_GRID_COLUMNS)";
   expect(view.split(GRID)).toHaveLength(3);
-  expect(view).not.toContain('xl:grid-cols-4"');
+  // The picker and everything that persisted it are gone.
+  expect(view).not.toContain('AppGridDensity');
+  expect(view).not.toContain('window.localStorage');
+  expect(view).not.toContain('useSyncExternalStore');
+  // The header is a title and a docs link — no size buttons to hide or show.
+  const header = view.slice(view.indexOf('function AppsHeader('), view.indexOf('export function AppsView('));
+  expect(header).not.toContain('<Button');
 
-  // The gallery column is sized for the default density: two 16:9 tiles inside
-  // a 1280px cap are ~600px wide, which is where a scaled-down desktop layout
-  // is still readable. `max-w-5xl` is what produced 230px tiles.
+  // The gallery column is also the grid's measuring box. A `@lg/apps:` variant
+  // with no `@container/apps` ancestor compiles and then never matches, so the
+  // grid would silently stay one column forever.
   expect(view).toContain('max-w-7xl flex-col px-4 py-6 pb-20');
   expect(view).not.toContain('max-w-5xl flex-col');
+  expect(view).toContain('APP_GRID_CONTAINER,');
+  expect(view).toContain("export const APP_GRID_CONTAINER = '@container/apps';");
 
   // The thumbnail is the only bordered surface; the caption is page text under
   // it, not the inside of a panel. The old card was one `bg-popover` panel with

--- a/apps/web/src/features/apps/apps-view.tsx
+++ b/apps/web/src/features/apps/apps-view.tsx
@@ -56,19 +56,15 @@ import {
   ClockCounterClockwiseIcon,
   DotsThreeIcon,
   GlobeIcon,
-  GridNineIcon,
-  type Icon as PhosphorIcon,
   LockKeyIcon,
   PauseIcon,
   PlayIcon,
-  SquareIcon,
-  SquaresFourIcon,
   TrashIcon,
   XIcon,
 } from '@phosphor-icons/react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 type DeploymentTone = 'success' | 'destructive' | 'warning' | 'muted';
 
@@ -288,164 +284,90 @@ export function AppPreviewOverlay({
  * it actually shows.
  *
  * Render at a desktop width instead and scale the result down. The App lays
- * out at 1280px, the tile shows that layout in miniature, and the thumbnail
- * finally looks like the App — the same thing a screenshot would give you.
+ * out at 1080px — still a desktop breakpoint, so no App answers with its
+ * hamburger — and the tile shows that layout in miniature.
  *
  * **The ratio is load-bearing.** The frame is scaled to the tile's WIDTH, so
  * any mismatch between the viewport's aspect and the tile's shows up as dead
  * space at the bottom of every tile (viewport shorter) or a crop (taller).
- * 1280x720 is 16:9 exactly, which is `PREVIEW_TILE_ASPECT`, so the scaled frame
+ * 1080x1350 is 4:5 exactly, which is `PREVIEW_TILE_ASPECT`, so the scaled frame
  * fills the tile edge to edge. Change one, change the other — the parity is
  * asserted in `app-preview.test.tsx`.
  *
- * 16:9 and not 4:5. A 4:5 tile at four columns is a 230px-wide portrait strip
- * of a 1600px-tall desktop page: the App's whole layout at 18% scale, where
- * nothing in it is legible and every card reads as the same grey rectangle. An
- * App is a web page, a web page is landscape, and 16:9 is the shape every other
- * thumbnail in this product already uses — `presentations/engine/deck.tsx` and
- * `FullScreenPresentationViewer` both render into one. Paired with a default of
- * two columns (`APP_GRID_DENSITY`), the tile is ~600px wide and the miniature
- * is readable as the App it is.
+ * The width and the height answer two different questions, and only the second
+ * is about the ratio. The viewport WIDTH decides which layout the App renders,
+ * and 1080px is a desktop breakpoint — no App answers the thumbnail with its
+ * hamburger. The viewport HEIGHT decides how far down that page the thumbnail
+ * reaches: 1350px of a 1080px-wide page is a hero and the section under it,
+ * where the 720px of the old 16:9 tile was the header alone.
+ *
+ * The ratio is a row-height decision: every candidate trades how much page a
+ * tile shows against how many rows fit a screen, at a fixed tile width.
+ *
+ *   | ratio     | height/width | tile at cap | four-across row              |
+ *   | ---       | ---          | ---         | ---                          |
+ *   | `16/9`    | 0.56x        | 300x169     | a letterbox of the header    |
+ *   | `1/1`     | 1.00x        | 300x300     | two rows and part of a third |
+ *   | **`4/5`** | **1.25x**    | **300x375** | **two rows on a laptop**     |
+ *   | `3/4`     | 1.33x        | 300x400     | a row and a half             |
+ *   | `2/3`     | 1.50x        | 300x450     | a row and a third            |
+ *   | `9/16`    | 1.78x        | 300x533     | about one row                |
+ *
+ * 4:5 is the one ratio here that shipped BEFORE and was reverted (`e56c580271`,
+ * reverted by `e6c4ba0b62`), so the reason it works now and did not then has to
+ * be written down: it was paired with a `max-w-5xl` cap and a fixed four-column
+ * grid, which is a 230px tile — the App at 18% scale, every card the same grey
+ * rectangle. What changed is not the ratio. The cap is `max-w-7xl` and the
+ * columns come from a container ladder floored at ~232px, so the tile is 300px
+ * at the cap and never the 230px that killed it. Do not revert this to 16:9
+ * again; fix the ladder if a tile ever gets small.
+ *
+ * At the four columns a docked desktop lands on (`APP_GRID_COLUMNS`), a tile is
+ * ~276x345 — the App at ~26% scale.
  *
  * Note what does NOT solve the mobile-layout problem — `showAspectRatioToCSS`
  * in `show-content-renderer.tsx` reshapes the BOX and leaves the guest laying
  * out at the host's width, which is the thing that produced it here.
  */
-export const PREVIEW_VIEWPORT_WIDTH = 1280;
-export const PREVIEW_VIEWPORT_HEIGHT = 720;
+export const PREVIEW_VIEWPORT_WIDTH = 1080;
+export const PREVIEW_VIEWPORT_HEIGHT = 1350;
 /** The tile's shape, written once so the class and the viewport cannot drift. */
-export const PREVIEW_TILE_ASPECT = 'aspect-[16/9]';
+export const PREVIEW_TILE_ASPECT = 'aspect-[4/5]';
 
 /**
- * How many tiles the gallery puts in a row, and therefore how big each App is.
+ * How many tiles the gallery puts in a row.
  *
- * There is a default and there is a choice, in that order. The default is two
- * across: a tile wide enough that the scaled-down desktop layout inside it is
- * readable as a page rather than a swatch, which is the whole reason the card
- * renders the App at all. Someone with twenty Apps wants to see twenty Apps,
- * so the control in the header trades size for count — but nobody has to touch
- * it to get a sane page.
+ * **Container queries, not viewport breakpoints.** This page sits beside a
+ * sidebar that docks and collapses, so the grid's real width swings by ~256px
+ * while the viewport never moves. `xl:grid-cols-4` on a 1280px viewport with
+ * the sidebar docked fires on a container that is actually ~1024px wide — four
+ * 236px tiles from a class chosen for 300px ones. `@5xl/apps:` asks the only
+ * question that decides whether a column fits: how wide is the box the grid is
+ * in. The named container is declared on the padded column in `AppsView`.
  *
- * The column classes are written out in full, one literal per density. Tailwind
- * scans source text, so a class assembled at runtime (`grid-cols-${n}`) is not
- * in the compiled stylesheet and silently does nothing.
+ * The steps are chosen so the TILE never drops below ~232px at any of them —
+ * the width where a 1080px page scaled into it stops reading as a page and
+ * starts reading as a grey rectangle. Container width -> tile width:
  *
- * Every density starts at one column on a phone and steps up: a 300px tile is
- * the mobile-layout problem again, and the point of the whole mechanism is to
- * never show one.
+ *   | step            | container | cols | tile    |
+ *   | ---             | ---       | ---  | ---     |
+ *   | (base)          | < 512px   | 1    | full    |
+ *   | `@lg`  (32rem)  | 512px     | 2    | 232x290 |
+ *   | `@3xl` (48rem)  | 768px     | 3    | 235x294 |
+ *   | `@5xl` (64rem)  | 1024px    | 4    | 236x295 |
+ *   | (cap)           | 1280px    | 4    | 300x375 |
+ *
+ * Four across is therefore what a docked desktop lands on, and a phone still
+ * gets one column — a 170px tile is the grey rectangle again.
+ *
+ * Written out as one literal. Tailwind scans source text, so a class assembled
+ * at runtime (`grid-cols-${n}`) never reaches the compiled stylesheet and
+ * silently does nothing.
  */
-export type AppGridDensity = 'large' | 'medium' | 'small';
+export const APP_GRID_CONTAINER = '@container/apps';
 
-export const APP_GRID_DEFAULT_DENSITY: AppGridDensity = 'large';
-
-export const APP_GRID_DENSITY: Record<
-  AppGridDensity,
-  { columns: number; label: string; grid: string; icon: PhosphorIcon }
-> = {
-  large: {
-    columns: 2,
-    label: 'Large — 2 per row',
-    grid: 'grid-cols-1 sm:grid-cols-2',
-    icon: SquareIcon,
-  },
-  medium: {
-    columns: 3,
-    label: 'Medium — 3 per row',
-    grid: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
-    icon: SquaresFourIcon,
-  },
-  small: {
-    columns: 4,
-    label: 'Small — 4 per row',
-    grid: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
-    icon: GridNineIcon,
-  },
-};
-
-/** Left to right in the control: biggest tile first, densest last. */
-export const APP_GRID_DENSITY_ORDER = ['large', 'medium', 'small'] as const;
-
-export const APP_GRID_DENSITY_STORAGE_KEY = 'kortix.apps.grid-density';
-
-/**
- * The stored preference, or `null` for anything that is not one of ours.
- *
- * `localStorage` is a string bucket shared with every other tab and every past
- * version of this page, so the value read back is untrusted input: a density
- * this build removed, a key someone else wrote, `undefined` stringified by a
- * bug. Any of those would land in `APP_GRID_DENSITY[density]` as `undefined`
- * and render a grid with no column class at all.
- */
-export function parseAppGridDensity(value: string | null): AppGridDensity | null {
-  if (!value) return null;
-  return Object.hasOwn(APP_GRID_DENSITY, value) ? (value as AppGridDensity) : null;
-}
-
-/**
- * Where the choice lives when `localStorage` will not take it.
- *
- * A browser set to block site data throws on `setItem`, and the reader who
- * clicked a size button is owed the size they clicked whether or not it can
- * outlive the tab. Module scope, so it survives a remount the way the real
- * store would.
- */
-let blockedStorageDensity: AppGridDensity | null = null;
-
-/** Same-tab subscribers. The `storage` event covers every OTHER tab, not this one. */
-const densityListeners = new Set<() => void>();
-
-function subscribeToDensity(onStoreChange: () => void) {
-  densityListeners.add(onStoreChange);
-  window.addEventListener('storage', onStoreChange);
-  return () => {
-    densityListeners.delete(onStoreChange);
-    window.removeEventListener('storage', onStoreChange);
-  };
-}
-
-function readDensity(): AppGridDensity {
-  try {
-    const stored = parseAppGridDensity(window.localStorage.getItem(APP_GRID_DENSITY_STORAGE_KEY));
-    if (stored) return stored;
-  } catch {
-    /* site data blocked — this page's own choice is all there is */
-  }
-  return blockedStorageDensity ?? APP_GRID_DEFAULT_DENSITY;
-}
-
-/** No `localStorage` on the server, so the server renders the default. */
-function serverDensity(): AppGridDensity {
-  return APP_GRID_DEFAULT_DENSITY;
-}
-
-/**
- * The density the page renders at, remembered across visits.
- *
- * `localStorage` is an external store, so it is read with the hook React
- * provides for external stores rather than copied into component state by an
- * effect. That buys three things at once: the server gets its own snapshot, so
- * a stored `small` cannot hydrate against a prerendered `large`; there is no
- * setState-in-an-effect cascade; and the `storage` event makes a change in one
- * tab land in every other one, which an effect that reads once never would.
- *
- * The snapshot is a string literal from a closed set, so React compares it by
- * value and an unchanged store cannot loop.
- */
-function useAppGridDensity() {
-  const density = useSyncExternalStore(subscribeToDensity, readDensity, serverDensity);
-
-  const choose = (next: AppGridDensity) => {
-    try {
-      window.localStorage.setItem(APP_GRID_DENSITY_STORAGE_KEY, next);
-      blockedStorageDensity = null;
-    } catch {
-      blockedStorageDensity = next;
-    }
-    for (const listener of densityListeners) listener();
-  };
-
-  return [density, choose] as const;
-}
+export const APP_GRID_COLUMNS =
+  'grid-cols-1 @lg/apps:grid-cols-2 @3xl/apps:grid-cols-3 @5xl/apps:grid-cols-4';
 
 /**
  * How far to shrink the desktop frame so it fits the tile. `null` for a width
@@ -466,7 +388,7 @@ export function previewScale(
  * Measures the tile and keeps the scale honest as it changes.
  *
  * A layout effect, not an effect: it runs after DOM mutation and BEFORE paint,
- * so the browser never shows the unscaled 1280px frame cropped to the tile's
+ * so the browser never shows the unscaled 1080px frame cropped to the tile's
  * top-left corner. The `ResizeObserver` then covers every later change — the
  * responsive grid going one-column, a sidebar opening, a window drag — none of
  * which fire anything else this component would hear.
@@ -584,7 +506,7 @@ export function AppPreview({
                 // Hidden, not unmounted, until the tile has been measured: an
                 // unmounted frame would restart the document load on every
                 // resize, and a visible unscaled one would flash the App's
-                // top-left 1280px corner. It still loads while hidden.
+                // top-left 1080px corner. It still loads while hidden.
                 ...(viewportScale === null
                   ? { visibility: 'hidden' as const }
                   : { transform: `scale(${viewportScale})` }),
@@ -623,61 +545,7 @@ export function AppPreview({
   );
 }
 
-/**
- * Tile size, as three states of one control rather than a menu.
- *
- * A segmented `ButtonGroup` of icon buttons is the pattern this product already
- * uses for a small closed set of view choices — `drive-header.tsx` picks list
- * vs grid the same way. Three options is few enough that every one of them is
- * visible without opening anything, and the glyphs read as the thing they do:
- * one square, four, then nine, each denser than the last.
- */
-function AppGridDensityControl({
-  value,
-  onChange,
-}: {
-  value: AppGridDensity;
-  onChange: (next: AppGridDensity) => void;
-}) {
-  return (
-    <ButtonGroup aria-label="Tile size">
-      {APP_GRID_DENSITY_ORDER.map((key) => {
-        const option = APP_GRID_DENSITY[key];
-        const Glyph = option.icon;
-        const active = value === key;
-        return (
-          <Hint key={key} label={option.label}>
-            <Button
-              type="button"
-              variant={active ? 'secondary' : 'outline'}
-              size="icon-sm"
-              aria-pressed={active}
-              aria-label={option.label}
-              onClick={() => onChange(key)}
-            >
-              <Glyph className="size-4" />
-            </Button>
-          </Hint>
-        );
-      })}
-    </ButtonGroup>
-  );
-}
-
-function AppsHeader({
-  density,
-  onDensityChange,
-  showDensity,
-}: {
-  density: AppGridDensity;
-  onDensityChange: (next: AppGridDensity) => void;
-  /**
-   * The control only exists to resize a grid, so it is absent whenever there is
-   * no grid — the feature gate, the error state, and the empty state each fill
-   * the page on their own and a size picker over any of them is a dead switch.
-   */
-  showDensity: boolean;
-}) {
+function AppsHeader() {
   const sidebar = useOptionalSidebar();
 
   return (
@@ -689,11 +557,6 @@ function AppsHeader({
       <div className="flex min-w-0 flex-1 items-center gap-2 px-3 py-3">
         <h1 className="text-foreground shrink-0 text-sm font-medium">Apps</h1>
       </div>
-      {showDensity ? (
-        <div className="flex flex-none items-center pr-1">
-          <AppGridDensityControl value={density} onChange={onDensityChange} />
-        </div>
-      ) : null}
       <Link
         href="/docs/feature-flags/apps"
         target="_blank"
@@ -727,8 +590,6 @@ export function AppsView({ projectId }: { projectId: string }) {
   // fresh row instead of a stale copy captured at click time.
   const [openAppId, setOpenAppId] = useState<string | null>(null);
   const openApp = apps.data?.find((item) => item.app_id === openAppId) ?? null;
-  const [density, setDensity] = useAppGridDensity();
-  const columns = APP_GRID_DENSITY[density].grid;
 
   useEffect(() => {
     const target = searchParams.get('open_app');
@@ -751,20 +612,16 @@ export function AppsView({ projectId }: { projectId: string }) {
     // assumes mobile browser chrome is visible, so the bar can never be pushed
     // under a toolbar that reappears.
     <div className="flex h-svh flex-col overflow-hidden">
-      <AppsHeader
-        density={density}
-        onDensityChange={setDensity}
-        showDensity={appsGate.enabled === true && Boolean(apps.data?.length)}
-      />
+      <AppsHeader />
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {/* `max-w-7xl px-4` — the gallery's column, sized for the DEFAULT
-            density. Two 16:9 tiles inside a 1280px cap are ~600px wide each,
-            which is where a 1280px desktop layout scaled into them is still
-            readable as a page. The cap held at `max-w-5xl` (1024px) while the
-            grid was four across, and 230px tiles are what that produced.
-            `px-4` matches `CapabilityPageShell`'s gutter so the grid never
-            presses flush against the browser edge.
+        {/* `max-w-7xl px-4` — the gallery's column, and the CONTAINER the grid
+            measures itself against (`@container/apps`). Putting the container
+            here and not on the scroll box is the point: this is the element
+            whose width the tiles actually divide, so it already accounts for
+            the cap, the gutter, and the sidebar. `px-4` matches
+            `CapabilityPageShell`'s gutter so the grid never presses flush
+            against the browser edge.
 
             `flex min-h-full flex-col` so the one child that asks for height
             gets it: `EmptyState`/`ErrorState` are built on `Empty`, which is
@@ -772,16 +629,21 @@ export function AppsView({ projectId }: { projectId: string }) {
             collapsed to their own content and clung to the top of a tall,
             otherwise blank page. The grid, the skeleton and the feature gate
             take their natural height and stay at the top, unaffected. */}
-        <div className="mx-auto flex min-h-full w-full max-w-7xl flex-col px-4 py-6 pb-20">
+        <div
+          className={cn(
+            'mx-auto flex min-h-full w-full max-w-7xl flex-col px-4 py-6 pb-20',
+            APP_GRID_CONTAINER,
+          )}
+        >
           {appsGate.isLoading ? (
-            <AppGridSkeleton columns={columns} />
+            <AppGridSkeleton />
           ) : !appsGate.enabled ? (
             <FeatureGateScreen
               featureName="Apps"
               description="Apps deploy static sites, JavaScript bundles, Dockerfiles, and OCI images to stable URLs. Each App wakes on its next request and suspends after its idle timeout."
             />
           ) : apps.isLoading ? (
-            <AppGridSkeleton columns={columns} />
+            <AppGridSkeleton />
           ) : apps.isError ? (
             <ErrorState
               size="sm"
@@ -794,13 +656,12 @@ export function AppsView({ projectId }: { projectId: string }) {
               }
             />
           ) : apps.data?.length ? (
-            /* A gallery grid: two wide tiles across at full width by default,
-               stepping down to one on a phone and up to four if the reader
-               asks for it in the header. `gap-y` is larger than `gap-x`
+            /* A gallery grid, sized by the space it has rather than by the
+               window (`APP_GRID_COLUMNS`). `gap-y` is larger than `gap-x`
                because each tile's caption hangs BELOW it with no border to
                close it off — an equal gap would let the next row's thumbnail
                crowd the previous row's text. */
-            <ul className={cn('grid gap-x-6 gap-y-8', columns)}>
+            <ul className={cn('grid gap-x-4 gap-y-6', APP_GRID_COLUMNS)}>
               {apps.data.map((app) => (
                 <AppCard
                   key={app.app_id}
@@ -834,18 +695,19 @@ export function AppsView({ projectId }: { projectId: string }) {
 }
 
 /**
- * Shape-matched placeholder: same grid, same 16:9 tile, same ONE-line caption
- * hanging below it as `AppCard`. Four tiles, because four is the widest row any
- * density reaches — fewer would reflow the grid the moment real data lands.
+ * Shape-matched placeholder: same grid, same 4:5 tile, same ONE-line caption
+ * hanging below it as `AppCard`. Eight tiles — two full rows at the four
+ * columns a desktop lands on, so the placeholder fills the page it stands in
+ * for instead of trailing off half way down it.
  *
  * The second caption bar went when the card's hostname line did. A skeleton
  * taller than the thing it stands in for is a layout shift dressed as a
  * loading state.
  */
-function AppGridSkeleton({ columns }: { columns: string }) {
+function AppGridSkeleton() {
   return (
-    <ul className={cn('grid gap-x-6 gap-y-8', columns)}>
-      {Array.from({ length: 4 }).map((_, index) => (
+    <ul className={cn('grid gap-x-4 gap-y-6', APP_GRID_COLUMNS)}>
+      {Array.from({ length: 8 }).map((_, index) => (
         <li key={index}>
           <Skeleton className={cn(PREVIEW_TILE_ASPECT, 'w-full rounded-lg')} />
           <Skeleton className="mt-3 h-3.5 w-1/2 rounded-sm" />


### PR DESCRIPTION
## Summary

Reworks the Apps gallery grid and card shape.

- **Tile is 4:5** (`aspect-[4/5]`), rendered from a `1080x1350` viewport. The
  ratio and the viewport are one decision — the iframe is scaled to the tile's
  width, so any mismatch letterboxes or crops every thumbnail. `1080/1350 = 0.8`
  exactly. A four-across tile is `300x375` at the container cap.
- **The tile-size control is gone.** `AppGridDensity`, `APP_GRID_DENSITY*`,
  `parseAppGridDensity`, `useAppGridDensity`, and the `useSyncExternalStore` +
  `localStorage` + `storage`-event subsystem behind it are deleted (~90 lines).
  `AppsHeader` now takes no props.
- **The grid sizes itself with container queries, not viewport breakpoints.**
  This page sits beside a sidebar that docks and collapses, so the grid's real
  width swings ~256px while the viewport never moves. `xl:grid-cols-4` on a
  1280px viewport with the sidebar docked fires on a container that is really
  ~1024px wide. `@container/apps` is declared on the padded column — the element
  whose width the tiles actually divide.

  | container | cols | tile |
  | --- | --- | --- |
  | < 512px (phone) | 1 | full width |
  | >= 512px (`@lg`) | 2 | 232 x 290 |
  | >= 768px (`@3xl`) | 3 | 235 x 293 |
  | >= 1024px (`@5xl`) | 4 | 236 x 295 |
  | 1280px (cap) | 4 | 300 x 375 |

  Steps are chosen so the tile never drops below ~232px — 230px is what the
  earlier 4:5 grid shipped at, where every card read as the same grey rectangle.

4:5 shipped once before (`e56c580271`) and was reverted (`e6c4ba0b62`). It was
paired with a `max-w-5xl` cap and a fixed four-column grid, which is a 230px
tile. The ratio was never the fault. The cap is `max-w-7xl` here and the columns
come from the container ladder above, so the tile is 300px at the cap. This is
recorded in the source comment and pinned by a test.

## Test plan

Run from `apps/web`:

- `bun test src/features/apps/` -> 53 pass, 0 fail, 198 expect() calls
- `npx tsc --noEmit | grep features/apps` -> 0 errors (also fixes a real
  `TS2367` where a dead comparison had silently disabled the parity check)
- `npx eslint src/features/apps/` -> clean, no output

Additional verification performed:

- Compiled the container-query classes against the repo's Tailwind (v4.3.3) to
  prove the variants are not inert. A `@lg/apps:` variant with no matching
  `@container/apps` ancestor compiles and then never matches, which would leave
  the grid at one column forever. Generated output contains
  `container-type: inline-size; container-name: apps` and the three
  `@container apps (width >= 32rem | 48rem | 64rem)` rules.
- Mutation-proved the viewport/tile parity guard: setting
  `PREVIEW_VIEWPORT_HEIGHT` to 1080 without touching `PREVIEW_TILE_ASPECT` fails
  2 tests, including the parity check. Restored and re-ran green.

Not verified: the rendered page in a browser.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790366948&installation_model_id=434224&pr_number=6939&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6939&signature=5a6c4fc39b6cf5b54487c72f0f84e201198acd28ca5ccdf75dc938391bf80414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->