### PR TITLE
test(daemon): per-test ephemeral ports in egress-shim suites

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-route-egress-shim.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-route-egress-shim.test.ts
@@ -28,23 +28,45 @@ import { buildOpencodeApp } from '../proxy'
 
 const TEST_TOKEN = 'egress-shim-test-kortix-token-32ch'
 const TEST_ENV_DIR = mkdtempSync(join(tmpdir(), 'kortix-env-shim-'))
-/** Well clear of the daemon's own 4319/4320/4321 block. */
-const PORT = 45322
-const SESSION_ENV = {
-  KORTIX_EGRESS_SHIM_PORT: String(PORT),
-  KORTIX_API_URL: 'https://api.kortix.test/v1',
-  KORTIX_PROJECT_ID: 'proj-hot-push',
-  KORTIX_TOKEN: 'kortix_pat_hot_push',
-} as const
 
+/**
+ * A fresh kernel-assigned port per test, never a fixed number. The CI packages
+ * lane can run this suite concurrently with — or right on the heels of —
+ * another run on the same runner, and two processes sharing one fixed port
+ * turn the arm/squat assertions into flakes. The ephemeral range is also
+ * inherently clear of the daemon's own 4319/4320/4321 block.
+ */
+function ephemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address() as net.AddressInfo
+      probe.close(() => resolve(port))
+    })
+  })
+}
+
+const SESSION_ENV_NAMES = [
+  'KORTIX_EGRESS_SHIM_PORT',
+  'KORTIX_API_URL',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_TOKEN',
+  'KORTIX_SECRET_CAPABILITIES',
+] as const
+
+let port = 0
 let testEnvFileSequence = 0
 let restoreEnv: Array<[string, string | undefined]> = []
 let squatter: net.Server | null = null
 
