### PR TITLE
Fix working status order and elapsed timer

### DIFF
--- a/apps/web/src/features/session/session-chat-working-projection.test.ts
+++ b/apps/web/src/features/session/session-chat-working-projection.test.ts
@@ -44,13 +44,20 @@ describe('the composer reads ONE working answer', () => {
     expect(chat).not.toContain('30_000');
   });
 
-  test('the send receipt is taken before the row is created and dropped if it never lands', () => {
-    const send = between(chat, 'const clientMessageId = overrides?.clientMessageId', 'return messageID;');
-    expect(send).toContain('noteSendReceipt(clientMessageId)');
+  test('the send receipt names the same wire message as the optimistic turn', () => {
+    const send = between(
+      chat,
+      'const clientMessageId = overrides?.clientMessageId',
+      'return messageID;',
+    );
+    expect(send).toContain('noteSendReceipt(messageID)');
     // Acceptance is what lets a `/turn` read answer for the send AT ALL: until
     // `POST .../prompts` returns there is no row for it to see.
-    expect(send).toContain('acceptSendReceipt(clientMessageId)');
-    expect(send).toContain('clearSendReceipt(clientMessageId)');
+    expect(send).toContain('acceptSendReceipt(messageID)');
+    expect(send).toContain('clearSendReceipt(messageID)');
+    expect(send).not.toContain('noteSendReceipt(clientMessageId)');
+    expect(send).not.toContain('acceptSendReceipt(clientMessageId)');
+    expect(send).not.toContain('clearSendReceipt(clientMessageId)');
   });
 
   test('the receipt is dropped on every path where nothing is coming', () => {
@@ -76,7 +83,11 @@ describe('the composer reads ONE working answer', () => {
     // full-prompt stash is POSTed to the inbox rather than dropped.
     expect(chat).not.toContain('replayStartStash');
     expect(chat).not.toContain('optimisticPrompt');
-    const seeding = between(chat, 'const stash = readStartStash(sessionId);', '}, [sessionId, projectId, projectSessionId]);');
+    const seeding = between(
+      chat,
+      'const stash = readStartStash(sessionId);',
+      '}, [sessionId, projectId, projectSessionId]);',
+    );
     expect(seeding).toContain('clearStartStash(sessionId)');
     expect(seeding).toContain('startSessionWithPrompt(projectId, projectSessionId');
   });
@@ -86,7 +97,11 @@ describe('the composer reads ONE working answer', () => {
     // through the inbox — so for a full minute after every `/compact` the
     // control plane's own "no turns" answer was discarded. The old machine this
     // replaced released at 30s; unaccepted, this was twice that.
-    const command = between(chat, 'const handleCommand = useCallback(', 'setTimeout(() => scrollToBottom()');
+    const command = between(
+      chat,
+      'const handleCommand = useCallback(',
+      'setTimeout(() => scrollToBottom()',
+    );
     expect(command).toContain('noteSendReceipt(label)');
     expect(command).toContain('acceptSendReceipt(label)');
     expect(command).toContain('clearSendReceipt(label)');
@@ -96,8 +111,12 @@ describe('the composer reads ONE working answer', () => {
     // `clearSendReceipt` is keyed by session, so an unguarded clear from an
     // older send's failure deleted a NEWER send's receipt while its POST was
     // still on the wire.
-    const send = between(chat, 'const clientMessageId = overrides?.clientMessageId', 'return messageID;');
-    expect(send).toContain('clearSendReceipt(clientMessageId)');
+    const send = between(
+      chat,
+      'const clientMessageId = overrides?.clientMessageId',
+      'return messageID;',
+    );
+    expect(send).toContain('clearSendReceipt(messageID)');
   });
 
   test('the stop is a receipt of its own, settled by the cancel it issues', () => {
@@ -173,7 +192,9 @@ describe('the turn card reads the same working answer', () => {
     expect(chat).toContain('resolveLastTurnWorking({');
     expect(chat).toContain('isChildSession');
     expect(chat).toContain('sessionWorking={lastTurnWorking}');
-    expect(chat).toContain('resolveWorkingTurn({ turns, hintMessageId: working.turnId, unrunTurnIds })');
+    expect(chat).toContain(
+      'resolveWorkingTurn({ turns, hintMessageId: working.turnId, unrunTurnIds })',
+    );
   });
 
   test('retry copy keeps the raw frame — the projection does not carry the reason', () => {
@@ -196,7 +217,11 @@ describe('the turn card reads the same working answer', () => {
     // A deduped re-POST of a clientMessageId whose row already dead-lettered
     // answers 200 with state 'failed'. Discarding the result accepted the
     // receipt, cleared the draft, and told the user nothing.
-    const send = between(chat, 'const created = await promptInbox.enqueue({', 'return { ok: true }');
+    const send = between(
+      chat,
+      'const created = await promptInbox.enqueue({',
+      'return { ok: true }',
+    );
     expect(send).toContain("created.state === 'failed'");
     // No after-the-fact bubble for a prompt sent while a turn is live: the
     // server HOLDS it (one prompt = one turn), so it belongs in the strip

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -62,6 +62,7 @@ import {
 } from './turn/queued-prompt-bubbles';
 import { segmentTurn } from './turn/segment-turn';
 import { stabilizeTurns } from './turn/stable-turns';
+import { statusElapsedFrame } from './turn/status-elapsed';
 import { ThrottledMarkdown } from './turn/throttled-markdown';
 import { TurnViewport } from './turn/turn-viewport';
 import { UserMessage } from './turn/user-message';
@@ -234,13 +235,13 @@ import {
   sessionComposerReadiness,
 } from './session-composer-readiness';
 import { captureTurnScrollAnchor, restoreTurnScrollAnchor } from './session-history-scroll';
-import { useHeldOlderLoading } from './session-older-loading';
 import { resolveSessionContentState } from './session-load-state';
 import {
   nextOlderAutoloadArm,
   olderAutoloadExhausted,
   shouldLoadOlderHistory,
 } from './session-older-autoload';
+import { useHeldOlderLoading } from './session-older-loading';
 import { useReadinessSettling } from './use-readiness-settling';
 
 // ============================================================================
@@ -1300,17 +1301,31 @@ function SessionTurnImpl({
   // How long the status has read the same thing. Past STATUS_STALL_AFTER_MS
   // the label carries the elapsed time, so a slow model step or a long tool
   // call reads as "still working, this long" instead of a frozen screen.
-  const [statusSinceMs, setStatusSinceMs] = useState(() => Date.now());
-  const [statusElapsedMs, setStatusElapsedMs] = useState(0);
+  const [statusElapsedState, setStatusElapsedState] = useState(() =>
+    statusElapsedFrame(undefined, {
+      status: throttledStatus,
+      working,
+      nowMs: Date.now(),
+    }),
+  );
+  const statusElapsedMs =
+    statusElapsedState.status === throttledStatus && statusElapsedState.working === working
+      ? statusElapsedState.elapsedMs
+      : 0;
   useEffect(() => {
-    setStatusSinceMs(Date.now());
-    setStatusElapsedMs(0);
-  }, [throttledStatus]);
-  useEffect(() => {
+    const update = () =>
+      setStatusElapsedState((previous) =>
+        statusElapsedFrame(previous, {
+          status: throttledStatus,
+          working,
+          nowMs: Date.now(),
+        }),
+      );
+    update();
     if (!working) return;
-    const timer = setInterval(() => setStatusElapsedMs(Date.now() - statusSinceMs), 1000);
+    const timer = setInterval(update, 1000);
     return () => clearInterval(timer);
-  }, [working, statusSinceMs]);
+  }, [working, throttledStatus]);
   /** The phrase alone — never the elapsed time. Folding the ticking duration in
    *  here changed the busy indicator's animation key once a second, which
    *  replayed its roll-swap forever during any long tool call. */
@@ -2779,8 +2794,7 @@ export function SessionChat({
   // user can always see while the queue is stopped. A FAILED row is not paused
   // by the hold, so it does not count.
   const heldQueueCount = useMemo(
-    () =>
-      promptInbox.prompts.filter((p) => p.reason === 'held' && p.state !== 'failed').length,
+    () => promptInbox.prompts.filter((p) => p.reason === 'held' && p.state !== 'failed').length,
     [promptInbox.prompts],
   );
 
@@ -3793,12 +3807,11 @@ export function SessionChat({
       // The WIRE id is minted here, by the SDK, and never by the control plane:
       // OpenCode resolves "has this prompt already been answered?" by id ORDER,
       // and only this process holds the transcript to place one against. It is
-      // NOT `messageID` above — that is `ascendingId`, which encodes the wrong
-      // bits and is optimistic-render-only (see the SDK's warning on it).
+      // `messageID` above. `clientMessageId` is only the inbox idempotency key.
       // The prompt is out of this tab's hands the moment the row lands, so the
       // receipt is taken BEFORE the POST: it is what holds the composer on
       // "working" until `GET .../turn` reports the turn the inbox admitted.
-      noteSendReceipt(clientMessageId);
+      noteSendReceipt(messageID);
       const result = await (async () => {
         try {
           if (!projectId || !projectSessionId) {
@@ -3837,7 +3850,7 @@ export function SessionChat({
           // for it. `useSessionPrompts` raises the inbox floor at the same
           // moment, which is what covers the window before the row is
           // delivered and becomes a turn.
-          acceptSendReceipt(clientMessageId);
+          acceptSendReceipt(messageID);
           return { ok: true } as const;
         } catch (cause) {
           // Ask the INBOX, not the runtime. This prompt's home is a durable
@@ -3873,7 +3886,7 @@ export function SessionChat({
         // own. This clear is still right in the moment — as far as this tab
         // knows right now, nothing is coming — and it is NAMED, so it can only
         // ever drop this send's own receipt.
-        clearSendReceipt(clientMessageId);
+        clearSendReceipt(messageID);
         setCommandError(result.error);
         throw result.cause instanceof Error ? result.cause : new Error(result.error.message);
       }
@@ -4579,7 +4592,8 @@ export function SessionChat({
             <div className="text-muted-foreground flex min-w-0 items-center gap-2 text-sm">
               <PauseIcon weight="fill" className="size-4 shrink-0" />
               <span className="truncate">
-                Queue paused — {heldQueueCount} {heldQueueCount === 1 ? 'prompt' : 'prompts'} waiting
+                Queue paused — {heldQueueCount} {heldQueueCount === 1 ? 'prompt' : 'prompts'}{' '}
+                waiting
               </span>
             </div>
             <Button
@@ -4811,9 +4825,7 @@ export function SessionChat({
             className="flex flex-1 flex-col items-center justify-center gap-3 p-6"
             data-testid="session-transcript-error"
           >
-            <p className="text-muted-foreground text-sm">
-              Couldn&apos;t load this conversation.
-            </p>
+            <p className="text-muted-foreground text-sm">Couldn&apos;t load this conversation.</p>
             <Button variant="outline" size="sm" onClick={() => retryTranscript()}>
               Retry
             </Button>
@@ -4965,7 +4977,9 @@ export function SessionChat({
                       {/* Sentinel: crossing into view pulls the previous page.
                         Sits above the spinner so it clears the viewport as
                         soon as the prepended turns render. */}
-                      {hasOlder && <div ref={olderSentinelRef} aria-hidden className="h-px w-full" />}
+                      {hasOlder && (
+                        <div ref={olderSentinelRef} aria-hidden className="h-px w-full" />
+                      )}
                       {/* A named state, not a bare spinner: the transcript is
                           about to grow upward and the reader is owed the
                           reason. Held for OLDER_LOADING_MIN_MS so a fast pull
@@ -5048,8 +5062,7 @@ export function SessionChat({
                       const compaction = compactionTurnInfo(turn);
                       const hasCompaction = compaction.isCompaction;
                       const isTurnWorking =
-                        lastTurnWorking &&
-                        turn.userMessage.info.id === workingTurn.workingTurnId;
+                        lastTurnWorking && turn.userMessage.info.id === workingTurn.workingTurnId;
                       // `inFlight` (message state) alongside the projection:
                       // classifying by projection alone flipped a streaming
                       // compaction to "failed" for the frames where the two
@@ -5097,9 +5110,7 @@ export function SessionChat({
                               ? ''
                               : lastTurnWorking &&
                                   pendingTurnIds.has(turn.userMessage.info.id) &&
-                                  pendingTurnIds.has(
-                                    turns[turnIndex - 1].userMessage.info.id,
-                                  )
+                                  pendingTurnIds.has(turns[turnIndex - 1].userMessage.info.id)
                                 ? 'mt-3'
                                 : 'mt-12'
                           }
@@ -5108,57 +5119,59 @@ export function SessionChat({
                               CompactionMarker rendered by SessionTurn IS the
                               divider (rule–pill–rule), through every phase. */}
                           {suppressedFailedCompaction ? null : (
-                          <SessionTurn
-                            turn={turn}
-                            isLast={turn.userMessage.info.id === lastUserMessageId}
-                            ownsPlan={turn.userMessage.info.id === planAnchorId}
-                            sessionId={sessionId}
-                            sessionStatus={sessionStatus}
-                            permissions={pendingPermissions}
-                            questions={pendingQuestions}
-                            agentNames={agentNames}
-                            isFirstTurn={turnIndex === 0}
-                            sessionWorking={lastTurnWorking}
-                            isWorkingTurn={turn.userMessage.info.id === workingTurn.workingTurnId}
-                            pending={
-                              lastTurnWorking && pendingTurnIds.has(turn.userMessage.info.id)
-                            }
-                            queueRow={inboxRowsByMessageId.get(turn.userMessage.info.id) ?? null}
-                            queueHeld={queueRows.held}
-                            onQueueRemove={handleRemoveQueuedMessage}
-                            onQueueSendNow={handleQueueSendNow}
-                            onQueueRetry={handleRetryQueuedMessage}
-                            interruptedBeforeRun={interruptedTurnIds.has(turn.userMessage.info.id)}
-                            isCompaction={hasCompaction}
-                            onOpenCompactionSummary={
-                              panel ? handleOpenCompactionSummary : undefined
-                            }
-                            providers={providers}
-                            commandMessages={commandMessagesRef.current}
-                            commands={commands}
-                            disableToolNavigation={disableToolNavigation}
-                            onPermissionReply={handlePermissionReply}
-                            onRewind={handleRewind}
-                            editingText={
-                              rewindTarget?.messageId === turn.userMessage.info.id
-                                ? rewindTarget.text
-                                : null
-                            }
-                            editPending={editSendPending || !!sessionState?.rewindPending}
-                            onEditCancel={handleEditCancel}
-                            onEditSend={handleEditSend}
-                            rewindDisabled={
-                              !!readOnly ||
-                              !sessionState ||
-                              isBusy ||
-                              sessionState.rewindPending ||
-                              // The runtime is not idle while queued prompts
-                              // are still on their way to it — a rewind mid-
-                              // delivery fails downstream with "Session is
-                              // busy" (measured); refuse it up front instead.
-                              promptInbox.prompts.length > 0
-                            }
-                          />
+                            <SessionTurn
+                              turn={turn}
+                              isLast={turn.userMessage.info.id === lastUserMessageId}
+                              ownsPlan={turn.userMessage.info.id === planAnchorId}
+                              sessionId={sessionId}
+                              sessionStatus={sessionStatus}
+                              permissions={pendingPermissions}
+                              questions={pendingQuestions}
+                              agentNames={agentNames}
+                              isFirstTurn={turnIndex === 0}
+                              sessionWorking={lastTurnWorking}
+                              isWorkingTurn={turn.userMessage.info.id === workingTurn.workingTurnId}
+                              pending={
+                                lastTurnWorking && pendingTurnIds.has(turn.userMessage.info.id)
+                              }
+                              queueRow={inboxRowsByMessageId.get(turn.userMessage.info.id) ?? null}
+                              queueHeld={queueRows.held}
+                              onQueueRemove={handleRemoveQueuedMessage}
+                              onQueueSendNow={handleQueueSendNow}
+                              onQueueRetry={handleRetryQueuedMessage}
+                              interruptedBeforeRun={interruptedTurnIds.has(
+                                turn.userMessage.info.id,
+                              )}
+                              isCompaction={hasCompaction}
+                              onOpenCompactionSummary={
+                                panel ? handleOpenCompactionSummary : undefined
+                              }
+                              providers={providers}
+                              commandMessages={commandMessagesRef.current}
+                              commands={commands}
+                              disableToolNavigation={disableToolNavigation}
+                              onPermissionReply={handlePermissionReply}
+                              onRewind={handleRewind}
+                              editingText={
+                                rewindTarget?.messageId === turn.userMessage.info.id
+                                  ? rewindTarget.text
+                                  : null
+                              }
+                              editPending={editSendPending || !!sessionState?.rewindPending}
+                              onEditCancel={handleEditCancel}
+                              onEditSend={handleEditSend}
+                              rewindDisabled={
+                                !!readOnly ||
+                                !sessionState ||
+                                isBusy ||
+                                sessionState.rewindPending ||
+                                // The runtime is not idle while queued prompts
+                                // are still on their way to it — a rewind mid-
+                                // delivery fails downstream with "Session is
+                                // busy" (measured); refuse it up front instead.
+                                promptInbox.prompts.length > 0
+                              }
+                            />
                           )}
                         </TurnViewport>
                       );

--- a/apps/web/src/features/session/turn/status-elapsed.test.ts
+++ b/apps/web/src/features/session/turn/status-elapsed.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { statusElapsedFrame } from './status-elapsed';
+
+describe('statusElapsedFrame', () => {
+  test('starts at zero when the same status becomes active again', () => {
+    const result = statusElapsedFrame(
+      {
+        status: 'Gathering thoughts',
+        working: false,
+        startedAtMs: 1_000,
+        elapsedMs: 0,
+      },
+      {
+        status: 'Gathering thoughts',
+        working: true,
+        nowMs: 2_401_000,
+      },
+    );
+
+    expect(result).toEqual({
+      status: 'Gathering thoughts',
+      working: true,
+      startedAtMs: 2_401_000,
+      elapsedMs: 0,
+    });
+  });
+
+  test('measures only the current active interval', () => {
+    const result = statusElapsedFrame(
+      {
+        status: 'Gathering thoughts',
+        working: true,
+        startedAtMs: 2_401_000,
+        elapsedMs: 0,
+      },
+      {
+        status: 'Gathering thoughts',
+        working: true,
+        nowMs: 2_426_000,
+      },
+    );
+
+    expect(result.elapsedMs).toBe(25_000);
+    expect(result.startedAtMs).toBe(2_401_000);
+  });
+
+  test('resets when the status text changes', () => {
+    const result = statusElapsedFrame(
+      {
+        status: 'Gathering thoughts',
+        working: true,
+        startedAtMs: 2_401_000,
+        elapsedMs: 25_000,
+      },
+      {
+        status: 'Reading files',
+        working: true,
+        nowMs: 2_426_000,
+      },
+    );
+
+    expect(result.elapsedMs).toBe(0);
+    expect(result.startedAtMs).toBe(2_426_000);
+  });
+
+  test('stops and clears elapsed time when the turn becomes inactive', () => {
+    const result = statusElapsedFrame(
+      {
+        status: 'Gathering thoughts',
+        working: true,
+        startedAtMs: 2_401_000,
+        elapsedMs: 25_000,
+      },
+      {
+        status: 'Gathering thoughts',
+        working: false,
+        nowMs: 2_426_000,
+      },
+    );
+
+    expect(result.elapsedMs).toBe(0);
+    expect(result.working).toBe(false);
+  });
+});

--- a/apps/web/src/features/session/turn/status-elapsed.ts
+++ b/apps/web/src/features/session/turn/status-elapsed.ts
@@ -1,0 +1,31 @@
+export interface StatusElapsedState {
+  status: string;
+  working: boolean;
+  startedAtMs: number;
+  elapsedMs: number;
+}
+
+export interface StatusElapsedInput {
+  status: string;
+  working: boolean;
+  nowMs: number;
+}
+
+export function statusElapsedFrame(
+  previous: StatusElapsedState | undefined,
+  input: StatusElapsedInput,
+): StatusElapsedState {
+  if (!previous || previous.status !== input.status || previous.working !== input.working) {
+    return {
+      status: input.status,
+      working: input.working,
+      startedAtMs: input.nowMs,
+      elapsedMs: 0,
+    };
+  }
+
+  return {
+    ...previous,
+    elapsedMs: input.working ? Math.max(0, input.nowMs - previous.startedAtMs) : 0,
+  };
+}


### PR DESCRIPTION
## Problem

A direct prompt used `clientMessageId` for its working receipt but rendered its optimistic turn with `messageID`. The working projection could not match the fresh prompt. It selected stale incomplete assistant metadata instead. This rendered the working status above the new prompt and made the new prompt appear queued.

The elapsed-status clock also preserved its timestamp when a turn became inactive and active with the same status text. This could display elapsed values from a previous turn.

## Change

- Name direct-send receipts with the rendered wire `messageID`.
- Reset elapsed status time on both status-text and working-state transitions.
- Add regression coverage for receipt wiring and elapsed-clock transitions.

## Verification

- `bun test apps/web/src/features/session` — 2,666 pass, 0 fail.
- `pnpm exec tsc --noEmit --pretty false` — 0 errors.
- `pnpm exec eslint <changed files>` — 0 errors; 30 existing warnings in `session-chat.tsx`; no new warning in changed lines.
- `pnpm exec prettier --check <changed files>` — pass.
- Chrome regression page: new-message bottom 217.25px; working-status top 246.6875px; elapsed 0ms. The temporary page was removed before commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790432489&installation_model_id=434224&pr_number=6970&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6970&signature=bb0fe270338c846f2e581f05c8277bf6bd8cebfb15d754fc98df7ddd5517703a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->