### PR TITLE
Fix working status order after a fresh prompt

### DIFF
--- a/apps/web/src/features/session/turn/working-turn.test.ts
+++ b/apps/web/src/features/session/turn/working-turn.test.ts
@@ -52,6 +52,15 @@ describe('resolveWorkingTurn', () => {
     expect(r.pendingTurnIds).toEqual([]);
   });
 
+  test('a fresh send receipt outranks stale open metadata on the previous answer', () => {
+    const r = resolveWorkingTurn({
+      turns: [turn('old', 'open'), turn('new')],
+      hintMessageId: 'new',
+    });
+    expect(r.workingTurnId).toBe('new');
+    expect(r.pendingTurnIds).toEqual([]);
+  });
+
   test('no hint: the NEWEST pending turn is where the next step lands', () => {
     // OpenCode parents the next step to the latest user message and answers
     // p1 and p2 together in it — p1 is taken, not pending.

--- a/apps/web/src/features/session/turn/working-turn.ts
+++ b/apps/web/src/features/session/turn/working-turn.ts
@@ -14,17 +14,14 @@
  *
  * The rule, in order:
  *
- *  1. The newest turn that has any assistant content. If its newest
+ *  1. The working projection names a turn. This is the server's current turn
+ *     or this tab's fresh send receipt. It outranks incomplete transcript
+ *     metadata because message completion can arrive one frame late.
+ *  2. The newest turn that has any assistant content. If its newest
  *     assistant message is still open (no `time.completed`), that is the
  *     working turn — the agent is visibly writing there. Older turns with an
  *     open assistant message are husks (a box that died mid-turn); the
  *     newest turn with content outranks them.
- *  2. Otherwise every turn after it is a PENDING turn — a user message with
- *     no answer yet. The server's own answer (`WorkingProjection.turnId`,
- *     the wire id of the prompt that opened the running turn, or this tab's
- *     receipt) picks between "still on the previous turn, between two
- *     steps" and "a fresh send that opened this turn" when it names one of
- *     them.
  *  3. Otherwise the NEWEST pending turn. OpenCode parents the next step to
  *     the latest user message and answers every queued message before it in
  *     that same step — so that is where the shimmer lands, and the ones
@@ -88,12 +85,6 @@ export function resolveWorkingTurn(input: {
     pendingTurnIds: turns.slice(index + 1).map((t) => t.userMessage.info.id),
   });
 
-  if (newestWithContent >= 0) {
-    const t = turns[newestWithContent];
-    const newest = t.assistantMessages[t.assistantMessages.length - 1];
-    if (!completedAt(newest.info)) return pick(newestWithContent);
-  }
-
   const hint = input.hintMessageId ?? null;
   if (hint) {
     if (newestWithContent >= 0 && turns[newestWithContent].userMessage.info.id === hint) {
@@ -101,6 +92,12 @@ export function resolveWorkingTurn(input: {
     }
     const idx = pendingIds.indexOf(hint);
     if (idx >= 0) return pick(newestWithContent + 1 + idx);
+  }
+
+  if (newestWithContent >= 0) {
+    const t = turns[newestWithContent];
+    const newest = t.assistantMessages[t.assistantMessages.length - 1];
+    if (!completedAt(newest.info)) return pick(newestWithContent);
   }
 
   // Rule 3, with the one fact the transcript cannot hold: the SERVER still has


### PR DESCRIPTION
## Problem

A fresh prompt could render below the working status for several seconds. The previous assistant response still carried stale open metadata, so `resolveWorkingTurn` attached the status row to the previous turn until the next server frame corrected it.

## Fix

- Let the working projection turn ID outrank incomplete transcript metadata.
- Keep the transcript-only open-message fallback when the projection names no turn.
- Add a regression test for an old response with stale open metadata followed by a fresh prompt receipt.

## Verification

- `bun test apps/web/src/features/session/turn` — 442 passed, 0 failed
- Focused session suite — 83 passed, 0 failed
- `pnpm --filter Kortix-Computer-Frontend exec eslint src/features/session/turn/working-turn.ts src/features/session/turn/working-turn.test.ts` — passed
- `pnpm --filter Kortix-Computer-Frontend typecheck` — passed
- Local browser DOM assertion — previous answer → new prompt → working status; status parent `data-turn-id=new`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429982&installation_model_id=434224&pr_number=6965&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6965&signature=db83e7bb51ea61145ab202ccf7946c8b5a48bcf0fbd0c5e856efb902d2635e61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->