### PR TITLE
fix(api): compress middleware fails open without CompressionStream — dev returned 500 for every response ≥ 1 KiB (Bun 1.2 image)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,32 @@ linked, not inlined.
 
 ## Register
 
+### A web API the middleware needs must exist in the IMAGE's runtime, not the laptop's (2026-08-27)
+
+**When:** adding any global middleware or hot-path code that uses a Web/Bun
+API (`CompressionStream`, `DecompressionStream`, `ReadableStream.from`,
+`Response.json`, …), or bumping/pinning Bun anywhere. `apps/api/Dockerfile`
+pins `ARG BUN_VERSION=1.2` (1.2.23 today) while every developer laptop and
+every CI lane runs Bun 1.3.x. `CompressionStream` does not exist in Bun 1.2.
+The compress middleware from #6946 peeked the body of every eligible response
+and then threw `ReferenceError: CompressionStream is not defined`, so on dev
+**every API response ≥ 1 KiB answered 500** (`GET /accounts`, `account-state`,
+`iam/permissions`, `iam/roles` — the whole account hub) while sub-KiB routes
+and `/health` stayed green. 8,545 green unit tests, a green typecheck and a green
+deploy proved nothing, because none of them ran on the image's Bun. Cloudflare
+sends `Accept-Encoding: gzip` to the origin regardless of the client, so no
+request could dodge the path.
+**Rules:** (1) feature-detect any Web API a middleware uses at module load and
+fail OPEN (skip the feature, never touch the body) when it is absent; (2) treat
+`BUN_VERSION` in the Dockerfile as the runtime contract — either pin the
+laptop/CI to it or add a test that runs the middleware under
+`oven/bun:<BUN_VERSION>`; (3) a green `/health` after deploy is not a smoke
+test — hit one route whose response exceeds 1 KiB.
+*Incident:* dev broken 2026-08-26 22:41 → 2026-08-27 (fix in progress) — first
+noticed only because the branding rollout verification hit `GET /accounts`.
+*Enforcer:* `compress.test.ts` pins the fail-open path with `CompressionStream`
+deleted from `globalThis`; nothing yet runs the suite under the image's Bun.
+
 ### A React effect keyed on a provider-issued object must cache its work by id, never bail — and only the deployed page proves it (2026-08-26)
 
 **When:** an effect does one-shot async work (a consent read + approve, an

--- a/apps/api/src/middleware/compress.test.ts
+++ b/apps/api/src/middleware/compress.test.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import {
   COMPRESSION_MIN_BYTES,
   compressResponse,
+  compressionAvailable,
   compressionCandidate,
   negotiateEncoding,
 } from './compress';
@@ -237,5 +238,59 @@ describe('compressResponse', () => {
         .pipeThrough(new DecompressionStream('deflate')),
     ).text();
     expect(text).toBe(bigJson);
+  });
+});
+
+// ─── Fail-open when the runtime cannot compress ──────────────────────────────
+//
+// The API image pins Bun 1.2 (`apps/api/Dockerfile` BUN_VERSION), which has no
+// `CompressionStream`; laptops and CI run Bun 1.3, which does. The first deploy
+// threw `ReferenceError: CompressionStream is not defined` AFTER peeking the
+// body, so on dev every response of 1 KiB or more answered 500 while `/health`
+// (small) stayed green. These pin the only acceptable behaviour without the
+// API: the body is passed through byte-identical, uncompressed, status intact.
+describe('compressResponse without CompressionStream (Bun 1.2 image)', () => {
+  const g = globalThis as { CompressionStream?: unknown };
+
+  function withoutCompressionStream<T>(run: () => Promise<T>): Promise<T> {
+    const saved = g.CompressionStream;
+    delete g.CompressionStream;
+    return run().finally(() => {
+      g.CompressionStream = saved;
+    });
+  }
+
+  test('compressionAvailable() reports the global, live', async () => {
+    expect(compressionAvailable()).toBe(true);
+    await withoutCompressionStream(async () => {
+      expect(compressionAvailable()).toBe(false);
+    });
+    expect(compressionAvailable()).toBe(true);
+  });
+
+  test('a large JSON GET with accept-encoding: gzip is served raw, 200, byte-identical', async () => {
+    await withoutCompressionStream(async () => {
+      const res = await app().request('/big.json', { headers: { 'accept-encoding': 'gzip' } });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-encoding')).toBeNull();
+      expect(await res.text()).toBe(bigJson);
+    });
+  });
+
+  test('a constructor that throws after the peek still yields the same bytes, uncompressed', async () => {
+    const saved = g.CompressionStream;
+    g.CompressionStream = class {
+      constructor() {
+        throw new TypeError('simulated: unsupported encoding');
+      }
+    };
+    try {
+      const res = await app().request('/big.json', { headers: { 'accept-encoding': 'gzip' } });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-encoding')).toBeNull();
+      expect(await res.text()).toBe(bigJson);
+    } finally {
+      g.CompressionStream = saved;
+    }
   });
 });

