### PR TITLE
fix(api): fresh-session git fast path gets its own switch (KORTIX_FAST_GIT_BOOT_ENABLED)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -543,10 +543,16 @@ const envSchema = z.object({
   //
   // NOT gated here any more (default boot since 2026-08-27, see
   // docs/specs/2026-08-27-fast-clone-path.md): the fresh-session Git fast path
-  // — KORTIX_SESSION_FRESH, the base-tip + scaffold-delta hint, and the OpenCode
-  // config-dir hint that lets the daemon spawn OpenCode before the checkout.
-  // Only an EXPLICIT `false` pins that path off again.
+  // has its own switch, KORTIX_FAST_GIT_BOOT_ENABLED below. deploy-dev.yml
+  // injects an explicit `false` here on every push, so this flag can never
+  // double as that path's kill switch.
   KORTIX_FAST_COLD_BOOT_ENABLED: optBoolUnset,
+  // The fresh-session Git fast path: KORTIX_SESSION_FRESH, the base-tip +
+  // scaffold-delta hint (inline or remote bundle), and the OpenCode config-dir
+  // hint that lets the daemon spawn OpenCode before the checkout. Default ON;
+  // `false` restores the pre-2026-08-27 create-time contract. The daemon side
+  // is additive and falls back to the clone path without these hints.
+  KORTIX_FAST_GIT_BOOT_ENABLED: optBoolTrue,
   // Experimental compiled boot path. The API builds a verified checkout and
   // OpenCode launcher for one exact Git SHA. `off` preserves the clone and
   // baked-agent path. `shadow` verifies both artifacts without using them.
@@ -1176,6 +1182,7 @@ export const config = {
   KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
   KORTIX_FAST_COLD_BOOT_ENABLED: env.KORTIX_FAST_COLD_BOOT_ENABLED ?? false,
   KORTIX_FAST_COLD_BOOT_CONFIGURED: env.KORTIX_FAST_COLD_BOOT_ENABLED !== undefined,
+  KORTIX_FAST_GIT_BOOT_ENABLED: env.KORTIX_FAST_GIT_BOOT_ENABLED,
   KORTIX_COMPILED_BOOT_MODE: env.KORTIX_COMPILED_BOOT_MODE,
 
   // Sandbox lifecycle intervals (minutes) — see schema comment above.

--- a/apps/api/src/projects/lib/session-runtime-env.test.ts
+++ b/apps/api/src/projects/lib/session-runtime-env.test.ts
@@ -200,8 +200,9 @@ describe('buildSessionRuntimeEnv — fast Git boot hints', () => {
   });
 
   test('sends fresh-session and base-tip hints even with the experiment disabled', () => {
-    // 2026-08-27: the fresh-session fast path is the default boot. Only the
-    // compiled-boot mode stays gated (see the compiled-boot tests above).
+    // 2026-08-27: the fresh-session fast path is the default boot
+    // (KORTIX_FAST_GIT_BOOT_ENABLED, decided at create). Only the compiled-boot
+    // mode stays gated here (see the compiled-boot tests above).
     const env = buildSessionRuntimeEnv({
       ...BASE_INPUT,
       fastColdBootEnabled: false,

--- a/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
+++ b/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
@@ -12,7 +12,7 @@ describe('session fast boot Git hint cache', () => {
   test('resolves a validated cache entry through the authenticated project', async () => {
     const source = await sessionsSource();
     const authPromise = source.indexOf('const projectWithGitAuthPromise');
-    const gate = source.indexOf('config.KORTIX_FAST_COLD_BOOT_ENABLED', authPromise);
+    const gate = source.indexOf('config.KORTIX_FAST_GIT_BOOT_ENABLED', authPromise);
     const resolver = source.indexOf('resolveFastBootGitHintWithCache(', gate);
     const provision = source.indexOf('provisionSessionSandbox({', resolver);
     expect(authPromise).toBeGreaterThan(-1);
@@ -25,7 +25,7 @@ describe('session fast boot Git hint cache', () => {
 
   test('keeps the cache lookup inside the existing two-second boot deadline', async () => {
     const source = await sessionsSource();
-    const gate = source.indexOf('config.KORTIX_FAST_COLD_BOOT_ENABLED');
+    const gate = source.indexOf('config.KORTIX_FAST_GIT_BOOT_ENABLED');
     const provision = source.indexOf('provisionSessionSandbox({', gate);
     const fastBootBlock = source.slice(gate, provision);
     expect(fastBootBlock).toContain('setTimeout(() => resolve(undefined), 2_000)');

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1658,13 +1658,14 @@ export async function createProjectSession(input: {
       // the hint is omitted → daemon delta-fetches as before. Runs CONCURRENTLY
       // with gitAuth (folded into the env-build chain, not awaited inline).
       let fastBootHintTimeout: ReturnType<typeof setTimeout> | undefined;
-      // Always on: the hint is what lets the daemon boot with ZERO proxied git
-      // requests (scaffold + delta) and spawn OpenCode before the checkout.
-      // Bounded by the 2 s race below; a miss just means the daemon's fetch
-      // fallback. (Kept as a ternary so the experiment kill switch can pin it
-      // off again without touching the create path.)
+      // Default on (KORTIX_FAST_GIT_BOOT_ENABLED): the hint is what lets the
+      // daemon boot with ZERO proxied git requests (scaffold + delta) and spawn
+      // OpenCode before the checkout. Bounded by the 2 s race below; a miss
+      // just means the daemon's fetch fallback. Deliberately NOT tied to
+      // KORTIX_FAST_COLD_BOOT_ENABLED (the image/rootfs experiment), which
+      // deploy-dev pins to an explicit `false`.
       const fastBootGitHintPromise =
-        !(config.KORTIX_FAST_COLD_BOOT_CONFIGURED && !config.KORTIX_FAST_COLD_BOOT_ENABLED)
+        config.KORTIX_FAST_GIT_BOOT_ENABLED
         ? Promise.race([
             projectWithGitAuthPromise
               .then((projectWithGitAuth) =>

--- a/docs/specs/2026-08-27-fast-clone-path.md
+++ b/docs/specs/2026-08-27-fast-clone-path.md
@@ -28,7 +28,9 @@ scaffold, ≤ 24 KiB.
 1. **Fresh sessions always get the fast path** (`session-runtime-env.ts`):
    `KORTIX_SESSION_FRESH=1`, `KORTIX_BASE_SHA`, the delta bundle and the
    OpenCode config-dir hint are emitted for every new full-repository session.
-   `KORTIX_FAST_COLD_BOOT_ENABLED=false` (explicit) pins it off; unset = on.
+   Own switch `KORTIX_FAST_GIT_BOOT_ENABLED` (default on; `false` pins it off).
+   It is NOT tied to `KORTIX_FAST_COLD_BOOT_ENABLED`: deploy-dev injects an
+   explicit `false` for that experiment flag on every push.
 2. **Delta = every commit above the scaffold root** (`commits.ts`
    `buildScaffoldDeltaBundle`): boundary is the first-parent root commit; the
    API bundles only when the root's tree equals the current starter scaffold's
@@ -70,6 +72,6 @@ present; `opencode-workspace-reloaded` marks the in-place reload.
 
 ## Rollback
 
-`KORTIX_FAST_COLD_BOOT_ENABLED=false` on the API restores the pre-2026-08-27
+`KORTIX_FAST_GIT_BOOT_ENABLED=false` on the API restores the pre-2026-08-27
 env contract (no fresh-session hints). The daemon paths are additive: without
 the env they run the previous scaffold-fetch / clone code.


### PR DESCRIPTION
Follow-up to #6964.

**Problem (found on dev):** `deploy-dev.yml:557` injects `KORTIX_FAST_COLD_BOOT_ENABLED=false` on every push deploy. #6964 read an explicit `false` as "pin the fresh-session git fast path off", so dev sessions received `KORTIX_SESSION_FRESH=1` but no `KORTIX_BASE_SHA` / delta bundle / config-dir hint, and still fetched `main` through the proxy (`repo-materialized` 3.0–3.4 s instead of ~0.1 s; verified with two seeded projects, `metadata.git.fast_boot` stayed `null`).

**Fix:** the hint has its own default-on flag `KORTIX_FAST_GIT_BOOT_ENABLED` (`false` restores the pre-#6964 create contract). It is no longer tied to the image/rootfs experiment flag.

**Verification:** `bun test --isolate --env-file=scripts/test.env src/projects/lib/session-runtime-env.test.ts src/projects/lib/sessions.fast-boot-git-hint.test.ts src/projects/lib/fast-boot-git-hint.test.ts src/__tests__/e2e-project-session-contract.test.ts src/config.test.ts` → 107 pass. `tsc --noEmit` clean (pre-existing composio noise excluded). Dev boot timelines will be posted after deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790435142&installation_model_id=434224&pr_number=6973&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6973&signature=7b176cc446b10d788d7b62cfbb17a031267bdcbca92e066b4d7bff93f74c8d75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->