### PR TITLE
feat(web): docs surface rework, tool-row disclosure, mono badge system

### DIFF
--- a/apps/web/content/docs/card-icons.test.ts
+++ b/apps/web/content/docs/card-icons.test.ts
@@ -1,0 +1,92 @@
+// Every `<Card>` in the docs shows a glyph.
+//
+// The cards on /docs rendered as eight identical blocks of text: each one
+// carries an `href` and none carried an `icon`, so the tile fumadocs reserves
+// for one (`fumadocs-ui/dist/components/card.js`) stayed empty and the grid
+// read as a wall.
+//
+// The check is on the CONTENT, not on a component, and that is deliberate.
+// Every page imports `Card` by name, so a default supplied through the MDX
+// components map would never reach it — an override there type-checks, renders
+// nothing different, and looks correct in review. What the page actually
+// renders is decided by the prop in the file.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DOCS = import.meta.dir;
+
+function mdxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return mdxFiles(path);
+    return entry.isFile() && entry.name.endsWith('.mdx') ? [path] : [];
+  });
+}
+
+/** Every `<Card …>` opening tag in the docs, with the file it came from. */
+const cards = mdxFiles(DOCS).flatMap((path) => {
+  const source = readFileSync(path, 'utf8');
+  return (source.match(/<Card\b[^>]*>/g) ?? []).map((tag) => ({
+    file: path.slice(DOCS.length + 1),
+    tag,
+  }));
+});
+
+describe('docs cards', () => {
+  test('there are cards to check', () => {
+    // A regex that silently matched nothing would make every assertion below
+    // pass on an empty list.
+    expect(cards.length).toBeGreaterThan(20);
+  });
+
+  test('every card carries an icon', () => {
+    const bare = cards.filter((c) => !c.tag.includes('icon=')).map((c) => `${c.file}: ${c.tag}`);
+
+    expect(bare).toEqual([]);
+  });
+
+  test('every icon comes from the app SSR set, and the file imports it', () => {
+    // Two failures this catches, both of which render as a broken page rather
+    // than a broken build: an icon used without its import, and an icon taken
+    // from `@phosphor-icons/react` directly — whose main entry calls
+    // `createContext` at module scope and crashes a server component.
+    for (const path of mdxFiles(DOCS)) {
+      const source = readFileSync(path, 'utf8');
+      const used = new Set(
+        [...source.matchAll(/<Card\b[^>]*\bicon=\{<(\w+)\s*\/>\}/g)].map((m) => m[1]),
+      );
+      if (used.size === 0) continue;
+
+      const importBlock = /import\s*\{([^}]+)\}\s*from\s*'@\/lib\/icons\/ssr';/.exec(source);
+      expect(
+        importBlock,
+        `${path} uses icons but imports none from @/lib/icons/ssr`,
+      ).not.toBeNull();
+
+      const imported = new Set(importBlock![1].split(',').map((name) => name.trim()));
+      for (const name of used) {
+        expect(imported.has(name), `${path} uses <${name} /> without importing it`).toBe(true);
+      }
+    }
+  });
+
+  test('cards come from the local component, not from fumadocs', () => {
+    // `docs-card.tsx` is what puts the glyph on the title's line without a
+    // tile around it. Fumadocs' own card hardcodes the opposite —
+    // `w-fit shadow-md rounded-lg border bg-fd-muted p-1.5`, stacked above the
+    // title — and nothing reaches those classes from the outside, so importing
+    // it again silently restores the boxed mark.
+    for (const path of mdxFiles(DOCS)) {
+      const source = readFileSync(path, 'utf8');
+      if (!source.includes('<Card')) continue;
+
+      expect(source, `${path} imports the card from fumadocs`).not.toContain(
+        "from 'fumadocs-ui/components/card'",
+      );
+      expect(source, `${path} renders cards without importing them`).toContain(
+        "from '@/components/markdown/docs-card'",
+      );
+    }
+  });
+});

--- a/apps/web/content/docs/connect/index.mdx
+++ b/apps/web/content/docs/connect/index.mdx
@@ -3,15 +3,21 @@ title: Connect & automate
 description: Connectors, Slack, computers, and triggers reach outside a project.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import {
+  AlarmIcon,
+  ChatsIcon,
+  DesktopIcon,
+  PlugsConnectedIcon,
+} from '@/lib/icons/ssr';
 
 A project reaches outside itself four ways. A connector calls an external
 tool. A channel starts a session from chat. A computer connects the agent to
 your own machine. A trigger starts a session with no person present.
 
 <Cards>
-  <Card title="Connectors" href="/docs/connect/connectors">Give the agent scoped, brokered access to external tools and APIs.</Card>
-  <Card title="Slack & channels" href="/docs/connect/slack">Start and continue a session from a Slack or Teams message.</Card>
-  <Card title="Computers" href="/docs/connect/computers">Connect your own machine to the agent through a permissioned tunnel.</Card>
-  <Card title="Triggers" href="/docs/connect/triggers">Start a session automatically, on a schedule or from a webhook.</Card>
+  <Card icon={<PlugsConnectedIcon />} title="Connectors" href="/docs/connect/connectors">Give the agent scoped, brokered access to external tools and APIs.</Card>
+  <Card icon={<ChatsIcon />} title="Slack & channels" href="/docs/connect/slack">Start and continue a session from a Slack or Teams message.</Card>
+  <Card icon={<DesktopIcon />} title="Computers" href="/docs/connect/computers">Connect your own machine to the agent through a permissioned tunnel.</Card>
+  <Card icon={<AlarmIcon />} title="Triggers" href="/docs/connect/triggers">Start a session automatically, on a schedule or from a webhook.</Card>
 </Cards>

--- a/apps/web/content/docs/feature-flags/index.mdx
+++ b/apps/web/content/docs/feature-flags/index.mdx
@@ -3,7 +3,8 @@ title: Feature flags
 description: Turn a Kortix surface on for one project, and read what every flag gates.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import { BrowserIcon } from '@/lib/icons/ssr';
 import { Callout } from 'fumadocs-ui/components/callout';
 
 A feature flag turns one Kortix surface on for one project. Any surface can
@@ -14,7 +15,7 @@ Flags are per project. Turning a flag on in one project changes nothing in
 another project, and nothing for other accounts.
 
 <Cards>
-  <Card title="Apps" href="/docs/feature-flags/apps">Deploy static sites, bundles, Dockerfiles, and OCI images to stable URLs.</Card>
+  <Card icon={<BrowserIcon />} title="Apps" href="/docs/feature-flags/apps">Deploy static sites, bundles, Dockerfiles, and OCI images to stable URLs.</Card>
 </Cards>
 
 ## Turn a flag on

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -3,7 +3,17 @@ title: Kortix
 description: Kortix is the AI command center for your company.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import {
+  CloudIcon,
+  CodeIcon,
+  CubeIcon,
+  FlagIcon,
+  PathIcon,
+  RocketIcon,
+  ShareNetworkIcon,
+  TerminalIcon,
+} from '@/lib/icons/ssr';
 
 Kortix is the Autonomous Company Operating System — a cloud computer where a
 workforce of AI agents runs your company, and everything is code you own.
@@ -23,12 +33,12 @@ New projects use a v2 manifest and OpenCode REST. Existing v1 projects keep
 their compatibility behavior.
 
 <Cards>
-  <Card title="Quickstart" href="/docs/quickstart">Create a project, start a session, and merge your first change request.</Card>
-  <Card title="Your project" href="/docs/project">Set up the manifest, agents, models, and secrets.</Card>
-  <Card title="Running work" href="/docs/work">Sessions, sandboxes, and change requests.</Card>
-  <Card title="Connect & automate" href="/docs/connect">Connectors, Slack, computers, and triggers.</Card>
-  <Card title="Feature flags" href="/docs/feature-flags">Per-project opt-ins, including Apps.</Card>
-  <Card title="CLI" href="/docs/cli">Develop and run Kortix from your terminal.</Card>
-  <Card title="SDK" href="/docs/sdk">Build on Kortix from TypeScript with the client SDK.</Card>
-  <Card title="Self-hosting" href="/docs/host">Install and operate Kortix on your own infrastructure.</Card>
+  <Card icon={<RocketIcon />} title="Quickstart" href="/docs/quickstart">Create a project, start a session, and merge your first change request.</Card>
+  <Card icon={<CubeIcon />} title="Your project" href="/docs/project">Set up the manifest, agents, models, and secrets.</Card>
+  <Card icon={<PathIcon />} title="Running work" href="/docs/work">Sessions, sandboxes, and change requests.</Card>
+  <Card icon={<ShareNetworkIcon />} title="Connect & automate" href="/docs/connect">Connectors, Slack, computers, and triggers.</Card>
+  <Card icon={<FlagIcon />} title="Feature flags" href="/docs/feature-flags">Per-project opt-ins, including Apps.</Card>
+  <Card icon={<TerminalIcon />} title="CLI" href="/docs/cli">Develop and run Kortix from your terminal.</Card>
+  <Card icon={<CodeIcon />} title="SDK" href="/docs/sdk">Build on Kortix from TypeScript with the client SDK.</Card>
+  <Card icon={<CloudIcon />} title="Self-hosting" href="/docs/host">Install and operate Kortix on your own infrastructure.</Card>
 </Cards>

--- a/apps/web/content/docs/project/index.mdx
+++ b/apps/web/content/docs/project/index.mdx
@@ -3,7 +3,14 @@ title: Your project
 description: A project is a git repository that holds your agent's config and state.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import {
+  BrainIcon,
+  FileTextIcon,
+  KeyIcon,
+  RobotIcon,
+  ScrollIcon,
+} from '@/lib/icons/ssr';
 
 A project is one git repository. It holds a manifest, agent config, and the
 state your agent produces. No separate database exists to keep in sync.
@@ -55,9 +62,9 @@ migration path.
 ## In this section
 
 <Cards>
-  <Card title="Manifest" href="/docs/project/manifest">The full kortix.yaml reference.</Card>
-  <Card title="Agents" href="/docs/project/agents">Markdown personas with scoped tools.</Card>
-  <Card title="Models" href="/docs/project/models">Which model a session uses, and who pays.</Card>
-  <Card title="Secrets" href="/docs/project/secrets">Encrypted values injected into a sandbox.</Card>
-  <Card title="Legacy TOML" href="/docs/project/legacy-toml">Migrating from kortix.toml.</Card>
+  <Card icon={<FileTextIcon />} title="Manifest" href="/docs/project/manifest">The full kortix.yaml reference.</Card>
+  <Card icon={<RobotIcon />} title="Agents" href="/docs/project/agents">Markdown personas with scoped tools.</Card>
+  <Card icon={<BrainIcon />} title="Models" href="/docs/project/models">Which model a session uses, and who pays.</Card>
+  <Card icon={<KeyIcon />} title="Secrets" href="/docs/project/secrets">Encrypted values injected into a sandbox.</Card>
+  <Card icon={<ScrollIcon />} title="Legacy TOML" href="/docs/project/legacy-toml">Migrating from kortix.toml.</Card>
 </Cards>

--- a/apps/web/content/docs/quickstart.mdx
+++ b/apps/web/content/docs/quickstart.mdx
@@ -4,7 +4,8 @@ description: Install the CLI, run a session, and merge your first change request
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import { PathIcon, TerminalIcon } from '@/lib/icons/ssr';
 
 This page takes you from a fresh terminal to a merged change request (CR).
 Every command below is copy-pasteable.
@@ -102,13 +103,13 @@ project's default branch until you merge.
 ## Next steps
 
 <Cards>
-  <Card title="How the pieces fit" href="/docs/work">
+  <Card icon={<PathIcon />} title="How the pieces fit" href="/docs/work">
     Projects, sessions, and change requests, explained.
   </Card>
-  <Card title="CLI command reference" href="/docs/cli">
+  <Card icon={<TerminalIcon />} title="CLI command reference" href="/docs/cli">
     Every command, flag, and subcommand.
   </Card>
-  <Card title="The CLI dev loop" href="/docs/cli">
+  <Card icon={<TerminalIcon />} title="The CLI dev loop" href="/docs/cli">
     Link a repo, ship code, and manage sessions from your terminal.
   </Card>
 </Cards>

--- a/apps/web/content/docs/sdk/index.mdx
+++ b/apps/web/content/docs/sdk/index.mdx
@@ -3,7 +3,14 @@ title: TypeScript SDK
 description: Install, authenticate, and send your first message with the typed SDK.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import {
+  AtomIcon,
+  BookOpenIcon,
+  ClipboardTextIcon,
+  GitBranchIcon,
+  KeyIcon,
+} from '@/lib/icons/ssr';
 
 `@kortix/sdk` is the typed client for the Kortix platform. It wraps the Kortix
 REST API and OpenCode REST runtime in one interface. The core client is
@@ -79,19 +86,19 @@ An agent-minted session token already carries its project scope. Use
 `createKortix` gives you an imperative client: call methods for every action, like projects, sessions, secrets, and triggers. `@kortix/sdk/react` gives you hooks for live UI data — `useSession` runs a whole session in one hook.
 
 <Cards>
-  <Card title="Full example" href="/docs/sdk/example">
+  <Card icon={<ClipboardTextIcon />} title="Full example" href="/docs/sdk/example">
     Zero to a streaming agent reply.
   </Card>
-  <Card title="Auth" href="/docs/sdk/auth">
+  <Card icon={<KeyIcon />} title="Auth" href="/docs/sdk/auth">
     API keys and Supabase JWTs.
   </Card>
-  <Card title="Sessions" href="/docs/sdk/sessions">
+  <Card icon={<GitBranchIcon />} title="Sessions" href="/docs/sdk/sessions">
     Lifecycle, streaming, and error handling.
   </Card>
-  <Card title="React hooks" href="/docs/sdk/react">
+  <Card icon={<AtomIcon />} title="React hooks" href="/docs/sdk/react">
     `useSession` and other reactive hooks.
   </Card>
-  <Card title="Reference" href="/docs/sdk/reference">
+  <Card icon={<BookOpenIcon />} title="Reference" href="/docs/sdk/reference">
     The full client, modules, turns, and distribution.
   </Card>
 </Cards>

--- a/apps/web/content/docs/work/index.mdx
+++ b/apps/web/content/docs/work/index.mdx
@@ -3,7 +3,20 @@ title: Running work
 description: How work moves from prompt to merged change, and the three ways it starts.
 ---
 
-import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Card, Cards } from '@/components/markdown/docs-card';
+import {
+  AlarmIcon,
+  BrainIcon,
+  ChatsIcon,
+  CpuIcon,
+  CubeIcon,
+  DesktopIcon,
+  GitBranchIcon,
+  GitPullRequestIcon,
+  PlugsConnectedIcon,
+  RobotIcon,
+  UsersIcon,
+} from '@/lib/icons/ssr';
 import { Callout } from 'fumadocs-ui/components/callout';
 
 Kortix does work inside a [session](/docs/work/sessions): a branch and a sandbox for one
@@ -12,9 +25,9 @@ merges back to the default branch. This page walks through the loop, then shows 
 three ways a session can start.
 
 <Cards>
-  <Card title="Sessions" href="/docs/work/sessions">A branch and a sandbox for one unit of work.</Card>
-  <Card title="Change requests" href="/docs/work/change-requests">The reviewed merge back to the default branch.</Card>
-  <Card title="Runtime" href="/docs/work/runtime">Env vars, tokens, and the sandbox image a session runs in.</Card>
+  <Card icon={<GitBranchIcon />} title="Sessions" href="/docs/work/sessions">A branch and a sandbox for one unit of work.</Card>
+  <Card icon={<GitPullRequestIcon />} title="Change requests" href="/docs/work/change-requests">The reviewed merge back to the default branch.</Card>
+  <Card icon={<CpuIcon />} title="Runtime" href="/docs/work/runtime">Env vars, tokens, and the sandbox image a session runs in.</Card>
 </Cards>
 
 ## What happens when a session starts
@@ -51,12 +64,12 @@ A session starts one of three ways.
 ## Related
 
 <Cards>
-  <Card title="Projects" href="/docs/project">A git repo with a manifest.</Card>
-  <Card title="Agents" href="/docs/project/agents">A markdown persona with scoped tools.</Card>
-  <Card title="Models" href="/docs/project/models">Which model a session uses, and who pays.</Card>
-  <Card title="Triggers" href="/docs/connect/triggers">Schedules and webhooks that start sessions.</Card>
-  <Card title="Connectors" href="/docs/connect/connectors">Scoped reach into external apps.</Card>
-  <Card title="Slack & channels" href="/docs/connect/slack">Chat surfaces that start sessions.</Card>
-  <Card title="Computers" href="/docs/connect/computers">Machines distinct from session sandboxes.</Card>
-  <Card title="Accounts" href="/docs/accounts">Principals, roles, and assignments — who can do what.</Card>
+  <Card icon={<CubeIcon />} title="Projects" href="/docs/project">A git repo with a manifest.</Card>
+  <Card icon={<RobotIcon />} title="Agents" href="/docs/project/agents">A markdown persona with scoped tools.</Card>
+  <Card icon={<BrainIcon />} title="Models" href="/docs/project/models">Which model a session uses, and who pays.</Card>
+  <Card icon={<AlarmIcon />} title="Triggers" href="/docs/connect/triggers">Schedules and webhooks that start sessions.</Card>
+  <Card icon={<PlugsConnectedIcon />} title="Connectors" href="/docs/connect/connectors">Scoped reach into external apps.</Card>
+  <Card icon={<ChatsIcon />} title="Slack & channels" href="/docs/connect/slack">Chat surfaces that start sessions.</Card>
+  <Card icon={<DesktopIcon />} title="Computers" href="/docs/connect/computers">Machines distinct from session sandboxes.</Card>
+  <Card icon={<UsersIcon />} title="Accounts" href="/docs/accounts">Principals, roles, and assignments — who can do what.</Card>
 </Cards>

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -1,6 +1,23 @@
-import { source } from '@/lib/source';
 import { createFromSource } from 'fumadocs-core/search/server';
 
-// Powers the fumadocs search dialog (RootProvider defaults to fetching
-// `/api/search`). ZBSearch index is built from the docs source at request time.
-export const { GET } = createFromSource(source);
+import { source } from '@/lib/source';
+
+/**
+ * The docs search index, served once as a static file.
+ *
+ * `GET` (the dynamic handler) ran a query on the SERVER for every keystroke:
+ * open the dialog, type eight characters, and that is eight round-trips, each
+ * one waiting on a debounce first. On a 31-page site the whole index is
+ * smaller than a single screenshot — shipping it once and querying it in the
+ * browser is both less work and an order of magnitude less waiting. That is
+ * what `staticGET` is for: it exports the index instead of answering queries,
+ * and the dialog's `type: 'static'` client (see `docs/layout.tsx`) fetches it
+ * one time and searches locally from then on.
+ *
+ * `revalidate = false` lets Next treat the response as immutable and serve it
+ * from the static cache; the index only changes when the docs are rebuilt,
+ * which rebuilds this route with them.
+ */
+export const revalidate = false;
+
+export const { staticGET: GET } = createFromSource(source);

--- a/apps/web/src/app/docs/docs-controls.test.tsx
+++ b/apps/web/src/app/docs/docs-controls.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+import { NextIntlClientProvider } from 'next-intl';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DocsSidebarFooter } from './docs-controls';
+
+/**
+ * The sidebar's bottom row.
+ *
+ * It replaced fumadocs' `links` + `themeSwitch` slots, which render into a
+ * container whose classes are hardcoded in the package —
+ * `border bg-fd-secondary/50 … rounded-lg` — with no prop to turn any of it
+ * off. This row owns its own markup, so the border and the tint are gone by
+ * construction rather than by an override.
+ *
+ * `ThemeToggle` renders null until it mounts (it reads next-themes' client-only
+ * `theme` to mark the active segment), so a static render shows the link only.
+ * That is the half this file can assert; the toggle's own presentation is
+ * pinned by its `variant="minimal"` branch.
+ */
+const render = () =>
+  renderToStaticMarkup(
+    <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
+      <DocsSidebarFooter />
+    </NextIntlClientProvider>,
+  );
+
+describe('DocsSidebarFooter', () => {
+  test('links out to the repo, in a new tab, with a label', () => {
+    const markup = render();
+
+    expect(markup).toContain('href="https://github.com/kortix-ai/suna"');
+    expect(markup).toContain('target="_blank"');
+    // The mark is a decoration; the accessible name is on the anchor.
+    expect(markup).toContain('aria-label="Kortix on GitHub"');
+  });
+
+  test("the mark is the app's own GitHub icon, not a phosphor glyph", () => {
+    // `features/icon/icons/github.tsx` — the same one `docs-page-actions.tsx`
+    // uses, so one GitHub glyph appears across the docs. Phosphor marks carry
+    // a 256-unit viewBox; this one is 24.
+    const markup = render();
+
+    expect(markup).toContain('<title>Github</title>');
+    expect(markup).toContain('viewBox="0 0 24 24"');
+    expect(markup).not.toContain('viewBox="0 0 256 256"');
+  });
+
+  test('the row draws no border and no tint — that was the whole complaint', () => {
+    const markup = render();
+
+    expect(markup).not.toContain('border');
+    expect(markup).not.toContain('bg-fd-secondary');
+    expect(markup).not.toContain('rounded-lg');
+  });
+});

--- a/apps/web/src/app/docs/docs-controls.tsx
+++ b/apps/web/src/app/docs/docs-controls.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { ThemeToggle } from '@/components/home/theme-toggle';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Kbd, KbdGroup } from '@/components/ui/kbd';
+import { Github } from '@/features/icon/icons/github';
 import { cn } from '@/lib/utils';
 import {
   SidebarSimpleIcon as PanelLeftIcon,
@@ -118,6 +120,45 @@ export function DocsCollapsedControls() {
           </Button>
         )}
       </ButtonGroup>
