### PR TITLE
fix(web): OAuth consent page — one shared load/approve per request id (spinner forever on dev)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,32 @@ linked, not inlined.
 
 ## Register
 
+### A React effect keyed on a provider-issued object must cache its work by id, never bail — and only the deployed page proves it (2026-08-26)
+
+**When:** an effect does one-shot async work (a consent read + approve, an
+exchange, anything consumed server-side) and its deps include an object the
+auth/data provider re-issues (`user`, `session`). The re-run cancels run #1
+via cleanup; a "started already" guard then makes run #2 bail, and the page
+holds its loading state forever. Cache the PROMISE per id and let whichever
+run is current apply it; a redirect after a consumed request fires
+unconditionally.
+*Incident:* Sign in with Kortix consent page (#6945) spun forever on
+dev.kortix.com for a fresh client while `/v1/oauth/authorize/consent/:id`
+answered 200; local Chromium never re-issued `user` in that window, so the
+local run passed. Fixed in #6949 the same evening; dev only.
+*Enforcer:* none — the rule is: drive the deployed page for any auth flow.
+
+### The dev edge WAF 403s any query string carrying a bare `localhost` / `127.0.0.1` host (2026-08-26)
+
+**When:** pointing a locally-running app at `dev-api.kortix.com` with a
+`redirect_uri`, `callback`, or `return_to` on `localhost`. Cloudflare answers
+403 before the API sees the request (cf-ray, no `x-kortix-*` headers). Use a
+`*.localhost` name (`demo.localhost:8792` — browsers resolve it to loopback
+and the OAuth registry accepts the suffix).
+*Near-miss:* the dev sign-in demo hit 403 on `/v1/oauth/authorize`; read as an
+API regression until curl with `app.example.test` returned the API's own 400.
+*Enforcer:* none — docs note in `/docs/sdk/sign-in` is the TODO.
+
 ### `github-release` needs the npm publishes, so an npm-publish failure silently strips the tag, Release, changelog, and VERSION sync from a shipped prod deploy (2026-08-26)
 
 **When:** touching `scripts/publish-npm-package.sh`, the deploy-prod publish

--- a/apps/web/src/app/(auth)/oauth/authorize/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/authorize/page.tsx
@@ -37,6 +37,58 @@ export default function OAuthConsentPage() {
   );
 }
 
