### PR TITLE
docs(learnings): a new import edge into a widely-mocked graph breaks hand-written mocks suite-wide

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,39 @@ linked, not inlined.
 
 ## Register
 
+### A new import edge into a widely-mocked graph breaks hand-written module mocks all over the suite — and the failure names no test (2026-08-27)
+
+**When:** adding an import to code that many suites exercise (a middleware, a
+proxy, a gate). `mock.module` replaces a module **WHOLESALE**, so every suite
+that stubs a module by listing its exports silently deletes the ones it did not
+name. Pull that module into a new part of the graph and those missing names
+become `SyntaxError: Export named 'X' not found in module …`, printed as
+`# Unhandled error between tests` — attributed to NO test, and it takes an
+unrelated parallel worker down with it, so the visible symptom is a stranger's
+suite failing.
+
+Fix them one at a time and it cascades: `loadTokenBinding` →
+`ensureAgentServiceAccount` → `createAccountToken` →
+`resolveInheritedSessionSharing`, each spread pulling the next real module in.
+
+**The rule: fix the import, not the mocks.** Ask what the new code actually
+needs. Here the Apps gate wanted one email lookup and reached it through
+`projects/lib/access`, which re-exports it from behind the whole
+project/session/IAM read graph; `accounts/core/owner-emails` is the same
+function with `drizzle` + `db` as its entire import list. One line, cascade
+gone, zero test churn. Spread the real module (the 2026-08-18 rule) when you
+own the mock and the dependency is genuinely needed — not as the way out of a
+cascade you created.
+
+**Diagnostic:** a suite that fails with `1 fail / 1 error` where the failing
+test is in a file your branch never touched, and the run prints `1 tests
+failed:` followed by nothing, is this. Read the `Unhandled error` block, not the
+failing test name.
+*Near-miss:* PR #6963 (the Apps viewer token). Cost two CI rounds and a wrong
+"it's a pre-existing flake" call before the real cause was read.
+*Enforcer:* none. A lint that flags `mock.module` factories which do not spread
+the real module would catch the mocks; nothing catches the import edge.
+
 ### Two migrations generated from the same parent fork the drizzle chain, and main then cannot generate ANY migration (2026-08-27)
 
 **When:** two PRs are open at once and each runs `pnpm migrate:generate`. Each


### PR DESCRIPTION
The rule paid for in #6963: `mock.module` replaces a module wholesale, so pulling a widely-mocked module into a new part of the import graph deletes every export the hand-written stubs did not name — surfacing as `# Unhandled error between tests` attributed to no test, and failing an unrelated parallel worker. Fixing the mocks cascades (four modules deep); fixing the import does not. Includes the diagnostic for the misleading symptom.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790431717&installation_model_id=434224&pr_number=6968&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6968&signature=a1e8db25a44fb31a178911c10519b5016e5bc77cffb548cb5fee8bb747659a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->