### PR TITLE
fix(worker): gateway-mode model resolution killed the first dev pi session

### DIFF
--- a/apps/kortix-worker/src/worker.ts
+++ b/apps/kortix-worker/src/worker.ts
@@ -214,6 +214,16 @@ export async function buildHarness(cfg: WorkerConfig) {
     }
     const list = models.getModels(provider.id);
     model = cfg.modelId ? models.getModel(provider.id, cfg.modelId) : list[0];
+    if (!model && cfg.modelId && cfg.gatewayUrl && list[0]) {
+      // Behind the Kortix gateway the model ref is the GATEWAY's contract
+      // (native `<provider>/<model>`), not a catalog-membership question —
+      // the first dev session died here with "no model resolved" because the
+      // baked ref is not an OpenRouter catalog id. Clone a catalog entry for
+      // its field shape, stamp the requested ref, and point it at the
+      // gateway directly so routing does not depend on auth-layer env
+      // plumbing.
+      model = { ...list[0], id: cfg.modelId, name: cfg.modelId, baseUrl: cfg.gatewayUrl };
+    }
     if (!model) throw new Error(`no model resolved for provider ${provider.id}`);
   }
 


### PR DESCRIPTION
First live pi session on dev (eacab9c9, bench project) booted, fetched its artifact, printed 'kortix-worker starting' — then died: `no model resolved for provider openrouter`. In gateway mode the baked ref (`openrouter/anthropic/claude-sonnet-4.5`, the gateway's native-ref contract) is not an OpenRouter catalog id, and the worker required catalog membership. Reproduced deterministically from the exact session env; fixed by cloning a catalog entry for shape and stamping the baked ref + gateway baseUrl. Verified: same repro now boots, runtimeReady true, correct commit; survival suite 3/3. Fast-forward per dev-trunk policy — merging on push.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790435928&installation_model_id=434224&pr_number=6975&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6975&signature=e3b39906475e834a4407aa2d2653e0b6e2104f14fcba1acb8d973b548f7e7e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->