### PR TITLE
fix(web): drop "In progress" from SOC 2 Type I trust badge

### DIFF
--- a/apps/web/src/features/marketing/landing/content.ts
+++ b/apps/web/src/features/marketing/landing/content.ts
@@ -54,12 +54,12 @@ export const cta = {
 /**
  * Trust / security block.
  *
- * ACCURACY GATE: SOC 2 Type I and Type II are NOT held — both badges render
- * de-emphasised and carry an explicit "In progress" state. GDPR is a compliance
- * posture the company does hold, so it carries no state and renders bare.
- * Never write "compliant", "certified", or "we are SOC 2" here — the `comms`
- * skill forbids claiming a certification we do not hold. Adding a badge without
- * holding it, or clearing a SOC 2 `state` before the report lands, is a copy bug.
+ * ACCURACY GATE: SOC 2 Type I is held — its badge renders bare (no state), like
+ * GDPR, which is a compliance posture the company holds. SOC 2 Type II is NOT
+ * held and carries an explicit "In progress" state. Never write "compliant",
+ * "certified", or "we are SOC 2" here — the `comms` skill forbids claiming a
+ * certification we do not hold. Adding a badge without holding it, or clearing
+ * a SOC 2 `state` before the report lands, is a copy bug.
  */
 export const trust = {
   eyebrow: 'Security & trust',
@@ -82,7 +82,7 @@ export const trust = {
   ctaHref: '/enterprise',
   /** Exactly three. No HIPAA, no ISO — we do not hold them. */
   badges: [
-    { id: 'soc2-type-1', line1: 'SOC 2', line2: 'TYPE I', state: 'In progress' },
+    { id: 'soc2-type-1', line1: 'SOC 2', line2: 'TYPE I', state: '' },
     { id: 'soc2-type-2', line1: 'SOC 2', line2: 'TYPE II', state: 'In progress' },
     { id: 'gdpr', line1: 'GDPR', line2: '', state: '' },
   ],

--- a/apps/web/src/features/marketing/landing/trust-section.tsx
+++ b/apps/web/src/features/marketing/landing/trust-section.tsx
@@ -53,8 +53,9 @@ function TrustColumn({
 /**
  * The closing section: what makes the platform trustworthy, and exactly where
  * we stand on certification. Tembo runs the same shape (one dark card, badges,
- * three pillars); the honest half is ours — the badge row states plainly that
- * nothing is certified yet.
+ * three pillars); the honest half is ours — the badge row states plainly what
+ * we hold and what is still in progress. SOC 2 Type I is held (rendered bare,
+ * like GDPR); SOC 2 Type II is still in progress.
  */
 export function TrustSection(): ReactNode {
   return (
@@ -86,7 +87,7 @@ export function TrustSection(): ReactNode {
 
             <div className="w-full min-w-0 lg:col-span-5 lg:justify-self-end">
               <ul className="grid w-full grid-cols-3 items-start">
-                <TrustSeal label="In progress">
+                <TrustSeal>
                   <Soc2Type1 />
                 </TrustSeal>
                 <TrustSeal label="In progress">


### PR DESCRIPTION
## Demo

Landing page trust section: the SOC 2 Type I badge now renders bare (no label), matching GDPR. SOC 2 Type II still carries "In progress".

## Why

The SOC 2 Type I report has landed, so the badge must stop advertising it as "In progress".

## What changed

- `apps/web/src/features/marketing/landing/trust-section.tsx`: remove `label="In progress"` from the `Soc2Type1` `TrustSeal`.
- `apps/web/src/features/marketing/landing/content.ts`: set `trust.badges` SOC 2 Type I `state` to `''`, and update the accuracy-gate comment.

## Verification

Type II badge unchanged (still "In progress"). Copy-only change; no logic touched.

## Risk / rollback

Trivial copy revert if the badge should carry state again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790409025&installation_model_id=434224&pr_number=6954&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6954&signature=bb728916462f8e5775f1bd11cb2824d092ea23b05dfed11ede30adc3c9c6cc2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->