### PR TITLE
feat(kortixd): daemon single-binary management CLI + safe self-update/rollback

### DIFF
--- a/DONE-KORTIXD.md
+++ b/DONE-KORTIXD.md
@@ -1,0 +1,201 @@
+# kortixd — build report
+
+Turn the sandbox agent server into a clean, installable, self-updating single
+binary named `kortixd`, with a management CLI, safe atomic updates, and
+auto-rollback on a failed update.
+
+Branch: `kortixd-daemon-app` (off `origin/main` @ `46cf3e9c87`). Committed, not
+pushed, no PR — the coordinator reviews + ships.
+
+Shippable: **YES** for Phases 1 + 2 (the functional core). Phase 3 done as a
+**safe, non-breaking subset** — product/package identity renamed to `kortixd`;
+the load-bearing on-disk artifact + directory names deliberately kept as a
+documented compatibility contract (rationale below). No fleet-risking rename was
+performed.
+
+---
+
+## What each phase added
+
+### Phase 1 — the `kortixd` management CLI
+New file `apps/kortix-sandbox-agent-server/src/cli.ts` (772 LOC). Wired into the
+existing subcommand dispatch in `src/main.ts` (+19 lines: one import, one
+`else if (isManagementSubcommand(...))` branch). The default path and the two
+pre-existing subcommands (`git-credential`, `install-compiled-runtime`) are
+untouched. Subcommands:
+
+- `kortixd` / `kortixd serve` → run the daemon exactly as today (unchanged).
+- `kortixd version` → prints `kortixd <pkg.version> (<digest12>)` + bun/platform/
+  binary/digest. The build digest is the running binary's own sha256 — the exact
+  value `update` compares against a manifest.
+- `kortixd install [--dir <path>] [--force]` → install the binary onto PATH.
+  Presence-based idempotent (see Phase-2 boot note).
+- `kortixd update [--from <path|url>] [--channel] [--version] [--boot] [--target]`
+  → self-update (Phase 2).
+- `kortixd rollback` → revert to `<name>.prev`.
+- `kortixd --health-check [--port] [--timeout]` → boots a self-contained health
+  server on an ephemeral port, hits `/kortix/health`, exits 0/non-zero.
+- `kortixd --help` / `-h` / `help` → usage.
+
+Bootstrap installer `apps/kortix-sandbox-agent-server/install.sh` (114 LOC),
+curl | sh style: detects os/arch, downloads the target binary (or `--from` a
+local file), verifies it runs `version`, atomic-renames it onto PATH. Flags/env:
+`--url`/`KORTIXD_URL`, `--base`/`KORTIXD_BASE_URL`, `--version`, `--dir`,
+`--from`/`KORTIXD_LOCAL_BINARY`.
+
+### Phase 2 — safe update + rollback (the core reliability property)
+Implemented in `src/cli.ts` (`performUpdate`, `performRollback`, `smokeTest`,
+digest cache). Flow:
+
+```
+resolve target (manifest digest, or --from file/url)
+  → CHEAP no-op check FIRST (compare target digest to the local binary's cached
+    sha256; exit 0 with no download when equal)
+  → download bytes (only on a real mismatch)
+  → verify content digest (sha256)
+  → smoke-test the candidate: `<tmp> version` AND `<tmp> --health-check` must
+    both exit 0
+  → atomic swap: copy current → <name>.prev, then rename(2) tmp → target
+  → post-swap health-check: `<target> --health-check`
+  → on any failure: keep/rollback to <name>.prev, non-zero exit + clear message
+```
+
+- Never leaves a half-written binary: bytes are written to a temp file in the
+  destination dir and only `rename(2)`d in after every gate passes.
+- Keeps exactly one previous version (`<name>.prev`), mirroring the
+  `entrypoint.sh` "current + previous" supervisor policy.
+- `--boot` / `KORTIXD_UPDATE_BEST_EFFORT=1` → best-effort: any failure keeps the
+  last-good binary and exits 0 so the boot proceeds to `serve`. Manual `update`
+  (no `--boot`) hard-fails non-zero.
+- Digest cache (`.kortixd-state.json`, keyed by path+size+mtime) so a converged
+  box answers "already current" without re-hashing a ~96 MB binary every boot.
+
+Manifest resolution reuses the daemon's existing runtime-assets contract:
+`GET {KORTIX_API_URL}/v1/runtime-assets/manifest` → agent `sha256` + `path`,
+download at `/v1/runtime-assets/agent`, same-origin URL guard, `policy
+.agent_self_update === false` kill switch respected.
+
+### Phase 3 — the rename (safe subset)
+- `package.json`: `name` `@kortix/sandbox-agent-server` → **`kortixd`**;
+  `bin` now `{ "kortixd": "./dist/kortixd", "kortix-agent": "./dist/kortix-agent" }`;
+  `start` → `./dist/kortixd`; description updated. Verified the old package name
+  is **not imported by name anywhere** (grep: only self-refs in package.json +
+  bun.lock), so this is safe.
+- `bun.lock`: root name synced to `kortixd`; `bun install --frozen-lockfile`
+  passes (the sandbox Dockerfile depends on frozen install).
+- `scripts/build.sh`: emits `dist/kortixd` (primary) **and** `dist/kortix-agent`
+  (compat copy) from one compile.
+- `README.md`: retitled `kortixd`, documents the CLI, the reliability flow, the
+  boot sequence, install.sh, and the compatibility note.
+
+---
+
+## Compatibility shims kept, and why
+
+The binary artifact name `kortix-agent` and the directory
+`apps/kortix-sandbox-agent-server` are **load-bearing fleet contracts**, not
+cosmetic names:
+
+- `apps/sandbox/entrypoint.sh` treats `/usr/local/bin/kortix-agent` as the
+  immutable baked floor (`AGENT_BAKED`), and swaps `agent.current`/`.next`/
+  `.prev` beside it. Every already-deployed box has that exact path on disk.
+- `apps/sandbox/Dockerfile` + `apps/api/Dockerfile` `COPY dist/kortix-agent →
+  /usr/local/bin/kortix-agent` and embed the runtime path.
+- `apps/api` snapshots + git-proxy + `runtime-assets/manifest.ts` serve that
+  binary as the `/agent` artifact with its digest.
+- CI (`.github/workflows/ci.yml`, `deploy-dev.yml`) filters and asserts on the
+  directory path and `dist/kortix-agent`.
+
+Renaming those is a staged fleet migration (new images bake both names, deprecate
+the old over releases), not a mechanical rename. A single missed reference
+silently 502s every sandbox — the exact 2026-06-19 class the `build.sh` tsc gate
+exists to prevent. So both names ship from one compile, the directory is kept,
+and `kortixd` is the new product/local identity. Documented in `build.sh`,
+`README.md`, and `src/cli.ts`.
+
+`install` idempotency is **presence-based, not digest-based**, on purpose: the
+boot path runs `install` (image-baked source) then `update` (newer published
+binary) into the same target every start. A digest-equality reinstall would
+re-copy the older baked binary over the update on every post-update boot. So a
+target that already exists is left untouched; `update` owns currency, `install`
+only guarantees presence. `--force` overwrites deliberately.
+
+---
+
+## Verification (real, pasted)
+
+### Gates
+- `bun run build` → `Built dist/kortixd (+ compat dist/kortix-agent) for
+  bun-linux-x64 (95819904 bytes) and dist/server.mjs`. Both artifacts present.
+- `tsc --noEmit` → clean (0 errors).
+- `bun test` (whole daemon suite) → **1117 pass, 0 fail** (92 files).
+- `bun install --frozen-lockfile` → no changes (frozen OK after name sync).
+- `./dist/kortixd-host version` → `kortixd 0.1.0 (a7f3d09778a1) …`.
+- `./dist/kortixd-host --health-check` → `health-check ok`, exit 0.
+
+### Unit tests — `src/__tests__/cli-update.test.ts` (10 pass)
+Covers: flag parsing; no-op digest match; happy-path swap + `.prev`; digest
+mismatch (no swap); pre-swap smoke fail (no swap); **post-swap health fail →
+auto-rollback to `.prev`**; best-effort exit 0; digest-cache write; rollback
+restore/consume; rollback-with-no-prev fails.
+
+### End-to-end with COMPILED binaries — 34/34 pass
+Script builds two distinct valid binaries (A = 0.1.0, B = 0.1.0-next) + a broken
+candidate, then exercises the real CLI. Key results:
+
+```
+PASS: install placed executable / installed bytes == binA / reports 0.1.0
+PASS: 2nd install reports already-installed / left the binary untouched
+PASS: update exited 0 / live binary swapped to B / .prev holds A / serves health-check
+PASS: no-op update reports already-current / was fast (67-81 ms < 1500)
+--- KEYSTONE (broken candidate = garbage shell script) ---
+PASS: broken update exited non-zero (1)
+PASS: live binary UNCHANGED after broken update (still B)
+PASS: original still serves after broken update
+PASS: error names the failed smoke test
+    -> rc=1  [update] candidate failed smoke test: `version` exited 1 — kept current binary
+--- KEYSTONE (real binary whose --health-check fails) ---
+PASS: health-failing update exited non-zero (1)
+PASS: live binary UNCHANGED (health-check gate blocked the swap)
+    -> rc=1  [update] candidate failed smoke test: `--health-check` exited 1 — kept current binary
+--- rollback ---
+PASS: rollback exited 0 / rolled back to A / .prev consumed / 2nd rollback exits non-zero
+--- BOOT SEQUENCE (install + update --boot + serve, twice) ---
+PASS: boot#1 update --boot exited 0 / converged target to B
+PASS: boot#2 install left the updated B in place (no clobber)
+PASS: boot#2 update is a fast no-op (68-70 ms)
+--- BOOT with a bad publish ---
+PASS: boot update --boot with a bad publish exits 0 (boot proceeds)
+PASS: original (A) still in place / box still serves / no half-written temp binary left behind
+--- serve dispatch ---
+PASS: serve launched the daemon (still running after 3s, not an instant CLI exit)
+RESULT: 34 passed, 0 failed
+```
+
+The post-swap auto-rollback branch (candidate passes as a temp file but fails at
+the live path) is deterministically covered by the unit test with an injected
+spawn seam; the real-binary e2e covers the pre-swap smoke-fail and health-fail
+gates.
+
+Test artifacts (not committed): `scratchpad/verify-kortixd.sh`,
+`scratchpad/test-install-sh.sh`.
+
+---
+
+## What is NOT done / risks
+
+- Full directory rename `apps/kortix-sandbox-agent-server → apps/kortixd` and the
+  on-disk artifact rename `kortix-agent → kortixd` are **deliberately deferred**
+  as a staged fleet migration (see Compatibility). ~84 files reference the dir
+  and ~60 the artifact name across Dockerfiles/CI/api-runtime/snapshots/deploy.
+- `--channel` / `--version` update flags are parsed and reserved but not yet
+  wired to a channel/version selection in the manifest (the manifest exposes one
+  current agent build). Manifest resolution + `--from`/`--url` are fully working.
+- The `--health-check` smoke test is self-contained (proves the binary runs and
+  can bind+serve HTTP); it does not boot the full opencode/session stack, by
+  design — that keeps it fast and deterministic as an update gate.
+
+## Files
+- new: `src/cli.ts`, `src/__tests__/cli-update.test.ts`, `install.sh`
+- changed: `src/main.ts`, `package.json`, `bun.lock`, `scripts/build.sh`,
+  `README.md`

