### PR TITLE
fix(release): pin npm@^11.5.1 in publish-npm-package.sh (npm@12 breaks prod npm publishes on node 22.22.0)

### DIFF
--- a/scripts/publish-npm-package.sh
+++ b/scripts/publish-npm-package.sh
@@ -32,7 +32,12 @@ fi
 
 # Trusted Publishing (OIDC) requires npm >= 11.5.1; node 22 ships npm 10. Do
 # not mutate the runner's npm installation until the auth preflight passes.
-npm install -g npm@latest
+# Pin to the 11.x line, NOT npm@latest: npm@12 requires node >= 22.22.2, but
+# `actions/setup-node@v7` with `node-version: 22` resolves to 22.22.0, so
+# `npm@latest` fails `EBADENGINE` before it can publish. This broke the
+# v0.13.6 deploy-prod npm publishes (2026-08-26). 11.x satisfies the OIDC
+# floor and runs on 22.22.0. Revisit when setup-node@22 ships >= 22.22.2.
+npm install -g 'npm@^11.5.1'
 echo "npm $(npm --version)"
 
 name="$(node -p "require('./package.json').name")"


### PR DESCRIPTION
deploy-prod's three npm publish jobs (@kortix/llm-catalog, @kortix/agent-tunnel, and @kortix/sdk which needs them) failed the v0.13.6 release with EBADENGINE: the script ran `npm install -g npm@latest` = npm@12.0.2, whose engines require node ^22.22.2 || ^24.15.0 || >=26.0.0, while actions/setup-node@v7 node-version:22 provisions 22.22.0. Because github-release needs publish-sdk + publish-agent-tunnel, the tag + GitHub Release were skipped and had to be created by hand. Pin the npm 11.x line, which still satisfies the OIDC >= 11.5.1 floor and runs on 22.22.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790367584&installation_model_id=434224&pr_number=6940&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6940&signature=bc9513241b563e7fcf287d2521ea9841239c82186b8e2436a37954d17a58aad9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->