### PR TITLE
docs(learnings): an experiment flag deploy-dev pins to false cannot be a kill switch

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,32 @@ linked, not inlined.
 
 ## Register
 
+### An experiment flag that deploy-dev pins to an explicit `false` can never double as a kill switch (2026-08-27)
+
+**When:** reusing an existing feature/experiment flag to gate a new default-on
+behaviour with "unset = on, explicit `false` = off" semantics.
+`deploy-dev.yml` injects `KORTIX_FAST_COLD_BOOT_ENABLED=false` into the API
+task on EVERY push deploy (`.github/workflows/deploy-dev.yml`, the
+`enable_fast_cold_boot` dispatch input), so on dev that flag is always
+"explicitly false" even though `apps/api/.env*` leave it unset. PR #6964 gated
+the fresh-session git hint (`KORTIX_BASE_SHA` + scaffold delta + OpenCode
+config-dir hint) on that reading; dev sessions got `KORTIX_SESSION_FRESH=1`
+only and still fetched `main` through the proxy (3.0–3.4 s instead of 0.2 s).
+`provision-core.ts` had the same gate on its seed-time hint for weeks.
+
+**The rule: a new default-on path gets its OWN flag** (#6973:
+`KORTIX_FAST_GIT_BOOT_ENABLED`, `optBoolTrue`), and before choosing
+"explicit false = off" semantics on any flag, grep the deploy workflows and
+`infra/scripts/ecs-deploy.sh` for who sets it — `.env` files are not the only
+source of the task environment.
+
+**Diagnostic:** the daemon env inside a box (`env | grep KORTIX_` via
+`POST <sandbox_url>/kortix/pty`) and `projects.metadata->'git'->'fast_boot'`
+staying `null` after a session: the API never even attempted the hint.
+*Near-miss:* #6964 → #6973, one wasted deploy cycle.
+*Enforcer:* none. A config test that asserts every `optBoolUnset`-style
+"configured?" gate is not also set by `deploy-*.yml` would catch it.
+
 ### A new import edge into a widely-mocked graph breaks hand-written module mocks all over the suite — and the failure names no test (2026-08-27)
 
 **When:** adding an import to code that many suites exercise (a middleware, a


### PR DESCRIPTION
Register entry for the #6964 → #6973 near-miss: `deploy-dev.yml` injects `KORTIX_FAST_COLD_BOOT_ENABLED=false` on every push, so gating a new default-on path on that flag's explicit `false` silently disabled it on dev. Rule: a new default-on path gets its own flag; grep deploy workflows before choosing explicit-false semantics. Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439255&installation_model_id=434224&pr_number=6979&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6979&signature=691ea8012b6827211ee0a7c9b8db7864cb8c3e8d93b20085f99b5f9419adc4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->