-beforeEach(() => {
-  restoreEnv = Object.entries(SESSION_ENV).map(([name]) => [name, process.env[name]])
-  restoreEnv.push(['KORTIX_SECRET_CAPABILITIES', process.env.KORTIX_SECRET_CAPABILITIES])
-  for (const [name, value] of Object.entries(SESSION_ENV)) process.env[name] = value
+beforeEach(async () => {
+  port = await ephemeralPort()
+  restoreEnv = SESSION_ENV_NAMES.map((name) => [name, process.env[name]])
+  process.env.KORTIX_EGRESS_SHIM_PORT = String(port)
+  process.env.KORTIX_API_URL = 'https://api.kortix.test/v1'
+  process.env.KORTIX_PROJECT_ID = 'proj-hot-push'
+  process.env.KORTIX_TOKEN = 'kortix_pat_hot_push'
   delete process.env.KORTIX_SECRET_CAPABILITIES
 })
 
@@ -175,10 +197,10 @@ describe('env route — mid-session boundary rules arm the shim', () => {
     expect(json.egress_shim_hosts).toEqual(['api.weather.test'])
     // Written AFTER the arm, so the agent's shells get the proxy on this push
     // rather than on the next one.
-    expect(readFileSync(envFile, 'utf8')).toContain(`export HTTPS_PROXY='http://127.0.0.1:${PORT}'`)
+    expect(readFileSync(envFile, 'utf8')).toContain(`export HTTPS_PROXY='http://127.0.0.1:${port}'`)
     // And the respawn triggered by the same push inherits it — a catalog change
     // is respawn-required, so this is the path opencode itself takes.
-    expect(proxyAtReload).toEqual([`http://127.0.0.1:${PORT}`])
+    expect(proxyAtReload).toEqual([`http://127.0.0.1:${port}`])
   })
 
   it('withdrawing the last boundary secret stops the listener and stops exporting the proxy', async () => {
@@ -240,8 +262,11 @@ describe('env route — mid-session boundary rules arm the shim', () => {
   })
 
   it('a listener that cannot bind still lets the rest of the env push land', async () => {
+    // The squatter binds first and OWNS the port the shim is pointed at, so
+    // the collision is deterministic instead of racing another process for it.
     squatter = net.createServer()
-    await new Promise<void>((resolve) => squatter!.listen(PORT, '127.0.0.1', () => resolve()))
+    await new Promise<void>((resolve) => squatter!.listen(0, '127.0.0.1', () => resolve()))
+    process.env.KORTIX_EGRESS_SHIM_PORT = String((squatter.address() as net.AddressInfo).port)
 
     const { opencode } = fakeOpencode()
     const { app } = buildTestApp(opencode)

--- a/apps/kortix-sandbox-agent-server/src/egress-shim/index.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/egress-shim/index.test.ts
@@ -22,17 +22,33 @@ import {
   syncEgressShim,
 } from './index'
 
-/** Well clear of the daemon's own 4319/4320/4321 block. */
-const PORT = 45321
-
 interface TestRule {
   identifier: string
   hosts: string[]
 }
 
-function sessionEnv(rules: TestRule[]): NodeJS.ProcessEnv {
+/**
+ * A fresh kernel-assigned port per test, never a fixed number. The CI packages
+ * lane can run this suite concurrently with — or right on the heels of —
+ * another run on the same runner, and two processes sharing one fixed port
+ * turn every "nothing listens here" assertion and the stop-then-rebind cycle
+ * into flakes. The ephemeral range is also inherently clear of the daemon's
+ * own 4319/4320/4321 block.
+ */
+function ephemeralPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = net.createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address() as net.AddressInfo
+      probe.close(() => resolve(port))
+    })
+  })
+}
+
+function sessionEnv(port: number, rules: TestRule[]): NodeJS.ProcessEnv {
   return {
-    KORTIX_EGRESS_SHIM_PORT: String(PORT),
+    KORTIX_EGRESS_SHIM_PORT: String(port),
     KORTIX_API_URL: 'https://api.kortix.test/v1',
     KORTIX_PROJECT_ID: 'proj-sync',
     KORTIX_TOKEN: 'kortix_pat_sync',
@@ -71,37 +87,40 @@ afterEach(async () => {
 
 describe('syncEgressShim', () => {
   test('a session that never had boundary rules and still has none arms nothing', async () => {
-    const result = await syncEgressShim(sessionEnv([]))
+    const port = await ephemeralPort()
+    const result = await syncEgressShim(sessionEnv(port, []))
 
     expect(result.outcome).toBe('unchanged')
     expect(egressShimEnv()).toEqual({})
-    expect(await isListening(PORT)).toBe(false)
+    expect(await isListening(port)).toBe(false)
   })
 
   test("the session's first boundary secret starts a listener mid-flight", async () => {
+    const port = await ephemeralPort()
     const result = await syncEgressShim(
-      sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
+      sessionEnv(port, [{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
     )
 
     expect(result.outcome).toBe('started')
     expect(result.hosts).toEqual(['api.weather.test'])
-    expect(egressShimEnv().HTTPS_PROXY).toBe(`http://127.0.0.1:${PORT}`)
-    expect(await isListening(PORT)).toBe(true)
+    expect(egressShimEnv().HTTPS_PROXY).toBe(`http://127.0.0.1:${port}`)
+    expect(await isListening(port)).toBe(true)
   })
 
   test('re-pushing the same rules leaves the running listener untouched', async () => {
+    const port = await ephemeralPort()
     const rules = [
       { identifier: 'WEATHER_API', hosts: ['api.weather.test', 'cdn.weather.test'] },
       { identifier: 'PAY_KEY', hosts: ['api.pay.test'] },
     ]
-    expect((await syncEgressShim(sessionEnv(rules))).outcome).toBe('started')
+    expect((await syncEgressShim(sessionEnv(port, rules))).outcome).toBe('started')
     const armed = egressShimEnv()
 
     // Same rule set, re-ordered — the fan-out that carries the catalog fires on
     // every secret-CRUD push, not only the ones that move a boundary rule. A
     // restart here would drop the agent's in-flight tunnels for nothing.
     const result = await syncEgressShim(
-      sessionEnv([
+      sessionEnv(port, [
         { identifier: 'PAY_KEY', hosts: ['api.pay.test'] },
         { identifier: 'WEATHER_API', hosts: ['cdn.weather.test', 'api.weather.test'] },
       ]),
@@ -111,45 +130,58 @@ describe('syncEgressShim', () => {
     // Identity, not equality: a restart mints a new env object even when the
     // port and the paths come out the same.
     expect(egressShimEnv()).toBe(armed)
-    expect(await isListening(PORT)).toBe(true)
+    expect(await isListening(port)).toBe(true)
   })
 
   test('widening a rule restarts the listener', async () => {
+    const port = await ephemeralPort()
     expect(
-      (await syncEgressShim(sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }])))
-        .outcome,
+      (
+        await syncEgressShim(
+          sessionEnv(port, [{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
+        )
+      ).outcome,
     ).toBe('started')
 
     const result = await syncEgressShim(
-      sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test', 'cdn.weather.test'] }]),
+      sessionEnv(port, [
+        { identifier: 'WEATHER_API', hosts: ['api.weather.test', 'cdn.weather.test'] },
+      ]),
     )
 
     expect(result.outcome).toBe('restarted')
     expect([...result.hosts].sort()).toEqual(['api.weather.test', 'cdn.weather.test'])
-    expect(await isListening(PORT)).toBe(true)
+    expect(await isListening(port)).toBe(true)
   })
 
   test('withdrawing the last boundary secret stops the listener and clears the proxy env', async () => {
+    const port = await ephemeralPort()
     expect(
-      (await syncEgressShim(sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }])))
-        .outcome,
+      (
+        await syncEgressShim(
+          sessionEnv(port, [{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
+        )
+      ).outcome,
     ).toBe('started')
 
-    const result = await syncEgressShim(sessionEnv([]))
+    const result = await syncEgressShim(sessionEnv(port, []))
 
     expect(result.outcome).toBe('stopped')
     // Leaving HTTPS_PROXY exported at a dead listener is worse than never
     // arming one: every HTTPS call the agent makes would fail to connect.
     expect(egressShimEnv()).toEqual({})
-    expect(await isListening(PORT)).toBe(false)
+    expect(await isListening(port)).toBe(false)
   })
 
   test('a listener that cannot bind reports failure instead of throwing', async () => {
+    // The squatter binds first and OWNS the port the shim is pointed at, so
+    // the collision is deterministic instead of racing another process for it.
     squatter = net.createServer()
-    await new Promise<void>((resolve) => squatter!.listen(PORT, '127.0.0.1', () => resolve()))
+    await new Promise<void>((resolve) => squatter!.listen(0, '127.0.0.1', () => resolve()))
+    const port = (squatter.address() as net.AddressInfo).port
 
     const result = await syncEgressShim(
-      sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
+      sessionEnv(port, [{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }]),
     )
 
     expect(result.outcome).toBe('failed')
@@ -161,13 +193,14 @@ describe('syncEgressShim', () => {
     // Fails closed, same as boot: no CLI token means nothing can spend the
     // secret, so a listener would accept the connection and then have nothing
     // to relay with.
-    const env = sessionEnv([{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }])
+    const port = await ephemeralPort()
+    const env = sessionEnv(port, [{ identifier: 'WEATHER_API', hosts: ['api.weather.test'] }])
     delete env.KORTIX_TOKEN
 
     const result = await syncEgressShim(env)
 
     expect(result.outcome).toBe('unchanged')
     expect(egressShimEnv()).toEqual({})
-    expect(await isListening(PORT)).toBe(false)
+    expect(await isListening(port)).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

\`apps/kortix-sandbox-agent-server/src/egress-shim/index.test.ts\` fails intermittently in the CI packages lane — always the same 4 tests — while passing locally 7/7. The suite hardcodes \`PORT = 45321\` (and \`env-route-egress-shim.test.ts\` hardcodes \`45322\`), so a concurrent or back-to-back lane run on the same runner that holds the port breaks every collision-sensitive test:

- \`widening a rule restarts the listener\` — rebind of the fixed port fails
- \`withdrawing the last boundary secret stops the listener\` — asserts nothing listens; the other process does
- \`a listener that cannot bind reports failure\` — the squatter itself cannot bind
- \`a session missing the credential the broker needs does not arm\` — asserts nothing listens; the other process does

Reproduced locally: two parallel \`bun test src/egress-shim/index.test.ts\` shells → one shell fails exactly those 4 tests.

## Fix

Test-only. Production code (\`egressShimPort\`, \`startEgressShim\`) is unchanged.

- Each test allocates a fresh kernel-assigned port (\`listen(0)\` on a probe, read it back, release it) and injects it via \`KORTIX_EGRESS_SHIM_PORT\`.
- The two squatter tests bind port 0 directly and point the shim at the port they OWN, so the bind collision is deterministic rather than a race.
- Same fix applied to \`src/__tests__/env-route-egress-shim.test.ts\`, which had the identical fixed-port pattern.
- \`shim.test.ts\` and \`ca.test.ts\` already use \`listen(0)\` + read-back; no change.

## Verification

- Pre-fix: 2 parallel shells → 4 fail / 3 pass in one shell (the exact CI set).
- Post-fix: 3 rounds × 2 parallel shells of both suites → 11 pass / 0 fail, exit 0, every round.
- \`bun tsc --noEmit\` — exit 0.
- Full daemon package \`bun test\` — 1107 pass, 0 fail across 91 files (95s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790432276&installation_model_id=434224&pr_number=6969&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6969&signature=1c0255980c7d48ae44d5128857b7498d50bba9d29ae51e4f4dee5fc241fe8156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->