### PR TITLE
fix(web): mark SOC 2 Type I as certified on /security

### DIFF
--- a/apps/web/src/features/marketing/security-page/content.ts
+++ b/apps/web/src/features/marketing/security-page/content.ts
@@ -9,9 +9,10 @@
  * every line below traces to shipped code, and the citation is in the comment
  * above it. This is the page an enterprise reviewer will hold us to.
  *
- *  - SOC 2 is IN PROGRESS. Never "compliant", never "certified". No ISO, no
- *    HIPAA — we do not hold them. GDPR is a posture we run, not a third-party
- *    certificate, so it carries no "in progress" state.
+ *  - SOC 2 Type I is held (certified — the report has landed). SOC 2 Type II is
+ *    IN PROGRESS — never "compliant", never "certified" for it until its report
+ *    lands. No ISO, no HIPAA — we do not hold them. GDPR is a posture we run,
+ *    not a third-party certificate, so it carries no "in progress" state.
  *  - Never name a licence — "open source" and stop.
  *  - Say "cloud computer" / "sandbox". NEVER "container".
  *  - No invented metrics, customers, latency, or uptime numbers.
@@ -368,9 +369,10 @@ export const audit = {
 } as const;
 
 /* ── 7 · deployment + posture ──────────────────────────────────────────────
-   HONESTY GATE. SOC 2 Type I and Type II are IN PROGRESS. GDPR is a posture we
-   operate, not a pending third-party certificate, so it has no state string.
-   No ISO. No HIPAA. Do not add a badge here without a report to point at. */
+   HONESTY GATE. SOC 2 Type I is held (the report has landed). SOC 2 Type II is
+   IN PROGRESS. GDPR is a posture we operate, not a pending third-party
+   certificate, so it has no state string. No ISO. No HIPAA. Do not add a badge
+   here without a report to point at. */
 export const posture = {
   eyebrow: 'Deployment & posture',
   title: 'Run it where your policy says it has to run.',
@@ -396,7 +398,7 @@ export const posture = {
     label: 'Where we actually stand',
     /** Never move an item out of "In progress" without the report in hand. */
     items: [
-      { k: 'SOC 2 Type I', v: 'In progress' },
+      { k: 'SOC 2 Type I', v: 'Certified' },
       { k: 'SOC 2 Type II', v: 'In progress' },
       { k: 'GDPR', v: 'Operated' },
     ],


### PR DESCRIPTION
## Demo

`/security` → "Where we actually stand": SOC 2 Type I now reads "Certified"; SOC 2 Type II stays "In progress"; GDPR unchanged.

## Why

The SOC 2 Type I report has landed. The compliance list must stop listing Type I as "In progress".

## What changed

- `apps/web/src/features/marketing/security-page/content.ts`: `posture.compliance.items` SOC 2 Type I value `In progress` → `Certified`. Updated the page accuracy gate + posture honesty-gate comments.

## Verification

Copy-only change. Type II and GDPR unchanged.

## Risk / rollback

Trivial copy revert.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411172&installation_model_id=434224&pr_number=6955&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6955&signature=d07e5bf42f5ab3a8d982eae7ef79c3a7219709de921c99b17f5df20f92078b9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->