### PR TITLE
fix(web): the markdown source toggle, and the oversized SVG thumbnail

### DIFF
--- a/apps/web/src/app/(system)/debug/file-preview/harness.tsx
+++ b/apps/web/src/app/(system)/debug/file-preview/harness.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { FilePreviewModal, type FileSource } from '@/features/file-viewer';
+import { FileExplorerSourceProvider } from '@/features/project-files/explorer-source';
+import { FileThumbnail } from '@/features/project-files/components/file-thumbnail';
+import { useState } from 'react';
+
+/**
+ * The harness body. Loaded with `ssr: false` by `page.tsx` because
+ * `FilePreviewModal` portals to `document.body`, which does not exist on the
+ * server.
+ */
+
+const MD = `---
+description: Generic Kortix general knowledge worker. Hands-on, full tool
+mode: primary
+permission: allow
+---
+
+You are a **Kortix general knowledge worker** for kaab-demo.
+
+- one
+- two
+`;
+
+const YAML = `kortix_version: 2\ndefault_agent: kortix\nproject:\n  name: kaab-demo\n  description: A Kortix project.\nenv:\n  required: []\n`;
+
+const SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="2000" viewBox="0 0 1600 2000"><rect width="1600" height="2000" fill="#111"/></svg>\n`;
+
+const FILES: Record<string, string> = { 'kortix.md': MD, 'kortix.yaml': YAML, 'brand.svg': SVG };
+const PATHS = Object.keys(FILES);
+
+const stubSource = {
+  useFileContent: (filePath: string) => ({
+    data: { type: 'text' as const, content: FILES[filePath] ?? '' },
+    isLoading: false,
+    error: null,
+    refetch: async () => undefined,
+  }),
+  useBinaryBlob: () => ({ blobUrl: null, blob: null, isLoading: false, error: null }),
+} as unknown as FileSource;
+
+export function DebugFilePreviewHarness() {
+  const [index, setIndex] = useState(0);
+
+  return (
+    <div className="bg-background min-h-screen p-6">
+      <p className="text-muted-foreground mb-4 text-xs">
+        Stub file source. Click the <code>&lt;/&gt;</code> toggle in the toolbar.
+      </p>
+      <FileExplorerSourceProvider value={{ useFileViewerSource: () => stubSource } as never}>
+        <div data-testid="thumbs" className="mb-6 flex gap-3">
+          {['brand.svg', 'kortix.yaml', 'kortix.md'].map((name) => (
+            <div key={name} data-thumb={name} className="w-[170px]">
+              <FileThumbnail filePath={name} fileName={name} className="h-[120px] border" />
+              <p className="text-muted-foreground mt-1 text-xs">{name}</p>
+            </div>
+          ))}
+        </div>
+      </FileExplorerSourceProvider>
+
+      <div data-testid="preview-host" className="relative h-[70vh] w-full overflow-hidden rounded-md border">
+        <FilePreviewModal
+          selectedFilePath={PATHS[index]}
+          panelMode="viewer"
+          filePathList={PATHS}
+          currentFileIndex={index}
+          onClose={() => undefined}
+          onNext={() => setIndex((i) => Math.min(i + 1, PATHS.length - 1))}
+          onPrev={() => setIndex((i) => Math.max(i - 1, 0))}
+          source={stubSource}
+          HistoryContent={() => null}
+          renderFileIcon={() => null}
+          embedded
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(system)/debug/file-preview/page.tsx
+++ b/apps/web/src/app/(system)/debug/file-preview/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+/**
+ * /debug/file-preview
+ *
+ * Visual harness for the shared file viewer with a STUB file source, so the
+ * markdown source/preview toggle and the thumbnail sizing can be exercised
+ * without a live sandbox, a project, or any API. Seeing either for real
+ * otherwise needs a running workspace with the right files in it.
+ *
+ * Not linked from anywhere; just hit /debug/file-preview.
+ */
+const DebugFilePreviewHarness = dynamic(
+  () => import('./harness').then((m) => m.DebugFilePreviewHarness),
+  { ssr: false },
+);
+
+export default function DebugFilePreviewPage() {
+  return <DebugFilePreviewHarness />;
+}

--- a/apps/web/src/features/file-viewer/file-content-renderer.tsx
+++ b/apps/web/src/features/file-viewer/file-content-renderer.tsx
@@ -442,16 +442,29 @@ export function FileContentRenderer({
     }
   }, [fileContent?.content]);
 
-  // Reset state when file changes — markdown defaults to rendered preview.
+  // Reset state when the FILE changes — markdown defaults to rendered preview.
+  //
+  // `setIsMarkdownPreview` MUST NOT be a dependency here, and this effect must
+  // not call it. That callback is memoized on the preview flag itself, so
+  // listing it made every toggle re-run this effect and force the flag back to
+  // `true` inside the same commit: the source/preview button flipped and
+  // snapped back, which reads as a dead button. It killed BOTH toggles — this
+  // component's own header button and `file-preview-modal`'s toolbar button,
+  // which drives the same state through `onMarkdownPreviewChange`.
+  //
+  // Only the internal (uncontrolled) flag is reset. A controlling parent owns
+  // its copy and resets it on the same file change — see
+  // `file-preview-modal.tsx`'s own `[selectedFilePath]` effect — so notifying
+  // it from here would be a second writer for one piece of state.
   useEffect(() => {
-    setIsMarkdownPreview(true);
+    setInternalMarkdownPreview(true);
     setIsJsonTreeView(false);
     setHasUnsavedChanges(false);
     setSaveFlash(false);
     // HTML files always default to preview mode
     setIsHtmlPreview(true);
     latestContentRef.current = '';
-  }, [filePath, setIsMarkdownPreview]);
+  }, [filePath]);
 
   // Notify parent of unsaved state changes
   useEffect(() => {

--- a/apps/web/src/features/file-viewer/markdown-preview-toggle.test.ts
+++ b/apps/web/src/features/file-viewer/markdown-preview-toggle.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * The markdown source/preview toggle was dead on every markdown file, on both
+ * surfaces that own it.
+ *
+ * `setIsMarkdownPreview` is memoized on the preview flag itself, so its
+ * identity changes every time the flag flips. The "reset when the file
+ * changes" effect listed that callback as a dependency AND called it, so a
+ * toggle re-ran the effect and forced the flag back to `true` inside the same
+ * commit. The button flipped and snapped back, which reads as a button that
+ * does nothing — in `file-content-renderer`'s own header and in
+ * `file-preview-modal`'s toolbar, which drives the same state through
+ * `onMarkdownPreviewChange`.
+ *
+ * Rendering this component in a test is not practical (it pulls next-intl,
+ * CodeMirror and a file source), so the invariant is pinned against the
+ * source, in the same style as `project-icon-field.test.tsx`.
+ */
+
+const source = readFileSync(
+  fileURLToPath(new URL('./file-content-renderer.tsx', import.meta.url)),
+  'utf8',
+);
+
+/** The `useEffect(...)` block whose body resets per-file view state. */
+function resetEffect(): string {
+  const start = source.indexOf('setInternalMarkdownPreview(true);');
+  expect(start).toBeGreaterThan(-1);
+  const open = source.lastIndexOf('useEffect(() => {', start);
+  expect(open).toBeGreaterThan(-1);
+  // The block ends at its dependency array, not at a `});` — the body has no
+  // nested call to close, so searching for `});` runs into the NEXT effect.
+  const close = source.indexOf('}, [', start);
+  expect(close).toBeGreaterThan(-1);
+  const end = source.indexOf(');', close);
+  return source.slice(open, end + 2);
+}
+
+describe('per-file reset effect', () => {
+  test('depends on the file path and nothing else', () => {
+    const deps = /\}, \[([^\]]*)\]\);?\s*$/.exec(resetEffect().trim())?.[1] ?? '';
+    const listed = deps
+      .split(',')
+      .map((d) => d.trim())
+      .filter(Boolean);
+
+    expect(listed).toEqual(['filePath']);
+  });
+
+  test('does not call the memoized setter, whose identity tracks the flag', () => {
+    // The whole failure: this callback is recreated on every flip, so calling
+    // it here — or listing it above — makes the reset chase the toggle.
+    expect(resetEffect()).not.toContain('setIsMarkdownPreview');
+  });
+
+  test('the setter really is memoized on the flag it would reset', () => {
+    // If this stops being true the guards above are merely harmless, not
+    // load-bearing — and this test should be revisited rather than deleted.
+    const memo = /const setIsMarkdownPreview = useCallback\([\s\S]*?\n {4}\[([^\]]*)\],/.exec(
+      source,
+    );
+    expect(memo).not.toBeNull();
+    expect(memo?.[1]).toContain('isMarkdownPreview');
+  });
+});

--- a/apps/web/src/features/project-files/components/file-thumbnail.test.ts
+++ b/apps/web/src/features/project-files/components/file-thumbnail.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { getFileCategory } from '@/features/file-viewer';
+
+/**
+ * A thumbnail sizes itself from what the renderer will actually PRODUCE, not
+ * from the file extension.
+ *
+ * An SVG is an `image` by extension but arrives as text, so
+ * `FileContentRenderer` draws its source — `imageDataUrl` only forms for
+ * base64 bytes with an `image/*` mime. The picture branch deliberately skips
+ * the thumbnail scale, because a picture fills its box on its own. An SVG
+ * therefore took the picture sizing and rendered `<svg xmlns="…" width="1600"`
+ * at full size inside a 120px card, while every other source file was a legible
+ * scaled preview.
+ */
+
+const source = readFileSync(
+  fileURLToPath(new URL('./file-thumbnail.tsx', import.meta.url)),
+  'utf8',
+);
+
+describe('thumbnail sizing', () => {
+  test('svg is still an image by category — that is why it needs the carve-out', () => {
+    expect(getFileCategory('brand.svg')).toBe('image');
+    expect(getFileCategory('brand.png')).toBe('image');
+  });
+
+  test('but svg is not sized as a picture', () => {
+    const predicate = /const rendersAsPicture = ([^;]+);/.exec(source)?.[1] ?? '';
+
+    expect(predicate).toContain("getFileCategory(fileName) === 'image'");
+    expect(predicate).toContain("!== 'svg'");
+  });
+
+  test('the picture branch is the one that skips the scale', () => {
+    // Pins the pairing: only `rendersAsPicture` may take the unscaled
+    // width/height sizing, so a file rendered as source always gets the scale.
+    expect(source).toContain('rendersAsPicture\n            ? { width: \'100%\', height: \'100%\' }');
+    expect(source).toContain(`transform: \`scale(\${THUMB_SCALE})\``);
+  });
+});

