### PR TITLE
docs(learnings): npm-publish failure silently strips the release record from a shipped prod deploy

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,40 @@ linked, not inlined.
 
 ## Register
 
+### `github-release` needs the npm publishes, so an npm-publish failure silently strips the tag, Release, changelog, and VERSION sync from a shipped prod deploy (2026-08-26)
+
+**When:** touching `scripts/publish-npm-package.sh`, the deploy-prod publish
+jobs, or diagnosing a deploy-prod run that went `failure` while
+`api.kortix.com` correctly serves the new version.
+`deploy-prod.yml`'s `github-release` job `needs: […, publish-sdk,
+publish-agent-tunnel, …]` with the default `if: success()`. `deploy-ecs` does
+NOT depend on the publishes, so the SERVICE rolls fine — but if any npm
+publish fails, `github-release` (tag + GitHub Release + release notes) and the
+`sync-main-version` / `sync-staging-version` / `announce` / `attach-desktop`
+jobs are all SKIPPED. The result: prod serves the release, and there is no
+tag, no Release, no changelog, no VERSION bump — an invisibly half-finished
+release. v0.13.6 hit this: `publish-npm-package.sh` ran `npm install -g
+npm@latest`, which is now `npm@12.0.2` requiring node `>=22.22.2`, while
+`actions/setup-node@22` provisions `22.22.0` → `EBADENGINE`, failing
+`publish-llm-catalog` + `publish-agent-tunnel` (and skipping `publish-sdk`,
+which needs `publish-llm-catalog`). Same node-floor class as the
+`pnpm/action-setup@v6` gate breaker the same day.
+Rules: (1) after any deploy-prod that reports `failure`, verify BY HAND that
+the tag, GitHub Release, and main/staging VERSION advanced — a green
+`/health` is not proof the release finished; recover a skipped `github-release`
+manually (`gh release create <tag> --target <prod-sha> --title … --notes-file
+RELEASE_NOTES.md`, attach the run's `cli-binaries`, then bump VERSION on both
+branches). (2) Pin publish tooling to a floor the runner's node satisfies
+(`npm@^11.5.1`, not `@latest`). (3) Better structurally: `github-release`
+should not hard-depend on the npm publishes — an npm outage should not erase
+the release record; make the publish jobs `continue-on-error` or drop them
+from `github-release.needs`.
+*Incident:* v0.13.6 deploy-prod run 33009428048 — service live on 0.13.6, but
+tag/Release/changelog/VERSION-sync skipped; recovered by hand. Script fix in
+#6940; the `needs`-decoupling is still a TODO.
+*Enforcer:* none — the decoupling and a post-deploy "release artifacts exist"
+check are the TODOs.
+
 ### A guard that has never fired has never been tested; and an artifact upload path is a publish path (2026-08-26)
 
 **When:** writing any secret guard in CI (`if grep …; then exit 1`), or


### PR DESCRIPTION
Register entry for the v0.13.6 deploy-prod anomaly (run 33009428048). Docs only. Pairs with the script fix #6940.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790368532&installation_model_id=434224&pr_number=6943&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6943&signature=a2c0949a0f5d1fef69da419d512a25db7f7eb495a3e3d6e8b0d636c83c5c02b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->