+    </div>
+  );
+}
+
+/**
+ * The sidebar's bottom row: one link out, and the theme control.
+ *
+ * It lives in `sidebar.footer` rather than in fumadocs' `links` +
+ * `themeSwitch` slots, and that is the whole fix. Those slots render into a
+ * container whose classes are hardcoded in the package —
+ * `flex items-center border bg-fd-secondary/50 p-0.5 rounded-lg`
+ * (`fumadocs-ui/dist/layouts/docs/slots/sidebar.js`) — so the bar arrived as a
+ * bordered, tinted pill with a filled segmented control inside it: four
+ * surfaces stacked at the quietest corner of the page, and no prop to turn any
+ * of them off. Emptying both slots lets the package's own `empty:hidden` drop
+ * that container, and this row takes its place. The same `footer` node is what
+ * the mobile drawer renders, so the two surfaces cannot drift.
+ *
+ * `Github` is the app's own brand mark (`features/icon/icons/github.tsx`), the
+ * one `docs-page-actions.tsx` already uses — not phosphor's `GithubLogoIcon`,
+ * so one GitHub glyph appears across the docs. It is a client component, which
+ * is why this row is one too; a server layout may RENDER it, it just cannot
+ * call into it.
+ */
+export function DocsSidebarFooter() {
+  return (
+    <div className="text-muted-foreground flex w-full items-center justify-between">
+      <a
+        href="https://github.com/kortix-ai/suna"
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Kortix on GitHub"
+        // Sized and toned exactly like a theme segment, so the row reads as
+        // one strip of icons rather than a link beside a control.
+        className="hover:text-foreground inline-flex size-7 items-center justify-center rounded-md transition-colors duration-150 ease-out"
+      >
+        <Github className="size-4" />
+      </a>
+      <ThemeToggle className="hover:bg-card ml-auto rounded-sm" />
     </div>
   );
 }

--- a/apps/web/src/app/docs/docs-page-actions.test.ts
+++ b/apps/web/src/app/docs/docs-page-actions.test.ts
@@ -15,8 +15,20 @@ import { resolve } from 'node:path';
 const WEB_ROOT = resolve(import.meta.dir, '../../..');
 const ACTIONS = resolve(WEB_ROOT, 'src/app/docs/docs-page-actions.tsx');
 