--- a/apps/web/src/features/project-files/components/file-thumbnail.tsx
+++ b/apps/web/src/features/project-files/components/file-thumbnail.tsx
@@ -24,13 +24,20 @@ const VIRTUAL_PCT = `${100 / THUMB_SCALE}%`;
  * rendered output reads as a zoomed-out thumbnail.
  */
 export function FileThumbnail({ filePath, fileName, className, deferPreview }: FileThumbnailProps) {
-  const isImage = getFileCategory(fileName) === 'image';
   const extLower = fileName.split('.').pop()?.toLowerCase() || '';
+  // An SVG is an `image` by extension but arrives as TEXT, so
+  // `FileContentRenderer` draws its SOURCE — `imageDataUrl` only forms for
+  // base64 bytes with an `image/*` mime (file-content-renderer.tsx:545). The
+  // image branch below deliberately skips the scale, because a picture fills
+  // its box on its own; source does not. An SVG therefore took the picture
+  // sizing and rendered `<svg xmlns="…" width="1600"` at full size inside a
+  // 120px card. It is a code preview, so it is scaled like one.
+  const rendersAsPicture = getFileCategory(fileName) === 'image' && extLower !== 'svg';
   const ext = fileName.includes('.') ? extLower.toUpperCase() : '';
   const extChalk = ext ? chalkColors(ext) : null;
 
   const extBadge =
-    ext && !isImage && extChalk ? (
+    ext && !rendersAsPicture && extChalk ? (
       <Badge
         variant="transparent"
         size="xs"
@@ -61,7 +68,7 @@ export function FileThumbnail({ filePath, fileName, className, deferPreview }: F
       <div
         className="pointer-events-none absolute top-0 left-0 origin-top-left select-none [&_*]:!cursor-default"
         style={
-          isImage
+          rendersAsPicture
             ? { width: '100%', height: '100%' }
             : {
                 transform: `scale(${THUMB_SCALE})`,


### PR DESCRIPTION
Two file-viewer defects, both reported from the session Files surface.

## 1. The `</>` toggle did nothing

The source/preview button was dead on **every markdown file**, on **both** surfaces that own it — `file-content-renderer`'s own header button and `file-preview-modal`'s toolbar button, which drives the same state through `onMarkdownPreviewChange`.

`setIsMarkdownPreview` is memoized on the preview flag itself, so its identity changes every time the flag flips. The "reset when the file changes" effect **listed that callback as a dependency and called it**:

```ts
useEffect(() => {
  setIsMarkdownPreview(true);   // ← forces it back
  …
}, [filePath, setIsMarkdownPreview]);   // ← re-runs on every flip
```

So a click flipped the flag, the callback was recreated, the effect re-ran, and the flag was forced back to `true` inside the same commit. The state changed and snapped back before paint, which is indistinguishable from a button with no handler.

The reset belongs to the **file** changing and nothing else. It now depends on `filePath` alone and resets only the internal (uncontrolled) flag — a controlling parent owns its own copy and already resets it on the same file change (`file-preview-modal`'s `[selectedFilePath]` effect), so notifying it from here was a second writer for one piece of state.

**Verified in a browser against the real component**, not by reading:

| | `aria-pressed` | CodeMirror mounted |
|---|---|---|
| initial | `false` | no |
| after 1st click | `true` | **yes** |
| after 2nd click | `false` | no |

Switching files still resets to preview (checked `kortix.md → kortix.yaml → kortix.md`).

Diagnosis note worth keeping: `Expand` and `History` — same toolbar, same `Hint`+`Button` pattern, same component's local state — worked fine, which is what ruled out event handling and pointed at the one piece of state with a second writer.

## 2. The SVG thumbnail rendered at full size

An SVG tile showed `<svg xmlns="…" width="1600"` in huge type inside a 120px card, while `kortix.yaml` beside it was a legible scaled preview.

`FileThumbnail` sized from the **extension**: `getFileCategory('x.svg')` is `'image'`, and the image branch deliberately skips the scale because a picture fills its box on its own. But an SVG arrives as **text**, so `FileContentRenderer` draws its source — `imageDataUrl` only forms for base64 bytes with an `image/*` mime. The tile asked for picture sizing and got source content.

The predicate now says what it means — `rendersAsPicture`, which excludes svg — so an SVG takes the scale like the code preview it is, and gains the ext badge every other non-picture file already had.

**Measured in a browser:** the svg tile now reports `scale(0.28)` and a 3.92px effective font, identical to the `kortix.yaml` tile beside it. Before: `transform: none` at 14px.

## Tests

Both components are awkward to render in `bun:test` (next-intl, CodeMirror, a file source), so the invariants are pinned against the source in the same style as `project-icon-field.test.tsx`.

`markdown-preview-toggle.test.ts` is **falsifiable** — 2 of its 3 cases go red against the pre-fix source. It pins the dependency array, pins that the effect does not call the memoized setter, and asserts the setter really is memoized on the flag (so the first two guards stay load-bearing rather than becoming decorative).

## `/debug/file-preview`

Both defects were invisible to the suite and awkward to reach by hand — seeing the file viewer for real needs a running workspace with the right files in it. The harness mounts the **real** `FilePreviewModal` and the **real** `FileThumbnail` against a stub file source, with a markdown file, a yaml file and an svg: the three cases that separate a rendered preview, a scaled source preview, and a picture. Mirrors the existing `/debug/permissions`.

## Gates

- `apps/web` file-viewer + project-files suites: **97 pass / 0 fail**
- `tsc --noEmit`: clean (pre-existing known failures excluded)
- `eslint`: clean on every touched file, no new warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790433099&installation_model_id=434224&pr_number=6971&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6971&signature=f197b4728dfda6ddeb09aad9df9b5eb2c9405bbe6a5b15ebe62b9101a869b495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->