--- a/apps/kortix-sandbox-agent-server/README.md
+++ b/apps/kortix-sandbox-agent-server/README.md
@@ -1,7 +1,19 @@
-# @kortix/sandbox-agent-server
+# kortixd
 
 Thin sandbox-side daemon that runs inside every Kortix project-session sandbox
 — and, in a second boot mode, inside every project **monitor box**.
+
+The compiled binary is a single, installable app named **`kortixd`**. Running
+it with no arguments (or `kortixd serve`) starts the daemon described below.
+It also manages its own lifecycle — see [Management CLI](#management-cli).
+
+> **Binary name compatibility.** The npm package and the product name are now
+> `kortixd`. The build still ALSO emits `dist/kortix-agent`, and the sandbox
+> image still bakes `/usr/local/bin/kortix-agent`. That path is a load-bearing
+> contract: `apps/sandbox/entrypoint.sh` treats it as the immutable floor, the
+> snapshot bake COPYs it, and the API serves it as the runtime-assets `/agent`
+> artifact for already-deployed boxes. Renaming that on-disk path is a fleet
+> migration, not a build change, so both names ship from one compile.
 
 **Boot modes** (decided by `KORTIX_WORKLOAD` at startup):
 
@@ -154,11 +166,11 @@ bun install
 bash scripts/build.sh
 ```
 
-Produces `dist/kortix-agent` — a single-file Bun binary targeting the current
-host architecture by default (`bun-linux-x64` or `bun-linux-arm64`). Set
-`BUN_COMPILE_TARGET` when building for a specific Docker/runtime architecture.
-The binary built on macOS will not execute locally; that's expected. To
-smoke-test the daemon on macOS, run from source:
+Produces `dist/kortixd` (primary) plus `dist/kortix-agent` (compatibility copy;
+see the note at the top) — a single-file Bun binary targeting `bun-linux-x64`
+by default. Set `BUN_COMPILE_TARGET` for another architecture. The Linux binary
+built on macOS will not execute locally; that's expected. To smoke-test the
+daemon on macOS, run from source:
 
 ```
 KORTIX_PROJECT_AUTO_CLONE=0 KORTIX_SERVICE_PORT=9999 bun run src/main.ts
@@ -167,3 +179,73 @@ curl -s http://localhost:9999/kortix/health
 
 The daemon should boot and report `opencode: "starting"` (or `"down"` if the
 binary is genuinely missing) without crashing.
+
+## Management CLI
+
+`kortixd` is a normal installable app. Its subcommands (`src/cli.ts`) manage the
+binary's own lifecycle; the default (no subcommand) and `serve` boot the daemon.
+
+| Command                          | Effect                                                            |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `kortixd` / `kortixd serve`      | Run the sandbox agent server (default).                          |
+| `kortixd version`                | Print version + build digest (the binary's own sha256).          |
+| `kortixd install [--dir <path>]` | Install the binary onto PATH. Idempotent; `--force` overwrites.  |
+| `kortixd update [flags]`         | Self-update to the current published build.                      |
+| `kortixd rollback`               | Revert to the previous binary (`<name>.prev`).                   |
+| `kortixd --health-check`         | Smoke-test: boot a health server on an ephemeral port, exit 0.   |
+| `kortixd --help`                 | Usage.                                                            |
+
+The daemon also keeps its two pre-existing subcommands: `git-credential`
+(git execs it as a credential helper) and `install-compiled-runtime`.
+
+### Self-update reliability
+
+`update` never bricks the app:
+
+```
+resolve target → verify content digest → smoke-test the new binary →
+atomic swap (keep the replaced binary as <name>.prev) → post-swap health-check →
+auto-rollback to <name>.prev on any failure
+```
+
+A half-written binary is never left on disk (write-to-temp + atomic
+`rename(2)`). Exactly one previous version is kept for fast rollback.
+
+### Boot sequence
+
+The sandbox boot path runs, every start, idempotently:
+
+```
+kortixd install && kortixd update --boot && kortixd serve
+```
+
+- `install` is a fast no-op when the target already holds a binary (presence-
+  based, so it never clobbers a binary that `update` already bumped).
+- `update` does the ~700 B manifest/digest check FIRST and exits 0 with no
+  download when the local binary already matches the target.
+- `update --boot` is best-effort: any download/verify/health failure keeps the
+  last-good binary and exits 0 so boot proceeds to `serve`. A bad publish never
+  bricks a box; it serves stale-but-working and logs loudly. Manual
+  `kortixd update` (no `--boot`) hard-fails non-zero instead.
+
+### Bootstrap install
+
+`install.sh` (curl | sh) is the one-line bootstrap that downloads the right
+target binary and puts `kortixd` on PATH:
+
+```
+curl -fsSL https://<host>/kortixd/install.sh | sh
+```
+
+After it lands the first binary, `kortixd update` self-manages. Flags/env:
+`--url`/`KORTIXD_URL`, `--base`/`KORTIXD_BASE_URL`, `--version`, `--dir`, and
+`--from <path>` for an offline/local install.
+
+### Relation to the sandbox supervisor
+
+Inside a deployed box, `apps/sandbox/entrypoint.sh` is a shell supervisor that
+performs the SAME kind of staged swap + crash-based rollback around the baked
+`/usr/local/bin/kortix-agent` floor (via `agent.current` / `agent.next` /
+`agent.prev` / exit code 75). The `kortixd update`/`rollback` subcommands bring
+that reliability property into the binary itself so it works as a standalone app
+on any machine, not only under the sandbox supervisor.

--- a/apps/kortix-sandbox-agent-server/bun.lock
+++ b/apps/kortix-sandbox-agent-server/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@kortix/sandbox-agent-server",
+      "name": "kortixd",
       "dependencies": {
         "hono": "^4.12.25",
         "node-forge": "^1.4.0",

--- a/apps/kortix-sandbox-agent-server/install.sh
+++ b/apps/kortix-sandbox-agent-server/install.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env sh
+# kortixd bootstrap installer — curl | sh style.
+#
+#   curl -fsSL https://<host>/kortixd/install.sh | sh
+#
+# Downloads the kortixd binary for this OS/arch and puts `kortixd` on PATH.
+# After this runs once, kortixd manages itself: `kortixd update` self-updates,
+# `kortixd rollback` reverts, `kortixd version` reports the build.
+#
+# This is only the BOOTSTRAP. It gets the first binary onto the machine; the
+# binary's own `install`/`update`/`rollback` subcommands take over from there.
+#
+# Configuration (env or flags):
+#   --url <u>     / KORTIXD_URL         Exact binary URL (skips OS/arch guessing).
+#   --base <u>    / KORTIXD_BASE_URL    Release base; URL = <base>/<version>/kortixd-<os>-<arch>.
+#   --version <v> / KORTIXD_VERSION     Release version (default: latest).
+#   --dir <d>     / KORTIXD_INSTALL_DIR Install dir (default: /usr/local/bin, else ~/.local/bin).
+#   --from <path> / KORTIXD_LOCAL_BINARY  Install from a local file instead of downloading.
+set -eu
+
+BASE_URL="${KORTIXD_BASE_URL:-}"
+URL="${KORTIXD_URL:-}"
+VERSION="${KORTIXD_VERSION:-latest}"
+INSTALL_DIR="${KORTIXD_INSTALL_DIR:-}"
+FROM="${KORTIXD_LOCAL_BINARY:-}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --url) URL="$2"; shift 2 ;;
+    --base) BASE_URL="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --dir) INSTALL_DIR="$2"; shift 2 ;;
+    --from) FROM="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "kortixd install: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { echo "kortixd install: $1" >&2; }
+die() { log "$1"; exit 1; }
+
+# Detect OS and architecture, normalised to the release naming.
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$os" in
+  linux) os="linux" ;;
+  darwin) os="darwin" ;;
+  *) die "unsupported OS: $os" ;;
+esac
+arch="$(uname -m)"
+case "$arch" in
+  x86_64|amd64) arch="x64" ;;
+  arm64|aarch64) arch="arm64" ;;
+  *) die "unsupported architecture: $arch" ;;
+esac
+log "target: ${os}-${arch}"
+
+# Choose an install directory that is writable.
+if [ -z "$INSTALL_DIR" ]; then
+  if [ -w /usr/local/bin ] 2>/dev/null; then
+    INSTALL_DIR="/usr/local/bin"
+  elif mkdir -p /usr/local/bin 2>/dev/null && [ -w /usr/local/bin ]; then
+    INSTALL_DIR="/usr/local/bin"
+  else
+    INSTALL_DIR="${HOME}/.local/bin"
+  fi
+fi
+mkdir -p "$INSTALL_DIR" || die "cannot create install dir: $INSTALL_DIR"
+TARGET="${INSTALL_DIR}/kortixd"
+
+# Stage into a temp file in the SAME directory, so the final move is an atomic
+# rename and never leaves a half-written binary at $TARGET.
+TMP="${INSTALL_DIR}/.kortixd.install.$$"
+cleanup() { rm -f "$TMP" 2>/dev/null || true; }
+trap cleanup EXIT INT TERM
+
+if [ -n "$FROM" ]; then
+  # Local-file install path — used for offline installs and testing.
+  [ -f "$FROM" ] || die "local binary not found: $FROM"
+  log "installing from local file: $FROM"
+  cp "$FROM" "$TMP"
+else
+  # Network install path.
+  if [ -z "$URL" ]; then
+    [ -n "$BASE_URL" ] || die "no download source: set --url, or --base (KORTIXD_BASE_URL)"
+    URL="${BASE_URL%/}/${VERSION}/kortixd-${os}-${arch}"
+  fi
+  log "downloading: $URL"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$URL" -o "$TMP" || die "download failed: $URL"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$TMP" "$URL" || die "download failed: $URL"
+  else
+    die "need curl or wget to download"
+  fi
+fi
+
+chmod 0755 "$TMP" || die "chmod failed"
+
+# Verify the downloaded binary actually runs before it takes the name.
+if ! "$TMP" version >/dev/null 2>&1; then
+  die "downloaded binary failed to run \`version\` — not installing"
+fi
+
+mv -f "$TMP" "$TARGET" || die "could not move binary into $TARGET"
+trap - EXIT INT TERM
+log "installed → $TARGET"
+"$TARGET" version || true
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) : ;;
+  *) log "add ${INSTALL_DIR} to your PATH to run \`kortixd\` directly" ;;
+esac

