### PR TITLE
feat(llm-catalog): add GLM 5.3 Flash (z-ai/glm-5.3-flash via OpenRouter) to Kortix managed

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -974,7 +974,10 @@ rendered under the turn that failed, or the user sees nothing at all.
 2026-08-12/13) returned no reply in every session on templates built before
 then; 0 gateway log rows ever. PR #6576.
 *Enforcer:* `managed-fallback-sync.test.ts` (bundled table vs `MANAGED_MODELS`
-drift), `managed-model-overlay.test.ts` (stale file + live overlay; failed
+drift — cited here since 2026-08-19 but ABSENT on `main` until 2026-08-27, when
+adding `glm-5.3-flash` found the gap; it now lives in
+`apps/kortix-sandbox-agent-server/src/__tests__/` and fails on a missing,
+misnamed, mis-sized, or mis-priced bundled entry), `managed-model-overlay.test.ts` (stale file + live overlay; failed
 fetch → bundled floor; await cap), `managed-scope.test.ts`; web: sync-store
 per-turn `session.error` tests. Not enforced: a live "picker ⊆ guest provider
 map" assertion after deploy — run the dev sweep by hand until it exists.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -445,9 +445,11 @@ const envSchema = z.object({
   LLM_GATEWAY_DEFAULT_MODEL: optStrDefault(PLATFORM_DEFAULT_MODEL_ID),
   // Target when a DEFAULT-model request carries image input and the default
   // model lacks vision. Empty = no reroute (the request goes to the default
-  // model as-is). gpt-5.6-luna is the cheapest vision-capable managed model
-  // ($0.20/$1.20) — the default platform model (deepseek-v4-flash) is
-  // text-only.
+  // model as-is). gpt-5.6-luna ($0.20/$1.20) is the vision reroute target —
+  // the default platform model (deepseek-v4-flash) is text-only. Since
+  // 2026-08-27 glm-5.3-flash ($0.075/$0.25) is the cheaper vision-capable
+  // managed model; switching the reroute target is a quality decision that
+  // has not been made yet, so the default stays on Luna.
   LLM_GATEWAY_VISION_MODEL: optStrDefault('gpt-5.6-luna'),
   LLM_GATEWAY_FALLBACK_POLICIES: optFallbackPolicies,
   // Optional JSON array replacing the platform managed-model overlay (transport,

--- a/apps/kortix-sandbox-agent-server/src/__tests__/managed-fallback-sync.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/managed-fallback-sync.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test'
+import { BUNDLED_MANAGED_MODELS } from '../opencode'
+
+// The bundled managed floor is what OpenCode sees when the live managed fetch
+// is down AND the baked image catalog predates a lineup change. A managed
+// model missing from it is the exact 2026-08-19 ModelNotFound outage: the
+// gateway serves the id, the picker shows it, and every turn on it fails.
+// This file is the enforcer that opencode.ts and the learnings register cite.
+//
+// The catalog is loaded from SOURCE via a dynamic import on purpose:
+//  - no package.json dependency — this app is built STANDALONE (see the
+//    api-contract note in tsconfig.json; a workspace dep breaks the image build);
+//  - no static import — that would pull packages/llm-catalog into this app's
+//    tsc program under `noUncheckedIndexedAccess`, which the catalog package
+//    does not compile under. Test-only, so the daemon binary is untouched.
+interface CatalogManagedModel {
+  id: string
+  name: string
+  vision: boolean
+  limit: { context: number; output: number }
+  pricing?: { inputPerMillion: number; outputPerMillion: number; cachedInputPerMillion?: number }
+}
+const catalogSource = new URL('../../../../packages/llm-catalog/src/index.ts', import.meta.url).pathname
+const { MANAGED_MODELS } = (await import(catalogSource)) as { MANAGED_MODELS: CatalogManagedModel[] }
+
+describe('BUNDLED_MANAGED_MODELS mirrors @kortix/llm-catalog MANAGED_MODELS', () => {
+  test('the catalog loaded', () => {
+    expect(MANAGED_MODELS.length).toBeGreaterThan(0)
+  })
+
+  test('the same set of ids, in both directions', () => {
+    expect(Object.keys(BUNDLED_MANAGED_MODELS).sort()).toEqual(MANAGED_MODELS.map((m) => m.id).sort())
+  })
+
+  for (const managed of MANAGED_MODELS) {
+    test(`${managed.id}: name, limit, vision, and declared cost agree`, () => {
+      const bundled = BUNDLED_MANAGED_MODELS[managed.id]
+      expect(bundled, `${managed.id} is missing from MINIMAL_FALLBACK_MODELS`).toBeDefined()
+      if (!bundled) return
+      expect(bundled.name).toBe(managed.name)
+      expect(bundled.provider).toBe('kortix')
+      // `limit` is served verbatim to size the conversation; a drift here
+      // means one surface compacts at the wrong wall.
+      expect(bundled.limit).toEqual(managed.limit)
+      expect(bundled.attachment ?? false).toBe(managed.vision)
+      // Cost is optional on the fallback record, but when it IS declared it
+      // must be the catalog's billed rate — the picker renders it.
+      if (bundled.cost && managed.pricing) {
+        expect(bundled.cost.input).toBe(managed.pricing.inputPerMillion)
+        expect(bundled.cost.output).toBe(managed.pricing.outputPerMillion)
+        if (bundled.cost.cache_read !== undefined) {
+          expect(bundled.cost.cache_read).toBe(managed.pricing.cachedInputPerMillion ?? Number.NaN)
+        }
+      }
+    })
+  }
+})

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1300,6 +1300,22 @@ export const MINIMAL_FALLBACK_MODELS: Record<string, KortixGatewayModel> = {
       context_over_200k: { input: 4, output: 12, cache_read: 1 },
     },
   },
