### PR TITLE
fix(sdk,api): session stream dies cross-origin — drop non-safelisted Cache-Control request header

### DIFF
--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -55,6 +55,11 @@ export function createCorsMiddleware(options: CorsMiddlewareOptions) {
       'X-Request-Id',
       'Last-Event-ID',
       'X-Kortix-Client',
+      // Defense in depth for the session stream: a cross-origin SSE reader that
+      // sends `Cache-Control: no-cache` (older SDKs, the opencode fallback) would
+      // otherwise fail preflight and the stream would never open. The current SDK
+      // no longer sends it, but allowing it keeps any client that does working.
+      'Cache-Control',
       // Act-as impersonation. A header absent from this list is stripped by the
       // browser's preflight, so the request arrives WITHOUT the grant and runs
       // as the operator's own account — the exact silent mis-scoping the

--- a/packages/sdk/src/core/rest/projects-client/session-stream.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/session-stream.test.ts
@@ -96,13 +96,14 @@ describe('the composite cursor codec', () => {
 
 describe('readSessionStream', () => {
   const originalFetch = globalThis.fetch;
-  let requested: Array<{ url: string; accept: string | null }> = [];
+  let requested: Array<{ url: string; accept: string | null; cacheControl?: string | null }> = [];
 
   function serve(chunks: string[], keepOpen = false): void {
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       requested.push({
         url: input instanceof Request ? input.url : String(input),
         accept: new Headers(init?.headers ?? {}).get('accept'),
+        cacheControl: new Headers(init?.headers ?? {}).get('cache-control'),
       });
       const encoder = new TextEncoder();
       let index = 0;
@@ -137,6 +138,10 @@ describe('readSessionStream', () => {
     for await (const _frame of readSessionStream(PROJECT, SESSION)) break;
     expect(requested[0]!.url).toBe(`http://api.test/v1/projects/${PROJECT}/sessions/${SESSION}/stream`);
     expect(requested[0]!.accept).toBe('text/event-stream');
+    // No `Cache-Control` REQUEST header: it is not CORS-safelisted, so sending it
+    // makes the browser preflight fail cross-origin and the stream never opens
+    // (dev, 2026-08-27). The only header on this GET is `Accept`.
+    expect(requested[0]!.cacheControl).toBeNull();
   });
 
   test('classifies frames by CHANNEL, not by event name', async () => {

--- a/packages/sdk/src/core/rest/projects-client/session-stream.ts
+++ b/packages/sdk/src/core/rest/projects-client/session-stream.ts
@@ -180,7 +180,14 @@ export async function* readSessionStream(
 
   const response = await authenticatedFetch(url, {
     method: 'GET',
-    headers: { Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
+    // Only `Accept` here. A `Cache-Control` REQUEST header is not CORS-safelisted,
+    // so cross-origin (web app -> API on another host) the browser preflights it;
+    // if the API's Access-Control-Allow-Headers omits it the preflight FAILS and
+    // the GET never fires — the stream dies with `net::ERR_FAILED` / "Failed to
+    // fetch" and the client falls back to polling forever (dev, 2026-08-27). The
+    // header bought nothing anyway: caching of an SSE stream is governed by the
+    // RESPONSE `Cache-Control` the server already sets, not by a request header.
+    headers: { Accept: 'text/event-stream' },
     signal: options?.signal,
   });
 


### PR DESCRIPTION
The web app (dev.kortix.com) opens the session stream on the API (dev-api.kortix.com),
a DIFFERENT origin. The SDK reader sent a `Cache-Control: no-cache` REQUEST header;
that header is not CORS-safelisted, so the browser preflights it, and the API's
Access-Control-Allow-Headers did not list it -> preflight FAILS -> the GET never
fires (net::ERR_FAILED / 'Failed to fetch') -> the stream never connects and the
client falls back to polling /turn, /prompts, /messages forever. This is why the
new Runtime API 'never works' in the browser while same-origin tests (Playwright,
the whitelabel BFF proxy) passed.

- SDK: send only `Accept: text/event-stream` on the stream GET (a request-side
  Cache-Control does nothing for an SSE fetch; the server sets the response one).
- API CORS: also allow `Cache-Control` as defense in depth for any client that
  still sends it (the opencode fallback path).
- Regression test pins that the stream GET carries no Cache-Control request header.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790423275&installation_model_id=434224&pr_number=6959&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6959&signature=0a61220a7809e2b8ae7e8925f7376fb348865d9a6ef3b2b329ce7a22513a0f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->