### PR TITLE
fix(worker): compiled artifact double-started and died with EADDRINUSE

### DIFF
--- a/apps/api/src/git-proxy/pi-worker-bundle.test.ts
+++ b/apps/api/src/git-proxy/pi-worker-bundle.test.ts
@@ -93,6 +93,13 @@ describe.skipIf(!existsSync(WORKER_DIST))('compiled pi runtime artifact (real bu
         await new Promise((r) => setTimeout(r, 50));
       }
       expect(health?.ok).toBe(true);
+      // The double-start regression crashed the process ~immediately AFTER
+      // health first answered, so a single poll flaky-passed. Survival for a
+      // beat plus a second answer is the actual assertion.
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(child.exitCode).toBeNull();
+      const again = await fetch(`http://127.0.0.1:${port}/health`);
+      expect(again.ok).toBe(true);
     } finally {
       child.kill('SIGKILL');
     }

--- a/apps/kortix-worker/src/worker.ts
+++ b/apps/kortix-worker/src/worker.ts
@@ -451,6 +451,8 @@ export async function startWorker(cfg = configFromEnv()) {
   return { server, agent, env, port, close: () => new Promise<void>((r) => server.close(() => r())) };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  startWorker().catch((e) => { console.error(e); process.exit(1); });
-}
+// No self-start guard here: src/main.ts is the bundle's sole entrypoint and
+// owns startup. In the compiled artifact every module shares one
+// import.meta.url, so a guard here fired ALONGSIDE main's start — two binds on
+// one port, EADDRINUSE ~1s after boot, dead worker. Found on the first
+// dev-served artifact; the api test now asserts survival past that window.


### PR DESCRIPTION
Found on the first dev-served artifact (project `pi-worker-bench`, dev): every compiled pi runtime crashed ~1 s after boot with `EADDRINUSE` when run as `node artifact.mjs`.

**Cause:** `apps/kortix-worker/src/worker.ts` kept its spike-era self-start guard (`import.meta.url === file://argv[1]`) while `src/main.ts` became the bundle entry. In the bundle every module shares one `import.meta.url`, so both fired: two `startWorker()` calls, two binds on one port, unhandled `'error'` event, dead process.

**Why the e2e test passed:** the crash lands ~0.8–1.2 s after `/health` first answers; the test's single poll (and my first hardening attempt at 600 ms) sat inside the race. The test now waits 1.5 s, asserts `child.exitCode === null`, and requires a second `/health`.

**Fix:** `main.ts` is the sole startup owner; the guard is gone with a comment explaining why it must not come back.

Verified: `bun test src/git-proxy/pi-worker-bundle.test.ts` 3/3 with the widened window, plus the exact dev repro — compiled artifact from the rebuilt dist runs as `node file`, alive at 3 s, `/health` answering (`bootMs: 5`).

Benchmark note: dev numbers were still collectable via an import wrapper (importing skips the argv-matched guard), so this blocked nothing — but any worker sandbox exec'ing the artifact directly would have died on arrival.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790427766&installation_model_id=434224&pr_number=6962&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6962&signature=430ac6a979e70ba7b2eb86e91b847c701de792ea5a566e46bebcac635de5ba2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->