+/**
+ * Comments in `docs-page-actions.tsx` legitimately name the things the
+ * negative assertions below forbid — the "Copied" label the icon replaced,
+ * the `@/lib/icons/ssr` module it must not import from. Strip them so those
+ * tests constrain the code and not the prose about it (the same rule the
+ * breadcrumb test at the bottom of this file follows).
+ */
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
 describe('docs page actions', () => {
   const source = readFileSync(ACTIONS, 'utf8');
+  const code = stripComments(source);
 
   test('is a client component', () => {
     const firstLine = source.split('\n').find((line) => line.trim().length > 0);
@@ -80,10 +92,62 @@ describe('docs page actions', () => {
     expect(source).toContain('size="sm"');
   });
 
-  test('copies markdown to the clipboard and shows a transient "Copied" state', () => {
+  test('copies markdown to the clipboard and confirms with the icon, not a label swap', () => {
     expect(source).toContain('navigator.clipboard.writeText');
+
+    // The label is fixed for the whole cycle — both the wide and the narrow
+    // form. Swapping it to "Copied" resized the button and shoved the "Open"
+    // trigger sideways for two seconds.
     expect(source).toContain('Copy Markdown');
-    expect(source).toContain('Copied');
+    expect(source).toContain('>Copy</span>');
+
+    // The word only survives on `aria-label`, lower-cased. A capital-C
+    // "Copied" anywhere in this file means the visible label swap is back.
+    // (`COPIED_RESET_MS` is all-caps, so it does not trip this.)
+    expect(code).not.toContain('Copied');
+    expect(code).toContain("aria-label={copied ? 'Markdown copied' : 'Copy markdown'}");
+  });
+
+  /**
+   * The design system bans the hard `{copied ? <Check/> : <Copy/>}` swap:
+   * both glyphs share one fixed box and cross-fade with blur + scale +
+   * opacity, exactly as `components/markdown/copy-button.tsx` does for code
+   * blocks. Pinned by the transition's own values, since a regression here
+   * looks identical in a screenshot and only shows up in motion.
+   */
+  test('cross-fades the copy and check icons instead of hard-swapping them', () => {
+    expect(source).toContain("import { AnimatePresence, m } from 'motion/react';");
+    expect(source).toContain("key={copied ? 'check' : 'copy'}");
+    expect(source).toContain("scale: 0.25, opacity: 0, filter: 'blur(4px)'");
+    expect(source).toContain("scale: 1, opacity: 1, filter: 'blur(0px)'");
+    expect(source).toContain("type: 'spring', duration: 0.3, bounce: 0");
+    // Nothing animates on first paint.
+    expect(source).toContain('initial={false}');
+  });
+
+  /**
+   * `@/lib/icons/ssr` exists for React Server Components, which cannot read
+   * context and so need the weight pre-bound. This file is 'use client', so
+   * its icons must come from the main entry and stay wired to `IconProvider`.
+   */
+  test('takes CheckIcon from the client Phosphor entry, not the RSC-only module', () => {
+    expect(code).toContain('<CheckIcon');
+    expect(code).not.toContain('@/lib/icons/ssr');
+
+    const importBlock = code.slice(0, code.indexOf('type OpenAction'));
+    expect(importBlock).toContain('CheckIcon,');
+    expect(importBlock).toContain("} from '@phosphor-icons/react';");
+  });
+
+  /**
+   * `size="sm"` reaches its tighter `px-2.5` through `has-[>svg]:px-2.5`,
+   * which stopped matching once the icon moved inside the crossfade wrapper.
+   * Without the explicit class this button sits a notch wider than the two
+   * beside it.
+   */
+  test('restores the icon-button padding the crossfade wrapper broke', () => {
+    const buttonBlock = source.slice(source.indexOf('function CopyMarkdownButton'));
+    expect(buttonBlock).toContain("'shrink-0 gap-1.5 px-2.5'");
   });
 
   /**

--- a/apps/web/src/app/docs/docs-page-actions.tsx
+++ b/apps/web/src/app/docs/docs-page-actions.tsx
@@ -13,14 +13,24 @@ import { Copy } from '@/features/icon/icons/copy';
 import { Cursor } from '@/features/icon/icons/cursor';
 import { Github } from '@/features/icon/icons/github';
 import { Kortix } from '@/features/icon/icons/kortix';
-import { CheckIcon } from '@/lib/icons/ssr';
 import { cn } from '@/lib/utils';
 // `docs-page-actions.tsx` is 'use client', so — unlike page.tsx/layout.tsx —
 // it is the one place in the docs surface allowed to dot into the client
-// `Icon` namespace directly.
-import { ArrowSquareOutIcon, CaretDownIcon, MarkdownLogoIcon } from '@phosphor-icons/react';
+// `Icon` namespace directly. That is also why `CheckIcon` comes from the main
+// entry and not `@/lib/icons/ssr`: the SSR module hard-binds the weight for
+// components that cannot read context, and using it here would cut the icon
+// off from `IconProvider`.
+import {
+  ArrowSquareOutIcon,
+  CaretDownIcon,
+  CheckIcon,
+  MarkdownLogoIcon,
+} from '@phosphor-icons/react';
+import { AnimatePresence, m } from 'motion/react';
 import Link from 'next/link';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { createMarkdownSource } from './markdown-source';
 
 type OpenAction = {
   key: string;
@@ -120,14 +130,41 @@ export function DocsPageActions({
 }
 
 /**
- * Fetches the page's markdown source and copies it to the clipboard, with a
- * transient "Copied" state (~2s) before reverting. A fetch or clipboard
- * failure reverts to the idle label silently — no toast, per the docs
- * surface's restrained chrome.
+ * Copies the page's markdown source, with a transient confirmation (~2s)
+ * before reverting. A fetch or clipboard failure reverts to the idle state
+ * silently — no toast, per the docs surface's restrained chrome.
+ *
+ * The fetch does NOT happen in the click. It used to, which made every copy
+ * cost a network round-trip before anything was on the clipboard — and on a
+ * cold dev server, where `/markdown/[...path]` is compiled and rendered per
+ * request, that is seconds of a button that looks stuck. The text never
+ * depended on the click, so it no longer waits for one: pointing at the
+ * button, tabbing to it, or pressing it starts the fetch, and by the time the
+ * click lands `peek()` usually answers.
+ *
+ * That also puts the clipboard write back INSIDE the user gesture on the warm
+ * path, which is the form Safari is strict about — an `await` in front of
+ * `writeText` is exactly what it rejects.
+ *
+ * The confirmation is carried entirely by the icon: the copy glyph
+ * cross-fades to a green check and the label stays "Copy Markdown"
+ * throughout. Swapping the label to "Copied" changed the button's width
+ * mid-row and shoved "Open" sideways for two seconds; a fixed-width label
+ * with a morphing icon says the same thing without the reflow. The word
+ * survives on `aria-label`, which is where a screen reader wants it anyway.
+ *
+ * The swap itself is the design system's icon-swap transition (blur + scale +
+ * opacity, spring `duration: 0.3, bounce: 0`, `initial={false}` so nothing
+ * animates on first paint) — the same one `components/markdown/copy-button.tsx`
+ * uses for code blocks, so the two copy affordances in the docs read as one
+ * control rather than two.
  */
 function CopyMarkdownButton({ markdownPath }: { markdownPath: string }) {
   const [state, setState] = useState<CopyState>('idle');
   const resetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keyed on the path, so a client-side move to another docs page cannot copy
+  // the page the reader just left.
+  const source = useMemo(() => createMarkdownSource(markdownPath, fetch), [markdownPath]);
 
   useEffect(() => {
     return () => {
@@ -135,38 +172,85 @@ function CopyMarkdownButton({ markdownPath }: { markdownPath: string }) {
     };
   }, []);
 
+  // Named `confirmCopy`, not `markCopied`: the pin in `docs-page-actions.test.ts`
+  // reads a capital-C "Copied" anywhere in this file as the visible label swap
+  // coming back, and it is right to be that blunt about it.
+  const confirmCopy = useCallback(() => {
+    setState('copied');
+    resetTimeout.current = setTimeout(() => setState('idle'), COPIED_RESET_MS);
+  }, []);
+
+  // Intent, not render: a reader who never reaches for this button never
+  // issues the request. A rejection here is not the user's problem yet — the
+  // click will surface it — so it is swallowed rather than left unhandled.
+  const prefetch = useCallback(() => {
+    void source.load().catch(() => {});
+  }, [source]);
+
   const handleClick = useCallback(async () => {
     if (state === 'copying') return;
+
+    // Warm: no await before the write, so the copy is instant and the gesture
+    // is still the one the browser sees.
+    const ready = source.peek();
+    if (ready !== null) {
+      try {
+        await navigator.clipboard.writeText(ready);
+        confirmCopy();
+      } catch {
+        setState('idle');
+      }
+      return;
+    }
+
     setState('copying');
     try {
-      const response = await fetch(markdownPath);
-      if (!response.ok) throw new Error(`Failed to fetch ${markdownPath}: ${response.status}`);
-      const text = await response.text();
-      await navigator.clipboard.writeText(text);
-      setState('copied');
-      resetTimeout.current = setTimeout(() => setState('idle'), COPIED_RESET_MS);
+      await navigator.clipboard.writeText(await source.load());
+      confirmCopy();
     } catch {
       setState('idle');
     }
-  }, [markdownPath, state]);
+  }, [confirmCopy, source, state]);
+
+  const copied = state === 'copied';
 
   return (
     <Button
       variant="outline"
       size="sm"
-      className={cn('shrink-0 gap-1.5', state === 'copying' && 'cursor-wait')}
+      aria-label={copied ? 'Markdown copied' : 'Copy markdown'}
+      // `px-2.5` is set by hand because the icon is no longer a direct `<svg>`
+      // child, so `size="sm"`'s own `has-[>svg]:px-2.5` stops matching. Without
+      // it this button would sit at `px-3` while "Open" and "Edit on GitHub"
+      // stay at `px-2.5`.
+      className={cn('shrink-0 gap-1.5 px-2.5', state === 'copying' && 'cursor-wait')}
       onClick={handleClick}
+      // Three chances to be warm before the click: the pointer arriving, the
+      // keyboard landing, and the press itself — `pointerdown` fires ahead of
+      // `click`, which is the only head start a touch reader gets.
+      onPointerEnter={prefetch}
+      onPointerDown={prefetch}
+      onFocus={prefetch}
       disabled={state === 'copying'}
     >
-      {state === 'copied' ? <CheckIcon className="size-3.5" /> : <Copy className="size-3.5" />}
-      {state === 'copied' ? (
-        'Copied'
-      ) : (
-        <>
-          <span className="sm:hidden">Copy</span>
-          <span className="hidden sm:inline">Copy Markdown</span>
-        </>
-      )}
+      {/* Both glyphs share one fixed box and overlap absolutely, so the blur
+          bridges the crossfade instead of two icons trading places. */}
+      <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
+        <AnimatePresence initial={false} mode="popLayout">
+          <m.span
+            key={copied ? 'check' : 'copy'}
+            initial={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            animate={{ scale: 1, opacity: 1, filter: 'blur(0px)' }}
+            exit={{ scale: 0.25, opacity: 0, filter: 'blur(4px)' }}
+            transition={{ type: 'spring', duration: 0.3, bounce: 0 }}
+            className="absolute inset-0 inline-flex items-center justify-center"
+          >
+            {copied ? <CheckIcon className="size-3.5" /> : <Copy className="size-3.5" />}
+          </m.span>
+        </AnimatePresence>
+      </span>
+      <span className="sm:hidden">Copy</span>
+      <span className="hidden sm:inline">Copy Markdown</span>
     </Button>
   );
 }

--- a/apps/web/src/app/docs/layout.tsx
+++ b/apps/web/src/app/docs/layout.tsx
@@ -1,11 +1,4 @@
-import { ThemeToggle } from '@/components/home/theme-toggle';
 import { KortixLogo } from '@/components/sidebar/kortix-logo';
-// Server components import icons from '@/lib/icons/ssr': phosphor's
-// context-free SSR entry defaults to weight "regular" and silently ignores
-// DEFAULT_ICON_WEIGHT (see ssr.tsx's docblock). The client-only brand marks
-// under '@/features/icon/icons/*' stay inside 'use client' surfaces like
-// docs-page-actions.tsx, which picks its own GitHub mark for its actions.
-import { GithubLogoIcon, SparkleIcon } from '@/lib/icons/ssr';
 import { source } from '@/lib/source';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { RootProvider } from 'fumadocs-ui/provider/next';
@@ -16,6 +9,7 @@ import {
   DocsSearchButton,
   DocsSearchIconButton,
   DocsSidebarCollapseButton,
+  DocsSidebarFooter,
   DocsSidebarSeparator,
 } from './docs-controls';
 
@@ -38,6 +32,23 @@ export default function Layout({ children }: { children: ReactNode }) {
       theme={{
         enabled: false,
       }}
+      search={{
+        options: {
+          // Search runs IN THE BROWSER against an index fetched once, instead
+          // of one server round-trip per keystroke — see `api/search/route.ts`
+          // for why. `delayMs: 0` goes with it: the 100ms debounce exists to
+          // spare the network, and there is no network left to spare, so the
+          // results move with the cursor.
+          //
+          // `type` is marked deprecated upstream in favour of re-creating the
+          // dialog around `staticClient`. Not worth it here: fumadocs' dialog
+          // owns the highlight rendering, the tag list and the keyboard model,
+          // and a local copy of all three would drift on the next release for
+          // the sake of one option that still works.
+          type: 'static',
+          delayMs: 0,
+        },
+      }}
     >
       <DocsLayout
         tree={source.getPageTree()}
@@ -54,26 +65,13 @@ export default function Layout({ children }: { children: ReactNode }) {
             sm: <DocsSearchIconButton />,
           },
         }}
-        links={[
-          {
-            type: 'icon',
-            text: 'Get started',
-            label: 'Get started',
-            icon: <SparkleIcon />,
-            url: '/auth',
-            external: false,
-          },
-          {
-            type: 'icon',
-            text: 'GitHub',
-            label: 'GitHub',
-            icon: <GithubLogoIcon />,
-            url: 'https://github.com/kortix-ai/suna',
-            external: true,
-          },
-        ]}
         sidebar={{
           defaultOpenLevel: 1,
+          // Our own bottom row (docs-controls.tsx). `links` and `themeSwitch`
+          // are deliberately left empty: fumadocs renders those two into a
+          // hardcoded `border bg-fd-secondary/50 rounded-lg` pill, and with
+          // both empty its own `empty:hidden` drops the container entirely.
+          footer: <DocsSidebarFooter />,
           // Collapse is still driven through useSidebar() by our own buttons
           // (docs-controls.tsx); false only strips fumadocs' built-in chrome.
           collapsible: false,
@@ -81,16 +79,11 @@ export default function Layout({ children }: { children: ReactNode }) {
             Separator: DocsSidebarSeparator,
           },
         }}
-        themeSwitch={{
-          // The app's own theme control (same one as the user menu) instead of
-          // the fumadocs switch. The app-level next-themes provider still owns
-          // persistence; RootProvider theme is disabled above.
-          component: (
-            <div className="ms-auto">
-              <ThemeToggle variant="compact" />
-            </div>
-          ),
-        }}
+        // The theme control moved into `sidebar.footer` above — it is the app's
+        // own toggle either way (the app-level next-themes provider owns
+        // persistence; RootProvider theme is disabled above), but rendered
+        // through this slot it was locked inside fumadocs' bordered pill.
+        themeSwitch={{ enabled: false }}
       >
         <DocsCollapsedControls />
         {children}

--- a/apps/web/src/app/docs/markdown-source.test.ts
+++ b/apps/web/src/app/docs/markdown-source.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createMarkdownSource } from './markdown-source';
+
+function response(text: string, ok = true, status = 200) {
+  return Promise.resolve({ ok, status, text: () => Promise.resolve(text) });
+}
+
+describe('createMarkdownSource', () => {
+  test('does not fetch until asked', () => {
+    let calls = 0;
+    const source = createMarkdownSource('/markdown/docs/index.md', () => {
+      calls += 1;
+      return response('# Kortix');
+    });
+
+    expect(source.peek()).toBeNull();
+    expect(calls).toBe(0);
+  });
+
+  test('one request serves every overlapping caller', async () => {
+    // A hover, a focus and a press can all land before the first response —
+    // three requests for one string would be worse than the bug being fixed.
+    let calls = 0;
+    const source = createMarkdownSource('/markdown/docs/index.md', () => {
+      calls += 1;
+      return response('# Kortix');
+    });
+
+    const [a, b, c] = await Promise.all([source.load(), source.load(), source.load()]);
+
+    expect(calls).toBe(1);
+    expect([a, b, c]).toEqual(['# Kortix', '# Kortix', '# Kortix']);
+  });
+
+  test('once loaded, the text is there without a request', async () => {
+    // This is the whole point: by the time the button is clicked, `peek()`
+    // answers, and the clipboard write happens inside the click with no await
+    // in front of it.
+    let calls = 0;
+    const source = createMarkdownSource('/markdown/docs/index.md', () => {
+      calls += 1;
+      return response('# Kortix');
+    });
+
+    await source.load();
+
+    expect(source.peek()).toBe('# Kortix');
+    await source.load();
+    expect(calls).toBe(1);
+  });
+
+  test('a failed response rejects and is not remembered', async () => {
+    // A reader whose first press hit a dead connection must be able to press
+    // again; a cached rejection would hand them the same failure forever.
+    let calls = 0;
+    const source = createMarkdownSource('/markdown/docs/index.md', () => {
+      calls += 1;
+      return calls === 1 ? response('', false, 500) : response('# Kortix');
+    });
+
+    await expect(source.load()).rejects.toThrow('500');
+    expect(source.peek()).toBeNull();
+
+    expect(await source.load()).toBe('# Kortix');
+    expect(calls).toBe(2);
+  });
+
+  test('a rejected fetch is not remembered either', async () => {
+    let calls = 0;
+    const source = createMarkdownSource('/markdown/docs/index.md', () => {
+      calls += 1;
+      return calls === 1 ? Promise.reject(new Error('offline')) : response('# Kortix');
+    });
+
+    await expect(source.load()).rejects.toThrow('offline');
+    expect(await source.load()).toBe('# Kortix');
+  });
+});

--- a/apps/web/src/app/docs/markdown-source.ts
+++ b/apps/web/src/app/docs/markdown-source.ts
@@ -1,0 +1,56 @@
+/**
+ * The page's markdown, fetched at most once and remembered.
+ *
+ * "Copy Markdown" used to run its `fetch` INSIDE the click: press the button
+ * and the first thing that happens is a network round-trip, so the copy is
+ * never faster than the request — and on a cold dev server, where
+ * `/markdown/[...path]` is compiled and rendered per request, that is seconds.
+ * The text does not depend on the click, so it does not have to wait for it.
+ *
+ * Splitting the cache out of the component is what makes it testable: this
+ * app has no DOM harness, so a `useRef` inside a client component is reachable
+ * only by rendering one. Everything decided here — fetch once, share the
+ * in-flight promise, forget a failure so the next press retries — is decided
+ * in a plain function instead.
+ */
+export interface MarkdownSource {
+  /** The text if it is already here, else `null`. Never triggers a fetch. */
+  peek(): string | null;
+  /** The text, fetching it if needed. Concurrent callers share one request. */
+  load(): Promise<string>;
+}
+
+type FetchLike = (input: string) => Promise<{
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+}>;
+
+export function createMarkdownSource(path: string, fetchImpl: FetchLike): MarkdownSource {
+  let text: string | null = null;
+  let pending: Promise<string> | null = null;
+
+  return {
+    peek: () => text,
+    load() {
+      if (text !== null) return Promise.resolve(text);
+      // `??=`, so a hover, a focus and a press that overlap issue ONE request
+      // and all three resolve from it.
+      pending ??= fetchImpl(path)
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Failed to fetch ${path}: ${response.status}`);
+          text = await response.text();
+          return text;
+        })
+        .catch((error: unknown) => {
+          // Drop the failed promise rather than caching a rejection: a reader
+          // whose first press hit a dead connection must be able to press
+          // again, and `??=` would otherwise hand them the same failure
+          // forever.
+          pending = null;
+          throw error;
+        });
+      return pending;
+    },
+  };
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -35,20 +35,71 @@
   --color-fd-ring: var(--ring);
 }
 
-/* Docs borders run a step darker than the app's hairline --border — the
-   default reads too faint on docs surfaces (callouts, tables, code chrome).
-   Scoped to the fumadocs layout root so the rest of the app keeps the lighter
-   token. --color-fd-border must be re-declared here: the :root mapping above
-   already resolved var(--border) at the root, so it would not pick up this
-   scoped override on its own. */
-#nd-docs-layout {
-  --border: oklch(0.86 0 0);
-  --color-fd-border: var(--border);
+/* Docs use the app's own hairline --border, with no scoped step.
+   `#nd-docs-layout` used to darken it (`oklch(0.86 0 0)` light, a lighter
+   `oklch(0.34 0.006 286.033)` dark) on the argument that the default read too
+   faint on callouts, tables and code chrome. In practice it read as heavy: the
+   docs draw far more borders per screen than an app view, so a step that is
+   right on one card compounds across a page of them. The fd-* mapping above
+   already carries --border through to fumadocs, so removing the override is
+   all that is needed — one hairline, one value, everywhere. */
+
+/* Inline code in a SEARCH RESULT is the same chip as inline code anywhere else.
+
+   Fumadocs renders each result's content as markdown and hands inline code its
+   own look — `border rounded-md px-px bg-fd-secondary text-fd-secondary-
+   foreground`, hardcoded in `mdComponents` inside
+   `fumadocs-ui/dist/components/dialog/search.js`. Against the app's chip that
+   is a different radius, a different inset and a filled surface, so the same
+   `agents:` reads as one thing on the page and another in the palette that
+   found it.
+
+   CSS rather than the dialog's `renderMarkdown` hook: overriding that means
+   supplying the whole component map, and the rest of it — the `mark` that
+   paints the matched term, the `a`-as-span, the custom-element chip — is
+   package-internal and unexported. Restyling one element beats re-declaring
+   five and drifting on the next release.
+
+   The values mirror `INLINE_CODE` (`components/markdown/code/inline-chip.tsx`).
+   They are restated because the element is built inside the package and there
+   is nowhere to hand it a class; change one, change the other. `color` is
+   inherited on purpose — a selected row paints itself `fd-accent-foreground`,
+   and a pinned colour would fight it.
+
+   `button[aria-selected]` is the result row: every item in the list is that
+   button (`SearchDialogListItem`), and it is what the pointer highlights. */
+[role='dialog'] button[aria-selected] code {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: transparent;
+  padding: 0 0.25em;
+  font-size: 0.8rem;
+  color: inherit;
 }
-.dark #nd-docs-layout {
-  /* In dark theme a literally darker border would vanish into the background —
-     step lighter instead for the same contrast boost. */
-  --border: oklch(0.34 0.006 286.033);
+
+/* Inline code in a TOC entry is code, not a button.
+
+   Fumadocs puts `prose` on every TOC LINK
+   (`fumadocs-ui/dist/components/toc/default.js`), so a heading's inline code
+   lands under the preset's own `.prose :where(code)` rule: a filled
+   `--color-fd-muted` chip with a hardcoded 13px size and 3px of padding on
+   every side. In a 14px column of muted links that reads as a pressable
+   control, and it is the only filled surface in the whole aside.
+
+   The body is unaffected — `docsMdxComponents.code` gives it the app's
+   `INLINE_CODE` class, and a utility class (0,1,0) plus later source order
+   beats the preset. A TOC item's `<code>` comes from the heading AST with no
+   class at all, so CSS is the only place to reach it.
+
+   `a.prose` rather than `#nd-toc`: `prose` on an ANCHOR is what causes this,
+   and it is what the popover TOC on narrow viewports carries too. If fumadocs
+   ever drops that class the bug goes with it and this rule becomes a no-op.
+   Fill and metrics only — the border and the inherited link colour are the
+   preset's, so the entry still takes its active and hover states. */
+a.prose code {
+  background: transparent;
+  padding: 0 0.25em;
+  font-size: 0.9em;
 }
 
 /* Legacy --sidebar-* values used by the app's own sidebar components. The
@@ -223,6 +274,9 @@
   --color-kortix-green: var(--kortix-green);
   --color-kortix-purple: var(--kortix-purple);
   --color-kortix-red: var(--kortix-red);
+  --color-liquid-glass: var(--liquid-glass-bg);
+  --color-liquid-glass-hover: var(--liquid-glass-bg-hover);
+  --shadow-liquid-glass: var(--liquid-glass-shadow);
   /* Terminal surface. The PTY pane and its chrome (the connect strip, the
      panel shell behind it) are always dark, in every app theme, because they
      mirror a real shell — so these are literals, not light/dark pairs. One
@@ -724,6 +778,19 @@
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
   --ease-out: cubic-bezier(0, 0, 0.2, 1);
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* Liquid glass — frosted secondary surface. Pair with `@utility liquid-glass`.
+     Mix with transparent (not --background) so backdrop-filter can show through.
+     Light: drop shadow + bright specular. Dark: no drop shadow, 1px inset rim.
+     Call sites should not need `dark:`. */
+  --liquid-glass-bg: color-mix(in oklch, var(--secondary) 45%, transparent);
+  --liquid-glass-bg-hover: color-mix(in oklch, var(--secondary) 62%, transparent);
+  --liquid-glass-blur: 20px;
+  --liquid-glass-saturate: 1.8;
+  --liquid-glass-shadow:
+    0 20px 48px -16px oklch(0 0 0 / 0.65), inset 0 1.5px 0 oklch(1 0 0 / 0.35),
+    inset 0 -1px 0 oklch(1 0 0 / 0.08);
+  --liquid-glass-highlight: radial-gradient(circle at 30% 20%, oklch(1 0 0 / 0.28), transparent 55%);
 }
 
 .dark {
@@ -775,6 +842,11 @@
   --kortix-green: oklch(0.581 0.165 146.619);
   --kortix-purple: oklch(0.675 0.131 306.212);
   --kortix-red: oklch(0.648 0.202 24.745);
+
+  --liquid-glass-bg: color-mix(in oklch, var(--secondary) 38%, transparent);
+  --liquid-glass-bg-hover: color-mix(in oklch, var(--secondary) 52%, transparent);
+  --liquid-glass-shadow: inset 0 0 0 1px oklch(1 0 0 / 0.1);
+  --liquid-glass-highlight: radial-gradient(circle at 30% 20%, oklch(1 0 0 / 0.12), transparent 55%);
 }
 
 @layer base {
@@ -868,6 +940,7 @@
       'Noto Sans Mono CJK SC', 'Noto Sans Mono CJK TC';
     font-weight: 500;
     line-height: 1.2;
+    letter-spacing: -0.025em; /* tracking-tight — mono glyphs read cleaner when pulled in */
   }
 }
 
@@ -1656,6 +1729,23 @@ html[data-desktop='true'] .kx-titlebar-row[data-sidebar-collapsed] {
    margin (e.g. the Files file-preview top bar): drop it past the inset too. */
 .kx-titlebar-safe-mt {
   margin-top: calc(0.75rem + var(--kx-titlebar-inset, 0px));
+}
+
+/* ─── Liquid glass — frosted tinted surface (tokens: --liquid-glass-*) ─────
+   Theme-aware: light drop-shadow, dark inset rim. Specular lives on
+   background-image so this does not steal ::before from hit-area.
+   Use: className="liquid-glass rounded-full" */
+@utility liquid-glass {
+  border: 1px solid var(--border);
+  background-color: var(--liquid-glass-bg);
+  background-image: var(--liquid-glass-highlight);
+  -webkit-backdrop-filter: blur(var(--liquid-glass-blur)) saturate(var(--liquid-glass-saturate));
+  backdrop-filter: blur(var(--liquid-glass-blur)) saturate(var(--liquid-glass-saturate));
+  box-shadow: var(--liquid-glass-shadow);
+
+  &:hover {
+    background-color: var(--liquid-glass-bg-hover);
+  }
 }
 
 /* ─── Hit area — expand interactive targets without layout shift ───────────

--- a/apps/web/src/components/home/theme-toggle.tsx
+++ b/apps/web/src/components/home/theme-toggle.tsx
@@ -6,12 +6,113 @@ import { Button } from '@/components/ui/marketing/button';
 import { getThemeById } from '@/lib/themes';
 import { cn } from '@/lib/utils';
 import { useUserPreferencesStore } from '@/stores/user-preferences-store';
-import { MoonStarsIcon as MoonStar, SunDimIcon as SunDim } from '@phosphor-icons/react';
 import { useTheme } from 'next-themes';
 import * as React from 'react';
 
+/**
+ * The three themes the toggle switches between.
+ *
+ * One table, two presentations. `compact` and `minimal` differ only in their
+ * chrome — the icons, the labels and the `setTheme` ids are the same control,
+ * and three hand-copied `<button>` blocks per variant is how the two drift.
+ */
+const THEME_OPTIONS = [
+  {
+    id: 'light',
+    labelKey: 'autoComponentsHomeThemeToggleJsxAttrAriaLabelLightTheme26963d69',
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="24px"
+        height="24px"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M13 2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2V3C11 3.55 11.45 4 12 4C12.55 4 13 3.55 13 3V2Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M13 21C13 20.45 12.55 20 12 20C11.45 20 11 20.45 11 21V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V21Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M19.78 4.22C20.17 4.61 20.17 5.25 19.78 5.64L19.07 6.35C18.68 6.74 18.04 6.74 17.65 6.35C17.26 5.96 17.26 5.32 17.65 4.93L18.36 4.22C18.75 3.83 19.39 3.83 19.78 4.22Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M6.35 19.07C6.74 18.68 6.74 18.04 6.35 17.65C5.96 17.26 5.32 17.26 4.93 17.65L4.22 18.36C3.83 18.75 3.83 19.39 4.22 19.78C4.61 20.17 5.25 20.17 5.64 19.78L6.35 19.07Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M20 12C20 11.45 20.45 11 21 11H22C22.55 11 23 11.45 23 12C23 12.55 22.55 13 22 13H21C20.45 13 20 12.55 20 12Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M2 11C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13H3C3.55 13 4 12.55 4 12C4 11.45 3.55 11 3 11H2Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M17.65 17.65C18.04 17.26 18.68 17.26 19.07 17.65L19.78 18.36C20.17 18.75 20.17 19.39 19.78 19.78C19.39 20.17 18.75 20.17 18.36 19.78L17.65 19.07C17.26 18.68 17.26 18.04 17.65 17.65Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M5.64 4.22C5.25 3.83 4.61 3.83 4.22 4.22C3.83 4.61 3.83 5.25 4.22 5.64L4.93 6.35C5.32 6.74 5.96 6.74 6.35 6.35C6.74 5.96 6.74 5.32 6.35 4.93L5.64 4.22Z"
+          fill="currentColor"
+        ></path>
+        <path
+          d="M7.76 7.76C10.1 5.41 13.9 5.41 16.24 7.76C18.59 10.1 18.59 13.9 16.24 16.24C13.9 18.59 10.1 18.59 7.76 16.24C5.41 13.9 5.41 10.1 7.76 7.76Z"
+          fill="currentColor"
+        ></path>
+      </svg>
+    ),
+  },
+  {
+    id: 'dark',
+    labelKey: 'autoComponentsHomeThemeToggleJsxAttrAriaLabelDarkThemebf1de1f0',
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="24px"
+        height="24px"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12.05 3.6C12.27 3.28 12.29 2.86 12.09 2.53C11.9 2.2 11.53 2 11.14 2.04C6.02 2.47 2 6.76 2 12C2 17.52 6.48 22 12 22C17.23 22 21.53 17.97 21.96 12.85C21.99 12.47 21.8 12.1 21.47 11.9C21.13 11.71 20.71 11.72 20.4 11.94C19.43 12.61 18.26 13 17 13C13.68 13 11 10.31 11 7C11 5.74 11.39 4.57 12.05 3.6Z"
+          fill="currentColor"
+        ></path>
+      </svg>
+    ),
+  },
+  {
+    id: 'system',
+    labelKey: 'autoComponentsHomeThemeToggleJsxAttrAriaLabelSystemThemeb9e760e3',
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="24px"
+        height="24px"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M6 3C3.79 3 2 4.79 2 7V12H22V7C22 4.79 20.21 3 18 3H6Z" fill="currentColor"></path>
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M2 14H22C22 16.21 20.21 18 18 18H15V21C15 21.55 14.55 22 14 22H10C9.45 22 9 21.55 9 21V18H6C3.79 18 2 16.21 2 14ZM11 18V20H13V18H11Z"
+          fill="currentColor"
+        ></path>
+      </svg>
+    ),
+  },
+] as const;
+
 interface ThemeToggleProps {
-  variant?: 'icon' | 'compact';
+  variant?: 'icon' | 'compact' | 'minimal';
   className?: string;
   systemTheme?: boolean;
 }
@@ -28,130 +129,70 @@ export function ThemeToggle({ variant = 'icon', className, systemTheme = true }:
     setMounted(true);
   }, []);
 
-  if (variant === 'compact') {
-    // Intentional mount gate: `theme` is client-only (next-themes), and the
-    // active-segment highlight below reads it during render. Rendering before
-    // mount would hydrate with no segment highlighted and then flash the
-    // correct one. The icon variant below renders nothing theme-dependent
-    // (CSS `dark:` classes swap the icon), so it is NOT gated and never
-    // flickers.
-    if (!mounted) {
-      return null;
-    }
+  // Both segmented presentations read `theme` during render, so both wait for
+  // mount: `theme` is client-only (next-themes), and rendering before mount
+  // hydrates with no segment marked and then flashes the right one. The icon
+  // variant below renders nothing theme-dependent (CSS `dark:` classes swap
+  // the icon), so it is NOT gated and never flickers.
+  const options = systemTheme ? THEME_OPTIONS : THEME_OPTIONS.filter((o) => o.id !== 'system');
+
+  if (variant === 'compact' || variant === 'minimal') {
+    if (!mounted) return null;
+
+    // `minimal` is the same control with the chrome taken off: no track, no
+    // filled chip on the active segment. It exists for surfaces that are
+    // already a quiet row of icons — the docs sidebar footer — where a filled
+    // segmented control is the loudest thing on the panel and reads as a
+    // separate widget rather than as three more icons. The active theme is
+    // said in colour instead, which is what the rest of that row uses.
+    const minimal = variant === 'minimal';
+
     return (
-      <div className="bg-foreground/10 shadow-custom flex items-center gap-0.5 rounded-sm p-0.5">
-        <button
-          aria-label={tI18nHardcoded.raw(
-            'autoComponentsHomeThemeToggleJsxAttrAriaLabelLightTheme26963d69',
-          )}
-          className="[&amp;&gt;svg]:size-4 text-foreground inline-flex size-7 cursor-pointer items-center justify-center rounded-[calc(var(--radius)-6px)] transition-colors duration-150 ease-out"
-          style={{ backgroundColor: theme === 'light' ? 'var(--background)' : 'transparent' }}
-          type="button"
-          onClick={() => setTheme('light')}
-        >
-          <svg
-            aria-hidden="true"
-            width="24px"
-            height="24px"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M13 2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2V3C11 3.55 11.45 4 12 4C12.55 4 13 3.55 13 3V2Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M13 21C13 20.45 12.55 20 12 20C11.45 20 11 20.45 11 21V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V21Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M19.78 4.22C20.17 4.61 20.17 5.25 19.78 5.64L19.07 6.35C18.68 6.74 18.04 6.74 17.65 6.35C17.26 5.96 17.26 5.32 17.65 4.93L18.36 4.22C18.75 3.83 19.39 3.83 19.78 4.22Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M6.35 19.07C6.74 18.68 6.74 18.04 6.35 17.65C5.96 17.26 5.32 17.26 4.93 17.65L4.22 18.36C3.83 18.75 3.83 19.39 4.22 19.78C4.61 20.17 5.25 20.17 5.64 19.78L6.35 19.07Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M20 12C20 11.45 20.45 11 21 11H22C22.55 11 23 11.45 23 12C23 12.55 22.55 13 22 13H21C20.45 13 20 12.55 20 12Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M2 11C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13H3C3.55 13 4 12.55 4 12C4 11.45 3.55 11 3 11H2Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M17.65 17.65C18.04 17.26 18.68 17.26 19.07 17.65L19.78 18.36C20.17 18.75 20.17 19.39 19.78 19.78C19.39 20.17 18.75 20.17 18.36 19.78L17.65 19.07C17.26 18.68 17.26 18.04 17.65 17.65Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M5.64 4.22C5.25 3.83 4.61 3.83 4.22 4.22C3.83 4.61 3.83 5.25 4.22 5.64L4.93 6.35C5.32 6.74 5.96 6.74 6.35 6.35C6.74 5.96 6.74 5.32 6.35 4.93L5.64 4.22Z"
-              fill="currentColor"
-            ></path>
-            <path
-              d="M7.76 7.76C10.1 5.41 13.9 5.41 16.24 7.76C18.59 10.1 18.59 13.9 16.24 16.24C13.9 18.59 10.1 18.59 7.76 16.24C5.41 13.9 5.41 10.1 7.76 7.76Z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </button>
-        <button
-          aria-label={tI18nHardcoded.raw(
-            'autoComponentsHomeThemeToggleJsxAttrAriaLabelDarkThemebf1de1f0',
-          )}
-          className="[&amp;&gt;svg]:size-4 hover:text-foreground text-foreground inline-flex size-7 cursor-pointer items-center justify-center rounded-[calc(var(--radius)-6px)] transition-colors duration-150 ease-out"
-          type="button"
-          style={{ backgroundColor: theme === 'dark' ? 'var(--background)' : 'transparent' }}
-          onClick={() => setTheme('dark')}
-        >
-          <svg
-            aria-hidden="true"
-            width="24px"
-            height="24px"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M12.05 3.6C12.27 3.28 12.29 2.86 12.09 2.53C11.9 2.2 11.53 2 11.14 2.04C6.02 2.47 2 6.76 2 12C2 17.52 6.48 22 12 22C17.23 22 21.53 17.97 21.96 12.85C21.99 12.47 21.8 12.1 21.47 11.9C21.13 11.71 20.71 11.72 20.4 11.94C19.43 12.61 18.26 13 17 13C13.68 13 11 10.31 11 7C11 5.74 11.39 4.57 12.05 3.6Z"
-              fill="currentColor"
-            ></path>
-          </svg>
-        </button>
-        {systemTheme && (
-          <button
-            aria-label={tI18nHardcoded.raw(
-              'autoComponentsHomeThemeToggleJsxAttrAriaLabelSystemThemeb9e760e3',
-            )}
-            className="[&amp;&gt;svg]:size-4 hover:text-foreground text-foreground inline-flex size-7 cursor-pointer items-center justify-center rounded-[calc(var(--radius)-6px)] transition-colors duration-150 ease-out"
-            type="button"
-            style={{ backgroundColor: theme === 'system' ? 'var(--background)' : 'transparent' }}
-            onClick={() => setTheme('system')}
-          >
-            <svg
-              aria-hidden="true"
-              width="24px"
-              height="24px"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
+      <div
+        className={
+          minimal
+            ? cn('flex items-center gap-0.5', className)
+            : 'bg-foreground/10 shadow-custom flex items-center gap-0.5 rounded-sm p-0.5'
+        }
+      >
+        {options.map((option) => {
+          const active = theme === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-label={tI18nHardcoded.raw(option.labelKey)}
+              // The pressed state is what a screen reader has instead of the
+              // fill/colour the eye gets.
+              aria-pressed={active}
+              onClick={() => setTheme(option.id)}
+              className={
+                minimal
+                  ? cn(
+                      'inline-flex size-7 cursor-pointer items-center justify-center rounded-md',
+                      'transition-colors duration-150 ease-out [&>svg]:size-4',
+                      active ? 'text-foreground' : 'text-muted-foreground/60 hover:text-foreground',
+                    )
+                  : '[&amp;&gt;svg]:size-4 hover:text-foreground text-foreground inline-flex size-7 cursor-pointer items-center justify-center rounded-[calc(var(--radius)-6px)] transition-colors duration-150 ease-out'
+              }
+              // Compact marks the active segment with a raised chip; minimal
+              // has no track for a chip to sit on.
+              style={
+                minimal
+                  ? undefined
+                  : { backgroundColor: active ? 'var(--background)' : 'transparent' }
+              }
             >
-              <path
-                d="M6 3C3.79 3 2 4.79 2 7V12H22V7C22 4.79 20.21 3 18 3H6Z"
-                fill="currentColor"
-              ></path>
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M2 14H22C22 16.21 20.21 18 18 18H15V21C15 21.55 14.55 22 14 22H10C9.45 22 9 21.55 9 21V18H6C3.79 18 2 16.21 2 14ZM11 18V20H13V18H11Z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </button>
-        )}
+              {option.icon}
+            </button>
+          );
+        })}
       </div>
     );
   }
+
+  const lightIcon = THEME_OPTIONS.find((o) => o.id === 'light')!.icon;
+  const darkIcon = THEME_OPTIONS.find((o) => o.id === 'dark')!.icon;
 
   return (
     <div className="flex items-center gap-1.5">
@@ -159,10 +200,10 @@ export function ThemeToggle({ variant = 'icon', className, systemTheme = true }:
         variant="transparent"
         size="icon-sm"
         onClick={() => setTheme(resolvedTheme === 'light' ? 'dark' : 'light')}
-        className={cn('cursor-pointer rounded-full', className)}
+        className={cn('cursor-pointer rounded-full [&>svg]:size-4', className)}
       >
-        <SunDim className="hidden dark:block" />
-        <MoonStar className="block dark:hidden" />
+        <span className="hidden dark:block">{darkIcon}</span>
+        <span className="block dark:hidden">{lightIcon}</span>
         <span className="sr-only">
           {tHardcodedUi.raw('componentsHomeThemeToggle.line93JsxTextToggleTheme')}
         </span>

--- a/apps/web/src/components/markdown/code/code-block.tsx
+++ b/apps/web/src/components/markdown/code/code-block.tsx
@@ -123,7 +123,7 @@ export function CodeBlock({
       <pre
         ref={scrollRef}
         className={cn(
-          'bg-popover max-h-[520px] overflow-auto py-2.5',
+          'bg-popover max-h-[520px] overflow-auto py-2.5 tracking-tight',
           'text-foreground rounded-t-sm font-mono text-xs leading-[1.65]',
           '[&_code]:border-none [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-xs',
           '[&_.shiki]:!bg-transparent [&_span]:border-none [&_span]:!bg-transparent [&_span]:outline-none',

--- a/apps/web/src/components/markdown/code/index.ts
+++ b/apps/web/src/components/markdown/code/index.ts
@@ -11,5 +11,9 @@
 export { childrenToText } from './children-text';
 export { CodeBlock, CodeHighlight, HighlightedCode } from './code-block';
 export { CopyOverlay } from './copy-overlay';
-export { ClickableInlineCode, INLINE_CODE } from './inline-code';
+export { ClickableInlineCode } from './inline-code';
+// From the server-safe module, not through the client one: re-exporting a
+// plain function out of a `'use client'` file hands a server consumer a client
+// reference, which throws the moment it is CALLED. See `inline-chip.tsx`.
+export { HexColorCode, INLINE_CODE, isHexColor } from './inline-chip';
 export { MarkdownCode } from './markdown-code';

--- a/apps/web/src/components/markdown/code/inline-chip.tsx
+++ b/apps/web/src/components/markdown/code/inline-chip.tsx
@@ -1,0 +1,132 @@
+/**
+ * The inline-code chip, and the one piece of markdown that draws something
+ * other than text.
+ *
+ * NO `'use client'`, deliberately. `inline-code.tsx` is a client module — its
+ * file-path and URL chips read stores and fire probes — and everything a
+ * client module exports becomes a client REFERENCE. The docs renderer
+ * (`docs-mdx-components.tsx`) is a server module, so importing the chip class
+ * or the hex predicate from there and calling one crashed the page with
+ * "Attempted to call isHexColor() from the server but isHexColor is on the
+ * client". A local copy of the class string was the old way around that, and
+ * it drifted; this is the same dedupe without the boundary.
+ *
+ * Nothing here may take a hook or touch a store. What lives here is what both
+ * surfaces can render: the class string, the hex test, and a swatch that is
+ * pure JSX.
+ */
+
+import { cn } from '@/lib/utils';
+import type React from 'react';
+
+// ─── Inline code ─────────────────────────────────────────────────────────────
+/**
+ * The chip sits IN the line, not beside it.
+ *
+ * No `display` of its own, and no `vertical-align`: an inline box shares the
+ * paragraph's baseline for free, and its border box hugs the font's content
+ * area, so the chip is the height of the text it interrupts. Both of the
+ * obvious-looking alternatives are what knocked it out of line:
+ *
+ *   - `align-middle` centres the box on the parent's baseline PLUS half the
+ *     parent's x-height. The chip is `text-[0.8rem]` inside `text-base` prose,
+ *     so its own baseline landed visibly BELOW the surrounding text's — the
+ *     chip appeared to sag under the sentence.
+ *   - `inline-flex` makes the chip atomic: its height comes from the flex line
+ *     box (`code { line-height: 1.2 }` in globals.css) plus padding rather than
+ *     from the glyphs, so it towers over the prose, and — being unbreakable —
+ *     a long URL can no longer wrap across two lines the way
+ *     `[overflow-wrap:anywhere]` promises.
+ *
+ * `text-center` is gone with them: a chip is one line of text as wide as its
+ * content, so there is nothing for it to centre.
+ */
+// Mirrored, out of necessity, by the search-dialog rule in `app/globals.css`:
+// fumadocs builds that chip inside its own package, so there is nowhere to
+// hand it this class. Change one, change the other.
+export const INLINE_CODE =
+  'rounded-[5px] bg-inherit dark:bg-card px-1.5 py-[0.08rem] font-mono text-[0.8rem] text-foreground/95 [overflow-wrap:anywhere] border border-border tracking-tight font-medium';
+
+/**
+ * The four CSS hex forms and nothing else: `#RGB`, `#RGBA`, `#RRGGBB`,
+ * `#RRGGBBAA`.
+ *
+ * Anchored at both ends on purpose — a swatch is a claim that the whole token
+ * IS a colour, so `#ff0000-ish` and a `#fff` buried in a longer string do not
+ * qualify. `#deadbeef` is a legal 8-digit hex and gets a swatch; that is the
+ * cost of the format having no other tell, and the value is still printed
+ * beside it.
+ */
+const HEX_COLOR = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+export function isHexColor(text: string): boolean {
+  return HEX_COLOR.test(text);
+}
+
+/**
+ * The checkerboard behind a swatch, so an ALPHA hex reads as translucent
+ * instead of as whatever it happens to composite to over the chip.
+ *
+ * `currentColor` rather than a hardcoded grey: the square sets its own
+ * `text-muted-foreground/30`, so the board follows the theme in both
+ * appearances without a second colour definition. Two 45° gradients offset by
+ * half a tile is the standard construction — one gradient draws the diagonal
+ * pair, the offset copy fills the other two quadrants.
+ */
+const CHECKER =
+  'linear-gradient(45deg, currentColor 25%, transparent 25%, transparent 75%, currentColor 75%),' +
+  'linear-gradient(45deg, currentColor 25%, transparent 25%, transparent 75%, currentColor 75%)';
+
+/**
+ * A hex colour in a message, showing the colour it names.
+ *
+ * `#0ea5e9` in prose is a value nobody can read: the reader has to paste it
+ * somewhere to find out whether the agent picked a blue or a green. The chip
+ * keeps the hex — it is what gets copied into a stylesheet, so it must stay
+ * literal and selectable — and puts a square of the actual colour in front of
+ * it, sized in `em` so it tracks the chip's own text.
+ *
+ * The square is `aria-hidden`: it adds no information a screen reader can use
+ * that the hex itself does not already carry. The ring is what keeps
+ * `#ffffff` visible on a light chip and `#000000` visible on a dark one — a
+ * swatch with no edge disappears into exactly the background it matches.
+ */
+export function HexColorCode({ hex, children }: { hex: string; children: React.ReactNode }) {
+  return (
+    <code title={hex} className={cn(INLINE_CODE, 'space-y-0 py-0')}>
+      {/* The square sits ON the baseline, so its bottom edge and the text's
+          share one line.
+
+          The anchor is the baseline rather than a centring rule, and Roobert
+          Mono's own metrics say why: capHeight is 700/1000 = 0.70em and
+          xHeight is 504/1000 = 0.504em (read from the `OS/2` table of
+          `public/fonts/roobert/RoobertMonoUprightsVF.woff2`). A hex value is
+          digits and capitals, so the text beside the square occupies
+          baseline → 0.70em. `align-baseline` puts the square in that same
+          band; at `0.8em` it stands a tenth of an em proud of the caps, which
+          is a swatch reading slightly bolder than its own text and not a
+          misalignment — both boxes still start at the baseline.
+
+          NOT `align-middle`: `vertical-align: middle` centres the box on half
+          the parent's X-HEIGHT (0.252em), the middle of LOWERCASE text. On
+          digits it put the square's bottom edge 0.148em BELOW the baseline, so
+          it read as sunk under its own hex. An inline-block whose `overflow`
+          is not `visible` takes its baseline from the bottom margin edge
+          (CSS2.1 §10.8.1), which is exactly the anchor wanted here.
+
+          `mr-1` replaces the flex `gap`. */}
+      <span
+        aria-hidden
+        className="text-muted-foreground/30 ring-foreground/15 relative mr-1 inline-block size-[0.8em] overflow-hidden rounded-[3px] align-baseline ring-1 ring-inset"
+        style={{
+          backgroundImage: CHECKER,
+          backgroundSize: '10px 10px',
+          backgroundPosition: '0 0, 5px 5px',
+        }}
+      >
+        <span className="absolute inset-0" style={{ backgroundColor: hex }} />
+      </span>
+      {children}
+    </code>
+  );
+}

--- a/apps/web/src/components/markdown/code/inline-code.tsx
+++ b/apps/web/src/components/markdown/code/inline-code.tsx
@@ -19,10 +19,11 @@ import Link from 'next/link';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { childrenToText } from './children-text';
+// Server-safe by design — see `inline-chip.tsx`. Re-exported so the client
+// consumers that already import them from here keep working.
+import { HexColorCode, INLINE_CODE, isHexColor } from './inline-chip';
 
-// ─── Inline code ─────────────────────────────────────────────────────────────
-export const INLINE_CODE =
-  'rounded-[5px] bg-muted px-1.5 py-[0.08rem] font-mono text-[0.9rem] text-foreground/95 [overflow-wrap:anywhere] dark:bg-card border border-muted-foreground/5';
+export { HexColorCode, INLINE_CODE, isHexColor };
 
 /**
  * A path inside a message, rendered as a door to the file — but only while
@@ -143,6 +144,13 @@ function FilePathCode({ text, children }: { text: string; children: React.ReactN
 export function ClickableInlineCode({ children }: { children: React.ReactNode }) {
   const { proxyUrl } = useSandboxProxy();
   const text = childrenToText(children).trim();
+
+  // Before the URL and path checks: a hex is neither, and the test is a single
+  // anchored regex against a string that is at most nine characters.
+  if (isHexColor(text)) {
+    return <HexColorCode hex={text}>{children}</HexColorCode>;
+  }
+
   const isUrl = looksLikeUrl(text);
 
   if (isUrl) {

--- a/apps/web/src/components/markdown/code/markdown-code.test.tsx
+++ b/apps/web/src/components/markdown/code/markdown-code.test.tsx
@@ -6,6 +6,7 @@ import {
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import { isHexColor } from './inline-chip';
 import { MarkdownCode, type MarkdownCodeProps } from './markdown-code';
 
 const render = (props: MarkdownCodeProps) => renderToStaticMarkup(<MarkdownCode {...props} />);
@@ -115,6 +116,84 @@ describe('MarkdownCode — inline code', () => {
     // Neither of the ClickableInlineCode treatments applies to a bare command.
     expect(markup).not.toContain('role="button"');
     expect(markup).not.toContain('href');
+  });
+
+  test('a hex colour shows the colour it names', () => {
+    // `#0ea5e9` in prose is a value nobody can read — the reader has to paste
+    // it somewhere to find out whether the agent picked a blue or a green.
+    const markup = render({ children: '#0ea5e9' });
+
+    expect(markup.startsWith('<code')).toBe(true);
+    // The hex itself stays literal: it is what gets copied into a stylesheet.
+    expect(markup).toContain('#0ea5e9');
+    expect(markup).toContain('background-color:#0ea5e9');
+    // The square carries no information the hex does not.
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  test('every CSS hex form is recognised, and nothing else is', () => {
+    for (const hex of ['#fff', '#FFFF', '#0ea5e9', '#0EA5E9FF']) {
+      expect(isHexColor(hex)).toBe(true);
+    }
+    // A swatch claims the WHOLE token is a colour.
+    for (const notHex of ['#ff0000-ish', 'color: #fff', '#12345', '#ghijkl', '#']) {
+      expect(isHexColor(notHex)).toBe(false);
+    }
+  });
+
+/**
+ * The `<code>` chip's own class attribute.
+ *
+ * The chip and the swatch inside it have separate alignment rules — the chip
+ * takes the paragraph's baseline, the swatch takes the chip's — so a
+ * whole-markup match would let one element's classes answer for the other.
+ */
+function chipClass(html: string): string {
+  const found = html.match(/<code\b[^>]*\bclass="([^"]*)"/);
+  if (!found) throw new Error('no <code> chip with a class in the rendered markup');
+  return found[1];
+}
+
+  test('the chip sits ON the line — no vertical-align, no flex box', () => {
+    // Both knocked it out of the sentence. `align-middle` centres the box on
+    // the parent's baseline plus half its x-height, and the chip is
+    // `text-[0.8rem]` inside `text-base` prose — so the chip's own baseline
+    // landed below the surrounding text and it read as sagging. `inline-flex`
+    // makes the chip atomic: it takes its height from the flex line box
+    // (`code { line-height: 1.2 }`) instead of the glyphs, and a long URL can
+    // no longer wrap the way `[overflow-wrap:anywhere]` promises.
+    for (const markup of [render({ children: 'npm run dev' }), render({ children: '#0ea5e9' })]) {
+      expect(chipClass(markup)).not.toContain('align-');
+      expect(chipClass(markup)).not.toContain('inline-flex');
+      expect(chipClass(markup)).not.toContain('text-center');
+    }
+  });
+
+  test('the swatch stands on the baseline, sized in the text\'s own em', () => {
+    // The baseline is the anchor: an inline-block whose `overflow` is not
+    // `visible` takes its baseline from the bottom margin edge, so the square
+    // and the hex beside it start on the same line. Roobert Mono's capHeight
+    // is 700/1000 = 0.70em, so at 0.8em the square stands a tenth of an em
+    // proud of the digits — a deliberate weight, not a drift.
+    //
+    // Not `align-middle`: `vertical-align: middle` centres on half the
+    // X-HEIGHT (0.504em → 0.252em), the middle of LOWERCASE text, which sank
+    // the square 0.148em below the baseline of its own hex. Not `size-3`
+    // either — a fixed 12px square in a 12.8px font is the whole em box.
+    const markup = render({ children: '#0ea5e9' });
+
+    expect(markup).toContain('inline-block');
+    expect(markup).toContain('align-baseline');
+    expect(markup).toContain('size-[0.8em]');
+    expect(markup).not.toContain('align-middle');
+    expect(markup).not.toContain('size-3');
+  });
+
+  test('a non-colour token keeps the plain chip — no swatch', () => {
+    const markup = render({ children: '#hashtag' });
+
+    expect(markup).not.toContain('aria-hidden="true"');
+    expect(markup).toContain('#hashtag');
   });
 
   test('inline code holding a setup-link path renders the setup chip', () => {

--- a/apps/web/src/components/markdown/code/shiki-highlighter.ts
+++ b/apps/web/src/components/markdown/code/shiki-highlighter.ts
@@ -255,7 +255,7 @@ export function highlightAsync(
 }
 
 export const SHIKI_RESET = cn(
-  'text-sm font-mono leading-[1.65] whitespace-pre',
+  'text-sm font-mono leading-[1.65] whitespace-pre tracking-tight',
   '[&_pre]:contents [&_code]:contents',
   '[&_.line]:m-0 [&_.line]:p-0 [&_.line]:border-none [&_.line]:outline-none [&_.line]:shadow-none',
 );

--- a/apps/web/src/components/markdown/docs-card.test.tsx
+++ b/apps/web/src/components/markdown/docs-card.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { RocketIcon } from '@/lib/icons/ssr';
+
+import { Card, Cards } from './docs-card';
+
+/**
+ * The docs card exists because fumadocs' own hardcodes the layout that was
+ * rejected: the icon in a `w-fit shadow-md rounded-lg border bg-fd-muted p-1.5`
+ * tile, stacked ABOVE the title. No prop reaches those classes, and swapping
+ * the icon and the title is a different tree, not a restyle.
+ */
+const render = (props: Partial<Parameters<typeof Card>[0]> = {}) =>
+  renderToStaticMarkup(
+    <Card
+      icon={<RocketIcon />}
+      title="Quickstart"
+      href="/docs/quickstart"
+      description="Create a project."
+      {...props}
+    />,
+  );
+
+describe('docs Card', () => {
+  test('the glyph wears no tile — no fill, no border, no shadow, no padding', () => {
+    const markup = render();
+
+    expect(markup).not.toContain('shadow-md');
+    expect(markup).not.toContain('bg-fd-muted');
+    expect(markup).not.toContain('w-fit');
+    // The mark is still there, at text size.
+    expect(markup).toContain('<svg');
+    expect(markup).toContain('size-4');
+  });
+
+  test('the glyph is a column beside the words, not a row above them', () => {
+    const markup = render();
+
+    expect(markup).toContain('flex items-start');
+    // The icon's span closes before the text block opens: two columns.
+    expect(markup).toMatch(/<\/span><div class="min-w-0 flex-1">/);
+  });
+
+  test('title and description are ONE block, so the description wraps under the title', () => {
+    const markup = render();
+
+    // Adjacent inside the same div — not two siblings under the icon, which
+    // would put the second line back under the mark.
+    expect(markup).toMatch(/<div class="min-w-0 flex-1"><h3[^>]*>Quickstart<\/h3><p/);
+  });
+
+  test('a card with no href is not a link', () => {
+    expect(render({ href: undefined }).startsWith('<div')).toBe(true);
+    expect(render().startsWith('<a')).toBe(true);
+  });
+
+  test('a card with no icon still lines up its words', () => {
+    const markup = render({ icon: undefined });
+
+    expect(markup).not.toContain('<svg');
+    expect(markup).toContain('Quickstart');
+    expect(markup).toContain('Create a project.');
+  });
+
+  test('the grid keeps the two-column container query it replaced', () => {
+    // Same geometry as fumadocs' `Cards`, so swapping the component did not
+    // silently reflow every docs index page.
+    const markup = renderToStaticMarkup(
+      <Cards>
+        <Card title="One" href="/docs/cli" />
+      </Cards>,
+    );
+
+    expect(markup).toContain('@container');
+    expect(markup).toContain('grid-cols-2');
+    expect(markup).toContain('@max-lg:col-span-full');
+  });
+});

--- a/apps/web/src/components/markdown/docs-card.tsx
+++ b/apps/web/src/components/markdown/docs-card.tsx
@@ -1,0 +1,91 @@
+import Link from 'fumadocs-core/link';
+import type { HTMLAttributes, ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * The docs card grid.
+ *
+ * Same geometry as the one it replaces (`fumadocs-ui/components/card`): a
+ * two-column grid on a container query, so a card in a narrow column can span
+ * the full width instead of being squeezed.
+ */
+export function Cards({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div {...props} className={cn('@container grid grid-cols-2 gap-3', className)} />;
+}
+
+export interface CardProps extends Omit<HTMLAttributes<HTMLElement>, 'title'> {
+  icon?: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  href?: string;
+  external?: boolean;
+}
+
+/**
+ * One docs card: a glyph in its own column, with the title and the
+ * description beside it as one block.
+ *
+ * This is a local component rather than a restyle of fumadocs' card because
+ * that card's chrome is hardcoded in the published package — it wraps the icon
+ * in `w-fit shadow-md rounded-lg border bg-fd-muted p-1.5` and stacks it ABOVE
+ * the title (`fumadocs-ui/dist/components/card.js`). Nothing reaches those
+ * classes from the outside: no prop, and no selector that would not be a guess
+ * at someone else's DOM. Reordering the icon and the title is not a styling
+ * change at all — it is a different tree.
+ *
+ * So the glyph is a glyph: muted, `size-4`, level with the title, with no
+ * tile, no fill, no border and no shadow around it. A card is a link in a list
+ * of links, and the boxed mark made each one read as a button with a badge on
+ * it.
+ *
+ * The card's OWN frame is unchanged from the package's — `rounded-xl border
+ * bg-fd-card p-4` with the accent wash on hover — because that part was never
+ * the complaint, and the docs grid should keep looking like the docs grid.
+ */
+export function Card({ icon, title, description, href, external, ...props }: CardProps) {
+  const Root = href ? Link : 'div';
+
+  return (
+    <Root
+      {...props}
+      {...(href ? { href, external } : {})}
+      data-card
+      className={cn(
+        // `not-prose`: the card sits inside the docs `.prose` scope, which
+        // would otherwise style the heading and the paragraph as body copy.
+        'not-prose block rounded-xl border p-4',
+        'bg-fd-card text-fd-card-foreground transition-colors',
+        href && 'hover:bg-fd-accent/80',
+        '@max-lg:col-span-full',
+        props.className,
+      )}
+    >
+      {/* One row: the glyph, then everything that is words.
+          Title and description live in ONE block beside the icon rather than
+          as two siblings under it, so the description wraps under the TITLE
+          and not back under the mark — the icon column stays a column. */}
+      <div className="flex items-start gap-2.5">
+        {/* `mt-0.5` centres a 16px glyph on the 20px first line of the title.
+            `shrink-0` and `[&_svg]:size-4`: the words wrap, the mark never
+            does, whatever component drew it. */}
+        {icon && (
+          <span className="text-fd-muted-foreground mt-0.5 flex shrink-0 items-center [&_svg]:size-4 border rounded-md bg-inherti p-2">
+            {icon}
+          </span>
+        )}
+        <div className="min-w-0 flex-1">
+          <h3 className="m-0 text-sm font-medium">{title}</h3>
+          {description && (
+            <p className="text-fd-muted-foreground mt-1 mb-0 text-sm">{description}</p>
+          )}
+          {props.children && (
+            <div className="text-fd-muted-foreground prose-no-margin mt-1 text-sm empty:hidden">
+              {props.children}
+            </div>
+          )}
+        </div>
+      </div>
+    </Root>
+  );
+}

--- a/apps/web/src/components/markdown/docs-mdx-components.test.tsx
+++ b/apps/web/src/components/markdown/docs-mdx-components.test.tsx
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { renderToStaticMarkup } from 'react-dom/server';
 
+import { INLINE_CODE } from './code/inline-chip';
 import { docsMdxComponents } from './docs-mdx-components';
 
 const Pre = docsMdxComponents.pre;
+const InlineCode = docsMdxComponents.code;
 
 /**
  * Same throw-on-miss selector discipline as markdown-code.test.tsx: the card
@@ -92,5 +95,66 @@ describe('docsMdxComponents.pre — app CodeBlock shell around rehype-code outpu
 
     expect(codeClass).toContain('language-ts');
     expect(codeClass).toContain('shiki');
+  });
+});
+
+describe('docsMdxComponents.code — one inline chip across docs and chat', () => {
+  const render = (children: string) => renderToStaticMarkup(<InlineCode>{children}</InlineCode>);
+
+  test('inline code takes the SHARED chip, not a docs-local near-miss', () => {
+    // This file used to carry its own copy of the class string — `rounded-sm`,
+    // `bg-muted`, `px-1.5` against the shared chip's `rounded-[5px]`,
+    // `bg-inherit`, `px-1` — so the same backticks drew two different chips
+    // and every tune to one skipped the other.
+    expect(codeClassOf(render('kortix cr open'))).toBe(INLINE_CODE);
+  });
+
+  test('a hex colour gets the same swatch the transcript draws', () => {
+    const markup = render('#0ea5e9');
+
+    // The value stays literal: it is what gets copied into a stylesheet.
+    expect(markup).toContain('#0ea5e9');
+    expect(markup).toContain('background-color:#0ea5e9');
+    // The square carries no information the hex does not.
+    expect(markup).toContain('aria-hidden="true"');
+  });
+
+  test('a fenced block is passed through untouched for fumadocs', () => {
+    // Multiline content is rehype-code's output on its way to the `pre`
+    // override — chipping it would wrap a whole highlighted block in a border.
+    const markup = renderToStaticMarkup(
+      <InlineCode className="language-ts">{'const x = 1;\nconst y = 2;'}</InlineCode>,
+    );
+
+    expect(markup).not.toContain(INLINE_CODE);
+    expect(markup).toContain('language-ts');
+  });
+});
+
+describe('the chip module stays server-safe', () => {
+  test('inline-chip.tsx declares no "use client"', () => {
+    // This file is a SERVER module. Everything a `'use client'` module exports
+    // is a client reference, so importing the hex predicate from the client
+    // `inline-code.tsx` and calling it crashed the docs page outright:
+    // "Attempted to call isHexColor() from the server but isHexColor is on the
+    // client". The chip and the swatch therefore live in a module with no
+    // directive; adding one here breaks every docs page, silently at build
+    // time and loudly at request time.
+    //
+    // The check is the DIRECTIVE, not the words: the module's own comment
+    // explains why it has none, so a plain substring match would fail on its
+    // own documentation.
+    const source = readFileSync(
+      new URL('./code/inline-chip.tsx', import.meta.url).pathname,
+      'utf8',
+    );
+    const firstStatement = source
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line && !line.startsWith('*') && !line.startsWith('/*'));
+
+    expect(firstStatement).toBeDefined();
+    expect(firstStatement).not.toBe("'use client';");
+    expect(firstStatement).not.toBe('"use client";');
   });
 });

--- a/apps/web/src/components/markdown/docs-mdx-components.tsx
+++ b/apps/web/src/components/markdown/docs-mdx-components.tsx
@@ -1,4 +1,5 @@
 import { CodeBlock } from '@/components/markdown/code/code-block';
+import { HexColorCode, INLINE_CODE, isHexColor } from '@/components/markdown/code/inline-chip';
 import { DocsMermaid } from '@/components/markdown/docs-mermaid';
 import { isInternalUrl } from '@/components/markdown/unified-markdown-utils';
 import { cn } from '@/lib/utils';
@@ -30,13 +31,6 @@ const linkClass = cn(
   'transition-colors hover:decoration-kortix-blue',
   '[overflow-wrap:anywhere]',
 );
-
-// Inline-code chip — unified-markdown's INLINE_CODE at its non-clickable size.
-// `[overflow-wrap:anywhere]` matches linkClass above: a long unbreakable token
-// (e.g. a full `kortix cr open --title ...` invocation) is wider than a 390px
-// viewport and scrolls the whole page sideways without it.
-const inlineCodeClass =
-  'rounded-sm border border-border/40 bg-muted px-1.5 py-[0.1rem] font-mono text-[0.8rem] text-foreground/95 dark:bg-card [overflow-wrap:anywhere]';
 
 // By the time the `pre` override runs, rehype-code has replaced the fence's
 // text with token spans — walk them back down to the raw string so the app
@@ -147,9 +141,21 @@ export const docsMdxComponents = {
 
   // Inline code becomes the bordered chip; multiline/block code is the shiki
   // <code> inside <pre> — pass it through untouched for fumadocs' CodeBlock.
+  //
+  // `INLINE_CODE` itself, not a copy of it. This file used to carry its own
+  // near-miss of the same class string (`rounded-sm`, `bg-muted`, `px-1.5`),
+  // so a docs page and a chat message drew visibly different chips for the
+  // same backticks and every tune to one silently skipped the other — the
+  // chip's baseline fix among them (see `code/inline-code.tsx`).
   code: ({ children, ...props }: ComponentPropsWithoutRef<'code'>) => {
     if (typeof children === 'string' && !children.includes('\n')) {
-      return <code className={inlineCodeClass}>{children}</code>;
+      // A docs page quoting `#0ea5e9` is as unreadable as a message quoting
+      // it, so the swatch is the shared component rather than a chat-only
+      // flourish. Everything else `ClickableInlineCode` does — file previews,
+      // URL links — is session behaviour and deliberately stays out of docs.
+      const text = children.trim();
+      if (isHexColor(text)) return <HexColorCode hex={text}>{children}</HexColorCode>;
+      return <code className={INLINE_CODE}>{children}</code>;
     }
     return <code {...props}>{children}</code>;
   },

--- a/apps/web/src/components/markdown/docs-mermaid.tsx
+++ b/apps/web/src/components/markdown/docs-mermaid.tsx
@@ -12,7 +12,7 @@ const MermaidRenderer = dynamic(
   {
     ssr: false,
     loading: () => (
-      <div className="border-border/40 bg-muted/30 text-muted-foreground my-5 rounded-md border p-6 text-center font-mono text-xs">
+      <div className="border-border/40 bg-muted/30 text-muted-foreground my-5 rounded-md border p-6 text-center font-mono text-xs tracking-tight">
         Rendering diagram…
       </div>
     ),

--- a/apps/web/src/components/markdown/katex-block.tsx
+++ b/apps/web/src/components/markdown/katex-block.tsx
@@ -21,7 +21,7 @@ export function KaTeXBlock({ math }: { math: string }) {
 
   if (!rendered.html) {
     return (
-      <pre className="katex-math-block border-border bg-muted text-muted-foreground my-5 overflow-x-auto rounded-md border px-4 py-3 font-mono text-sm">
+      <pre className="katex-math-block border-border bg-muted text-muted-foreground my-5 overflow-x-auto rounded-md border px-4 py-3 font-mono text-sm tracking-tight">
         {rendered.error}
       </pre>
     );

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -26,42 +26,53 @@ const badgeColors = {
 
 type BadgeColor = keyof typeof badgeColors;
 
+/** Framer tint badge: 10% fill + matching inset ring + saturated label color. */
+function tintStyle(color: string) {
+  const fill = `color-mix(in srgb, ${color} 10%, transparent)`;
+  return {
+    color,
+    backgroundColor: fill,
+    boxShadow: `inset 0 0 0 1px ${fill}`,
+  } as const;
+}
+
 const badgeVariants = cva(
-  'border-transparent disabled:border-alpha-300 focus-visible:ring-offset-background outline-hidden has-focus-visible:ring-2 pointer-events-none inline-flex shrink-0 cursor-pointer items-center justify-center gap-1.5 whitespace-nowrap px-2.5 text-xs font-medium leading-none ring-blue-600 transition-[color,background-color,border-color,box-shadow,opacity,scale] focus-visible:ring-2 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-400 disabled:ring-0 [&>svg]:pointer-events-none bg-accent text-accent-foreground hover:bg-accent focus:bg-accent focus-visible:bg-accent has-[>svg]:gap-2 has-[>svg]:pl-[10px] [&>svg]:size-3 h-6 rounded-full',
+  'inline-flex shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-[5px] px-1.5 py-[0.1rem] font-mono text-[0.8rem] font-medium tracking-tight [overflow-wrap:anywhere] has-[>svg]:gap-0.5 has-[>[data-slot=status-dot]]:gap-1 [&>svg]:block [&>svg]:!size-[0.75em] [&>svg]:shrink-0 [&>svg]:pointer-events-none [&>[data-slot=status-dot]]:shrink-0 [&>[data-slot=status-dot]]:!size-[0.45em] uppercase',
   {
     variants: {
       variant: {
         solid: '',
-        default: 'border border-foreground/10 bg-foreground text-background',
-        secondary: 'border border-secondary/10 bg-secondary text-secondary-foreground',
-        accent: 'bg-foreground/5  ',
-        destructive:
-          'border-transparent bg-red-100   text-red-800   dark:bg-red-900/30 dark:text-red-400',
-        success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
+        default: 'bg-foreground/10 text-foreground ring-1 ring-inset ring-foreground/10',
+        secondary:
+          'bg-secondary/80 text-secondary-foreground ring-1 ring-inset ring-border/60 normal-case',
+        accent: 'bg-foreground/5 text-foreground ring-1 ring-inset ring-foreground/5',
+        destructive: 'bg-destructive/10 text-destructive ring-1 ring-inset ring-destructive/10',
+        success:
+          'bg-emerald-500/10 text-emerald-600 ring-1 ring-inset ring-emerald-500/10 dark:text-emerald-400',
         badgeSuccess:
-          'border-transparent bg-emerald-200 text-emerald-800 dark:bg-emerald-900/50 dark:text-emerald-500 bg-teal-100 text-teal-700 hover:bg-teal-100 focus:bg-teal-100 focus-visible:bg-teal-100 px-1.5 text-[11px]',
-        update: 'border-transparent text-kortix-orange bg-chart-2/25 border',
-        kortix: 'border-transparent text-foreground bg-kortix-base/25 border',
+          'bg-teal-500/10 text-teal-700 ring-1 ring-inset ring-teal-500/10 dark:text-teal-400',
+        update: 'bg-chart-2/10 text-kortix-orange ring-1 ring-inset ring-chart-2/10',
+        kortix: 'bg-foreground/10 text-foreground ring-1 ring-inset ring-foreground/10',
         warning:
-          'border-transparent bg-amber-400/30 border  text-amber-800  dark:bg-amber-900/30 dark:text-amber-400',
-        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
-        new: 'border-transparent bg-primary/15 text-primary',
-        beta: 'border-transparent bg-primary/15 text-primary',
-        highlight: 'border-transparent bg-primary/15 text-primary',
-        info: 'border-transparent bg-neutral-200 border  text-neutral-800 dark:bg-neutral-900/50 dark:text-neutral-500',
-        muted: 'border-transparent bg-muted/50 text-muted-foreground',
-        transparent: 'border-transparent bg-transparent text-foreground',
+          'bg-amber-500/10 text-amber-700 ring-1 ring-inset ring-amber-500/10 dark:text-amber-400',
+        outline: 'bg-transparent text-foreground ring-1 ring-inset ring-border normal-case',
+        new: 'bg-primary/10 text-primary ring-1 ring-inset ring-primary/10',
+        beta: 'bg-primary/10 text-primary ring-1 ring-inset ring-primary/10',
+        highlight: 'bg-primary/10 text-primary ring-1 ring-inset ring-primary/10',
+        info: 'bg-neutral-500/10 text-neutral-700 ring-1 ring-inset ring-neutral-500/10 dark:text-neutral-400 normal-case',
+        muted: 'bg-muted/50 text-muted-foreground ring-1 ring-inset ring-muted/50 normal-case',
+        transparent: 'bg-transparent text-foreground ring-0 normal-case',
       },
       size: {
-        default: 'px-3 gap-1 [&>svg]:size-4',
-        sm: 'h-5 px-2 gap-0.5 has-[>svg]:gap-1 [&>svg]:size-3',
-        xs: 'h-5 px-1.5 text-[11px] gap-0.5 has-[>svg]:gap-1.5 [&>svg]:size-2',
-        tabular: 'h-5 min-w-5 px-1.5 text-[11px] tabular-nums gap-0 has-[>svg]:gap-1 [&>svg]:size-2',
+        default: 'px-1.5',
+        sm: '',
+        xs: '',
+        tabular: 'min-w-5 gap-0 px-1 tabular-nums tracking-normal',
       },
     },
     defaultVariants: {
       variant: 'default',
-      size: 'default',
+      size: 'xs',
     },
   },
 );
@@ -82,11 +93,8 @@ function Badge({
 
   const colorStyle = isSolid
     ? color === 'gray'
-      ? { backgroundColor: 'var(--accent)', color: 'var(--foreground)' }
-      : {
-          color: 'var(--foreground)',
-          backgroundColor: `color-mix(in srgb, ${colorValue} 15%, var(--background))`,
-        }
+      ? tintStyle('var(--foreground)')
+      : tintStyle(colorValue)
     : {};
 
   return (

--- a/apps/web/src/components/ui/status.tsx
+++ b/apps/web/src/components/ui/status.tsx
@@ -110,7 +110,7 @@ export function StatusDot({
     <span
       data-slot="status-dot"
       className={cn(
-        'inline-block size-1.5 shrink-0 rounded-full',
+        'inline-block size-2 shrink-0 rounded-full',
         STATUS_DOT[tone],
         pulse && 'animate-pulse',
         className,

--- a/apps/web/src/features/apps/apps-view.tsx
+++ b/apps/web/src/features/apps/apps-view.tsx
@@ -792,7 +792,7 @@ function AppCard({ projectId, app, onOpen }: { projectId: string; app: App; onOp
           <h3 className="text-foreground min-w-0 flex-1 truncate text-sm font-medium">
             {app.name}
           </h3>
-          <Badge size="xs" variant={status.live ? 'success' : 'muted'} className="shrink-0">
+          <Badge variant={status.live ? 'success' : 'muted'} className="shrink-0">
             {status.label}
           </Badge>
         </div>

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5307,20 +5307,21 @@ export function SessionChat({
 
             <div
               className={cn(
-                'absolute bottom-4 left-1/2 z-20 -translate-x-1/2 transition-[opacity,translate,scale] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:translate-y-0 motion-reduce:scale-100 motion-reduce:transition-opacity',
-                showScrollButton
-                  ? 'translate-y-0 scale-100 opacity-100 duration-150'
-                  : 'pointer-events-none translate-y-1 scale-[0.97] opacity-0 duration-100',
+                'absolute inset-x-0 bottom-4 z-20 flex justify-center',
+                !showScrollButton && 'pointer-events-none',
               )}
             >
               <Button
-                variant="secondary"
+                variant="transparent"
                 size="icon-md"
                 aria-hidden={!showScrollButton}
                 tabIndex={showScrollButton ? undefined : -1}
                 className={cn(
-                  'hit-area-2 hover:bg-secondary border-border border shadow-xs',
-                  'transition-[scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96]',
+                  'hit-area-2 liquid-glass bg-liquid-glass hover:bg-liquid-glass-hover shadow-liquid-glass rounded-full',
+                  'transition-[opacity,scale] ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] motion-reduce:scale-100 motion-reduce:transition-opacity',
+                  showScrollButton
+                    ? 'scale-100 opacity-100 duration-150'
+                    : 'scale-[0.97] opacity-0 duration-100',
                 )}
                 onClick={smoothScrollToAbsoluteBottom}
               >

--- a/apps/web/src/features/session/tool/shared/infrastructure.test.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.test.tsx
@@ -27,7 +27,8 @@ import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 //     `size-4` icon (replaced by the outcome glyph when the call failed), title
 //     `text-sm font-medium truncate`, mono `text-xs` subtitle, then the badge
 //     and a `CaretRightIcon` that rotates 90° when open;
-//   • body: rendered only while open, `border-t px-3 py-3 text-sm`;
+//   • body: `border-t px-3 py-3 text-sm`, inside a `DisclosureContent` that
+//     animates `height: 0 → auto` — the payload is mounted only while open;
 //   • open state: seeded by `defaultOpen`/`forceOpen`, held open by `locked`,
 //     driven by the same `useState` the inline surface uses — the branch used
 //     to compute that state and then ignore it entirely;
@@ -398,6 +399,125 @@ describe('a payload card de-nests on the panel and is unchanged inline (gate fin
 
     expect(html).toContain('border-destructive/40 bg-destructive/10');
     expect(html).toContain('rounded-md border');
+  });
+});
+
+describe('a subtitle the open body repeats is dropped from the trigger', () => {
+  /**
+   * `hideSubtitleWhenOpen` — the same rule the `bash` row follows in its own
+   * component: a closed row is the only place the text appears, so it stays
+   * there; open, it is the same string twice, and the trigger's copy is the
+   * truncated one.
+   *
+   * Opt-IN. Most subtitles are not repeated by the body — a `pty` row's
+   * terminal id appears nowhere in the buffer it opens — so the default must
+   * leave them alone.
+   */
+  const SUBTITLE = 'ls -la /workspace';
+
+  test('inline: closed keeps it, open drops it', () => {
+    const trigger = { title: 'Started terminal', subtitle: SUBTITLE, hideSubtitleWhenOpen: true };
+
+    const closed = renderToStaticMarkup(
+      <BasicTool trigger={trigger}>
+        <div>the card</div>
+      </BasicTool>,
+    );
+    expect(closed).toContain(SUBTITLE);
+
+    const open = renderToStaticMarkup(
+      <BasicTool trigger={trigger} defaultOpen>
+        <div>the card</div>
+      </BasicTool>,
+    );
+    expect(open).not.toContain(SUBTITLE);
+    // The row still says what it is, and the body it opened is still there.
+    expect(open).toContain('Started terminal');
+    expect(open).toContain('the card');
+  });
+
+  test('panel: the same, on the surface that shares the behaviour', () => {
+    const trigger = { title: 'Started terminal', subtitle: SUBTITLE, hideSubtitleWhenOpen: true };
+
+    expect(
+      renderPanel(
+        <BasicTool trigger={trigger}>
+          <div>the card</div>
+        </BasicTool>,
+      ),
+    ).toContain(SUBTITLE);
+    expect(
+      renderPanel(
+        <BasicTool trigger={trigger} defaultOpen>
+          <div>the card</div>
+        </BasicTool>,
+      ),
+    ).not.toContain(SUBTITLE);
+  });
+
+  test('without the flag an open row keeps its subtitle — this is opt-in', () => {
+    const html = renderToStaticMarkup(
+      <BasicTool trigger={{ title: 'Terminal output', subtitle: 'pty_a1b2c3' }} defaultOpen>
+        <div>the buffer</div>
+      </BasicTool>,
+    );
+
+    expect(html).toContain('pty_a1b2c3');
+  });
+});
+
+describe('BasicTool body opens with the same animation a thought does', () => {
+  /**
+   * The reported drift: an expanding tool row POPPED while a `Thinking` row in
+   * the same chain unfurled. Both are disclosures, but only the thought went
+   * through `DisclosureContent` — the tool rows rendered their body as a bare
+   * `{open && <div>}`, which mounts at full height in one frame.
+   *
+   * `DisclosureContent` animates `height: 0 → auto` with opacity through
+   * `AnimatePresence` (`ui/disclosure.tsx`). Static markup cannot watch an
+   * animation, but it CAN prove the animated element is the one rendering the
+   * body — `height:auto` in an inline style is written by motion, not by any
+   * class in this tree.
+   */
+  const OPEN_STATE = 'style="height:auto';
+
+  test('inline: the payload rides the animated element', () => {
+    const html = renderToStaticMarkup(
+      <BasicTool trigger={{ title: 'Ran command' }} defaultOpen>
+        <div>the payload</div>
+      </BasicTool>,
+    );
+
+    expect(html).toContain(OPEN_STATE);
+    expect(html).toContain('the payload');
+  });
+
+  test('panel: the same, on the surface that shares the behaviour', () => {
+    const html = renderPanel(
+      <BasicTool trigger={{ title: 'Ran command' }} defaultOpen>
+        <div>the payload</div>
+      </BasicTool>,
+    );
+
+    expect(html).toContain(OPEN_STATE);
+    expect(html).toContain('the payload');
+  });
+
+  test('closed, the wrapper is empty — a collapsed row is still zero-height', () => {
+    // `DisclosureContent` keeps its clipping wrapper mounted while the body is
+    // gone, so the wrapper must contribute nothing: no payload, and the 4px
+    // seam is PADDING on a child of the animated element rather than a margin
+    // on the wrapper, which would leave 8px of dead space under every closed
+    // row in a transcript.
+    const html = renderToStaticMarkup(
+      <BasicTool trigger={{ title: 'Ran command' }}>
+        <div>the payload</div>
+      </BasicTool>,
+    );
+
+    expect(html).toContain('<div class="overflow-hidden text-xs"></div>');
+    expect(html).not.toContain('the payload');
+    expect(html).not.toContain(OPEN_STATE);
   });
 });
 

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -49,7 +49,7 @@ import {
 import { useTranslations } from 'next-intl';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { Disclosure, DisclosureTrigger } from '@/components/ui/disclosure';
+import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
 import Loading from '@/components/ui/loading';
 import type { BasicToolProps, ParsedJsonFailure } from '@/features/session/tool/shared/types';
 import { ToolError } from '@/features/session/tool/tool-error';
@@ -812,6 +812,27 @@ export function RawOutputBlock({ output, maxChars = 2000 }: { output: string; ma
 export const ToolRunningContext = createContext(false);
 
 /**
+ * Whether the row a trigger belongs to is currently expanded.
+ *
+ * A trigger is a node the tool builds and {@link BasicTool} renders, so the
+ * tool itself cannot see the disclosure state it lives above — the `open` state
+ * is `BasicTool`'s. This context is that one fact, published where the trigger
+ * is RENDERED (inside the provider below) rather than where its element is
+ * created, so `useToolOpen()` inside a trigger component reads the real value
+ * while the same call in the tool's own body would not.
+ *
+ * It exists so a trigger can stop repeating what the open card already shows —
+ * `bash` drops the command line from its row once the card beneath is spelling
+ * the whole command out. Rows with no body never open, so the default is
+ * `false` and a non-disclosure surface needs no provider.
+ */
+export const ToolOpenContext = createContext(false);
+
+export function useToolOpen(): boolean {
+  return useContext(ToolOpenContext);
+}
+
+/**
  * This step's verdict, supplied once by `ToolPartRenderer` and read by
  * {@link BasicTool} — the same ambient-per-part seam `ToolRunningContext` and
  * `ToolDurationContext` already use.
@@ -931,15 +952,20 @@ function InlineTriggerTitle({
   onSubtitleClick?: () => void;
 }) {
   const args = trigger.args ?? [];
+  // Read HERE rather than in the tool: this component renders inside
+  // `BasicTool`'s `ToolOpenContext` provider, and the tool's own body does not.
+  // See `TriggerTitle.hideSubtitleWhenOpen` for when a caller sets the flag.
+  const open = useToolOpen();
+  const subtitle = open && trigger.hideSubtitleWhenOpen ? undefined : trigger.subtitle;
 
   return (
     <>
       <span className="text-foreground shrink-0 text-sm whitespace-nowrap">{trigger.title}</span>
-      {(trigger.subtitle || args.length > 0 || trigger.stat) && (
+      {(subtitle || args.length > 0 || trigger.stat) && (
         <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-          {trigger.subtitle &&
+          {subtitle &&
             (running ? (
-              <TextShimmer className="min-w-0 truncate text-sm">{trigger.subtitle}</TextShimmer>
+              <TextShimmer className="min-w-0 truncate text-sm">{subtitle}</TextShimmer>
             ) : (
               // Painted as a link, so it must behave like one for the keyboard
               // too. Kept as a <span role="button"> rather than a real <button>
@@ -955,7 +981,7 @@ function InlineTriggerTitle({
                 tabIndex={onSubtitleClick ? 0 : undefined}
                 // Last, so the rendered markup keeps `title="…">…</span>` — the
                 // shape the memory-tool trigger tests pin.
-                title={trigger.subtitle}
+                title={subtitle}
                 onKeyDown={
                   onSubtitleClick
                     ? (e) => {
@@ -975,7 +1001,7 @@ function InlineTriggerTitle({
                     : undefined
                 }
               >
-                {trigger.subtitle}
+                {subtitle}
               </span>
             ))}
           {/* `shrink-0`: the count is the row's verdict-sized fact, so a long
@@ -990,7 +1016,7 @@ function InlineTriggerTitle({
           )}
           {args.length > 0 && (
             <>
-              {trigger.subtitle && <span className="text-muted-foreground/40 shrink-0">·</span>}
+              {subtitle && <span className="text-muted-foreground/40 shrink-0">·</span>}
               <span
                 className="text-muted-foreground/40 min-w-0 truncate text-sm"
                 title={args.join(' · ')}
@@ -1089,6 +1115,9 @@ function PanelRowTitle({
   onSubtitleClick?: () => void;
 }) {
   const args = trigger.args ?? [];
+  // Same read, same reason as the inline row — one behaviour, two surfaces.
+  const open = useToolOpen();
+  const subtitle = open && trigger.hideSubtitleWhenOpen ? undefined : trigger.subtitle;
 
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
@@ -1101,14 +1130,14 @@ function PanelRowTitle({
           {trigger.title}
         </span>
       )}
-      {trigger.subtitle && (
+      {subtitle && (
         <span
           className={cn(
             'text-muted-foreground min-w-0 truncate font-mono text-xs',
             onSubtitleClick &&
               'hover:text-foreground cursor-pointer underline-offset-2 hover:underline',
           )}
-          title={trigger.subtitle}
+          title={subtitle}
           // `stopPropagation` is load-bearing now and was not before: the
           // subtitle sits INSIDE the disclosure trigger, so without it every
           // "open this file" click would also toggle the row it lives on.
@@ -1121,7 +1150,7 @@ function PanelRowTitle({
               : undefined
           }
         >
-          {trigger.subtitle}
+          {subtitle}
         </span>
       )}
       {/* Same slot as the inline row's: after the name, never truncated. */}
@@ -1258,8 +1287,16 @@ function PanelToolRow({
       className="bg-popover border-border overflow-hidden rounded-md border"
     >
       {hasBody ? <DisclosureTrigger>{row}</DisclosureTrigger> : row}
-      {hasBody && open && (
-        <div className={cn('border-border border-t px-3 py-3 text-sm', className)}>{children}</div>
+      {/* Animated for the same reason the inline row is — see
+          `CollapsibleToolRow`. The border and inset ride the inner div rather
+          than the animated element: they are the body's own chrome, and a
+          border on a `height: 0` box draws a hairline across a closed row. */}
+      {hasBody && (
+        <DisclosureContent>
+          <div className={cn('border-border border-t px-3 py-3 text-sm', className)}>
+            {children}
+          </div>
+        </DisclosureContent>
       )}
     </Disclosure>
   );
@@ -1376,7 +1413,23 @@ function CollapsibleToolRow({
     <Disclosure open={open} onOpenChange={onOpenChange}>
       {hasBody ? <DisclosureTrigger>{row}</DisclosureTrigger> : row}
 
-      {hasBody && open && <div className="mt-1 mb-1 overflow-hidden text-xs">{children}</div>}
+      {/* `DisclosureContent`, not a bare `{open && <div>}`. The raw conditional
+          is why an expanding tool row POPPED while a thinking row in the same
+          chain unfurled: `DisclosureContent` animates `height: 0 → auto` with
+          opacity through `AnimatePresence` (see `ui/disclosure.tsx`), and
+          `ThoughtChainStep` has always used it. Two presentations of one
+          gesture, and this was the half that had drifted.
+
+          The 4px seam is PADDING on a child of the animated element, never a
+          margin on it. A margin sits outside the animated height, so a
+          collapsed row would keep 8px of dead space; and a margin on the inner
+          child would collapse straight back out through the `height: auto`
+          element and escape the clip. Padding does neither. */}
+      {hasBody && (
+        <DisclosureContent className="text-xs">
+          <div className="py-1">{children}</div>
+        </DisclosureContent>
+      )}
     </Disclosure>
   );
 }
@@ -1433,21 +1486,23 @@ export function BasicTool({
   // they render as the plain, non-interactive rows they already were here.
   if (surface === 'panel') {
     return (
-      <PanelToolRow
-        icon={icon}
-        trigger={trigger}
-        running={running}
-        badge={badge}
-        outcome={outcome}
-        onSubtitleClick={onSubtitleClick}
-        locked={locked}
-        open={open}
-        onOpenChange={handleOpenChange}
-        className={className}
-        action={triggerAction}
-      >
-        {children}
-      </PanelToolRow>
+      <ToolOpenContext.Provider value={open}>
+        <PanelToolRow
+          icon={icon}
+          trigger={trigger}
+          running={running}
+          badge={badge}
+          outcome={outcome}
+          onSubtitleClick={onSubtitleClick}
+          locked={locked}
+          open={open}
+          onOpenChange={handleOpenChange}
+          className={className}
+          action={triggerAction}
+        >
+          {children}
+        </PanelToolRow>
+      </ToolOpenContext.Provider>
     );
   }
 
@@ -1478,9 +1533,16 @@ export function BasicTool({
 
   // Default: expand/collapse children inline.
   return (
-    <CollapsibleToolRow header={header} locked={locked} open={open} onOpenChange={handleOpenChange}>
-      {children}
-    </CollapsibleToolRow>
+    <ToolOpenContext.Provider value={open}>
+      <CollapsibleToolRow
+        header={header}
+        locked={locked}
+        open={open}
+        onOpenChange={handleOpenChange}
+      >
+        {children}
+      </CollapsibleToolRow>
+    </ToolOpenContext.Provider>
   );
 }
 

--- a/apps/web/src/features/session/tool/tools/bash-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/bash-tool.test.tsx
@@ -66,6 +66,21 @@ function triggerTitle(html: string): string {
   return html.slice(start, html.indexOf('</span>', marker) + '</span>'.length);
 }
 
+/**
+ * The disclosure body's text, tags stripped.
+ *
+ * The command pane renders through Shiki, which splits the command across one
+ * `<span>` per token — so `toContain('python main.py')` over raw markup is an
+ * assertion about the TRIGGER's plain copy, not about the card. That is
+ * exactly what these tests were silently doing until the trigger stopped
+ * repeating the command on an open row.
+ */
+function cardText(html: string): string {
+  const body = html.indexOf('class="overflow-hidden text-xs"');
+  if (body < 0) throw new Error('the row rendered no disclosure body');
+  return html.slice(body).replace(/<[^>]*>/g, '');
+}
+
 // `hasStructuredContent` fires on a Python traceback.
 const TRACEBACK = [
   'Traceback (most recent call last):',
@@ -101,7 +116,7 @@ describe('BashTool renders rich output without pushing elements through Shiki', 
 
     // Pre-fix this render threw `code.slice is not a function`.
     expect(html).toContain('ValueError');
-    expect(html).toContain('python main.py');
+    expect(cardText(html)).toContain('python main.py');
   });
 
   test('session metadata output renders the session list', () => {
@@ -129,7 +144,7 @@ describe('BashTool renders rich output without pushing elements through Shiki', 
       withProviders(<BashTool part={makePart('echo hi', 'hi')} defaultOpen />),
     );
 
-    expect(html).toContain('echo hi');
+    expect(cardText(html)).toContain('echo hi');
     expect(html).toContain('hi');
   });
 });
@@ -435,6 +450,87 @@ describe('BashTool trigger renders the title the helper answers (W9)', () => {
   });
 });
 
+/**
+ * Just the trigger row's markup — from the row element to the start of the
+ * disclosure body.
+ *
+ * The open card renders the same command the trigger used to, so a
+ * whole-document `not.toContain` could never tell "the trigger dropped it"
+ * apart from "the card lost it". Slicing to the trigger is what makes the
+ * assertion about the row.
+ */
+function triggerRegion(html: string): string {
+  const start = html.indexOf('data-component="tool-trigger"');
+  if (start < 0) throw new Error('no [data-component="tool-trigger"] in the rendered row');
+  const body = html.indexOf('class="overflow-hidden text-xs"', start);
+  return html.slice(start, body < 0 ? undefined : body);
+}
+
+describe('BashTool trigger drops the command once the card is showing it', () => {
+  test('closed, the command is the row — open, it is the card', () => {
+    const part = makePart('pnpm install', 'done', 'install the workspace dependencies');
+
+    const closed = renderToStaticMarkup(withProviders(<BashTool part={part} />));
+    expect(triggerRegion(closed)).toContain('pnpm install');
+
+    const open = renderToStaticMarkup(withProviders(<BashTool part={part} defaultOpen />));
+    // The row keeps the half the card does not repeat…
+    expect(triggerRegion(open)).toContain('Install the workspace dependencies');
+    // …and drops the half it does. The truncated copy also disagreed with the
+    // full one for every command longer than the row.
+    expect(triggerRegion(open)).not.toContain('pnpm install');
+    // The command is still on screen — one line down, highlighted and whole.
+    expect(cardText(open)).toContain('pnpm install');
+  });
+
+  test('the +N line count goes with it', () => {
+    const part = makePart('cat <<EOF\ntwo\nthree\nEOF', 'done');
+
+    expect(triggerRegion(renderToStaticMarkup(withProviders(<BashTool part={part} />)))).toContain(
+      '+3',
+    );
+    expect(
+      triggerRegion(renderToStaticMarkup(withProviders(<BashTool part={part} defaultOpen />))),
+    ).not.toContain('+3');
+  });
+
+  test('a failed row keeps its verdict when open — the card never says it', () => {
+    // The exit-code strip is inside the card; the WORD "failed" is the row's.
+    const part = makePart('bun test', 'FAIL\n<exit_code>1</exit_code>', 'run the unit suite');
+    const open = triggerRegion(
+      renderToStaticMarkup(withProviders(<BashTool part={part} defaultOpen />)),
+    );
+
+    expect(open).toContain('Command failed');
+    expect(open).not.toContain('bun test');
+  });
+
+  test('a RUNNING row still shimmers when open, with the label carrying it', () => {
+    // Mid-flight the row has to read as in-progress. With the command gone
+    // there is nothing else left on it to carry the motion, so the shimmer
+    // moves to the label.
+    const running = {
+      type: 'tool',
+      tool: 'bash',
+      callID: 'call-1',
+      state: { status: 'running', input: { command: 'pnpm install' }, metadata: {} },
+    } as unknown as ToolPart;
+    const html = renderToStaticMarkup(
+      withProviders(
+        <ToolRunningContext.Provider value>
+          <BashTool part={running} defaultOpen />
+        </ToolRunningContext.Provider>,
+      ),
+    );
+    const trigger = triggerRegion(html);
+
+    expect(trigger).toContain('Running command');
+    expect(trigger).not.toContain('pnpm install');
+    // `TextShimmer`'s own paint, on the label.
+    expect(trigger).toContain('bg-clip-text');
+  });
+});
+
 describe('BashTool card, for the cases with nothing to show', () => {
   test('a multi-line command admits there is more than the line shown', () => {
     // A collapsed row drew line 1 of a 30-line heredoc and said nothing about
@@ -635,13 +731,35 @@ describe('dedentCommand — incidental indent never reaches the pane', () => {
     expect(dedentCommand('ls -la\n')).toBe('ls -la');
   });
 
+  test('a one-line command loses EVERY leading blank, not just spaces and tabs', () => {
+    // The reported bug. A common-indent rule only strips what it can measure,
+    // and the measure was `[ \t]` — so a command indented with a non-breaking
+    // space (agents paste these out of rendered docs and spreadsheets) kept its
+    // indent, and the card drew line 1 two characters deeper than its own
+    // wrapped continuation and the output below.
+    expect(dedentCommand('\u00a0\u00a0agent-browser screenshot shot.png')).toBe(
+      'agent-browser screenshot shot.png',
+    );
+    // The other Unicode spaces a paste can carry: figure, narrow no-break,
+    // ideographic.
+    expect(dedentCommand('\u2007\u202f\u3000ls -la')).toBe('ls -la');
+    // A single line has no structure to protect, so a mixed run goes whole.
+    expect(dedentCommand(' \t\u00a0 echo hi')).toBe('echo hi');
+  });
+
+  test('a SCRIPT still keeps its shape — the rule is common indent, not a trim', () => {
+    // The broadened character class must not turn the multi-line branch into a
+    // per-line trim: nesting is what a script's indentation is FOR.
+    expect(dedentCommand('\u00a0\u00a0a\n\u00a0\u00a0\u00a0\u00a0b')).toBe('a\n\u00a0\u00a0b');
+  });
+
   test('the rendered card starts the command at the pane inset, not two characters in', () => {
     const html = renderToStaticMarkup(
       withProviders(<BashTool part={makePart('  echo hi', 'hi')} defaultOpen />),
     );
 
-    expect(html).toContain('echo hi');
-    expect(html).not.toContain('  echo hi');
+    expect(cardText(html)).toContain('echo hi');
+    expect(cardText(html)).not.toContain('  echo hi');
   });
 });
 

--- a/apps/web/src/features/session/tool/tools/bash-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/bash-tool.tsx
@@ -14,6 +14,7 @@ import {
   useToolCardFrame,
   useToolCardPad,
   useToolIndent,
+  useToolOpen,
 } from '@/features/session/tool/shared/infrastructure';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import type { ToolProps } from '@/features/session/tool/shared/types';
@@ -76,32 +77,45 @@ export function bashRowTitle(description: unknown, failed: boolean): string {
 }
 
 /**
- * The command as the reader should see it: common indent stripped, blank
+ * The command as the reader should see it: leading indent stripped, blank
  * edges dropped.
  *
  * Commands arrive with incidental leading whitespace — a model quoting a
  * command out of indented YAML/JSON sends `  agent-browser open …`. The
- * trigger row hid it (a `truncate` span collapses spaces under normal
- * white-space), but the card's `whitespace-pre-wrap` pane rendered it
- * verbatim, so the first line sat two characters deeper than its own wrapped
- * continuation and the output below — an inverse hanging indent that read as
+ * trigger row hides it (a `truncate` span collapses spaces under normal
+ * white-space), but the card's `whitespace-pre-wrap` pane renders it verbatim,
+ * so the first line sits two characters deeper than its own wrapped
+ * continuation and the output below — an inverse hanging indent that reads as
  * broken padding.
  *
- * COMMON indent, not a per-line trim: a multi-line script keeps its internal
- * structure, only the shared margin goes. Heredocs survive by construction — a
- * non-`<<-` heredoc needs its terminator at column 0, which pins the common
- * indent to 0 and makes this a no-op exactly where indentation is
- * load-bearing. The trailing trim also stops a final `\n` from counting as a
+ * Two rules, because a one-line command and a script are different documents:
+ *
+ * - **One line has no structure to protect**, so every leading blank is noise
+ *   and all of it goes. This is the case a common-indent rule cannot be
+ *   trusted with alone: it only strips what it can MEASURE, and the measure
+ *   used to be `[ \t]` — so a command indented with a non-breaking space (or
+ *   any other Unicode space; agents paste these out of rendered docs and
+ *   spreadsheets) kept its indent and drew exactly the misalignment above.
+ * - **A script keeps its shape**: the COMMON indent goes, never a per-line
+ *   trim, so nesting survives. Heredocs survive by construction — a non-`<<-`
+ *   heredoc needs its terminator at column 0, which pins the common indent to
+ *   0 and makes this a no-op exactly where indentation is load-bearing.
+ *
+ * `[^\S\r\n]` is "whitespace that is not a line break", so both rules count
+ * every horizontal space character the Unicode table has, not just the two on
+ * a US keyboard. The trailing trim also stops a final `\n` from counting as a
  * phantom `+1` line in the trigger.
  */
 export function dedentCommand(raw: string): string {
-  const text = raw.replace(/^\n+/, '').trimEnd();
+  const text = raw.replace(/^[\r\n]+/, '').trimEnd();
   if (!text) return '';
   const lines = text.split('\n');
+  // One line: strip the lot. `trimEnd` above already took the other end.
+  if (lines.length === 1) return lines[0].replace(/^[^\S\r\n]+/, '');
   let min = Infinity;
   for (const line of lines) {
     if (!line.trim()) continue;
-    min = Math.min(min, /^[ \t]*/.exec(line)![0].length);
+    min = Math.min(min, /^[^\S\r\n]*/.exec(line)![0].length);
   }
   if (!min || min === Infinity) return text;
   return lines.map((line) => line.slice(min)).join('\n');
@@ -250,6 +264,97 @@ function CommandBlock({
   );
 }
 
+/**
+ * The words on the trigger row.
+ *
+ * Its own component, not inline JSX in {@link BashTool}, because
+ * `useToolOpen()` only answers truthfully where the trigger is RENDERED —
+ * inside `BasicTool`'s provider. Called from `BashTool`'s body it would read
+ * the context default and never change.
+ *
+ * Open, the row drops the command. The card directly beneath is already
+ * showing that exact text — highlighted, whole, with its own copy button — so
+ * the trigger's one line was spending itself on the only thing the reader
+ * cannot be missing, in a truncated copy that disagreed with the full one for
+ * every command longer than the row. What survives is the part the card does
+ * not repeat: the description, or the failure verdict.
+ *
+ * Closed, that line is the only evidence of what ran, so it stays exactly as
+ * it was — preview, `+N` line count, and the full command as the native
+ * tooltip.
+ */
+function BashTrigger({
+  title,
+  failed,
+  command,
+  commandPreview,
+  extraLines,
+  live,
+}: {
+  title: string;
+  failed: boolean;
+  command: string;
+  commandPreview: string;
+  extraLines: number;
+  /** The call is still running under a live stream. */
+  live: boolean;
+}) {
+  const open = useToolOpen();
+
+  if (live) {
+    return (
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+        {open ? (
+          // The shimmer moves to the label: mid-flight the row still has to
+          // read as in-progress, and with the command gone there is nothing
+          // else left on it to carry the motion.
+          <TextShimmer duration={1} spread={2} className="min-w-0 truncate text-xs">
+            Running command
+          </TextShimmer>
+        ) : (
+          <>
+            <span className="text-foreground shrink-0 text-xs">Running command</span>
+            <TextShimmer
+              duration={1}
+              spread={2}
+              className="text-muted-foreground min-w-0 truncate font-mono text-xs"
+            >
+              {commandPreview}
+            </TextShimmer>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
+      <span
+        className="flex min-w-0 shrink-0 items-center gap-2 text-xs"
+        // Redundant once the card spells the command out below.
+        title={open ? undefined : command}
+      >
+        {/* `truncate`, not `shrink-0`: a description title is a sentence, and
+            on a narrow row a rigid one would be clipped mid-word by the
+            trigger's `overflow-hidden` instead of ending in an ellipsis. */}
+        <span className={cn('min-w-0 truncate', failed ? 'text-kortix-red' : 'text-foreground')}>
+          {title}
+        </span>
+        {!open && (
+          <>
+            <span className="text-muted-foreground/60 min-w-0 truncate font-mono">
+              {commandPreview}
+            </span>
+            {extraLines > 0 && (
+              <span className="text-muted-foreground/40 shrink-0 tabular-nums">+{extraLines}</span>
+            )}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
 export function BashTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
   const input = partInput(part);
   const streamingInput = partStreamingInput(part);
@@ -324,40 +429,14 @@ export function BashTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
             </TextShimmer>
           </div>
         ) : commandPreview ? (
-          <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
-            {running && status !== 'completed' && status !== 'error' ? (
-              <>
-                <span className="text-foreground shrink-0 text-xs">Running command</span>
-                <TextShimmer
-                  duration={1}
-                  spread={2}
-                  className="text-muted-foreground min-w-0 truncate font-mono text-xs"
-                >
-                  {commandPreview}
-                </TextShimmer>
-              </>
-            ) : (
-              <span className="flex min-w-0 shrink-0 items-center gap-2 text-xs" title={command}>
-                {/* `truncate`, not `shrink-0`: a description title is a
-                    sentence, and on a narrow row a rigid one would be clipped
-                    mid-word by the trigger's `overflow-hidden` instead of
-                    ending in an ellipsis. */}
-                <span
-                  className={cn('min-w-0 truncate', failed ? 'text-kortix-red' : 'text-foreground')}
-                >
-                  {title}
-                </span>
-                <span className="text-muted-foreground/60 min-w-0 truncate font-mono">
-                  {commandPreview}
-                </span>
-                {extraLines > 0 && (
-                  <span className="text-muted-foreground/40 shrink-0 tabular-nums">
-                    +{extraLines}
-                  </span>
-                )}
-              </span>
-            )}
-          </div>
+          <BashTrigger
+            title={title}
+            failed={failed}
+            command={command}
+            commandPreview={commandPreview}
+            extraLines={extraLines}
+            live={running && status !== 'completed' && status !== 'error'}
+          />
         ) : null
       }
       defaultOpen={defaultOpen}

--- a/apps/web/src/features/session/tool/tools/pty-spawn-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/pty-spawn-tool.test.tsx
@@ -1,0 +1,79 @@
+import type { ToolPart } from '@/ui';
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { PtySpawnTool } from './pty-spawn-tool';
+
+/**
+ * The spawn row follows `bash`'s rule: the trigger keeps what the open card
+ * does not say.
+ *
+ * The card prints the command under a `$`, so an open row that also carried it
+ * in the subtitle said it twice — and the trigger's copy is truncated to one
+ * line, so a long invocation disagreed with the full text directly beneath it.
+ * A model-supplied `Title` is different: the card never repeats it, so it
+ * stays.
+ */
+
+/** Just the trigger row — the card below renders the command too, so a
+ *  whole-document match could not tell the two apart. */
+function triggerRegion(html: string): string {
+  const start = html.indexOf('data-component="tool-trigger"');
+  if (start < 0) throw new Error('no [data-component="tool-trigger"] in the rendered row');
+  const body = html.indexOf('class="overflow-hidden text-xs"', start);
+  return html.slice(start, body < 0 ? undefined : body);
+}
+
+const COMMAND = 'npm run dev -- --port 3000';
+
+function part(output: string, input: Record<string, unknown> = { command: COMMAND }): ToolPart {
+  return {
+    type: 'tool',
+    tool: 'pty_spawn',
+    callID: 'call-1',
+    state: { status: 'completed', input, output, metadata: {} },
+  } as unknown as ToolPart;
+}
+
+const spawned = (fields: Record<string, string>) =>
+  `<pty_spawned>\n${Object.entries(fields)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n')}\n</pty_spawned>`;
+
+describe('PtySpawnTool trigger drops the command once the card is showing it', () => {
+  test('closed, the command is the row — open, it is the card', () => {
+    const p = part(spawned({ Command: COMMAND, Status: 'running', PID: '4210' }));
+
+    expect(triggerRegion(renderToStaticMarkup(<PtySpawnTool part={p} />))).toContain(COMMAND);
+
+    const open = renderToStaticMarkup(<PtySpawnTool part={p} defaultOpen />);
+    expect(triggerRegion(open)).not.toContain(COMMAND);
+    // Still on screen, one line down, under the `$`.
+    expect(open).toContain(COMMAND);
+    // And the row still says what it is.
+    expect(triggerRegion(open)).toContain('Started terminal');
+  });
+
+  test('a model-supplied Title survives — the card never repeats it', () => {
+    const p = part(spawned({ Title: 'Dev server', Command: COMMAND, Status: 'running' }));
+    const open = renderToStaticMarkup(<PtySpawnTool part={p} defaultOpen />);
+
+    expect(triggerRegion(open)).toContain('Dev server');
+    // The command still belongs to the card alone.
+    expect(triggerRegion(open)).not.toContain(COMMAND);
+  });
+
+  test('the process meta stays in the card, open or not', () => {
+    // Nothing here is repeated by the trigger, so nothing here is hidden.
+    const open = renderToStaticMarkup(
+      <PtySpawnTool
+        part={part(spawned({ Command: COMMAND, Status: 'running', PID: '4210', ID: 'pty_a1b2' }))}
+        defaultOpen
+      />,
+    );
+
+    expect(open).toContain('pty_a1b2');
+    expect(open).toContain('PID 4210');
+    expect(open).toContain('running');
+  });
+});

--- a/apps/web/src/features/session/tool/tools/pty-spawn-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/pty-spawn-tool.tsx
@@ -44,7 +44,18 @@ export function PtySpawnTool({ part, defaultOpen, forceOpen, locked }: ToolProps
   return (
     <BasicTool
       icon={<Terminal className="size-3.5 shrink-0" />}
-      trigger={{ title: 'Started terminal', subtitle: title || command }}
+      trigger={{
+        title: 'Started terminal',
+        subtitle: title || command,
+        // Only when the subtitle IS the command. The card below prints the
+        // command under a `$`, so open, the row would say it twice — and the
+        // trigger's copy is the truncated one, so a long invocation disagrees
+        // with the full text directly beneath it. When the model supplied a
+        // `Title`, the subtitle is that name, the card never repeats it, and
+        // it stays. Same rule as `bash`: the row keeps what the card does not
+        // say.
+        hideSubtitleWhenOpen: !title,
+      }}
       defaultOpen={defaultOpen}
       forceOpen={forceOpen}
       locked={locked}
@@ -68,8 +79,6 @@ export function PtySpawnTool({ part, defaultOpen, forceOpen, locked }: ToolProps
                 {processStatus && (
                   <Badge
                     variant={processStatus === 'running' ? 'success' : 'muted'}
-                    size="sm"
-                    className="gap-1"
                   >
                     {processStatus === 'running' && <StatusDot tone="success" pulse />}
                     {processStatus}

--- a/apps/web/src/features/session/turn/activity-burst.test.tsx
+++ b/apps/web/src/features/session/turn/activity-burst.test.tsx
@@ -534,14 +534,18 @@ describe('ActivityBurst', () => {
     expect(markup).toContain('data-tone="failed"');
   });
 
-  test('a bare step drops its leading glyph — the icon was the rail anchor', () => {
-    // The family icon holds the 16px gutter `ChainOfThought` runs its connector
-    // down (`left-2`). One row has no connector, so the glyph holds a column
-    // that does not exist and pushes the only words 28px off the turn's margin.
+  test('a bare step KEEPS its leading glyph — the icon is what names the tool', () => {
+    // It used to be stripped, on the argument that the glyph only exists to
+    // anchor the chain rail and one row has no chain. That cost the row the
+    // only thing saying WHICH tool ran: a lone write rendered as a line of
+    // text with nothing on it. The tool's name is not always in the words —
+    // "Write" is, "Ran command" is not.
     const markup = renderBurst([done('1', 'bash', { command: 'pnpm build' })]);
-    // The class arrives HTML-escaped in static markup, so match the escaped
-    // tail rather than the source string.
-    expect(markup).toContain('&gt;span:first-child]:hidden');
+    // The hide rule is gone; the class arrives HTML-escaped in static markup,
+    // so match the escaped tail rather than the source string.
+    expect(markup).not.toContain('&gt;span:first-child]:hidden');
+    // `ToolHeaderRow`'s leading span, holding the terminal glyph.
+    expect(markup).toContain('<span class="text-muted-foreground size-4 shrink-0">');
     expect(markup).toContain('pnpm build');
   });
 
@@ -662,6 +666,62 @@ describe('ActivityBurst', () => {
     ]);
     expect(markup).toContain('Thinking');
     expect(markup).not.toContain('Weighing two schemas');
+  });
+
+  test('a settled thought reports how long it took', () => {
+    // `Thinking` alone answered "the model did something" and nothing else —
+    // not whether that was two seconds or ninety, which is the one question a
+    // reader waiting on a thought has.
+    const markup = renderBurst([
+      {
+        id: 'r',
+        type: 'reasoning',
+        text: 'Weighing two schemas',
+        time: { start: 1_700_000_000_000, end: 1_700_000_012_000 },
+      } as unknown as Part,
+    ]);
+    expect(markup).toContain('Thought for 12s');
+  });
+
+  test('a thought under a second stays plain "Thinking"', () => {
+    // `formatDuration` returns '' below 1000ms on purpose. A row saying "0s" is
+    // worse than one saying nothing, and the same fallback covers a provider
+    // that sends no timing at all.
+    const timed = renderBurst([
+      {
+        id: 'r',
+        type: 'reasoning',
+        text: 'Weighing two schemas',
+        time: { start: 1_700_000_000_000, end: 1_700_000_000_400 },
+      } as unknown as Part,
+    ]);
+    expect(timed).toContain('>Thinking<');
+    expect(timed).not.toContain('Thought for');
+
+    const untimed = renderBurst([
+      { id: 'r', type: 'reasoning', text: 'Weighing two schemas' } as unknown as Part,
+    ]);
+    expect(untimed).toContain('Thinking');
+    expect(untimed).not.toContain('Thought for');
+  });
+
+  test('a LIVE thought never claims a total — it counts up instead', () => {
+    // Past tense on a thought that has not finished would report a number the
+    // run has not reached. The live row counts from the client (see
+    // `useLiveElapsedMs`), so a static render is always at zero seconds.
+    const markup = renderBurst(
+      [
+        {
+          id: 'r',
+          type: 'reasoning',
+          text: 'Weighing two schemas',
+          time: { start: 1_700_000_000_000 },
+        } as unknown as Part,
+      ],
+      { working: true, isTrailing: true },
+    );
+    expect(markup).not.toContain('Thought for');
+    expect(markup).toContain('Thinking');
   });
 
   test('a thought opens itself while the model is still thinking', () => {
@@ -1060,10 +1120,10 @@ describe('step family glyphs', () => {
 
 describe('bare row alignment', () => {
   /**
-   * A bare row hides its ICON but keeps its rail, so the two have to agree about
-   * the same 28px lane: the rail hangs at `left-2`, and content flush to the
-   * margin puts that hairline 8px inside it — straight through the left edge of
-   * the file chip. The indent is what the rail runs in.
+   * A bare row keeps its icon AND its rail, so the two have to agree about the
+   * same 28px lane: the rail hangs at `left-2`, and content flush to the margin
+   * puts that hairline 8px inside it — straight through the left edge of the
+   * file chip. The indent is what the rail runs in.
    */
   const renderBare = (parts: Part[]) =>
     renderToStaticMarkup(
@@ -1100,9 +1160,10 @@ describe('bare row alignment', () => {
         time: { start: 1, end: 2 },
       }),
     ]);
-    // The icon is hidden…
-    expect(markup).toContain('&gt;span:first-child]:hidden');
-    // …but the card still sits in the rail's lane, never at 0.
+    // The icon stays…
+    expect(markup).not.toContain('&gt;span:first-child]:hidden');
+    expect(markup).toContain('<span class="text-muted-foreground size-4 shrink-0">');
+    // …and the card sits in the rail's lane, never at 0.
     expect(markup).toContain('[--tool-indent:1.75rem]');
     expect(markup).not.toContain('[--tool-indent:0rem]');
   });
@@ -1160,21 +1221,18 @@ describe('chain alignment', () => {
     expect(markup).toContain('[--tool-indent:1.75rem]');
   });
 
-  test('a BARE row hides its icon but keeps the card in the rail lane', () => {
-    // The icon goes; the indent must not. The chain rail still runs at `left-2`,
-    // so a card at the margin would have the hairline cutting through it.
+  test('a lone row keeps both its icon and the card in the rail lane', () => {
+    // `ActivityStep` has no bare/not-bare rendering left: one row and twenty
+    // draw the same glyph in the same 28px lane, and the card follows it. The
+    // chain rail runs at `left-2`, so a card at the margin would have the
+    // hairline cutting through it.
     const markup = wrap(
       <ChainOfThoughtStep>
-        <ActivityStep
-          part={bashPart}
-          sessionId="session-1"
-          running={false}
-          bare
-          disableNavigation
-        />
+        <ActivityStep part={bashPart} sessionId="session-1" running={false} disableNavigation />
       </ChainOfThoughtStep>,
     );
-    expect(markup).toContain('&gt;span:first-child]:hidden');
+    expect(markup).not.toContain('&gt;span:first-child]:hidden');
+    expect(markup).toContain('<span class="text-muted-foreground size-4 shrink-0">');
     expect(markup).toContain('[--tool-indent:1.75rem]');
     expect(markup).not.toContain('[--tool-indent:0rem]');
   });

--- a/apps/web/src/features/session/turn/activity-burst.tsx
+++ b/apps/web/src/features/session/turn/activity-burst.tsx
@@ -9,9 +9,10 @@
  * so the expansion groups the work the same way the summary line counts it.
  *
  * A burst holding exactly ONE call has no summary line at all. It renders as
- * that call and nothing else: no title, no chain rail, no closing step, and no
- * leading glyph on the row (see `bare` below). "Completed 1 step" over a single
- * row is a door in front of a door.
+ * that call and nothing else: no title, no chain rail, no closing step.
+ * "Completed 1 step" over a single row is a door in front of a door. The row
+ * keeps its leading glyph either way — the icon names which tool ran, and a
+ * lone row is where the reader has the least other context (see `ActivityStep`).
  *
  * The trailing burst stays open for the whole working turn (so SSE gaps between
  * tool calls do not blink it shut); earlier bursts auto-collapse once later
@@ -26,7 +27,7 @@ import { TextShimmer } from '@/components/ui/text-shimmer';
 import { ToolActivateContext } from '@/features/session/tool/shared/infrastructure';
 import { cn } from '@/lib/utils';
 import type { ConversationDensity } from '@/stores/user-preferences-store';
-import { isReasoningPart, isToolPart, type Part } from '@/ui';
+import { formatDuration, isReasoningPart, isToolPart, type Part } from '@/ui';
 import { CaretRightIcon, CircleDashedIcon } from '@phosphor-icons/react';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import type { Step } from '../action-panel/shared/group-steps';
@@ -107,6 +108,37 @@ function ThoughtStepBody({ texts, running }: { texts: ReadonlyArray<string>; run
 }
 
 /**
+ * Whole seconds since this row went live, or 0 when it is not.
+ *
+ * Measured from the client, deliberately, rather than from the part's
+ * `time.start`: a transcript restored hours later carries a start timestamp
+ * from the original run, and subtracting it from `Date.now()` would render
+ * "Thinking for 4h". The settled label uses the provider's timestamps, where
+ * the arithmetic is between two values that belong to the same run.
+ *
+ * One second is the resolution the label shows, so that is the tick rate.
+ */
+function useLiveElapsedMs(running: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!running) return;
+    const startedAt = Date.now();
+    const id = setInterval(() => setElapsed(Date.now() - startedAt), 1000);
+    // Reset on the way OUT, not on the way in: a synchronous `setElapsed(0)`
+    // in the effect body is a cascading render, and clearing here means a row
+    // that goes live a second time starts from zero rather than showing the
+    // previous run's count until its first tick.
+    return () => {
+      clearInterval(id);
+      setElapsed(0);
+    };
+  }, [running]);
+
+  return running ? elapsed : 0;
+}
+
+/**
  * The model's reasoning, as a row that says so.
  *
  * The text used to render inline and unlabelled — a paragraph hanging in the
@@ -129,18 +161,29 @@ function ThoughtStepBody({ texts, running }: { texts: ReadonlyArray<string>; run
  * burst-wide flag here made every thought in the turn shimmer at once and
  * unfurl reasoning that closed twenty steps ago. `mergeBurstSteps` decides.
  *
- * `bare` — this thought IS the whole burst — drops the glyph for the reason
- * every bare row does: the icon is the rail's anchor, and one row has no rail.
+ * The label carries the clock. `Thinking` alone answered "the model is doing
+ * something" and nothing else — no sense of whether that was two seconds or
+ * ninety, which is the one question a reader waiting on a thought actually
+ * has. So it counts up live (`Thinking for 12s`, measured from when this row
+ * went live, not from a provider timestamp that a reload would turn into
+ * nonsense) and settles on the run's real total (`Thought for 12s`, first
+ * fragment's start to the last one's end).
+ *
+ * Sub-second thoughts stay plain `Thinking`: `formatDuration` returns '' under
+ * 1000ms on purpose, and a row that says "0s" is worse than one that says
+ * nothing. Same fallback covers a provider that sends no timing at all.
  */
+
 function ThoughtChainStepImpl({
   texts,
   running,
-  bare,
+  durationMs,
   autoOpen = true,
 }: {
   texts: ReadonlyArray<string>;
   running: boolean;
-  bare?: boolean;
+  /** The settled run's total, from `mergeBurstSteps`. */
+  durationMs?: number;
   /**
    * Whether live reasoning may unfurl its paragraph on its own. `false` under
    * minimal density: the row still shimmers `Thinking`, but the streaming
@@ -151,6 +194,13 @@ function ThoughtChainStepImpl({
 }) {
   const [open, setOpen] = useState(autoOpen && running);
   const userToggled = useRef(false);
+  const liveElapsed = useLiveElapsedMs(running);
+  const elapsed = formatDuration(running ? liveElapsed : (durationMs ?? 0));
+  const label = elapsed
+    ? running
+      ? `Thinking for ${elapsed}`
+      : `Thought for ${elapsed}`
+    : 'Thinking';
 
   useEffect(() => {
     if (userToggled.current) return;
@@ -182,11 +232,11 @@ function ThoughtChainStepImpl({
               'text-left text-sm leading-[1.5] transition-colors',
             )}
           >
-            {!bare && <CircleDashedIcon className="text-muted-foreground size-4 flex-none" />}
+            <CircleDashedIcon className="text-muted-foreground size-4 flex-none" />
             {running ? (
-              <TextShimmer className="leading-[1.5] font-medium">Thinking</TextShimmer>
+              <TextShimmer className="leading-[1.5] font-medium tabular-nums">{label}</TextShimmer>
             ) : (
-              <span className="font-medium">Thinking</span>
+              <span className="font-medium tabular-nums">{label}</span>
             )}
             <CaretRightIcon
               className={cn(
@@ -439,8 +489,10 @@ function ActivityBurstImpl({
    * Shared by the chain and by the bare single-step burst, so the two can never
    * draw the same row two different ways.
    *
-   * `bare` is not styling — it says the row is the ONLY thing here, which is
-   * what makes the leading glyph pointless (see `ActivityStep`).
+   * `bare` says the row is the ONLY thing here — which is what lets a file-chip
+   * run with no chips fall back to the plain tool row instead of drawing a
+   * "Read 1 file" door in front of it. It is not styling, and it no longer
+   * touches the leading glyph: every row keeps its icon (see `ActivityStep`).
    */
   const stepBody = (
     step: Exclude<(typeof steps)[number], { kind: 'thought' }>,
@@ -488,7 +540,6 @@ function ActivityBurstImpl({
     return (
       <ActivityStep
         part={step.part}
-        bare={bareRow}
         sessionId={sessionId}
         running={running}
         disableNavigation={disableNavigation}
@@ -514,13 +565,10 @@ function ActivityBurstImpl({
    * prose: unwrapping THAT would have pinned the model's reasoning open with
    * nothing left to close it.
    *
-   * `bare` drops the summary line ONLY. It does not, on its own, decide that a
-   * row has no thread — a lone sub-agent is one row here and a whole nested
-   * list of steps one level down, so `ActivityStep` keeps a delegate row's
-   * leading glyph even when bare. See the `hideIcon` note there; the two rules
-   * are separate on purpose, because "there is nothing to summarise" and "there
-   * is nothing under this row" are different facts and only the first is what
-   * `summary.total === 1` establishes.
+   * `bare` drops the summary line ONLY. Every row keeps its own leading glyph
+   * — "there is nothing to summarise" and "this row needs no icon" are
+   * different facts, and only the first is what `summary.total === 1`
+   * establishes.
    */
   const bare = steps.length === 1 && summary.total === 1;
 
@@ -645,7 +693,7 @@ function ActivityBurstImpl({
                     key={step.key}
                     texts={step.texts}
                     running={running && step.running}
-                    bare={bare}
+                    durationMs={step.durationMs}
                     autoOpen={autoExpand}
                   />
                 ) : (
@@ -741,7 +789,7 @@ const ThoughtChainStep = memo(
   ThoughtChainStepImpl,
   (a, b) =>
     a.running === b.running &&
-    a.bare === b.bare &&
+    a.durationMs === b.durationMs &&
     a.autoOpen === b.autoOpen &&
     samePartsList(a.texts, b.texts),
 );

--- a/apps/web/src/features/session/turn/activity-file-chips.tsx
+++ b/apps/web/src/features/session/turn/activity-file-chips.tsx
@@ -267,7 +267,6 @@ function ActivityFileChipStepImpl({
           <ActivityStep
             key={part.id}
             part={part}
-            bare
             sessionId={sessionId}
             running={running}
             disableNavigation={disableNavigation}

--- a/apps/web/src/features/session/turn/activity-step.tsx
+++ b/apps/web/src/features/session/turn/activity-step.tsx
@@ -14,8 +14,6 @@ import {
   UsersThreeIcon,
 } from '@phosphor-icons/react';
 
-import { familyForTool } from '@/features/session/action-panel/shared/narration';
-import { partOutcome } from '@/features/session/tool/shared/tool-outcome';
 import { ToolPartRenderer } from '@/features/session/tool/tool-renderers';
 import { cn } from '@/lib/utils';
 import { isToolPart, type Part } from '@/ui';
@@ -57,56 +55,38 @@ function ActivityStepImpl({
   sessionId,
   running,
   disableNavigation,
-  bare,
 }: {
   part: Part;
   sessionId: string;
   running: boolean;
   disableNavigation?: boolean;
-  /**
-   * This row is the WHOLE burst — no summary line above it, no siblings, no
-   * chain rail. See `ActivityBurst`.
-   */
-  bare?: boolean;
 }) {
   const label = stepLabel(part);
   const Icon = iconFor(part);
   const verb = running ? label.running : label.verb;
 
   /**
-   * A bare row drops its leading glyph.
+   * EVERY row keeps its leading glyph, single-step bursts included.
    *
-   * The family icon is not a label — it is the rail's anchor. `ChainOfThought`
-   * runs its connector down the centre of that 16px gutter (`left-2`), so the
-   * icons are what make a chain read as one thread rather than as loose lines.
-   * A single row has no rail and no thread, so the glyph is left holding a
-   * column that no longer exists, and it pushes the only words on the row 28px
-   * off the margin every other line of the turn starts at.
+   * A lone row used to drop it. The reasoning was geometric — the family icon
+   * anchors the chain rail `ChainOfThought` runs down that 16px gutter
+   * (`left-2`), and one row has no chain — and it cost the row the only thing
+   * that names WHICH tool ran at a glance. A lone write rendered as a line of
+   * text with nothing on it: no pencil, no terminal, nothing to tell it apart
+   * from the row above at a glance, and the tool's own name is not always in
+   * the words ("Write" is, "Ran command" is not).
    *
-   * The OUTCOME mark is not dropped, and that is the whole subtlety: on a bare
-   * row it is the only failure signal left — the summary line that said
-   * "1 step failed" and the chain's closing step are both gone. `partOutcome`
-   * decides, not `state.status`, so a call that RETURNED its error keeps its
-   * mark too.
-   *
-   * Neither is a DELEGATE row's glyph, for the reason the paragraph above gives
-   * and not despite it. "A single row has no rail and no thread" is true of a
-   * read or a command; it is false of a sub-agent. `task` / `agent_spawn` /
-   * `session_spawn` render a nested thread of their own — the sub-agent's steps,
-   * with their own hairline (`tool/shared/sub-agent.tsx`) — so the row IS a
-   * parent, and the icon is that thread's anchor exactly as it is in the chain.
-   * Stripping it left a lone sub-agent's twenty rows hanging off a line of bare
-   * text. The family table decides rather than a local list of tool names, so a
-   * new delegation alias cannot land on one side of this and not the other.
+   * The glyph is not decoration on this surface, it is the row's identity, and
+   * a turn made of single-call bursts is exactly the case where the reader has
+   * the least other context. The 28px lane it holds is the same lane every
+   * other row's content sits in and the same lane `--tool-indent` puts the
+   * expanded card in, so keeping it is also what keeps a bare row aligned with
+   * the chain rows around it.
    */
-  const hideIcon =
-    Boolean(bare) &&
-    (!isToolPart(part) || partOutcome(part) === 'ok') &&
-    !(isToolPart(part) && familyForTool(part.tool) === 'delegate');
 
   const header = (
     <div className="flex min-w-0 items-center gap-3">
-      {!hideIcon && <Icon className="text-muted-foreground size-4 flex-none" />}
+      <Icon className="text-muted-foreground size-4 flex-none" />
       <span className="text-foreground/80 flex-none text-sm leading-[1.5]">{verb}</span>
       {label.object && (
         <span
@@ -156,20 +136,16 @@ function ActivityStepImpl({
         "[&_[data-component='tool-trigger']_span]:!leading-[1.5]",
         "[&_[data-component='tool-trigger']_[data-slot='favicon-avatar']]:!size-4",
         "[&_[data-component='tool-trigger']_[data-slot='favicon-avatar']_svg]:!size-2.5",
-        // The tool's leading glyph lives in the trigger's first span
-        // (`ToolHeaderRow`'s `leading`). Scoped to the trigger, so the expanded
-        // content — and the Action Panel rendering the same component — keep
-        // theirs. `hideIcon` has already spared the outcome mark.
-        hideIcon && "[&_[data-component='tool-trigger']>span:first-child]:hidden",
         // The gap above moves the trigger's TEXT column; this moves the card
         // under it to the same place. `TOOL_INDENT` derives 22px from the row's
         // native `gap-1.5`, so overriding the gap and not the indent is what
         // left an expanded command's block 6px left of every other row's
         // content in the same chain. One override is half an override.
         //
-        // 1.75rem = the 16px icon + the 12px `gap-3` above. A bare row hides the
-        // icon but keeps this: the chain rail still runs at `left-2`, so a card
-        // at the margin would have the hairline cutting through it.
+        // 1.75rem = the 16px icon + the 12px `gap-3` above, so the card lands
+        // in the same column as the row's words. The chain rail runs at
+        // `left-2`, so a card at the margin would have the hairline cutting
+        // through it.
         '[--tool-indent:1.75rem]',
       )}
     >

--- a/apps/web/src/features/session/turn/merge-steps.test.ts
+++ b/apps/web/src/features/session/turn/merge-steps.test.ts
@@ -110,6 +110,38 @@ describe('mergeBurstSteps', () => {
   });
 });
 
+describe('mergeBurstSteps — how long a thought took', () => {
+  const durationOf = (step: BurstStep) =>
+    (step as Extract<BurstStep, { kind: 'thought' }>).durationMs;
+
+  test('one run of fragments reports first start to last end', () => {
+    // The fragments of one thought are one stretch of thinking, gaps included.
+    // Summing per-fragment durations would silently drop the gaps between them.
+    const steps = mergeBurstSteps(
+      [
+        { ...reasoning('r1', 'first'), time: { start: 1_000, end: 3_000 } } as Part,
+        { ...reasoning('r2', 'second'), time: { start: 5_000, end: 9_000 } } as Part,
+      ],
+      () => 'primary',
+    );
+    expect(steps).toHaveLength(1);
+    expect(durationOf(steps[0])).toBe(8_000);
+  });
+
+  test('a thought still being written has no duration', () => {
+    const steps = mergeBurstSteps(
+      [{ ...reasoning('r1', 'first'), time: { start: 1_000 } } as Part],
+      () => 'primary',
+    );
+    expect(durationOf(steps[0])).toBeUndefined();
+  });
+
+  test('a thought with no timing at all has no duration', () => {
+    const steps = mergeBurstSteps([reasoning('r1', 'first')], () => 'primary');
+    expect(durationOf(steps[0])).toBeUndefined();
+  });
+});
+
 describe('mergeBurstSteps — which thought is still live', () => {
   test('a thought whose last fragment has ended is not running', () => {
     const steps = mergeBurstSteps([settledReasoning('r1', 'done thinking')], tierOf);

--- a/apps/web/src/features/session/turn/merge-steps.ts
+++ b/apps/web/src/features/session/turn/merge-steps.ts
@@ -33,7 +33,22 @@ import { groupSteps, type Step } from '../action-panel/shared/group-steps';
 import type { StepTier } from './step-label';
 
 export type BurstStep =
-  | { kind: 'thought'; key: string; texts: string[]; running: boolean }
+  | {
+      kind: 'thought';
+      key: string;
+      texts: string[];
+      running: boolean;
+      /**
+       * How long the whole run of reasoning took, in ms — first fragment's
+       * `time.start` to the last one's `time.end`.
+       *
+       * Undefined when either end is missing (a live thought has no end yet,
+       * and some providers send no timing at all), so the row can tell "not
+       * timed" apart from "took no time" and fall back to the bare label
+       * rather than printing a zero.
+       */
+      durationMs?: number;
+    }
   | { kind: 'part'; key: string; part: Part }
   | { kind: 'group'; key: string; step: Step };
 
@@ -59,16 +74,31 @@ export function mergeBurstSteps(
   tierOf: (part: Part) => StepTier,
 ): BurstStep[] {
   const steps: BurstStep[] = [];
-  let pending: { key: string; texts: string[]; running: boolean } | null = null;
+  let pending: {
+    key: string;
+    texts: string[];
+    running: boolean;
+    startedAt?: number;
+    endedAt?: number;
+  } | null = null;
   let tools: ToolPart[] = [];
 
   const flushThought = () => {
     if (pending && pending.texts.length > 0) {
+      // FIRST start to LAST end: the fragments of one thought are one stretch
+      // of thinking, and the row that merges them reports the stretch. A sum of
+      // per-fragment durations would silently drop the gaps between them.
+      const { startedAt, endedAt } = pending;
+      const durationMs =
+        typeof startedAt === 'number' && typeof endedAt === 'number' && endedAt > startedAt
+          ? endedAt - startedAt
+          : undefined;
       steps.push({
         kind: 'thought',
         key: pending.key,
         texts: pending.texts,
         running: pending.running,
+        durationMs,
       });
     }
     pending = null;
@@ -108,6 +138,13 @@ export function mergeBurstSteps(
       flushTools();
       if (!pending) pending = { key: `thought-${part.id}`, texts: [], running: false };
       pending.texts.push(text);
+      const time = (part as { time?: { start?: number; end?: number } }).time;
+      if (pending.startedAt === undefined && typeof time?.start === 'number') {
+        pending.startedAt = time.start;
+      }
+      // The LAST fragment's end is the run's end, for the same reason it
+      // decides `running` below: an earlier fragment closes as the next opens.
+      pending.endedAt = typeof time?.end === 'number' && time.end > 0 ? time.end : undefined;
       // The LAST fragment decides. Fragments arrive one at a time and each
       // closes as the next opens, so an early `time.end` says nothing about
       // whether the run as a whole is still being written.

--- a/apps/web/src/lib/icons/ssr.tsx
+++ b/apps/web/src/lib/icons/ssr.tsx
@@ -29,7 +29,11 @@ import {
   ArrowRightIcon as ArrowRightBase,
   ArrowClockwiseIcon as ArrowsClockwiseBase,
   AtIcon as AtBase,
+  AtomIcon as AtomBase,
+  BookOpenIcon as BookOpenBase,
+  BrainIcon as BrainBase,
   BroadcastIcon as BroadcastBase,
+  BrowserIcon as BrowserBase,
   BugIcon as BugBase,
   CalculatorIcon as CalculatorBase,
   CalendarDotsIcon as CalendarDotsBase,
@@ -39,14 +43,18 @@ import {
   ChartBarIcon as ChartBarBase,
   ChartLineIcon as ChartLineBase,
   ChatsIcon as ChatsBase,
-  CheckCircleIcon as CheckCircleBase,
   CheckIcon as CheckBase,
+  CheckCircleIcon as CheckCircleBase,
   ClipboardTextIcon as ClipboardTextBase,
   CloudIcon as CloudBase,
+  CodeIcon as CodeBase,
   CoffeeIcon as CoffeeBase,
+  CpuIcon as CpuBase,
   CreditCardIcon as CreditCardBase,
+  CubeIcon as CubeBase,
   CurrencyCircleDollarIcon as CurrencyCircleDollarBase,
   DatabaseIcon as DatabaseBase,
+  DesktopIcon as DesktopBase,
   DeviceMobileIcon as DeviceMobileBase,
   EnvelopeIcon as EnvelopeBase,
   FileLockIcon as FileLockBase,
@@ -57,6 +65,7 @@ import {
   FlaskIcon as FlaskBase,
   FunnelIcon as FunnelBase,
   GaugeIcon as GaugeBase,
+  GitBranchIcon as GitBranchBase,
   GitMergeIcon as GitMergeBase,
   GitPullRequestIcon as GitPullRequestBase,
   GithubLogoIcon as GithubLogoBase,
@@ -69,10 +78,12 @@ import {
   PaperPlaneTiltIcon as PaperPlaneTiltBase,
   PathIcon as PathBase,
   PhoneCallIcon as PhoneCallBase,
+  PlugsConnectedIcon as PlugsConnectedBase,
   PresentationIcon as PresentationBase,
   QuestionIcon as QuestionBase,
   ReceiptIcon as ReceiptBase,
   RepeatIcon as RepeatBase,
+  RobotIcon as RobotBase,
   RocketIcon as RocketBase,
   ScalesIcon as ScalesBase,
   ScrollIcon as ScrollBase,
@@ -93,8 +104,8 @@ import {
   UserPlusIcon as UserPlusBase,
   UsersIcon as UsersBase,
   WalletIcon as WalletBase,
-  WindowsLogoIcon as WindowsLogoBase,
   WarningIcon as WarningBase,
+  WindowsLogoIcon as WindowsLogoBase,
   WrenchIcon as WrenchBase,
 } from '@phosphor-icons/react/dist/ssr';
 
@@ -113,6 +124,17 @@ export const ArrowLeftIcon = withDefaultWeight(ArrowLeftBase);
 export const ArrowRightIcon = withDefaultWeight(ArrowRightBase);
 export const ArrowClockwiseIcon = withDefaultWeight(ArrowsClockwiseBase);
 export const AtIcon = withDefaultWeight(AtBase);
+export const AtomIcon = withDefaultWeight(AtomBase);
+export const BookOpenIcon = withDefaultWeight(BookOpenBase);
+export const BrainIcon = withDefaultWeight(BrainBase);
+export const BrowserIcon = withDefaultWeight(BrowserBase);
+export const CodeIcon = withDefaultWeight(CodeBase);
+export const CpuIcon = withDefaultWeight(CpuBase);
+export const CubeIcon = withDefaultWeight(CubeBase);
+export const DesktopIcon = withDefaultWeight(DesktopBase);
+export const GitBranchIcon = withDefaultWeight(GitBranchBase);
+export const PlugsConnectedIcon = withDefaultWeight(PlugsConnectedBase);
+export const RobotIcon = withDefaultWeight(RobotBase);
 export const BroadcastIcon = withDefaultWeight(BroadcastBase);
 export const BugIcon = withDefaultWeight(BugBase);
 export const CalculatorIcon = withDefaultWeight(CalculatorBase);

--- a/apps/web/src/lib/seo/content-timestamps.json
+++ b/apps/web/src/lib/seo/content-timestamps.json
@@ -49,7 +49,7 @@
   "docs:project": "2026-08-19T07:16:09.000Z",
   "docs:project/legacy-toml": "2026-07-30T12:52:42.000Z",
   "docs:project/manifest": "2026-08-23T00:12:23.000Z",
-  "docs:project/models": "2026-08-25T19:54:58.000Z",
+  "docs:project/models": "2026-08-25T21:11:32.000Z",
   "docs:project/secrets": "2026-08-22T20:28:33.000Z",
   "docs:quickstart": "2026-07-22T02:58:51.000Z",
   "docs:sdk/apps": "2026-08-19T07:16:09.000Z",
@@ -58,10 +58,10 @@
   "docs:sdk": "2026-08-18T23:05:42.000Z",
   "docs:sdk/react": "2026-08-25T18:58:01.000Z",
   "docs:sdk/reference": "2026-08-22T22:45:02.000Z",
-  "docs:sdk/sessions": "2026-08-19T07:16:09.000Z",
+  "docs:sdk/sessions": "2026-08-26T13:06:00.000Z",
   "docs:sdk/sign-in": "2026-08-26T20:50:28.000Z",
   "docs:work/change-requests": "2026-07-22T02:58:51.000Z",
   "docs:work": "2026-08-19T17:39:34.000Z",
-  "docs:work/runtime": "2026-08-23T14:04:43.000Z",
+  "docs:work/runtime": "2026-08-26T00:19:20.000Z",
   "docs:work/sessions": "2026-08-19T16:27:13.000Z"
 }

--- a/apps/web/src/lib/seo/public-content.ts
+++ b/apps/web/src/lib/seo/public-content.ts
@@ -372,6 +372,36 @@ export function parseFrontmatter(source: string): Record<string, string> {
   return result;
 }
 
+/**
+ * A tag's attribute text, including values that are JSX expressions.
+ *
+ * `[^>]*` stood in for this, which is right until an attribute VALUE contains
+ * a `>` — and `icon={<RocketIcon />}` does. The tag then appeared to end
+ * inside the expression: every matcher below missed, and a docs card fell
+ * through to the prose path as the literal `} title="Quickstart" href=…`
+ * instead of becoming `- [Quickstart](/docs/quickstart)`.
+ *
+ * One level of braces, deliberately — that is what a JSX attribute value is
+ * here, and a nested-brace grammar is not something to hand-roll in a regex.
+ */
+const MDX_TAG_ATTRS = String.raw`((?:[^>{]|\{[^{}]*\})*)`;
+
+const MDX_TAG_NAME = String.raw`([A-Z][A-Za-z0-9_.]*)`;
+const MDX_PAIRED_TAG = new RegExp(
+  String.raw`^\s*<${MDX_TAG_NAME}\b${MDX_TAG_ATTRS}>([\s\S]*?)<\/\1>\s*$`,
+);
+const MDX_SELF_CLOSING_TAG = new RegExp(String.raw`^\s*<${MDX_TAG_NAME}\b${MDX_TAG_ATTRS}\/>\s*$`);
+const MDX_OPENING_TAG = new RegExp(String.raw`^\s*<${MDX_TAG_NAME}\b${MDX_TAG_ATTRS}>\s*$`);
+
+/**
+ * True when the line closes the tag it opened — a `>` that is not inside a
+ * JSX expression. `line.includes('>')` answered this before, and stopped
+ * joining continuation lines one attribute too early on `icon={<X />}`.
+ */
+function closesTag(text: string): boolean {
+  return text.replace(/\{[^{}]*\}/g, '').includes('>');
+}
+
 const MDX_WRAPPER_TAGS = new Set(['Cards', 'KeyFacts', 'StatGrid', 'Steps']);
 const MDX_BLOCK_TAGS = new Set(['Callout', 'Card', 'Fact', 'Step']);
 
@@ -422,7 +452,7 @@ function renderMdxTagLine(line: string, stack: MdxRenderContext[]): string | nul
     return undefined;
   }
 
-  const paired = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)>([\s\S]*?)<\/\1>\s*$/.exec(line);
+  const paired = MDX_PAIRED_TAG.exec(line);
   if (paired) {
     const [, tag, rawAttrs, body] = paired;
     const attrs = parseMdxAttributes(rawAttrs);
@@ -434,7 +464,7 @@ function renderMdxTagLine(line: string, stack: MdxRenderContext[]): string | nul
     return undefined;
   }
 
-  const selfClosing = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)\/>\s*$/.exec(line);
+  const selfClosing = MDX_SELF_CLOSING_TAG.exec(line);
   if (selfClosing) {
     const [, tag, rawAttrs] = selfClosing;
     const attrs = parseMdxAttributes(rawAttrs);
@@ -444,7 +474,7 @@ function renderMdxTagLine(line: string, stack: MdxRenderContext[]): string | nul
     return undefined;
   }
 
-  const opening = /^\s*<([A-Z][A-Za-z0-9_.]*)\b([^>]*)>\s*$/.exec(line);
+  const opening = MDX_OPENING_TAG.exec(line);
   if (!opening) return undefined;
 
   const [, tag, rawAttrs] = opening;
@@ -512,9 +542,9 @@ export function renderPlainMarkdownFromMdx(source: string): string {
       continue;
     }
 
-    if (/^\s*<[A-Z][A-Za-z0-9_.]*\b/.test(line) && !line.includes('>')) {
+    if (/^\s*<[A-Z][A-Za-z0-9_.]*\b/.test(line) && !closesTag(line)) {
       const tagLines = [line.trim()];
-      while (index + 1 < lines.length && !tagLines.join(' ').includes('>')) {
+      while (index + 1 < lines.length && !closesTag(tagLines.join(' '))) {
         index += 1;
         tagLines.push(lines[index].trim());
       }

--- a/apps/web/src/ui/types.ts
+++ b/apps/web/src/ui/types.ts
@@ -94,6 +94,22 @@ export interface TriggerTitle {
    * numbers mean the same thing on every surface.
    */
   stat?: { additions: number; deletions: number };
+  /**
+   * The subtitle repeats text the OPEN body already shows, so the row drops it
+   * once it is expanded.
+   *
+   * A closed row is the only place that text appears, so it stays there. Open,
+   * it is the same string twice — and the trigger's copy is the worse one: it
+   * is truncated to one line, so a long value disagrees with the full one
+   * directly beneath it.
+   *
+   * Opt-in per call, not a blanket rule, because most subtitles are NOT
+   * repeated by the body: a `pty` row's terminal id, for instance, appears
+   * nowhere in the buffer it opens, and hiding it would lose the only thing
+   * saying WHICH terminal this is. Set it where the body genuinely echoes the
+   * subtitle, and leave it off everywhere else.
+   */
+  hideSubtitleWhenOpen?: boolean;
 }
 
 /** A file entry in an apply_patch tool part's metadata. */


### PR DESCRIPTION
## Summary

Three surfaces in `apps/web`, sharing the same primitives.

### Docs

- **Search index is now static.** `api/search/route.ts` exports `staticGET` with `revalidate = false`. The dialog fetches the 31-page index once and queries in-browser, instead of one round-trip per keystroke behind a debounce.
- **`markdown-source.ts`** — fetch-once / share-in-flight cache for the page markdown, split out of the component so it is testable without a DOM harness. `CopyMarkdownButton` prefetches on `pointerenter` / `pointerdown` / `focus`, so the clipboard write stays inside the user gesture (Safari is strict about this) and the warm path has no `await` in front of `writeText`.
- **Copy confirmation moved from the label to the icon.** The copy glyph cross-fades to a check on the design system's icon-swap spring (`duration: 0.3, bounce: 0`). The label stays `Copy Markdown`, so the row no longer reflows for 2s and shoves "Open" sideways. The word survives on `aria-label`.
- **`docs-card.tsx`** replaces `fumadocs-ui/components/card`; **`inline-chip.tsx`** extracts the inline-code chip and hex predicate out of the client module so the server-side docs renderer can use them without crossing the client boundary. Hex values get a checkerboard-backed swatch.
- **`public-content.ts`** JSX attribute parsing now tolerates expression values. `icon={<RocketIcon />}` no longer ends the tag early and drop a card into the prose path.

### Session

- **`ToolOpenContext`** publishes a row's disclosure state where the trigger is *rendered*, so a trigger can stop repeating what the open card already shows. `bash` drops the truncated command line from its row once the card beneath spells it out in full.
- **`normalizeCommand`** strips leading indent with `[^\S\r\n]` — every Unicode horizontal space, not just space/tab — for one-liners, and common-indent only for scripts, so heredocs and nesting survive.
- **Thought rows carry a live clock.** `Thinking for 12s` counted from the client, settling to `Thought for 12s` from the run's own timestamps. Sub-second thoughts stay plain `Thinking`.
- Every activity row keeps its leading glyph; `bare` no longer touches the icon, only the summary line.

### Shared UI

- **`Badge` rebuilt as a mono chip**: `rounded-[5px]`, `font-mono`, `text-[0.8rem]`, inset ring instead of a border, `xs` as the default size.
- **`theme-toggle`** collapses three hand-copied `<button>` blocks per variant into one table driving both `compact` and `minimal`.
- Docs use the app's own hairline `--border`; adds inline-code rules for search results and TOC entries.

## Test plan

New pinned tests:

- `apps/web/content/docs/card-icons.test.ts`
- `apps/web/src/app/docs/docs-controls.test.tsx`
- `apps/web/src/app/docs/markdown-source.test.ts`
- `apps/web/src/components/markdown/docs-card.test.tsx`
- `apps/web/src/features/session/tool/tools/pty-spawn-tool.test.tsx`

Extended:

- `docs-page-actions.test.ts` — pins that no capital-C `Copied` label returns
- `markdown-code.test.tsx`, `docs-mdx-components.test.tsx`
- `bash-tool.test.tsx`, `infrastructure.test.tsx`
- `activity-burst.test.tsx`, `merge-steps.test.ts`

50 files, +2306 / −491.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790380054&installation_model_id=434224&pr_number=6952&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6952&signature=caf6f8526b7deac274c42d3162d131005f8d899e9e2ce73951b144c1c266b24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->