+  // Mirrors @kortix/llm-catalog `glm-5.3-flash` (added 2026-08-27). Capabilities
+  // = models.dev openrouter/z-ai/glm-5.3-flash: effort low/high/max, image
+  // input, temperature:true, structured_output:true. Limit = the safe
+  // intersection of the pinned z-ai + novita hosts.
+  'glm-5.3-flash': {
+    name: 'GLM 5.3 Flash',
+    provider: 'kortix',
+    reasoning: true,
+    reasoning_options: [{ type: 'effort', values: ['low', 'high', 'max'] }],
+    tool_call: true,
+    attachment: true,
+    structured_output: true,
+    temperature: true,
+    limit: { context: 1_048_576, output: 131_072 },
+    cost: { input: 0.075, output: 0.25, cache_read: 0.015 },
+  },
   // Second Kortix-managed AsterLab model (Kimi K3). Same `kortix` provider
   // branding + `aster` transport (ASTER_API_KEY) as GLM 5.2.
   // `temperature:false` — models.dev advertises Kimi K3 as

--- a/packages/llm-catalog/src/index.ts
+++ b/packages/llm-catalog/src/index.ts
@@ -537,6 +537,11 @@ export function pricingRefLookupCandidates(pricingRef: string): string[] {
 // model), and DeepSeek V4 Flash became the platform default (cheapest
 // credible agentic coder; beats GLM 5.2 on every published agentic
 // benchmark while costing ~10x less per unit of work).
+//
+// 2026-08-27: GLM 5.3 Flash added (OpenRouter transport, Z.ai first-party
+// endpoint). Cheapest managed model with vision ($0.075/$0.25 vs Luna's
+// $0.20/$1.20); LLM_GATEWAY_VISION_MODEL deliberately stays on gpt-5.6-luna
+// until the reroute target is re-evaluated on quality, not price alone.
 export const MANAGED_MODELS: ManagedModel[] = [
   {
     // Grok 4.6 through OpenRouter's first-party xAI endpoint. The explicit
@@ -811,6 +816,51 @@ export const MANAGED_MODELS: ManagedModel[] = [
     limit: { context: 1_050_000, output: 128_000 },
     openrouterProvider: {
       order: ['openai'],
+      allow_fallbacks: true,
+    },
+  },
+  {
+    // Z.ai's GLM 5.3 Flash (released 2026-08-26) via OpenRouter. 12 endpoints
+    // serve the slug (measured 2026-08-27) and they are NOT interchangeable:
+    //  - `z-ai` (first-party) and `novita`: $0.075/$0.25, cache read $0.015,
+    //    1_048_576 ctx / 131_072 max out, tools + reasoning_effort, 99.1% /
+    //    99.8% 30m uptime. Pinned in that order. Verified live: a tool-call
+    //    request with this exact `provider` block landed on Z.AI (HTTP 200,
+    //    4.95s, finish_reason:tool_calls, cost 1.49e-5 USD = this entry's
+    //    rate to the cent); `z-ai` alone with allow_fallbacks:false also 200s,
+    //    which proves the slug. Novita was 429 "rate-limited upstream" on the
+    //    shared pool at measurement time — a second choice, not a first.
+    //  - `gmicloud`: same price but status -2 / 86.9% uptime → explicit `ignore`.
+    //  - `reka/fp8` and `io-net/fp8` cap context at 262_144 and `reka` caps
+    //    output at 48_000 — they cannot hold a session this entry advertises.
+    //  - every other host (venice, modal, parasail, together, cloudflare,
+    //    deepinfra, baseten) bills 2x ($0.15/$0.50): the fallback pool.
+    // The advertised limit is the SAFE INTERSECTION of the two pinned hosts.
+    // `pricingRef` resolves on LIVE models.dev (openrouter/z-ai/glm-5.3-flash:
+    // effort low/high/max, image+video input, temperature:true,
+    // structured_output:true); the committed catalog.generated.json predates
+    // the release, so snapshot-only consumers use the synthetic record until
+    // the weekly regen (same as muse-spark-1.2 on 2026-08-10).
+    // PRICE NOTE: $0.075/$0.25 is OpenRouter's current rate on the pinned
+    // hosts, shown there as a 50% launch discount off $0.15/$0.50. If the
+    // discount ends, or a turn falls back off the pinned hosts, upstream cost
+    // is 2x this entry — bump `pricing` (or overlay LLM_GATEWAY_MANAGED_MODELS).
+    id: 'glm-5.3-flash',
+    name: 'GLM 5.3 Flash',
+    upstreamModelId: 'z-ai/glm-5.3-flash',
+    transport: 'openrouter',
+    pricingRef: 'openrouter/z-ai/glm-5.3-flash',
+    pricing: {
+      inputPerMillion: 0.075,
+      cachedInputPerMillion: 0.015,
+      outputPerMillion: 0.25,
+    },
+    tier: 'fast',
+    vision: true,
+    limit: { context: 1_048_576, output: 131_072 },
+    openrouterProvider: {
+      order: ['z-ai', 'novita'],
+      ignore: ['gmicloud'],
       allow_fallbacks: true,
     },
   },

--- a/packages/llm-catalog/src/managed.test.ts
+++ b/packages/llm-catalog/src/managed.test.ts
@@ -12,7 +12,8 @@ import {
 describe('managed catalog', () => {
   // 2026-08-10: claude-opus-4.8 / claude-sonnet-4.6 / kimi-k3 deactivated
   // (commented out in MANAGED_MODELS, reactivatable by diff); muse-spark-1.2,
-  // minimax-m3, and gpt-5.6-luna added the same day.
+  // minimax-m3, and gpt-5.6-luna added the same day. 2026-08-27: glm-5.3-flash
+  // (OpenRouter, Z.ai first-party) added.
   test('exposes the managed lineup', () => {
     expect(DEFAULT_MANAGED_MODEL_IDS).toEqual([
       'grok-4.6',
@@ -22,6 +23,7 @@ describe('managed catalog', () => {
       'muse-spark-1.2',
       'minimax-m3',
       'gpt-5.6-luna',
+      'glm-5.3-flash',
     ]);
   });
 
@@ -178,6 +180,29 @@ describe('managed resolution + back-compat aliases', () => {
       limit: { context: 1_048_575, output: 384_000 },
       openrouterProvider: {
         order: ['gmicloud'],
+        allow_fallbacks: true,
+      },
+    });
+    // Measured 2026-08-27 on OpenRouter: z-ai (first-party) + novita at
+    // $0.075/$0.25/$0.015, 1_048_576 ctx / 131_072 out; gmicloud degraded
+    // (status -2, 86.9% uptime) and ignored. Vision: models.dev lists
+    // text+image+video input.
+    expect(getManagedModel('glm-5.3-flash')).toMatchObject({
+      name: 'GLM 5.3 Flash',
+      upstreamModelId: 'z-ai/glm-5.3-flash',
+      transport: 'openrouter',
+      pricingRef: 'openrouter/z-ai/glm-5.3-flash',
+      pricing: {
+        inputPerMillion: 0.075,
+        cachedInputPerMillion: 0.015,
+        outputPerMillion: 0.25,
+      },
+      tier: 'fast',
+      vision: true,
+      limit: { context: 1_048_576, output: 131_072 },
+      openrouterProvider: {
+        order: ['z-ai', 'novita'],
+        ignore: ['gmicloud'],
         allow_fallbacks: true,
       },
     });


### PR DESCRIPTION
## What
Adds `glm-5.3-flash` (Z.ai GLM 5.3 Flash, released 2026-08-26) to the Kortix-managed lineup via OpenRouter.

| field | value |
|---|---|
| id / name | `glm-5.3-flash` / GLM 5.3 Flash |
| transport / upstream | `openrouter` / `z-ai/glm-5.3-flash` |
| pricingRef | `openrouter/z-ai/glm-5.3-flash` (resolves on live models.dev; committed snapshot predates the release) |
| pricing | $0.075 in / $0.25 out / $0.015 cache read per M (current OpenRouter rate on the pinned hosts; shown there as a 50 % launch discount off $0.15/$0.50 — see PRICE NOTE in the entry) |
| tier / vision | `fast` / `true` (models.dev: text+image+video input) |
| limit | 1_048_576 ctx / 131_072 out — safe intersection of the pinned hosts |
| provider pin | `order: [z-ai, novita]`, `ignore: [gmicloud]` (status −2, 86.9 % uptime), `allow_fallbacks: true` |

Files:
- `packages/llm-catalog/src/index.ts` — entry + header note; `managed.test.ts` lineup + shape assertion.
- `apps/kortix-sandbox-agent-server/src/opencode.ts` — mirrored `MINIMAL_FALLBACK_MODELS` entry (effort low/high/max, attachment, structured_output, cost).
- **NEW** `apps/kortix-sandbox-agent-server/src/__tests__/managed-fallback-sync.test.ts` — the enforcer the 2026-08-19 ModelNotFound learning cites did not exist on `main`. It now asserts bundled ids == `MANAGED_MODELS` ids in both directions and that name / limit / vision / declared cost agree. Loads the catalog source via dynamic import so the standalone sandbox build gets no workspace dep and its `noUncheckedIndexedAccess` tsc program is untouched. Negative proof: deleting the sandbox entry fails with `glm-5.3-flash is missing from MINIMAL_FALLBACK_MODELS`.
- `apps/api/src/config.ts` — comment only. `LLM_GATEWAY_VISION_MODEL` stays `gpt-5.6-luna`; glm-5.3-flash is now the cheaper vision-capable managed model, switching is a separate quality decision.
- `.claude/skills/learnings/SKILL.md` — enforcer gap recorded.

## Verified
1. OpenRouter direct, 12 endpoints measured 2026-08-27. `provider.order=[z-ai]` + `allow_fallbacks:false` → HTTP 200 served by Z.AI (slug proven). Tool-call request with the entry's exact `provider` block → 200 in 4.95 s, `finish_reason: tool_calls`, `{"value":7}`, cost 1.49e-5 USD = entry rate exactly. Novita: valid slug, 429 "rate-limited upstream (shared pool)" at measurement time → second choice.
2. Local worktree API (`:20708`, real OpenRouter key): `GET /v1/llm/models?scope=managed` → 8 ids incl. `glm-5.3-flash` with `limit {1048576,131072}`, `cost {0.075,0.25,0.015}`, `attachment:true`. `POST /v1/llm/chat/completions` `model=glm-5.3-flash` + tool → HTTP 200 in 5.05 s; `gateway_request_logs`: `resolved_model z-ai/glm-5.3-flash`, `provider openrouter`, `attempts 1`, tool call `{"value":42}`, `billing_mode credits`, upstream_cost 2e-5 → final_cost 2.4e-5.
3. `bun test`: llm-catalog 72/72; sandbox agent server 55/55 + sync 10/10; api `llm-gateway/{models,resolution,routing}` 211/211. `tsc --noEmit` exit 0 in llm-catalog, sandbox agent server, api.

## After merge
Dev auto-deploys. I will verify `dev-api` `GET /v1/llm/models?scope=managed` + a real completion, and the picker on `dev.kortix.com`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790423245&installation_model_id=434224&pr_number=6958&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6958&signature=74e2ada5a33524594f498ae4959c0a4edfd0a0d3be8b85b8f3a31dd4d7a5e385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->