--- a/apps/api/src/middleware/compress.ts
+++ b/apps/api/src/middleware/compress.ts
@@ -65,6 +65,22 @@ import type { Context, Next } from 'hono';
 export const COMPRESSION_MIN_BYTES = 1024;
 
 /**
+ * Whether THIS runtime can compress at all. `CompressionStream` is a Web API
+ * that Bun 1.2 (the API image's pinned major, `apps/api/Dockerfile`
+ * `BUN_VERSION`) does not implement, while Bun 1.3 — every laptop and CI lane
+ * — does. Checked per call, not once at import, so a test can remove the
+ * global and prove the fail-open path; the cost is one property read.
+ *
+ * Fail OPEN: without the API the middleware must not touch the body. The
+ * first deploy of this file threw `ReferenceError: CompressionStream is not
+ * defined` AFTER peeking the body, so on dev every response of 1 KiB or more
+ * answered 500 while `/health` stayed green (2026-08-26 22:41 → 2026-08-27).
+ */
+export function compressionAvailable(): boolean {
+  return typeof (globalThis as { CompressionStream?: unknown }).CompressionStream === 'function';
+}
+
+/**
  * Content types worth compressing.
  *
  * `text/event-stream` and `application/x-ndjson` are deliberately absent: they
@@ -253,6 +269,7 @@ export async function compressResponse(c: Context, next: Next): Promise<void> {
   // `Vary: Origin`, dropping the `Accept-Encoding` this middleware had added.)
   appendVaryAcceptEncoding(res.headers);
   if (!encoding) return;
+  if (!compressionAvailable()) return;
 
   const reader = (res.body as ReadableStream<Uint8Array>).getReader();
   let peek: Peek;
@@ -278,21 +295,40 @@ export async function compressResponse(c: Context, next: Next): Promise<void> {
     return;
   }
 
+  // The body has been partially consumed by the peek, so from here on the
+  // ONLY correct outcomes are "compressed" or "the same bytes, re-streamed".
+  // A throw would surface as a 500 for a response that was perfectly fine.
+  let transform: ReadableWritablePair<Uint8Array, Uint8Array> | null = null;
+  try {
+    transform = new CompressionStream(encoding) as unknown as ReadableWritablePair<
+      Uint8Array,
+      Uint8Array
+    >;
+  } catch (err) {
+    console.warn('[compress] CompressionStream unavailable — sending uncompressed', {
+      encoding,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const passthrough = restream(peek.chunks, reader);
+  if (!transform) {
+    // Uncompressed re-stream: the original length (when declared) still holds.
+    c.res = new Response(passthrough, { status: res.status, statusText: res.statusText, headers });
+    return;
+  }
+
   headers.set('content-encoding', encoding);
   // The compressed length is unknown until the stream ends, so any declared
   // length must go: keeping it would describe the wrong number of bytes and the
   // client would truncate or hang. Bun frames the response as chunked instead.
   headers.delete('content-length');
 
-  c.res = new Response(
-    restream(peek.chunks, reader).pipeThrough(
-      new CompressionStream(encoding) as unknown as ReadableWritablePair<
-        Uint8Array,
-        Uint8Array
-      >,
-    ),
-    { status: res.status, statusText: res.statusText, headers },
-  );
+  c.res = new Response(passthrough.pipeThrough(transform), {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
 }
 
 /** Add `Accept-Encoding` to `Vary` without dropping what is already there. */


### PR DESCRIPTION
## Incident

Since the 22:41 deploy of `a3d67ea661` (#6946), **dev-api returns 500 for every response of 1 KiB or more** (`GET /accounts`, `billing/account-state`, `iam/permissions`, `iam/roles` — the entire account hub), while sub-KiB routes and `/health` are 200. Any `Accept-Encoding`, including none: Cloudflare sends `gzip` to the origin regardless.

## Root cause

`apps/api/Dockerfile` pins `BUN_VERSION=1.2` (1.2.23). Bun 1.2 has no `CompressionStream`. `compressResponse` peeks the body and then throws `ReferenceError: CompressionStream is not defined`, which the error handler turns into the generic 500. Laptops and CI run Bun 1.3.14, where the API exists — 8,545 green unit tests and a green deploy caught nothing.

Reproduced outside the app: the middleware's hot path replayed under `oven/bun:1.2-slim` → `ReferenceError: CompressionStream is not defined`; under `oven/bun:1.3.14-slim` → gzip round-trip OK.

## Fix

- `compressionAvailable()` feature-detects the global per call; when absent the middleware returns before touching the body (fail open — no compression, no change).
- The constructor is guarded after the peek too: on a throw, the peeked bytes + remainder are re-streamed uncompressed with the original status/headers.

## Verified

- `compress.test.ts`: 24/24 pass under Bun 1.3.14; the two new tests pin (a) global removed → raw byte-identical 200, no `content-encoding`; (b) throwing constructor → same.
- Same suite run under **`oven/bun:1.2-slim`** against this tree (the image's runtime) — see the CI comment / final response for output.
- Learnings register: "A web API the middleware needs must exist in the IMAGE's runtime, not the laptop's".

## Follow-up (not in this PR)

Bump `BUN_VERSION` to 1.3 (with the `Bun.spawn({ terminal })` semantics re-checked) or run the API unit suite under the image's Bun in CI, so the runtime contract is enforced rather than remembered.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790378694&installation_model_id=434224&pr_number=6951&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6951&signature=7b9c093829615c10e85196fae9a759c0d559154341edb9e1cc66b09c511ebb48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->