### PR TITLE
Fix idle messages appearing queued

### DIFF
--- a/apps/web/src/features/session/session-chat-working-projection.test.ts
+++ b/apps/web/src/features/session/session-chat-working-projection.test.ts
@@ -44,13 +44,16 @@ describe('the composer reads ONE working answer', () => {
     expect(chat).not.toContain('30_000');
   });
 
-  test('the send receipt names the same wire message as the optimistic turn', () => {
+  test('the send receipt names the optimistic turn only when the session was idle', () => {
     const send = between(
       chat,
       'const clientMessageId = overrides?.clientMessageId',
       'return messageID;',
     );
-    expect(send).toContain('noteSendReceipt(messageID)');
+    expect(send).toContain(
+      'const receiptTurnId = sendingIntoRunningTurn ? workingTurnIdRef.current : messageID;',
+    );
+    expect(send).toContain('noteSendReceipt(messageID, receiptTurnId)');
     // Acceptance is what lets a `/turn` read answer for the send AT ALL: until
     // `POST .../prompts` returns there is no row for it to see.
     expect(send).toContain('acceptSendReceipt(messageID)');

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -2380,10 +2380,10 @@ export function SessionChat({
    */
   const receiptSessionId = projectSessionId ?? '';
   const noteSendReceipt = useCallback(
-    (messageId: string) =>
+    (messageId: string, turnId: string | null = messageId) =>
       useSessionWorkingStore
         .getState()
-        .noteSendReceipt(receiptSessionId, { messageId, atMs: Date.now() }),
+        .noteSendReceipt(receiptSessionId, { messageId, turnId, atMs: Date.now() }),
     [receiptSessionId],
   );
   const acceptSendReceipt = useCallback(
@@ -3251,6 +3251,10 @@ export function SessionChat({
     () => resolveWorkingTurn({ turns, hintMessageId: working.turnId, unrunTurnIds }),
     [turns, working.turnId, unrunTurnIds],
   );
+  const workingTurnIdRef = useRef<string | null>(workingTurn.workingTurnId);
+  useEffect(() => {
+    workingTurnIdRef.current = workingTurn.workingTurnId;
+  }, [workingTurn.workingTurnId]);
   const pendingTurnIds = useMemo(() => new Set(workingTurn.pendingTurnIds), [workingTurn]);
   /**
    * ONE render key per turn. A turn keeps the id its bubble was FIRST painted
@@ -3637,6 +3641,7 @@ export function SessionChat({
       // row that no longer had a transcript twin to hide behind.
       markOptimisticSendInboxBacked(sessionId, messageID);
       const sendingIntoRunningTurn = isBusyRef.current;
+      const receiptTurnId = sendingIntoRunningTurn ? workingTurnIdRef.current : messageID;
 
       // A send follows from here: the new bubble lands at the top of the
       // screen the frame it commits (use-auto-scroll.ts, FACT 2 + THE RULE).
@@ -3811,7 +3816,7 @@ export function SessionChat({
       // The prompt is out of this tab's hands the moment the row lands, so the
       // receipt is taken BEFORE the POST: it is what holds the composer on
       // "working" until `GET .../turn` reports the turn the inbox admitted.
-      noteSendReceipt(messageID);
+      noteSendReceipt(messageID, receiptTurnId);
       const result = await (async () => {
         try {
           if (!projectId || !projectSessionId) {

--- a/apps/web/src/features/session/turn/working-turn.test.ts
+++ b/apps/web/src/features/session/turn/working-turn.test.ts
@@ -1,3 +1,4 @@
+import { projectWorking } from '@kortix/sdk';
 import { describe, expect, test } from 'bun:test';
 import { resolveWorkingTurn } from './working-turn';
 
@@ -59,6 +60,52 @@ describe('resolveWorkingTurn', () => {
     });
     expect(r.workingTurnId).toBe('new');
     expect(r.pendingTurnIds).toEqual([]);
+  });
+
+  test('an idle send admitted by the inbox owns the indicator instead of becoming queued', () => {
+    const working = projectWorking({
+      optimistic: {
+        messageId: 'new',
+        turnId: 'new',
+        atMs: 1_000,
+        acceptedAtMs: 1_100,
+      },
+      inbox: { pending: 1, atMs: 1_100 },
+      server: { turns: [], atMs: 1_200 },
+      stream: { type: 'idle', atMs: 900 },
+      nowMs: 1_300,
+    });
+
+    expect(
+      resolveWorkingTurn({
+        turns: [turn('old', 'done'), turn('new')],
+        hintMessageId: working.turnId,
+        unrunTurnIds: new Set(['new']),
+      }),
+    ).toEqual({ workingTurnId: 'new', pendingTurnIds: [] });
+  });
+
+  test('a send admitted during an active response stays queued behind that response', () => {
+    const working = projectWorking({
+      optimistic: {
+        messageId: 'queued',
+        turnId: 'active',
+        atMs: 1_000,
+        acceptedAtMs: 1_100,
+      },
+      inbox: { pending: 1, atMs: 1_100 },
+      server: { turns: [], atMs: 1_200 },
+      stream: { type: 'busy', atMs: 900 },
+      nowMs: 1_300,
+    });
+
+    expect(
+      resolveWorkingTurn({
+        turns: [turn('active', 'open'), turn('queued')],
+        hintMessageId: working.turnId,
+        unrunTurnIds: new Set(['queued']),
+      }),
+    ).toEqual({ workingTurnId: 'active', pendingTurnIds: ['queued'] });
   });
 
   test('no hint: the NEWEST pending turn is where the next step lands', () => {

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,6 +12,20 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
+### 2026-08-27 — session `session-queue-state` — direct idle sends must own the working turn — IN PROGRESS
+
+**Defect:** every direct composer send briefly becomes a durable inbox row. The
+inbox working observation currently replaces the send receipt's `turnId` with
+`null`, so the web transcript classifies the new bubble as pending. The bubble
+renders dimmed with queue controls and the working indicator stays on the prior
+turn, even when no response was active at send time.
+
+**Scope:** preserve the receipt's explicit turn association through inbox
+admission. Keep sends made during an active response pending. Add RED-first SDK
+projection coverage and web working-turn integration coverage.
+
+---
+
 ### 2026-08-27 — session `app-viewer-token` — a Kortix-hosted App is already signed in — DONE
 
 **Files:** `core/auth/app-viewer.ts` (+ test) — `fetchKortixAppViewer`,

--- a/packages/sdk/PROGRESS.md
+++ b/packages/sdk/PROGRESS.md
@@ -12,7 +12,7 @@ tracked, and it is not forgotten just because it isn't scheduled.
 
 ---
 
-### 2026-08-27 — session `session-queue-state` — direct idle sends must own the working turn — IN PROGRESS
+### 2026-08-27 — session `session-queue-state` — direct idle sends must own the working turn — DONE
 
 **Defect:** every direct composer send briefly becomes a durable inbox row. The
 inbox working observation currently replaces the send receipt's `turnId` with
@@ -20,9 +20,18 @@ inbox working observation currently replaces the send receipt's `turnId` with
 renders dimmed with queue controls and the working indicator stays on the prior
 turn, even when no response was active at send time.
 
-**Scope:** preserve the receipt's explicit turn association through inbox
-admission. Keep sends made during an active response pending. Add RED-first SDK
-projection coverage and web working-turn integration coverage.
+**Fix:** `SendReceipt` now carries an optional `turnId`. `projectWorking`
+preserves that association when the durable inbox outranks the receipt. The web
+composer captures the working turn at Enter: an idle send names itself, while a
+send during an active response names the existing turn. The existing fallback
+for callers that omit `turnId` remains `messageId`. Commit `24d35ca894`.
+
+**RED first:** 4 new assertions failed with `turnId: null`; the idle integration
+resolved `{workingTurnId:'old', pendingTurnIds:['new']}`. GREEN: 113 targeted
+tests pass. Full evidence: SDK typecheck clean; SDK suite 2723 pass / 0 fail
+across 168 files; packed-tarball smoke install passed; web session suite 2668
+pass / 0 fail across 190 files; changed-file TypeScript check has 0 matches;
+ESLint has 0 errors (30 pre-existing warnings in `session-chat.tsx`).
 
 ---
 

--- a/packages/sdk/src/browser/stores/session-working-store.test.ts
+++ b/packages/sdk/src/browser/stores/session-working-store.test.ts
@@ -29,6 +29,21 @@ describe('send receipts', () => {
     });
   });
 
+  test('preserves the turn associated with the send receipt', () => {
+    useSessionWorkingStore.getState().noteSendReceipt('sess_1', {
+      messageId: 'msg_queued',
+      turnId: 'msg_active',
+      atMs: 10,
+    });
+
+    expect(useSessionWorkingStore.getState().receipts.sess_1).toEqual({
+      messageId: 'msg_queued',
+      turnId: 'msg_active',
+      atMs: 10,
+      acceptedAtMs: null,
+    });
+  });
+
   test('acceptance stamps the instant the server took the send', () => {
     const store = useSessionWorkingStore.getState();
     store.noteSendReceipt('sess_1', { messageId: 'msg_1', atMs: 10 });

--- a/packages/sdk/src/browser/stores/session-working-store.ts
+++ b/packages/sdk/src/browser/stores/session-working-store.ts
@@ -29,7 +29,10 @@ interface SessionWorkingState {
   /** Record that a prompt just left this tab. Replaces any previous receipt:
    *  the newest send is the one the UI is standing on. Also releases any
    *  pending stop — sending is the user saying they are not stopping. */
-  noteSendReceipt: (sessionId: string, receipt: { messageId: string; atMs: number }) => void;
+  noteSendReceipt: (
+    sessionId: string,
+    receipt: { messageId: string; turnId?: string | null; atMs: number },
+  ) => void;
   /** The server durably accepted `messageId`. Ignored when a NEWER send has
    *  already replaced the receipt — otherwise the old response would release a
    *  receipt for a send it knows nothing about. */
@@ -83,7 +86,7 @@ export const useSessionWorkingStore = create<SessionWorkingState>()((set) => ({
       return {
         receipts: {
           ...state.receipts,
-          [sessionId]: { messageId: receipt.messageId, atMs: receipt.atMs, acceptedAtMs: null },
+          [sessionId]: { ...receipt, acceptedAtMs: null },
         },
         // A send releases the stop. Leaving it would bar `/turn` from reporting
         // the turn this very send is about to start.

--- a/packages/sdk/src/core/session/working.test.ts
+++ b/packages/sdk/src/core/session/working.test.ts
@@ -341,6 +341,46 @@ describe('projectWorking', () => {
     });
   });
 
+  test('an accepted idle send keeps its turn id while the inbox owns working', () => {
+    const projection = projectWorking({
+      optimistic: {
+        messageId: 'msg_new',
+        turnId: 'msg_new',
+        atMs: T0,
+        acceptedAtMs: T0 + 300,
+      },
+      inbox: { pending: 1, atMs: T0 + 300 },
+      server: { turns: [], atMs: T0 + 400 },
+      stream: { type: 'idle', atMs: T0 - 1 },
+      nowMs: T0 + 500,
+    });
+
+    expect(projection).toEqual({
+      state: 'working',
+      source: 'server',
+      turnId: 'msg_new',
+      since: T0 + 300,
+      serverOpenTurnToken: null,
+    });
+  });
+
+  test('a send made during another response keeps the existing turn association', () => {
+    const projection = projectWorking({
+      optimistic: {
+        messageId: 'msg_queued',
+        turnId: 'msg_active',
+        atMs: T0,
+        acceptedAtMs: T0 + 300,
+      },
+      inbox: { pending: 1, atMs: T0 + 300 },
+      server: { turns: [], atMs: T0 + 400 },
+      stream: { type: 'busy', atMs: T0 - 1 },
+      nowMs: T0 + 500,
+    });
+
+    expect(projection.turnId).toBe('msg_active');
+  });
+
   test('an inbox reading nobody has refreshed stops deciding on ITS own bound', () => {
     // Three prompt-list cadences, not three `/turn` cadences. The list polls at
     // 3s while rows exist, so a reading that has survived 10s is one the poll

--- a/packages/sdk/src/core/session/working.ts
+++ b/packages/sdk/src/core/session/working.ts
@@ -147,9 +147,17 @@ export const OPTIMISTIC_ABORT_MAX_MS = 15_000;
 
 /** This tab's own record that a prompt went out. */
 export interface SendReceipt {
-  /** The submission's tab-local name — never sent anywhere. It exists so a
-   *  `working` state can say WHICH send it is standing on. */
+  /** The submission's tab-local name — never sent anywhere. */
   messageId: string;
+  /**
+   * The user-message turn that owns the working indicator while this receipt
+   * is live. A direct idle send names itself. A send made during an existing
+   * response names that existing turn, so its new bubble remains pending.
+   *
+   * `undefined` preserves the original contract and falls back to
+   * `messageId`. `null` explicitly means the caller cannot identify the turn.
+   */
+  turnId?: string | null;
   /** ms epoch at which the send left this tab. */
   atMs: number;
   /**
@@ -334,6 +342,11 @@ function instant(value: string | null | undefined): number | null {
 export function projectWorking(inputs: WorkingInputs): WorkingProjection {
   const { optimistic, abort, inbox, server, stream, activity, nowMs } = inputs;
   const receiptLive = !!optimistic && nowMs - optimistic.atMs < OPTIMISTIC_RECEIPT_MAX_MS;
+  const receiptTurnId = optimistic
+    ? optimistic.turnId === undefined
+      ? optimistic.messageId
+      : optimistic.turnId
+    : null;
   // TWO floors, because the two server-side observers have different knowledge.
   //
   // `GET .../turn` reads the control plane's ledger, and there is NO row in it
@@ -522,7 +535,7 @@ export function projectWorking(inputs: WorkingInputs): WorkingProjection {
     return {
       state: 'working',
       source: 'server',
-      turnId: null,
+      turnId: receiptLive ? receiptTurnId : null,
       since: inbox!.atMs,
       serverOpenTurnToken,
     };
@@ -555,7 +568,7 @@ export function projectWorking(inputs: WorkingInputs): WorkingProjection {
     return {
       state: 'working',
       source: 'optimistic',
-      turnId: optimistic!.messageId,
+      turnId: receiptTurnId,
       since: optimistic!.atMs,
       serverOpenTurnToken,
     };


### PR DESCRIPTION
## Problem
Every composer message entered the durable inbox first. The inbox working observation erased the send receipt turn ID. The transcript then classified an idle send as pending, dimmed it, showed queue controls, and left the working indicator on the prior turn.

## Fix
- carry an explicit turn association on send receipts
- preserve that association while inbox admission owns working state
- associate idle sends with themselves
- associate sends during active responses with the existing working turn

## Verification
- RED: 4 regression assertions failed with `turnId: null`
- targeted: 113 pass, 0 fail
- SDK: 2723 pass, 0 fail across 168 files
- SDK typecheck: clean
- SDK packed install smoke: pass
- web session suite: 2668 pass, 0 fail across 190 files
- ESLint: 0 errors; 30 existing warnings in session-chat.tsx
- TypeScript: 0 errors in changed session files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790435473&installation_model_id=434224&pr_number=6974&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6974&signature=fc35514d953b46299b2a9b0bf90dd700c562289f07fad877a4909dd54d90fa7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->