+type ConsentRequestView = { clientName: string; scopes: string[]; remembered: boolean };
+type ConsentLoadResult =
+  | { kind: 'consent'; request: ConsentRequestView }
+  | { kind: 'redirecting' }
+  | { kind: 'error'; message: string; request?: ConsentRequestView };
+
+/** Read the pending request; when the consent is remembered, approve it and redirect. */
+async function loadAndMaybeApprove(requestId: string): Promise<ConsentLoadResult> {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) return { kind: 'error', message: 'Session expired. Please sign in again.' };
+  const backendUrl = getEnv().BACKEND_URL || '';
+  let data;
+  try {
+    data = await getOAuthConsentRequest(requestId, { backendUrl, accessToken: session.access_token });
+  } catch {
+    return { kind: 'error', message: 'Network error. Please try again.' };
+  }
+  const request: ConsentRequestView = {
+    clientName: data.client_name || 'Unknown App',
+    scopes: Array.isArray(data.scopes)
+      ? data.scopes.filter((scope: unknown): scope is string => typeof scope === 'string')
+      : String(data.scope || '')
+          .split(' ')
+          .filter(Boolean),
+    remembered: data.remembered === true,
+  };
+  if (!request.remembered) return { kind: 'consent', request };
+
+  // Remembered consent: approve straight away and send the user back. A
+  // failure falls through to the normal Allow/Deny screen with the error strip.
+  try {
+    const approved = await submitOAuthConsent(
+      { requestId, approved: true },
+      { backendUrl, accessToken: session.access_token },
+    );
+    if (approved.redirect_uri) {
+      window.location.href = approved.redirect_uri;
+      return { kind: 'redirecting' };
+    }
+    return { kind: 'error', message: 'The authorization did not return a redirect.', request: { ...request, remembered: false } };
+  } catch (err) {
+    return {
+      kind: 'error',
+      message: err instanceof Error && err.message ? err.message : 'Network error. Please try again.',
+      request: { ...request, remembered: false },
+    };
+  }
+}
+
 function OAuthConsent() {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -55,16 +107,25 @@ function OAuthConsent() {
   } | null>(null);
 
   const requestId = searchParams.get('request_id') || '';
-  /**
-   * One load (and, when remembered, one approval) per request id. The effect
-   * below re-runs whenever `user` changes identity — the auth provider hands
-   * out a fresh object after its own /user refresh — and a second run would
-   * re-read a request the first run already consumed (400) while the first
-   * run's cleanup had told it to drop the redirect. Seen live 2026-08-26.
-   */
-  const startedFor = useRef<string | null>(null);
   const clientName = consentRequest?.clientName || 'Unknown App';
   const scopes = consentRequest?.scopes || [];
+
+  /**
+   * ONE load (and, when remembered, one approval) per request id, shared by
+   * every run of the effect below. The effect re-runs whenever the auth
+   * provider hands out a fresh `user` object (it does, right after its own
+   * /user refresh). Two earlier shapes both failed live on 2026-08-26:
+   *
+   *  - no guard: run #2 re-read a request run #1 had already consumed (400),
+   *    and run #1's cleanup had told it to drop the redirect;
+   *  - a bail-out guard: run #1 was cancelled by the re-run and dropped its
+   *    result, run #2 bailed on the guard — the page spun forever.
+   *
+   * So the WORK is cached per request id, and whichever run is still current
+   * when it settles applies the result. A remembered consent redirects from
+   * inside the shared work, unconditionally — the request is consumed by then.
+   */
+  const loadRef = useRef<{ requestId: string; promise: Promise<ConsentLoadResult> } | null>(null);
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -77,71 +138,21 @@ function OAuthConsent() {
 
   useEffect(() => {
     if (isLoading || !user || !requestId) return;
-    if (startedFor.current === requestId) return;
-    startedFor.current = requestId;
     let cancelled = false;
-
-    async function loadConsentRequest() {
-      setError(null);
-      setConsentRequest(null);
-      try {
-        const supabase = createClient();
-        const {
-          data: { session },
-        } = await supabase.auth.getSession();
-        if (!session?.access_token) {
-          setError('Session expired. Please sign in again.');
-          return;
-        }
-
-        const backendUrl = getEnv().BACKEND_URL || '';
-        const data = await getOAuthConsentRequest(requestId, {
-          backendUrl,
-          accessToken: session.access_token,
-        });
-        if (cancelled) return;
-        const remembered = data.remembered === true;
-        setConsentRequest({
-          clientName: data.client_name || 'Unknown App',
-          scopes: Array.isArray(data.scopes)
-            ? data.scopes.filter((scope: unknown): scope is string => typeof scope === 'string')
-            : String(data.scope || '')
-                .split(' ')
-                .filter(Boolean),
-          remembered,
-        });
-        if (!remembered) return;
-
-        // Remembered consent: approve straight away and send the user back.
-        // A failure here falls through to the normal Allow/Deny screen with
-        // the error strip, so the person can still decide by hand.
-        try {
-          const approved = await submitOAuthConsent(
-            { requestId, approved: true },
-            { backendUrl, accessToken: session.access_token },
-          );
-          // The request is consumed at this point: the ONLY correct outcome is
-          // the redirect, whether or not this effect instance was cleaned up.
-          if (approved.redirect_uri) {
-            window.location.href = approved.redirect_uri;
-            return;
-          }
-          if (cancelled) return;
-          throw new Error('The authorization did not return a redirect.');
-        } catch (err) {
-          if (cancelled) return;
-          setError(
-            err instanceof Error && err.message ? err.message : 'Network error. Please try again.',
-          );
-          setConsentRequest((prev) => (prev ? { ...prev, remembered: false } : prev));
-        }
-      } catch {
-        if (!cancelled) setError('Network error. Please try again.');
-      }
+    if (loadRef.current?.requestId !== requestId) {
+      loadRef.current = { requestId, promise: loadAndMaybeApprove(requestId) };
     }
-
-    loadConsentRequest();
-
+    loadRef.current.promise.then((result) => {
+      if (cancelled) return;
+      if (result.kind === 'redirecting') return; // the browser is leaving
+      if (result.kind === 'error') {
+        setError(result.message);
+        setConsentRequest(result.request ?? null);
+        return;
+      }
+      setError(null);
+      setConsentRequest(result.request);
+    });
     return () => {
       cancelled = true;
     };


### PR DESCRIPTION
Follow-up to #6945. On dev the consent page stayed on the spinner for a fresh client although `GET /v1/oauth/authorize/consent/:id` answered 200 `remembered:false`: the effect re-runs when the auth provider re-issues `user`; the bail-out guard made run #1 (cancelled) drop the loaded request and run #2 bail. Now one load/approve promise is cached per request id and whichever run is current applies it; remembered consents still redirect unconditionally. eslint + tsc clean on the file. Verified on dev after merge (see final report).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790375742&installation_model_id=434224&pr_number=6949&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6949&signature=c7ccf5772b69c4449b7e7ac02de9ade8c82eeaa673f11919a5e2373947424971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->