--- a/apps/kortix-sandbox-agent-server/package.json
+++ b/apps/kortix-sandbox-agent-server/package.json
@@ -1,19 +1,20 @@
 {
-  "name": "@kortix/sandbox-agent-server",
+  "name": "kortixd",
   "version": "0.1.0",
-  "description": "Sandbox-side OpenCode REST supervisor and Kortix API surface.",
+  "description": "kortixd — the Kortix sandbox agent daemon and its self-update manager (single compiled binary).",
   "type": "module",
   "main": "src/main.ts",
   "engines": {
     "bun": "1.3.11"
   },
   "bin": {
+    "kortixd": "./dist/kortixd",
     "kortix-agent": "./dist/kortix-agent"
   },
   "scripts": {
     "dev": "bun run --hot src/main.ts",
     "build": "bash scripts/build.sh",
-    "start": "./dist/kortix-agent",
+    "start": "./dist/kortixd",
     "typecheck": "bun tsc --noEmit",
     "test": "bun test"
   },

--- a/apps/kortix-sandbox-agent-server/scripts/build.sh
+++ b/apps/kortix-sandbox-agent-server/scripts/build.sh
@@ -60,6 +60,18 @@ bun run typecheck
 bun build --target=bun --format=esm --outfile=dist/server.mjs src/main.ts
 compile_with_retry
 chmod +x dist/kortix-agent
+
+# The product name is `kortixd`. `dist/kortixd` is the primary artifact — what
+# install.sh downloads and what `kortixd install/update` manage on a normal
+# machine. `dist/kortix-agent` is KEPT as a compatibility name: it is the
+# load-bearing on-disk contract for already-deployed boxes and the snapshot
+# bake (apps/sandbox/Dockerfile COPYs dist/kortix-agent → /usr/local/bin/
+# kortix-agent, entrypoint.sh treats that path as the immutable floor, and the
+# API serves it as the runtime-assets `/agent` artifact). Renaming that path is
+# a fleet migration, not a build change, so both names ship from one compile.
+cp -f dist/kortix-agent dist/kortixd
+chmod +x dist/kortixd
+
 size="$(stat -f%z dist/kortix-agent 2>/dev/null || stat -c%s dist/kortix-agent)"
 bundle_size="$(stat -f%z dist/server.mjs 2>/dev/null || stat -c%s dist/server.mjs)"
-echo "Built dist/kortix-agent for ${target} (${size} bytes) and dist/server.mjs (${bundle_size} bytes)"
+echo "Built dist/kortixd (+ compat dist/kortix-agent) for ${target} (${size} bytes) and dist/server.mjs (${bundle_size} bytes)"

--- a/apps/kortix-sandbox-agent-server/src/__tests__/cli-update.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/cli-update.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  parseFlags,
+  performRollback,
+  performUpdate,
+  type ResolvedTarget,
+  type SpawnDeps,
+  type UpdateOptions,
+} from '../cli'
+
+function sha(bytes: Buffer | string): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'kortixd-cli-'))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/** A spawn seam that reports each candidate as healthy or not by path substring. */
+function spawnWith(rule: (bin: string, args: string[]) => number): SpawnDeps {
+  return { run: async (bin, args) => rule(bin, args) }
+}
+
+function baseOpts(overrides: Partial<UpdateOptions>): UpdateOptions {
+  return {
+    targetPath: join(dir, 'kortixd'),
+    bestEffort: false,
+    statePath: join(dir, '.state.json'),
+    spawn: spawnWith(() => 0), // everything healthy by default
+    ...overrides,
+  }
+}
+
+function resolveTo(bytes: Buffer): (o: UpdateOptions) => Promise<ResolvedTarget> {
+  return async () => ({ sha256: sha(bytes), bytes, source: 'file' })
+}
+
+describe('parseFlags', () => {
+  test('parses value, equals, and boolean forms', () => {
+    expect(parseFlags(['--from', 'x', '--dir=y', '--boot'])).toEqual({
+      from: 'x',
+      dir: 'y',
+      boot: true,
+    })
+  })
+})
+
+describe('performUpdate', () => {
+  test('no-op when the current binary already matches the target digest', async () => {
+    const current = Buffer.from('BINARY-V1')
+    writeFileSync(join(dir, 'kortixd'), current)
+    const res = await performUpdate(baseOpts({ resolveTarget: resolveTo(current) }))
+    expect(res.outcome).toBe('current')
+    expect(res.code).toBe(0)
+    // The running binary is untouched and no .prev appears.
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+  })
+
+  test('happy path: swaps in the new binary and keeps .prev', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2')
+    const res = await performUpdate(baseOpts({ resolveTarget: resolveTo(next) }))
+    expect(res.outcome).toBe('updated')
+    expect(res.code).toBe(0)
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V2')
+    expect(readFileSync(join(dir, 'kortixd.prev')).toString()).toBe('BINARY-V1')
+  })
+
+  test('digest mismatch: nothing is swapped', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2')
+    // Claim a digest that does not describe the bytes.
+    const badResolve = async (): Promise<ResolvedTarget> => ({
+      sha256: sha(Buffer.from('SOMETHING-ELSE')),
+      bytes: next,
+      source: 'file',
+    })
+    const res = await performUpdate(baseOpts({ resolveTarget: badResolve }))
+    expect(res.outcome).toBe('failed')
+    expect(res.code).toBe(1)
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+  })
+
+  test('pre-swap smoke failure: keeps the current binary, no swap', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2-BROKEN')
+    // Any candidate that is not the live target path fails its smoke test.
+    const spawn = spawnWith((bin) => (bin.endsWith('kortixd') ? 0 : 1))
+    const res = await performUpdate(baseOpts({ resolveTarget: resolveTo(next), spawn }))
+    expect(res.outcome).toBe('failed')
+    expect(res.code).toBe(1)
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+  })
+
+  test('post-swap health failure: auto-rolls back to .prev', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2-BAD')
+    // The candidate passes as a temp file (pre-swap), but the live target path
+    // fails (post-swap). This is the auto-rollback branch.
+    const spawn = spawnWith((bin) => (bin.endsWith('kortixd') ? 1 : 0))
+    const res = await performUpdate(baseOpts({ resolveTarget: resolveTo(next), spawn }))
+    expect(res.outcome).toBe('failed')
+    expect(res.code).toBe(1)
+    // Rolled back: the live binary is the original, and .prev is consumed.
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+  })
+
+  test('best-effort (boot) mode: a failure exits 0 and keeps the last-good binary', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2-BROKEN')
+    const spawn = spawnWith((bin) => (bin.endsWith('kortixd') ? 0 : 1)) // candidate fails
+    const res = await performUpdate(
+      baseOpts({ resolveTarget: resolveTo(next), spawn, bestEffort: true }),
+    )
+    expect(res.outcome).toBe('failed')
+    expect(res.code).toBe(0) // boot proceeds to serve
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+  })
+
+  test('no-op update never re-hashes: uses the digest cache', async () => {
+    const current = Buffer.from('BINARY-V1')
+    writeFileSync(join(dir, 'kortixd'), current)
+    const opts = baseOpts({ resolveTarget: resolveTo(current) })
+    await performUpdate(opts)
+    // The cache file now exists and records the digest.
+    const cache = JSON.parse(readFileSync(opts.statePath, 'utf8'))
+    expect(cache.current.sha256).toBe(sha(current))
+  })
+})
+
+describe('performRollback', () => {
+  test('restores .prev and consumes it', () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('CURRENT'))
+    writeFileSync(join(dir, 'kortixd.prev'), Buffer.from('PREVIOUS'))
+    const r = performRollback(join(dir, 'kortixd'), join(dir, '.state.json'))
+    expect(r.code).toBe(0)
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('PREVIOUS')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+  })
+
+  test('fails cleanly when there is no previous version', () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('CURRENT'))
+    const r = performRollback(join(dir, 'kortixd'), join(dir, '.state.json'))
+    expect(r.code).toBe(1)
+    expect(r.message).toContain('no previous version')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/cli.ts
+++ b/apps/kortix-sandbox-agent-server/src/cli.ts
@@ -1,0 +1,772 @@
+/**
+ * kortixd — the management CLI baked into the daemon binary.
+ *
+ * The compiled binary is a single, normal, installable app. Its DEFAULT job is
+ * to run the sandbox agent server (`kortixd` / `kortixd serve`), but it also
+ * manages its own lifecycle on any machine: print its version, install itself
+ * onto PATH, self-update to the current published build, and roll back the last
+ * update. All of that lives here so `main.ts` keeps serving the daemon.
+ *
+ * THE RELIABILITY PROPERTY. A self-update never bricks the app. The flow is
+ * download → verify content digest → smoke-test the new binary → atomic swap
+ * (keeping the replaced binary as `<name>.prev`) → post-swap health-check →
+ * auto-rollback to `.prev` on any failure. A half-written binary is never left
+ * on disk: bytes are written to a temp file in the destination directory and
+ * only `rename(2)`d into place after they pass every gate.
+ *
+ * THE BOOT CONTRACT. The primary caller is the sandbox boot path, which runs,
+ * every start, idempotently: `kortixd install` → `kortixd update --boot` →
+ * `kortixd serve`. So:
+ *   - `install` is a fast no-op when the target already holds this exact binary.
+ *   - `update` does the ~700 B manifest/digest check FIRST and exits 0 with no
+ *     download when the local binary already matches the target.
+ *   - `update --boot` is best-effort: any download/verify/health failure keeps
+ *     the last-good binary and exits 0 so boot proceeds to `serve`. A manual
+ *     `kortixd update` (no `--boot`) hard-fails non-zero instead.
+ *
+ * This module is intentionally decoupled from the server module graph so it
+ * loads fast and is unit-testable without booting the daemon.
+ */
+import { createHash } from 'node:crypto'
+import { spawn as nodeSpawn } from 'node:child_process'
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import pkg from '../package.json'
+
+/** What the caller of {@link dispatchCli} must do next. */
+export type CliOutcome =
+  | { action: 'exit'; code: number }
+  /** Not a management verb — boot the daemon server via `main()`. */
+  | { action: 'serve' }
+
+/** Management verbs this CLI owns. Everything else falls through to `serve`. */
+const MANAGEMENT_VERBS = new Set([
+  'version',
+  '--version',
+  '-v',
+  'update',
+  'rollback',
+  'install',
+  'help',
+  '--help',
+  '-h',
+  '--health-check',
+])
+
+export function isManagementSubcommand(sub: string | undefined): boolean {
+  return sub !== undefined && MANAGEMENT_VERBS.has(sub)
+}
+
+// ── small utilities ──────────────────────────────────────────────────────────
+
+function out(line: string): void {
+  process.stdout.write(`${line}\n`)
+}
+function err(line: string): void {
+  process.stderr.write(`${line}\n`)
+}
+
+/** sha256 of a file's bytes, hex. Throws if the file is unreadable. */
+export function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex')
+}
+
+function sha256Bytes(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex')
+}
+
+/** Parse `--flag value` / `--flag=value` / boolean `--flag` into a map. */
+export function parseFlags(argv: string[]): Record<string, string | boolean> {
+  const flags: Record<string, string | boolean> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i]
+    if (!tok || !tok.startsWith('--')) continue
+    const eq = tok.indexOf('=')
+    if (eq !== -1) {
+      flags[tok.slice(2, eq)] = tok.slice(eq + 1)
+      continue
+    }
+    const key = tok.slice(2)
+    const next = argv[i + 1]
+    if (next !== undefined && !next.startsWith('--')) {
+      flags[key] = next
+      i++
+    } else {
+      flags[key] = true
+    }
+  }
+  return flags
+}
+
+// ── digest cache ─────────────────────────────────────────────────────────────
+//
+// Hashing a ~100 MB binary on every boot would add real latency, and the boot
+// path calls `update` every start. Cache the running binary's digest keyed by
+// {path,size,mtime} so a converged box answers "already current" without
+// re-hashing. The key changes the instant the file changes, so a stale hit is
+// impossible.
+
+interface DigestCacheEntry {
+  path: string
+  size: number
+  mtimeMs: number
+  sha256: string
+}
+
+function defaultStatePath(binPath: string): string {
+  const envPath = (process.env.KORTIXD_STATE_PATH ?? '').trim()
+  if (envPath) return envPath
+  return join(dirname(binPath), '.kortixd-state.json')
+}
+
+function cachedFileSha(binPath: string, statePath: string): string {
+  let st: ReturnType<typeof statSync>
+  try {
+    st = statSync(binPath)
+  } catch {
+    throw new Error(`cannot stat binary at ${binPath}`)
+  }
+  const size = st.size
+  const mtimeMs = Math.trunc(st.mtimeMs)
+  try {
+    const cache = JSON.parse(readFileSync(statePath, 'utf8')) as { current?: DigestCacheEntry }
+    const e = cache.current
+    if (
+      e &&
+      e.path === binPath &&
+      e.size === size &&
+      e.mtimeMs === mtimeMs &&
+      /^[0-9a-f]{64}$/.test(e.sha256)
+    ) {
+      return e.sha256
+    }
+  } catch {
+    /* no cache yet */
+  }
+  const sha = sha256File(binPath)
+  writeDigestCache(statePath, { path: binPath, size, mtimeMs, sha256: sha })
+  return sha
+}
+
+function writeDigestCache(statePath: string, entry: DigestCacheEntry): void {
+  try {
+    mkdirSync(dirname(statePath), { recursive: true })
+    writeFileSync(statePath, `${JSON.stringify({ current: entry })}\n`, 'utf8')
+  } catch {
+    /* the cache is an optimisation; a read-only fs just re-hashes next time */
+  }
+}
+
+function invalidateDigestCache(statePath: string): void {
+  try {
+    rmSync(statePath, { force: true })
+  } catch {
+    /* best-effort */
+  }
+}
+
+// ── version ──────────────────────────────────────────────────────────────────
+
+/** The build digest is the running binary's own sha256 — the exact value the
+ *  update path compares against a published manifest. Truthful and self-
+ *  consistent: `version` and `update`'s no-op check read the same number. */
+export function buildDigest(binPath: string): string {
+  try {
+    return sha256File(binPath)
+  } catch {
+    return 'unknown'
+  }
+}
+
+function cmdVersion(binPath: string): number {
+  const digest = buildDigest(binPath)
+  const short = digest === 'unknown' ? 'unknown' : digest.slice(0, 12)
+  out(`kortixd ${pkg.version} (${short})`)
+  out(`  bun:      ${typeof Bun !== 'undefined' ? Bun.version : 'n/a'}`)
+  out(`  platform: ${process.platform}/${process.arch}`)
+  out(`  binary:   ${binPath}`)
+  if (digest !== 'unknown') out(`  digest:   ${digest}`)
+  return 0
+}
+
+// ── health-check ─────────────────────────────────────────────────────────────
+//
+// The smoke test the updater runs on a candidate binary, and a standalone
+// liveness probe. It boots a self-contained HTTP server on an ephemeral port,
+// answers /kortix/health, self-connects, and exits. It deliberately does NOT
+// touch opencode, a workspace, or the network: the point is to prove the
+// binary is a valid, runnable executable of the right architecture that can
+// bind a socket and serve HTTP — not to boot a full session.
+
+const HEALTH_PATH = '/kortix/health'
+
+async function cmdHealthCheck(argv: string[]): Promise<number> {
+  // Deliberate failure hook for tests: lets a REAL kortixd binary fail its own
+  // smoke test so the auto-rollback path can be exercised end to end. Unset in
+  // production.
+  if ((process.env.KORTIXD_FORCE_HEALTHCHECK_FAIL ?? '') === '1') {
+    err('health-check: forced failure (KORTIXD_FORCE_HEALTHCHECK_FAIL=1)')
+    return 1
+  }
+  const flags = parseFlags(argv)
+  const timeoutMs = Number(flags.timeout ?? 5000) || 5000
+  let server: ReturnType<typeof Bun.serve> | null = null
+  try {
+    server = Bun.serve({
+      port: 0,
+      hostname: '127.0.0.1',
+      fetch(req) {
+        const url = new URL(req.url)
+        if (url.pathname === HEALTH_PATH) {
+          return new Response(
+            JSON.stringify({ ok: true, service: 'kortixd', version: pkg.version }),
+            { headers: { 'content-type': 'application/json' } },
+          )
+        }
+        return new Response('not found', { status: 404 })
+      },
+    })
+    const res = await fetch(`http://127.0.0.1:${server.port}${HEALTH_PATH}`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    if (!res.ok) {
+      err(`health-check: unexpected status ${res.status}`)
+      return 1
+    }
+    const body = (await res.json()) as { ok?: boolean }
+    if (body?.ok !== true) {
+      err('health-check: body did not report ok')
+      return 1
+    }
+    out('health-check ok')
+    return 0
+  } catch (e) {
+    err(`health-check failed: ${e instanceof Error ? e.message : String(e)}`)
+    return 1
+  } finally {
+    server?.stop(true)
+  }
+}
+
+// ── spawn helper (smoke-tests) ───────────────────────────────────────────────
+
+export interface SpawnDeps {
+  /** Run `bin args…`, resolve its exit code. Injected in tests. */
+  run: (bin: string, args: string[], timeoutMs: number) => Promise<number>
+}
+
+function realRun(bin: string, args: string[], timeoutMs: number): Promise<number> {
+  return new Promise((resolve) => {
+    let settled = false
+    const child = nodeSpawn(bin, args, { stdio: 'ignore', env: process.env })
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        /* already gone */
+      }
+      resolve(124) // timeout
+    }, timeoutMs)
+    child.on('error', () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(126) // not executable / spawn error
+    })
+    child.on('exit', (code, signal) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      resolve(signal ? 128 : code ?? 1)
+    })
+  })
+}
+
+const defaultSpawn: SpawnDeps = { run: realRun }
+
+/** Smoke-test a candidate binary: `version` and `--health-check` must both
+ *  exit 0 within their timeouts. Returns the failing gate, or null on pass. */
+async function smokeTest(candidate: string, spawn: SpawnDeps): Promise<string | null> {
+  const v = await spawn.run(candidate, ['version'], 15_000)
+  if (v !== 0) return `\`version\` exited ${v}`
+  const h = await spawn.run(candidate, ['--health-check'], 20_000)
+  if (h !== 0) return `\`--health-check\` exited ${h}`
+  return null
+}
+
+// ── install ──────────────────────────────────────────────────────────────────
+
+/** Pick a writable standard install directory. Prefer /usr/local/bin (system),
+ *  fall back to ~/.local/bin (user). */
+function resolveInstallDir(explicit: string | undefined): string {
+  if (explicit) return explicit
+  const system = '/usr/local/bin'
+  if (canWriteDir(system)) return system
+  const user = join(homedir(), '.local', 'bin')
+  return user
+}
+
+function canWriteDir(dir: string): boolean {
+  try {
+    mkdirSync(dir, { recursive: true })
+    const probe = join(dir, `.kortixd-write-probe-${process.pid}`)
+    writeFileSync(probe, '')
+    rmSync(probe, { force: true })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function atomicInstall(source: string, target: string): void {
+  const dir = dirname(target)
+  mkdirSync(dir, { recursive: true })
+  const tmp = join(dir, `.kortixd.install.${process.pid}.${Math.random().toString(36).slice(2, 10)}`)
+  try {
+    copyFileSync(source, tmp)
+    chmodSync(tmp, 0o755)
+    renameSync(tmp, target)
+  } finally {
+    try {
+      rmSync(tmp, { force: true })
+    } catch {
+      /* already renamed away */
+    }
+  }
+}
+
+function cmdInstall(binPath: string, argv: string[]): number {
+  const flags = parseFlags(argv)
+  const dir = resolveInstallDir(typeof flags.dir === 'string' ? flags.dir : undefined)
+  const name = typeof flags.name === 'string' ? flags.name : 'kortixd'
+  const force = flags.force === true
+  const target = join(dir, name)
+  const source = binPath
+
+  if (source === target) {
+    out(`kortixd already running from the install path: ${target}`)
+    return 0
+  }
+  // Idempotency is PRESENCE-based, not digest-based, on purpose. The boot path
+  // runs `install` every start with the image-baked binary as the source, then
+  // `update` swaps a newer published binary into the SAME target. A digest-
+  // equality check would see "target != source" on every post-update boot and
+  // re-copy the OLDER baked binary over the newer one — undoing every update.
+  // So a target that already exists is left untouched; `update` owns currency,
+  // `install` only guarantees presence. `--force` overwrites deliberately.
+  if (existsSync(target) && !force) {
+    let note = ''
+    try {
+      note = sha256File(target) === sha256File(source) ? ' (matches this build)' : ' (a different build is present — likely from an update; --force to overwrite)'
+    } catch {
+      /* stat/hash failure is not fatal for a presence no-op */
+    }
+    out(`kortixd already installed at ${target}${note}`)
+    return 0
+  }
+  try {
+    atomicInstall(source, target)
+  } catch (e) {
+    err(`install failed: ${e instanceof Error ? e.message : String(e)}`)
+    return 1
+  }
+  out(`installed kortixd → ${target}`)
+  if (dir !== '/usr/local/bin' && !process.env.PATH?.split(':').includes(dir)) {
+    out(`note: add ${dir} to PATH to run \`kortixd\` directly`)
+  }
+  return 0
+}
+
+// ── update / rollback ────────────────────────────────────────────────────────
+
+export interface ResolvedTarget {
+  /** Expected content digest (sha256 hex) of the target build. */
+  sha256: string
+  /** Bytes of the target build, or null if not fetched yet (manifest-only). */
+  bytes: Buffer | null
+  /** URL to download the bytes from, when `bytes` is null. */
+  downloadUrl?: string
+  /** For logging. */
+  version?: string
+  source: 'manifest' | 'url' | 'file'
+}
+
+export interface UpdateOptions {
+  /** The binary to update. Defaults to the running executable. */
+  targetPath: string
+  /** `--from <path|url>`: a local file or an explicit download URL. */
+  from?: string
+  channel?: string
+  version?: string
+  apiUrl?: string
+  token?: string
+  /** Boot / best-effort mode: never hard-fail, keep the last-good binary. */
+  bestEffort: boolean
+  statePath: string
+  fetchImpl?: typeof fetch
+  spawn?: SpawnDeps
+  /** Test seam: resolve the target directly instead of hitting the network. */
+  resolveTarget?: (opts: UpdateOptions) => Promise<ResolvedTarget>
+}
+
+export interface UpdateResult {
+  /** 'current' = already up to date (no swap). 'updated' = swapped in a new
+   *  binary. 'failed' = kept the last-good binary. */
+  outcome: 'current' | 'updated' | 'failed'
+  code: number
+  message: string
+}
+
+const MANIFEST_TIMEOUT_MS = 15_000
+const DOWNLOAD_TIMEOUT_MS = 180_000
+
+function resolveApi(opts: UpdateOptions): { apiRoot: string; token: string } | null {
+  const token = (
+    opts.token ??
+    process.env.KORTIX_CLI_TOKEN ??
+    process.env.KORTIX_SANDBOX_TOKEN ??
+    process.env.KORTIX_TOKEN ??
+    ''
+  ).trim()
+  const rawApiUrl = (opts.apiUrl ?? process.env.KORTIX_API_URL ?? '').trim().replace(/\/+$/, '')
+  if (!token || !rawApiUrl) return null
+  const apiRoot = rawApiUrl.endsWith('/v1') ? rawApiUrl : `${rawApiUrl}/v1`
+  return { apiRoot, token }
+}
+
+/** Only accept a manifest-supplied path that names a route on the SAME API
+ *  origin — never an absolute URL to another host. Mirrors runtime-assets. */
+function resolveArtifactUrl(apiRoot: string, path: unknown, fallback: string): string {
+  if (typeof path !== 'string' || !path.startsWith('/') || path.startsWith('//')) return fallback
+  if (/\s/.test(path) || path.includes('://')) return fallback
+  const origin = apiRoot.replace(/\/v1$/, '')
+  return `${origin}${path}`
+}
+
+async function defaultResolveTarget(opts: UpdateOptions): Promise<ResolvedTarget> {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const from = opts.from?.trim()
+
+  // 1) Explicit local file — the operator points us at a built binary.
+  if (from && !/^https?:\/\//.test(from) && existsSync(from)) {
+    const bytes = readFileSync(from)
+    return { sha256: sha256Bytes(bytes), bytes, source: 'file', version: `file:${from}` }
+  }
+  // 2) Explicit URL — download; the bytes' own digest is the expectation.
+  if (from && /^https?:\/\//.test(from)) {
+    const res = await fetchImpl(from, { signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS) })
+    if (!res.ok) throw new Error(`download from ${from} returned ${res.status}`)
+    const bytes = Buffer.from(await res.arrayBuffer())
+    return { sha256: sha256Bytes(bytes), bytes, source: 'url', version: from }
+  }
+  // 3) Runtime-assets manifest — the boot path. Cheap: the manifest is ~700 B.
+  const api = resolveApi(opts)
+  if (!api) {
+    throw new Error('no update source: pass --from <path|url>, or set KORTIX_API_URL + a token')
+  }
+  const base = `${api.apiRoot}/runtime-assets`
+  const manRes = await fetchImpl(`${base}/manifest`, {
+    headers: { Authorization: `Bearer ${api.token}` },
+    signal: AbortSignal.timeout(MANIFEST_TIMEOUT_MS),
+  })
+  if (!manRes.ok) throw new Error(`manifest fetch returned ${manRes.status}`)
+  const manifest = (await manRes.json()) as {
+    components?: Record<string, { sha256?: unknown; version?: unknown; path?: unknown }>
+    agent_sha256?: string
+    policy?: { agent_self_update?: unknown }
+  }
+  if (manifest.policy && manifest.policy.agent_self_update === false) {
+    throw new Error('agent self-update disabled by manifest policy')
+  }
+  const component = manifest.components?.agent
+  const sha =
+    (typeof component?.sha256 === 'string' ? component.sha256 : undefined) ??
+    (typeof manifest.agent_sha256 === 'string' ? manifest.agent_sha256 : undefined)
+  if (!sha || !/^[0-9a-f]{64}$/.test(sha)) {
+    throw new Error('manifest states no agent digest to converge on')
+  }
+  const downloadUrl = resolveArtifactUrl(api.apiRoot, component?.path, `${base}/agent`)
+  return {
+    sha256: sha,
+    bytes: null,
+    downloadUrl,
+    version: typeof component?.version === 'string' ? component.version : undefined,
+    source: 'manifest',
+  }
+}
+
+/**
+ * The keystone: download → verify → smoke-test → atomic swap → post-swap
+ * health → auto-rollback. Pure enough to unit-test with injected seams; the
+ * real filesystem operations are synchronous and atomic.
+ */
+export async function performUpdate(opts: UpdateOptions): Promise<UpdateResult> {
+  const spawn = opts.spawn ?? defaultSpawn
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const target = opts.targetPath
+  const prev = `${target}.prev`
+  const dir = dirname(target)
+
+  const fail = (message: string): UpdateResult => {
+    err(`[update] ${message}`)
+    if (opts.bestEffort) {
+      err('[update] best-effort mode: keeping the last-good binary, boot may proceed')
+      return { outcome: 'failed', code: 0, message }
+    }
+    return { outcome: 'failed', code: 1, message }
+  }
+
+  // Resolve what we should be running (cheap: manifest is tiny).
+  let resolved: ResolvedTarget
+  try {
+    resolved = await (opts.resolveTarget ?? defaultResolveTarget)(opts)
+  } catch (e) {
+    return fail(`could not resolve update target: ${e instanceof Error ? e.message : String(e)}`)
+  }
+
+  // No-op check BEFORE downloading the big artifact.
+  let currentSha: string
+  try {
+    currentSha = cachedFileSha(target, opts.statePath)
+  } catch (e) {
+    return fail(`cannot read current binary: ${e instanceof Error ? e.message : String(e)}`)
+  }
+  if (currentSha === resolved.sha256) {
+    out(`kortixd already current (${currentSha.slice(0, 12)})`)
+    return { outcome: 'current', code: 0, message: 'already current' }
+  }
+
+  // Fetch the bytes if the resolver only gave us a URL + digest.
+  let bytes = resolved.bytes
+  if (!bytes) {
+    if (!resolved.downloadUrl) return fail('resolver returned neither bytes nor a download URL')
+    try {
+      const api = resolveApi(opts)
+      const headers = api ? { Authorization: `Bearer ${api.token}` } : undefined
+      const res = await fetchImpl(resolved.downloadUrl, {
+        headers,
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      })
+      if (!res.ok) return fail(`download returned ${res.status}`)
+      bytes = Buffer.from(await res.arrayBuffer())
+    } catch (e) {
+      return fail(`download failed: ${e instanceof Error ? e.message : String(e)}`)
+    }
+  }
+
+  // Verify content digest.
+  const gotSha = sha256Bytes(bytes)
+  if (gotSha !== resolved.sha256) {
+    return fail(
+      `digest mismatch: expected ${resolved.sha256.slice(0, 12)}, got ${gotSha.slice(0, 12)}`,
+    )
+  }
+
+  // Write to a temp file in the destination dir (same fs → atomic rename).
+  const tmp = join(dir, `.kortixd.download.${process.pid}.${Math.random().toString(36).slice(2, 10)}`)
+  try {
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(tmp, bytes)
+    chmodSync(tmp, 0o755)
+  } catch (e) {
+    try {
+      rmSync(tmp, { force: true })
+    } catch {
+      /* nothing to clean */
+    }
+    return fail(`could not stage temp binary: ${e instanceof Error ? e.message : String(e)}`)
+  }
+
+  // Smoke-test the candidate BEFORE it goes anywhere near the live path.
+  const smokeFail = await smokeTest(tmp, spawn)
+  if (smokeFail) {
+    rmSync(tmp, { force: true })
+    return fail(`candidate failed smoke test: ${smokeFail} — kept current binary`)
+  }
+
+  // Atomic swap. Keep exactly one previous version for fast rollback.
+  try {
+    copyFileSync(target, prev)
+  } catch (e) {
+    rmSync(tmp, { force: true })
+    return fail(`could not preserve current binary as .prev: ${e instanceof Error ? e.message : String(e)}`)
+  }
+  try {
+    renameSync(tmp, target) // atomic within the same filesystem
+  } catch (e) {
+    rmSync(tmp, { force: true })
+    return fail(`atomic swap failed: ${e instanceof Error ? e.message : String(e)}`)
+  }
+
+  // Post-swap health-check. If the freshly-installed binary will not serve,
+  // roll back to the binary we just preserved.
+  const postFail = await smokeTest(target, spawn)
+  if (postFail) {
+    try {
+      renameSync(prev, target) // restore the last-good binary
+      invalidateDigestCache(opts.statePath)
+      const msg = `post-swap health failed (${postFail}); rolled back to previous binary`
+      err(`[update] ${msg}`)
+      // A failed update that self-healed is still a failure the operator must
+      // see — but the box is on its last-good binary, so boot may proceed.
+      return { outcome: 'failed', code: opts.bestEffort ? 0 : 1, message: msg }
+    } catch (e) {
+      // Could not restore — surface loudly. The swapped-in binary already
+      // passed the pre-swap smoke test, so it is the same class of "runnable".
+      const msg = `post-swap health failed and rollback failed: ${e instanceof Error ? e.message : String(e)}`
+      err(`[update] ${msg}`)
+      return { outcome: 'failed', code: opts.bestEffort ? 0 : 1, message: msg }
+    }
+  }
+
+  writeDigestCache(opts.statePath, {
+    path: target,
+    size: statSync(target).size,
+    mtimeMs: Math.trunc(statSync(target).mtimeMs),
+    sha256: resolved.sha256,
+  })
+  const label = resolved.version ? ` (${resolved.version})` : ''
+  out(`kortixd updated → ${resolved.sha256.slice(0, 12)}${label}; previous kept at ${prev}`)
+  return { outcome: 'updated', code: 0, message: 'updated' }
+}
+
+async function cmdUpdate(binPath: string, argv: string[]): Promise<number> {
+  const flags = parseFlags(argv)
+  const bestEffort =
+    flags.boot === true ||
+    flags['best-effort'] === true ||
+    (process.env.KORTIXD_UPDATE_BEST_EFFORT ?? '') === '1'
+  const targetPath = typeof flags.target === 'string' ? flags.target : binPath
+  const result = await performUpdate({
+    targetPath,
+    from:
+      typeof flags.from === 'string'
+        ? flags.from
+        : typeof flags.url === 'string'
+          ? flags.url
+          : undefined,
+    channel: typeof flags.channel === 'string' ? flags.channel : undefined,
+    version: typeof flags.version === 'string' ? flags.version : undefined,
+    bestEffort,
+    statePath: defaultStatePath(targetPath),
+  })
+  return result.code
+}
+
+/** Roll back to `<name>.prev` on demand. Consumes the `.prev` (one previous
+ *  version kept), mirroring the supervisor's rollback policy. */
+export function performRollback(
+  targetPath: string,
+  statePath: string,
+): { code: number; message: string } {
+  const prev = `${targetPath}.prev`
+  if (!existsSync(prev)) {
+    return { code: 1, message: 'no previous version to roll back to (.prev absent)' }
+  }
+  try {
+    renameSync(prev, targetPath) // atomic
+    chmodSync(targetPath, 0o755)
+    invalidateDigestCache(statePath)
+    return { code: 0, message: `rolled back to previous binary (${targetPath})` }
+  } catch (e) {
+    return { code: 1, message: `rollback failed: ${e instanceof Error ? e.message : String(e)}` }
+  }
+}
+
+function cmdRollback(binPath: string, argv: string[]): number {
+  const flags = parseFlags(argv)
+  const targetPath = typeof flags.target === 'string' ? flags.target : binPath
+  const r = performRollback(targetPath, defaultStatePath(targetPath))
+  if (r.code === 0) out(r.message)
+  else err(`rollback: ${r.message}`)
+  return r.code
+}
+
+// ── help ─────────────────────────────────────────────────────────────────────
+
+function printHelp(): number {
+  out(`kortixd ${pkg.version} — the Kortix sandbox agent daemon and its manager.
+
+USAGE
+  kortixd [serve]                 Run the sandbox agent server (default).
+  kortixd version                 Print version and build digest.
+  kortixd install [--dir <path>]  Install this binary onto PATH (idempotent;
+                                  no-op if present, --force to overwrite).
+  kortixd update [flags]          Self-update to the current published build.
+  kortixd rollback                Revert to the previous binary (<name>.prev).
+  kortixd --health-check          Smoke-test: boot a health server and exit 0.
+  kortixd --help                  Show this help.
+
+UPDATE FLAGS
+  --from <path|url>   Update from a local file or an explicit URL instead of
+                      the runtime-assets manifest.
+  --channel <c>       Reserved for channel selection.
+  --version <v>       Reserved for pinning a specific version.
+  --boot              Best-effort: never hard-fail; keep the last-good binary
+                      and exit 0 so a boot sequence can proceed to \`serve\`.
+                      (Also enabled by KORTIXD_UPDATE_BEST_EFFORT=1.)
+  --target <path>     Update a binary other than the running one (testing).
+
+BOOT SEQUENCE (idempotent, run every start)
+  kortixd install && kortixd update --boot && kortixd serve
+
+RELIABILITY
+  update = download → verify digest → smoke-test → atomic swap (keep .prev) →
+  post-swap health → auto-rollback on any failure. A half-written binary is
+  never left on disk. A bad publish never bricks the box.
+
+ENV
+  KORTIX_API_URL, KORTIX_CLI_TOKEN   Runtime-assets manifest source.
+  KORTIXD_STATE_PATH                 Digest-cache location.
+  KORTIXD_UPDATE_BEST_EFFORT=1       Force best-effort update.`)
+  return 0
+}
+
+// ── dispatch ─────────────────────────────────────────────────────────────────
+
+/**
+ * Handle a management verb, or say `serve`. `main.ts` calls this for the verbs
+ * in {@link MANAGEMENT_VERBS}; everything else boots the daemon.
+ */
+export async function dispatchCli(argv: string[]): Promise<CliOutcome> {
+  const sub = argv[0]
+  const rest = argv.slice(1)
+  const binPath = process.execPath
+
+  switch (sub) {
+    case 'version':
+    case '--version':
+    case '-v':
+      return { action: 'exit', code: cmdVersion(binPath) }
+    case '--health-check':
+      return { action: 'exit', code: await cmdHealthCheck(rest) }
+    case 'install':
+      return { action: 'exit', code: cmdInstall(binPath, rest) }
+    case 'update':
+      return { action: 'exit', code: await cmdUpdate(binPath, rest) }
+    case 'rollback':
+      return { action: 'exit', code: cmdRollback(binPath, rest) }
+    case 'help':
+    case '--help':
+    case '-h':
+      return { action: 'exit', code: printHelp() }
+    case 'serve':
+    case undefined:
+    default:
+      return { action: 'serve' }
+  }
+}

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -2,6 +2,7 @@ import { writeFileSync, readFileSync, existsSync, mkdirSync, openSync, unlinkSyn
 import { spawn } from 'node:child_process'
 import { dirname, join } from 'node:path'
 import { agentEnvDirIsTmpfs, writeAgentEnvFile } from './agent-env-file'
+import { dispatchCli, isManagementSubcommand } from './cli'
 import { loadConfig, resolveOpencodeConfigDir, resolveSandboxOnBoot, type Config } from './config'
 import {
   configureGitCredentialHelper,
@@ -3113,6 +3114,24 @@ if (import.meta.main) {
         process.stderr.write(
           `[compiled-runtime] install failed: ${error instanceof Error ? error.message : String(error)}\n`,
         )
+        process.exit(1)
+      })
+  } else if (isManagementSubcommand(subcommand)) {
+    // kortixd management CLI: version / install / update / rollback /
+    // --health-check / --help. `serve` and any unrecognized verb fall through
+    // to the daemon below. See src/cli.ts.
+    dispatchCli(process.argv.slice(2))
+      .then((outcome) => {
+        if (outcome.action === 'exit') process.exit(outcome.code)
+        // action === 'serve' cannot happen here (management verbs never serve),
+        // but boot the daemon defensively rather than exit silently.
+        main().catch((err) => {
+          logger.error('[boot] fatal', err)
+          process.exit(1)
+        })
+      })
+      .catch((err) => {
+        process.stderr.write(`[kortixd] ${err instanceof Error ? err.message : String(err)}\n`)
         process.exit(1)
       })
   } else {


### PR DESCRIPTION
Turns the sandbox agent server into `kortixd` — a single binary treated like a normal app.

## What
- **Management CLI** on the existing `bun --compile` binary: `serve` (default, unchanged), `version`, `install`, `update`, `rollback`, `--health-check`, `--help`. Pre-existing `git-credential` + `install-compiled-runtime` subcommands preserved.
- **Safe self-update**: cheap digest no-op when current → download → verify sha256 → smoke-test (`version` + `--health-check`) → atomic swap (keep `<name>.prev`) → **auto-rollback on any failure**. `--boot`/`KORTIXD_UPDATE_BEST_EFFORT=1` = best-effort for the sandbox boot path (keep last-good, exit 0). Write-to-temp + rename(2) — never a half-written binary.
- **Rename = safe subset**: package/name/bin/output are `kortixd`; `kortix-agent` filename + dir kept as a **documented load-bearing compatibility floor** (entrypoint, snapshot bake, runtime-assets `/agent`). Full dir/artifact rename deferred as a staged fleet migration.

## Verified
- tsc clean · `bun test` 1117/0 · CLI unit 10/0 (incl auto-rollback) · compiled-binary e2e 34/34 (broken update → original still serves; boot no-op update fast + serves; bad publish → serve last-good).
- Coordinator re-verified: real local binary runs `version` + `--help` shows all subcommands.

## Not in this PR (deliberate, staged)
- Wiring the sandbox BOOT to `install → update --boot → serve` (high-risk entrypoint change — separate staged PR, tested on a real box first).
- Full directory/`kortix-agent` artifact rename (staged fleet migration).
- `--channel`/`--version` flags parsed but not yet wired to channel selection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790434004&installation_model_id=434224&pr_number=6972&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6972&signature=b53afae46f9551fd2668b4582ed64998889f259c88c81995c6c86dc4c67bd8b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->