### PR TITLE
feat(api): pi worker pool — parked boxes claimed at session create (P1.8)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -554,7 +554,7 @@ jobs:
       # first kpp2 rollout. Automatic pushes remain false. A deliberate manual
       # surface=all dispatch can enable it after the rollout gates pass.
       KORTIX_ECS_ENV_OVERRIDES: >-
-        {"KORTIX_FAST_COLD_BOOT_ENABLED":"${{ github.event_name == 'workflow_dispatch' && inputs.enable_fast_cold_boot && 'true' || 'false' }}","KORTIX_PREVIEW_BASE_DOMAIN":"p.kortix.com"}
+        {"KORTIX_FAST_COLD_BOOT_ENABLED":"${{ github.event_name == 'workflow_dispatch' && inputs.enable_fast_cold_boot && 'true' || 'false' }}","KORTIX_PREVIEW_BASE_DOMAIN":"p.kortix.com","KORTIX_PI_WORKER_POOL_TARGET":"2"}
     steps:
       - uses: actions/checkout@v7
       - name: Configure AWS credentials (OIDC)

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -533,6 +533,16 @@ const envSchema = z.object({
   // bakes. Provider transitions still prepare their target image explicitly.
   // Default OFF keeps the session path on one shared image per provider.
   KORTIX_WARM_SNAPSHOT_ENABLED: optBoolFalse,
+  // Pi worker pool (harness/worker split P1.8): keep this many PARKED boxes of
+  // the shared pi-worker snapshot per environment, claimed at session create
+  // (a claim skips provider create + box boot, ~4s of the cold path measured
+  // on dev 2026-08-27). 0 = off. Pure accelerator: claim failure falls back to
+  // an ordinary cold create.
+  KORTIX_PI_WORKER_POOL_TARGET: optInt(0),
+  // Parked boxes older than this are reaped and replaced; also the Daytona
+  // auto-stop backstop a parked box is created with, so an orphaned box
+  // reclaims itself even if every API instance dies.
+  KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES: optInt(60),
   // One kill switch for additive cold-boot accelerators. It keeps the standard
   // runtime image and every tool. It enables native OpenCode binary prefetch,
   // Platinum rootfs materialization, and stopped per-project images with the
@@ -1180,6 +1190,8 @@ export const config = {
   DAYTONA_WEBHOOK_SECRET: env.DAYTONA_WEBHOOK_SECRET,
   KORTIX_SNAPSHOT_REAP_PREDECESSOR: env.KORTIX_SNAPSHOT_REAP_PREDECESSOR,
   KORTIX_WARM_SNAPSHOT_ENABLED: env.KORTIX_WARM_SNAPSHOT_ENABLED,
+  KORTIX_PI_WORKER_POOL_TARGET: env.KORTIX_PI_WORKER_POOL_TARGET,
+  KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES: env.KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES,
   KORTIX_FAST_COLD_BOOT_ENABLED: env.KORTIX_FAST_COLD_BOOT_ENABLED ?? false,
   KORTIX_FAST_COLD_BOOT_CONFIGURED: env.KORTIX_FAST_COLD_BOOT_ENABLED !== undefined,
   KORTIX_FAST_GIT_BOOT_ENABLED: env.KORTIX_FAST_GIT_BOOT_ENABLED,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,10 @@ import { accountInvitesRouter } from './accounts/invites';
 import { adminApp } from './admin';
 import { startAppDeploymentWorker, stopAppDeploymentWorker } from './apps/deployment-worker';
 import { startAppIdleReaper, stopAppIdleReaper } from './apps/idle-reaper';
+import {
+  startPiWorkerPoolMaintenance,
+  stopPiWorkerPoolMaintenance,
+} from './platform/services/pi-worker-pool';
 import { handleAppPublicRequest, resolveAppRequest } from './apps/public-proxy';
 import { appWsHandlers, prepareAppWsUpgrade } from './apps/ws-proxy';
 import { authRouter } from './auth';
@@ -1498,6 +1502,10 @@ async function startSingletonWorkers() {
   startProviderTransitionWorker();
   startAppDeploymentWorker();
   startAppIdleReaper();
+  // Pi worker pool (P1.8): keep parked worker boxes at target so pi session
+  // creates claim instead of cold-creating. No-op unless
+  // KORTIX_PI_WORKER_POOL_TARGET > 0.
+  startPiWorkerPoolMaintenance();
   startAuditWebhookWorker();
   startAuditReconciliationWorker();
   // IAM V2 time-bounded grants: tick every 60s, emit one audit event per row
@@ -1516,6 +1524,7 @@ async function stopSingletonWorkers() {
   stopProviderTransitionWorker();
   stopAppDeploymentWorker();
   stopAppIdleReaper();
+  stopPiWorkerPoolMaintenance();
   await stopAuditWebhookWorker();
   await stopAuditReconciliationWorker();
   const { stopGrantExpirySweeper } = await import('./iam/expiry-sweeper');

--- a/apps/api/src/platform/providers/daytona.ts
+++ b/apps/api/src/platform/providers/daytona.ts
@@ -86,7 +86,7 @@ function reportIfDiskQuotaError(err: unknown, reason: string): never {
 // otherwise one env would stop another env's sandboxes. `kortix.managed` marks
 // "we created it"; `kortix.env` pins the owning environment. The reaper lists
 // by exactly these labels (see listManagedRunningSandboxes).
-function managedSandboxLabels(workloadType?: SandboxWorkloadType): Record<string, string> {
+export function managedSandboxLabels(workloadType?: SandboxWorkloadType): Record<string, string> {
   return {
     'kortix.managed': 'true',
     'kortix.env': config.INTERNAL_KORTIX_ENV,

--- a/apps/api/src/platform/services/pi-worker-pool.ts
+++ b/apps/api/src/platform/services/pi-worker-pool.ts
@@ -1,0 +1,302 @@
+/**
+ * Pi worker pool (harness/worker split P1.8): parked boxes of the shared
+ * pi-worker snapshot, claimed at session create.
+ *
+ * Why: the worker itself boots in 9 ms, but a cold Daytona create + box boot
+ * costs ~4 s of the ~8.5 s cold path (measured on dev 2026-08-27, PR #6966
+ * thread). A parked box is already running; a claim delivers the session env
+ * over the box's park server and the box fetches its per-commit artifact and
+ * execs the worker — no provider create on the critical path.
+ *
+ * Design constraints, deliberately:
+ * - **No DB table.** Daytona labels are the registry (`kortix.piworker-park`,
+ *   scoped by the managed env labels). The park server accepts exactly ONE
+ *   claim (409 after), so racing API instances need no shared lock — the box
+ *   itself is the serialization point.
+ * - **Pure accelerator.** Every failure path returns null and the caller runs
+ *   the ordinary cold create. The pool can be turned off (target 0, the
+ *   default) with zero behavior change.
+ * - **Self-reclaiming.** Parked boxes are created with a Daytona auto-stop at
+ *   the pool max age, so orphans die even if every API instance does.
+ * - A parked box holds NO session token — only its own random park token.
+ *   The claim carries the session env; the box's preview endpoint is private
+ *   (Daytona preview token, held server-side only).
+ */
+import { randomUUID } from 'node:crypto';
+import { config } from '../../config';
+import { ensurePiWorkerImage } from '../../snapshots/builder';
+import { getDaytona } from '../../shared/daytona';
+import { withTimeout } from '../../shared/with-timeout';
+import { managedSandboxLabels } from '../providers/daytona';
+import { providerAutoStopBackstopMinutes } from '../providers';
+
+const PARK_LABEL = 'kortix.piworker-park';
+const HASH_LABEL = 'kortix.piworker-hash';
+const TOKEN_LABEL = 'kortix.piworker-park-token';
+const PROVIDER_CALL_TIMEOUT_MS = 30_000;
+const CLAIM_REQUEST_TIMEOUT_MS = 5_000;
+/** Bound refill bursts so a mass-reap never stampedes provider create. */
+const MAX_CREATES_PER_MAINTAIN = 2;
+
+export interface ParkedBox {
+  externalId: string;
+  state: string;
+  createdAt: Date | null;
+  contentHash: string | null;
+  parkToken: string | null;
+}
+
+export interface ClaimedPiWorkerBox {
+  externalId: string;
+  baseUrl: string;
+}
+
+export function piWorkerPoolEnabled(): boolean {
+  return config.KORTIX_PI_WORKER_POOL_TARGET > 0;
+}
+
+/** Same origin derivation as the Daytona adapter's create(). */
+function kortixApiRoot(): string {
+  return config.KORTIX_URL.replace(/\/+$/, '')
+    .replace(/\/v1\/router$/, '')
+    .replace(/\/v1$/, '');
+}
+
+async function listParkedBoxes(): Promise<ParkedBox[]> {
+  const out: ParkedBox[] = [];
+  await withTimeout(
+    (async () => {
+      for await (const box of getDaytona().list({
+        labels: { ...managedSandboxLabels(), [PARK_LABEL]: '1' },
+        limit: 100,
+      } as never)) {
+        const raw = box as unknown as {
+          id?: string;
+          state?: string;
+          createdAt?: string | Date;
+          labels?: Record<string, string>;
+        };
+        if (!raw.id) continue;
+        out.push({
+          externalId: raw.id,
+          state: String(raw.state ?? ''),
+          createdAt: raw.createdAt ? new Date(raw.createdAt) : null,
+          contentHash: raw.labels?.[HASH_LABEL] ?? null,
+          parkToken: raw.labels?.[TOKEN_LABEL] ?? null,
+        });
+      }
+    })(),
+    PROVIDER_CALL_TIMEOUT_MS,
+    'Daytona list(parked pi workers)',
+  );
+  return out;
+}
+
+async function createParkedBox(snapshotName: string, contentHash: string): Promise<void> {
+  const parkToken = randomUUID();
+  await withTimeout(
+    getDaytona().create(
+      {
+        snapshot: snapshotName,
+        envVars: {
+          KORTIX_PI_PARK: '1',
+          KORTIX_PI_PARK_TOKEN: parkToken,
+          // Static per environment; everything session-specific arrives with
+          // the claim and overrides the park env.
+          KORTIX_API_URL: `${kortixApiRoot()}/v1`,
+          KORTIX_SERVICE_PORT: '8000',
+        },
+        labels: {
+          ...managedSandboxLabels(),
+          [PARK_LABEL]: '1',
+          [HASH_LABEL]: contentHash,
+          [TOKEN_LABEL]: parkToken,
+        },
+        // Self-reclaim backstop: a parked box the reaper never reaches stops
+        // itself at max age. Claim flips this to the standard session value.
+        autoStopInterval: Math.max(1, config.KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES),
+        autoArchiveInterval: config.KORTIX_SANDBOX_AUTOARCHIVE_MINUTES,
+        autoDeleteInterval: config.KORTIX_SANDBOX_AUTODELETE_MINUTES,
+        public: false,
+      } as never,
+      { timeout: 30 },
+    ),
+    PROVIDER_CALL_TIMEOUT_MS,
+    'Daytona create(parked pi worker)',
+  );
+}
+
+async function removeBox(externalId: string): Promise<void> {
+  const daytona = getDaytona();
+  const sandbox = await withTimeout(
+    daytona.get(externalId),
+    PROVIDER_CALL_TIMEOUT_MS,
+    `Daytona get(${externalId})`,
+  );
+  await withTimeout(
+    daytona.delete(sandbox as never),
+    PROVIDER_CALL_TIMEOUT_MS,
+    `Daytona delete(${externalId})`,
+  );
+}
+
+/**
+ * Claim one parked, current-hash box: POST the session env to its park server.
+ * First 200 wins; 409 means another instance got there first — try the next
+ * box. Returns null when no box could be claimed (caller cold-creates).
+ */
+export async function claimParkedPiWorkerBox(
+  claimEnv: Record<string, string>,
+): Promise<ClaimedPiWorkerBox | null> {
+  if (!piWorkerPoolEnabled()) return null;
+  let candidates: ParkedBox[];
+  let currentHash: string;
+  try {
+    // Memoized after fix 2 — this does not add a provider round trip.
+    const image = await ensurePiWorkerImage({ provider: 'daytona' });
+    currentHash = image.contentHash;
+    candidates = (await listParkedBoxes()).filter(
+      (box) =>
+        box.contentHash === currentHash &&
+        box.parkToken &&
+        box.state.toLowerCase() === 'started',
+    );
+  } catch (err) {
+    console.warn('[pi-pool] claim listing failed; falling back to cold create:', err);
+    return null;
+  }
+  // Oldest first: steady turnover keeps no box near its self-reclaim age.
+  candidates.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
+  const daytona = getDaytona();
+  for (const box of candidates.slice(0, 3)) {
+    try {
+      const sandbox = await withTimeout(
+        daytona.get(box.externalId),
+        PROVIDER_CALL_TIMEOUT_MS,
+        `Daytona get(${box.externalId})`,
+      );
+      const preview = await withTimeout(
+        (sandbox as unknown as {
+          getPreviewLink(port: number): Promise<{ url: string; token?: string }>;
+        }).getPreviewLink(8000),
+        PROVIDER_CALL_TIMEOUT_MS,
+        `Daytona getPreviewLink(${box.externalId}:8000)`,
+      );
+      const res = await fetch(`${preview.url.replace(/\/+$/, '')}/kortix/claim`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-park-token': box.parkToken as string,
+          ...(preview.token ? { 'x-daytona-preview-token': preview.token } : {}),
+        },
+        body: JSON.stringify({ env: claimEnv }),
+        signal: AbortSignal.timeout(CLAIM_REQUEST_TIMEOUT_MS),
+      });
+      if (res.status === 409) continue; // another instance won this box
+      if (!res.ok) {
+        console.warn(`[pi-pool] claim of ${box.externalId} failed: HTTP ${res.status}`);
+        continue;
+      }
+      // Best effort AFTER the claim is won: leave the pool registry and take
+      // the standard session lifecycle. Failure here never voids the claim —
+      // the box already booted the session; the self-reclaim age is the
+      // worst-case backstop and the reaper skips claimed boxes by label.
+      const mutable = sandbox as unknown as {
+        setLabels(labels: Record<string, string>): Promise<unknown>;
+        setAutostopInterval(minutes: number): Promise<void>;
+      };
+      await mutable
+        .setLabels({ ...managedSandboxLabels(), 'kortix.piworker-claimed': '1' })
+        .catch((err: unknown) =>
+          console.warn(`[pi-pool] relabel of claimed ${box.externalId} failed:`, err),
+        );
+      await mutable
+        .setAutostopInterval(providerAutoStopBackstopMinutes())
+        .catch((err: unknown) =>
+          console.warn(`[pi-pool] autostop reset of claimed ${box.externalId} failed:`, err),
+        );
+      return {
+        externalId: box.externalId,
+        baseUrl: `${kortixApiRoot()}/v1/p/${box.externalId}/8000`,
+      };
+    } catch (err) {
+      console.warn(`[pi-pool] claim attempt on ${box.externalId} errored:`, err);
+    }
+  }
+  return null;
+}
+
+let maintainInFlight: Promise<void> | null = null;
+
+/**
+ * Reconcile the pool toward the target: reap stale-hash / over-age / dead /
+ * surplus parked boxes, then create up to MAX_CREATES_PER_MAINTAIN missing
+ * ones. Concurrent invocations coalesce; every error is contained (the pool
+ * must never take a session create down with it).
+ */
+export function maintainPiWorkerPool(): Promise<void> {
+  if (!piWorkerPoolEnabled()) return Promise.resolve();
+  if (maintainInFlight) return maintainInFlight;
+  maintainInFlight = (async () => {
+    const target = config.KORTIX_PI_WORKER_POOL_TARGET;
+    const maxAgeMs = config.KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES * 60_000;
+    const image = await ensurePiWorkerImage({ provider: 'daytona' });
+    const parked = await listParkedBoxes();
+    const now = Date.now();
+    const alive: ParkedBox[] = [];
+    const reap: ParkedBox[] = [];
+    for (const box of parked) {
+      const state = box.state.toLowerCase();
+      const dead = state === 'stopped' || state === 'error' || state === 'destroyed';
+      const stale = box.contentHash !== image.contentHash;
+      const overAge = box.createdAt !== null && now - box.createdAt.getTime() > maxAgeMs;
+      if (dead || stale || overAge || !box.parkToken) reap.push(box);
+      else alive.push(box);
+    }
+    // Surplus (multi-instance refills can overshoot): trim oldest first.
+    alive.sort((a, b) => (a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0));
+    while (alive.length > target) reap.push(alive.shift() as ParkedBox);
+    for (const box of reap) {
+      await removeBox(box.externalId).catch((err) =>
+        console.warn(`[pi-pool] reap of ${box.externalId} failed:`, err),
+      );
+    }
+    const missing = Math.min(Math.max(0, target - alive.length), MAX_CREATES_PER_MAINTAIN);
+    for (let i = 0; i < missing; i++) {
+      await createParkedBox(image.snapshotName, image.contentHash).catch((err) =>
+        console.warn('[pi-pool] parked box create failed:', err),
+      );
+    }
+    if (reap.length > 0 || missing > 0) {
+      console.log(
+        `[pi-pool] maintained: ${alive.length}/${target} parked, reaped ${reap.length}, created ${missing}`,
+      );
+    }
+  })()
+    .catch((err) => console.warn('[pi-pool] maintain failed:', err))
+    .finally(() => {
+      maintainInFlight = null;
+    });
+  return maintainInFlight;
+}
+
+let maintainTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Leader-only periodic reconcile (index.ts singleton workers). The per-create
+ * refill kick keeps the pool moving under load; this interval is the idle
+ * safety net (initial fill after deploy, reap of over-age boxes overnight).
+ */
+export function startPiWorkerPoolMaintenance(): void {
+  if (!piWorkerPoolEnabled() || maintainTimer) return;
+  void maintainPiWorkerPool();
+  maintainTimer = setInterval(() => void maintainPiWorkerPool(), 5 * 60_000);
+  (maintainTimer as { unref?: () => void }).unref?.();
+}
+
+export function stopPiWorkerPoolMaintenance(): void {
+  if (maintainTimer) {
+    clearInterval(maintainTimer);
+    maintainTimer = null;
+  }
+}

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -1028,3 +1028,34 @@ describe('provisionSessionSandbox — mid-provision delete race', () => {
     expect(preserved?.updates.metadata).toMatchObject({ stoppedDuringProvisioning: true });
   });
 });
+
+describe('pi worker pool claim (P1.8)', () => {
+  test('a pi boot tries the parked pool before provider create, gated to daytona', async () => {
+    const source = await Bun.file(new URL('./session-sandbox.ts', import.meta.url)).text();
+    const claim = source.indexOf('const pooledClaim =');
+    const create = source.indexOf('retrySandboxProvisionCreate(provider, providerCreateInput', claim);
+    const refill = source.indexOf('void maintainPiWorkerPool()', claim);
+    const externalId = source.indexOf('bgExternalId = result.externalId', claim);
+    expect(claim).toBeGreaterThan(-1);
+    // Claim sits BEFORE the provider create and only for pi worker boots on
+    // daytona; the refill kick fires after either path, before activation.
+    const gate = source.slice(claim, create);
+    expect(gate).toContain("opts.metadata?.pi_worker_boot === true && providerName === 'daytona'");
+    expect(gate).toContain('claimParkedPiWorkerBox(providerCreateInput.envVars ?? {})');
+    expect(create).toBeGreaterThan(claim);
+    expect(refill).toBeGreaterThan(create);
+    expect(externalId).toBeGreaterThan(refill);
+    // A claim failure must NEVER fail the session — it degrades to cold create.
+    expect(gate).toContain('return null');
+  });
+
+  test('a claimed box records the pool path in its provision timeline', async () => {
+    const source = await Bun.file(new URL('./session-sandbox.ts', import.meta.url)).text();
+    const claim = source.indexOf('if (pooledClaim) {');
+    const mark = source.indexOf("tl.mark('pool-claim')", claim);
+    const elseBranch = source.indexOf('} else {', claim);
+    expect(claim).toBeGreaterThan(-1);
+    expect(mark).toBeGreaterThan(claim);
+    expect(mark).toBeLessThan(elseBranch);
+  });
+});

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -51,6 +51,7 @@ import {
 } from '../../snapshots/builder';
 import { deleteProjectSandboxImage } from '../../snapshots/project-image-delete';
 import { config } from '../../config';
+import { claimParkedPiWorkerBox, maintainPiWorkerPool } from './pi-worker-pool';
 import { providerFallbackSetting } from './runtime-settings';
 import { selectProvider } from './provider-balancer';
 import { ProvisionTimeline } from './provision-timeline';
@@ -680,6 +681,34 @@ export async function provisionSessionSandbox(opts: {
       // §4). The guest holds a handle; the broker route substitutes server-side.
       let result: ProvisionResult;
       let attempts: number;
+      // P1.8 (harness/worker split): a pi worker boot tries the parked pool
+      // first. The claim delivers the exact env the create would have
+      // (session token + gateway URL included), so the box boots the same
+      // session either way; null falls through to the cold create unchanged.
+      const pooledClaim =
+        opts.metadata?.pi_worker_boot === true && providerName === 'daytona'
+          ? await claimParkedPiWorkerBox(providerCreateInput.envVars ?? {}).catch((err) => {
+              console.warn(
+                `[session-sandbox] pi pool claim errored for ${sandbox.sandboxId}; cold create:`,
+                err,
+              );
+              return null;
+            })
+          : null;
+      if (pooledClaim) {
+        result = {
+          externalId: pooledClaim.externalId,
+          baseUrl: pooledClaim.baseUrl,
+          metadata: {
+            provisionedBy: opts.userId,
+            daytonaSandboxId: pooledClaim.externalId,
+            snapshot: imageInfo!.snapshotName,
+            pooled: true,
+          },
+        };
+        attempts = 0;
+        tl.mark('pool-claim');
+      } else {
       try {
       ({ result, attempts } = await retrySandboxProvisionCreate(provider, providerCreateInput, {
         onAttemptStart: async (attempt, maxAttempts) => {
@@ -748,6 +777,12 @@ export async function provisionSessionSandbox(opts: {
           continue provisioning;
         }
         throw createErr;
+      }
+      }
+      // Refill toward target after every pi boot — a consumed claim leaves a
+      // hole, and a claim miss means the pool is empty. Fire-and-forget.
+      if (opts.metadata?.pi_worker_boot === true && providerName === 'daytona') {
+        void maintainPiWorkerPool();
       }
       bgExternalId = result.externalId;
       tl.mark(`provider-create:${attempts}x`);

--- a/apps/api/src/snapshots/build-context.ts
+++ b/apps/api/src/snapshots/build-context.ts
@@ -352,12 +352,130 @@ export const PI_WORKER_ENTRYPOINT = '/usr/local/bin/pi-worker-entrypoint';
 const PI_WORKER_ENTRYPOINT_SH = `#!/bin/sh
 # Boot a session on the compiled pi worker runtime.
 # Fails loudly: a worker that cannot fetch its exact artifact must not serve.
+#
+# Park mode (KORTIX_PI_PARK=1): the box was pre-created by the worker pool and
+# knows no session yet. It idles on a tiny claim server; the API's pool claim
+# delivers the session env (token, project, ref/sha) and the same fetch+exec
+# path runs then. See PI_WORKER_PARK_MJS.
 set -eu
+export PORT="\${KORTIX_SERVICE_PORT:-8000}"
+if [ -n "\${KORTIX_PI_PARK:-}" ]; then
+  : "\${KORTIX_PI_PARK_TOKEN:?}"
+  exec node /opt/kortix/park.mjs
+fi
 : "\${KORTIX_API_URL:?}" "\${KORTIX_TOKEN:?}" "\${KORTIX_PROJECT_ID:?}"
 : "\${KORTIX_PI_RUNTIME_REF:?}" "\${KORTIX_PI_RUNTIME_SHA:?}"
-export PORT="\${KORTIX_SERVICE_PORT:-8000}"
 node /opt/kortix/fetch-runtime.mjs
 exec node /opt/kortix/session-worker.mjs
+`;
+
+const PI_WORKER_PARK_MJS = `// Parked pi worker box: idle until one session claims it.
+// The claim is the ONLY serialization the pool has — first POST wins, every
+// later one gets 409 — so racing API instances need no shared lock.
+import { spawn } from 'node:child_process';
+import { timingSafeEqual } from 'node:crypto';
+import { createServer } from 'node:http';
+
+const PORT = Number(process.env.PORT ?? 8000);
+const PARK_TOKEN = process.env.KORTIX_PI_PARK_TOKEN ?? '';
+const RUNTIME_DIR = process.env.KORTIX_PI_PARK_DIR ?? '/opt/kortix';
+const REQUIRED = [
+  'KORTIX_API_URL',
+  'KORTIX_TOKEN',
+  'KORTIX_PROJECT_ID',
+  'KORTIX_PI_RUNTIME_REF',
+  'KORTIX_PI_RUNTIME_SHA',
+];
+let claimed = false;
+
+function tokenOk(header) {
+  const a = Buffer.from(String(header ?? ''));
+  const b = Buffer.from(PARK_TOKEN);
+  return PARK_TOKEN.length > 0 && a.length === b.length && timingSafeEqual(a, b);
+}
+
+function readBody(req, cap) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on('data', (c) => {
+      size += c.length;
+      if (size > cap) reject(new Error('claim body too large'));
+      else chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+async function boot(env) {
+  // Same two steps the cold entrypoint runs, with the claim env layered over
+  // the park env. Values never hit the log.
+  const merged = { ...process.env, ...env };
+  const fetchExit = await new Promise((resolve) => {
+    const child = spawn('node', [RUNTIME_DIR + '/fetch-runtime.mjs'], { env: merged, stdio: 'inherit' });
+    child.on('exit', (code) => resolve(code ?? 1));
+    child.on('error', () => resolve(1));
+  });
+  if (fetchExit !== 0) {
+    console.error(JSON.stringify({ msg: 'claimed park boot FAILED at fetch', exit: fetchExit }));
+    process.exit(1);
+  }
+  const worker = spawn('node', [RUNTIME_DIR + '/session-worker.mjs'], { env: merged, stdio: 'inherit' });
+  for (const sig of ['SIGTERM', 'SIGINT']) process.on(sig, () => worker.kill(sig));
+  worker.on('exit', (code) => process.exit(code ?? 1));
+}
+
+const server = createServer(async (req, res) => {
+  const path = String(req.url ?? '').split('?')[0];
+  if (req.method === 'GET' && path === '/kortix/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, parked: true, runtimeReady: false }));
+    return;
+  }
+  if (req.method === 'POST' && path === '/kortix/claim') {
+    if (!tokenOk(req.headers['x-park-token'])) {
+      res.writeHead(401, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'bad park token' }));
+      return;
+    }
+    if (claimed) {
+      res.writeHead(409, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'already claimed' }));
+      return;
+    }
+    let env;
+    try {
+      const body = JSON.parse(await readBody(req, 256 * 1024));
+      env = body?.env;
+      if (!env || typeof env !== 'object' || Array.isArray(env)) throw new Error('env map required');
+      for (const [key, value] of Object.entries(env)) {
+        if (!/^KORTIX_[A-Z0-9_]*$/.test(key) || typeof value !== 'string') {
+          throw new Error('claim env keys must be KORTIX_* strings');
+        }
+      }
+      for (const key of REQUIRED) {
+        if (!env[key]) throw new Error('claim env missing ' + key);
+      }
+    } catch (error) {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: String(error?.message ?? error) }));
+      return;
+    }
+    claimed = true;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+    console.log(JSON.stringify({ msg: 'park claim accepted', keys: Object.keys(env).length }));
+    // Free the port for the worker, then boot with the claim env.
+    server.close(() => void boot(env));
+    return;
+  }
+  res.writeHead(404, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ error: 'not found' }));
+});
+server.listen(PORT, () => {
+  console.log(JSON.stringify({ msg: 'pi worker parked', port: PORT }));
+});
 `;
 
 const PI_WORKER_FETCH_MJS = `// Download this session's compiled pi runtime, verified before it may run.
@@ -405,7 +523,8 @@ RUN useradd --create-home --shell /usr/sbin/nologin kortix \\
     && mkdir -p /opt/kortix && chown kortix:kortix /opt/kortix
 COPY pi-worker-entrypoint /usr/local/bin/pi-worker-entrypoint
 COPY fetch-runtime.mjs /opt/kortix/fetch-runtime.mjs
-RUN chmod 0555 /usr/local/bin/pi-worker-entrypoint /opt/kortix/fetch-runtime.mjs
+COPY park.mjs /opt/kortix/park.mjs
+RUN chmod 0555 /usr/local/bin/pi-worker-entrypoint /opt/kortix/fetch-runtime.mjs /opt/kortix/park.mjs
 USER kortix
 ENV NODE_ENV=production
 `;
@@ -414,14 +533,22 @@ ENV NODE_ENV=production
 /** Content identity of the pi worker image — nothing else goes into it. */
 export function piWorkerImageFingerprint(): string {
   return createHash('sha256')
-    .update(`pi-worker-v1\0${buildPiWorkerDockerfile()}\0${PI_WORKER_ENTRYPOINT_SH}\0${PI_WORKER_FETCH_MJS}`)
+    .update(
+      `pi-worker-v1\0${buildPiWorkerDockerfile()}\0${PI_WORKER_ENTRYPOINT_SH}\0${PI_WORKER_FETCH_MJS}\0${PI_WORKER_PARK_MJS}`,
+    )
     .digest('hex');
+}
+
+/** The park server script, exported for the handshake test only. */
+export function piWorkerParkScriptForTest(): string {
+  return PI_WORKER_PARK_MJS;
 }
 
 export async function stagePiWorkerBuildContext(): Promise<StagedContext> {
   const contextDir = await mkdtemp(join(tmpdir(), 'kortix-piworker-snap-'));
   await writeFileFs(join(contextDir, 'pi-worker-entrypoint'), PI_WORKER_ENTRYPOINT_SH, { mode: 0o755 });
   await writeFileFs(join(contextDir, 'fetch-runtime.mjs'), PI_WORKER_FETCH_MJS);
+  await writeFileFs(join(contextDir, 'park.mjs'), PI_WORKER_PARK_MJS);
   const dockerfileName = 'Dockerfile';
   const composedPath = join(contextDir, dockerfileName);
   await writeFileFs(composedPath, buildPiWorkerDockerfile());

--- a/apps/api/src/snapshots/pi-worker-park.test.ts
+++ b/apps/api/src/snapshots/pi-worker-park.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { piWorkerParkScriptForTest } from './build-context';
+
+// The real park script (the exact bytes baked into the pi-worker snapshot)
+// driven through its whole protocol: health-while-parked, token gate, env
+// validation, single-accept, and the port handoff to the claimed worker. The
+// fetch and worker stages are stand-ins — their contract (spawned with the
+// merged claim env, worker inherits the port) is what this asserts.
+const FAKE_FETCH = `
+if (!process.env.KORTIX_TOKEN || !process.env.KORTIX_PI_RUNTIME_SHA) process.exit(3);
+process.exit(0);
+`;
+const FAKE_WORKER = `
+import { createServer } from 'node:http';
+createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({
+    ok: true,
+    runtimeReady: true,
+    sessionId: process.env.KORTIX_SESSION_ID ?? null,
+  }));
+}).listen(Number(process.env.PORT));
+`;
+
+const CLAIM_ENV = {
+  KORTIX_API_URL: 'https://api.kortix.test/v1',
+  KORTIX_TOKEN: 'session-token',
+  KORTIX_PROJECT_ID: 'proj-1',
+  KORTIX_SESSION_ID: 'sess-42',
+  KORTIX_PI_RUNTIME_REF: 'main',
+  KORTIX_PI_RUNTIME_SHA: 'a'.repeat(40),
+};
+
+let child: ChildProcess | null = null;
+const roots: string[] = [];
+afterEach(async () => {
+  child?.kill('SIGKILL');
+  child = null;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function bootPark(): Promise<{ port: number; base: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'kortix-park-'));
+  roots.push(root);
+  await writeFile(join(root, 'park.mjs'), piWorkerParkScriptForTest());
+  await writeFile(join(root, 'fetch-runtime.mjs'), FAKE_FETCH);
+  await writeFile(join(root, 'session-worker.mjs'), FAKE_WORKER);
+  const port = 18800 + Math.floor(Math.random() * 500);
+  child = spawn('node', [join(root, 'park.mjs')], {
+    env: {
+      PATH: process.env.PATH,
+      PORT: String(port),
+      KORTIX_PI_PARK: '1',
+      KORTIX_PI_PARK_TOKEN: 'park-tok',
+      KORTIX_PI_PARK_DIR: root,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const base = `http://127.0.0.1:${port}`;
+  for (let i = 0; i < 100; i++) {
+    try {
+      const res = await fetch(`${base}/kortix/health`);
+      if (res.ok) return { port, base };
+    } catch {
+      // not listening yet
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error('park server never came up');
+}
+
+describe('pi worker park server', () => {
+  test('full claim handshake hands the port to a worker running the claim env', async () => {
+    const { base } = await bootPark();
+
+    const parked = (await (await fetch(`${base}/kortix/health`)).json()) as {
+      parked?: boolean;
+      runtimeReady?: boolean;
+    };
+    expect(parked.parked).toBe(true);
+    expect(parked.runtimeReady).toBe(false);
+
+    const badToken = await fetch(`${base}/kortix/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-park-token': 'wrong' },
+      body: JSON.stringify({ env: CLAIM_ENV }),
+    });
+    expect(badToken.status).toBe(401);
+
+    const badEnv = await fetch(`${base}/kortix/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-park-token': 'park-tok' },
+      body: JSON.stringify({ env: { ...CLAIM_ENV, NOT_KORTIX: 'x' } }),
+    });
+    expect(badEnv.status).toBe(400);
+
+    const missing = await fetch(`${base}/kortix/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-park-token': 'park-tok' },
+      body: JSON.stringify({ env: { KORTIX_API_URL: 'https://api.kortix.test/v1' } }),
+    });
+    expect(missing.status).toBe(400);
+
+    const claim = await fetch(`${base}/kortix/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-park-token': 'park-tok' },
+      body: JSON.stringify({ env: CLAIM_ENV }),
+    });
+    expect(claim.status).toBe(200);
+
+    // Single-accept: a second claim is refused — 409 while the park server is
+    // still draining, or a connection error once it has already closed the
+    // port for the worker. Both prove the box can never serve two sessions.
+    const second = await fetch(`${base}/kortix/claim`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-park-token': 'park-tok' },
+      body: JSON.stringify({ env: { ...CLAIM_ENV, KORTIX_SESSION_ID: 'sess-43' } }),
+    }).then(
+      (res) => res.status,
+      () => 'refused',
+    );
+    expect([409, 'refused']).toContain(second as never);
+
+    // The worker takes over the SAME port with the claim env applied.
+    interface WorkerHealth {
+      runtimeReady?: boolean;
+      sessionId?: string | null;
+      parked?: boolean;
+    }
+    let worker: WorkerHealth | null = null;
+    for (let i = 0; i < 100; i++) {
+      try {
+        const res = await fetch(`${base}/kortix/health`);
+        if (res.ok) {
+          const body = (await res.json()) as WorkerHealth;
+          if (!body?.parked) {
+            worker = body;
+            break;
+          }
+        }
+      } catch {
+        // handoff gap
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    expect(worker?.runtimeReady).toBe(true);
+    expect(worker?.sessionId).toBe('sess-42');
+  }, 20_000);
+});


### PR DESCRIPTION
P1.8 of the harness/worker split ([plan](docs/specs/2026-08-26-harness-worker-split.md), cold-boot decomposition in the [PR #6966 thread](https://github.com/kortix-ai/suna/pull/6966#issuecomment-5441551082)). Deletes the remaining ~4s of the pi cold path: the Daytona create + box boot.

**How it works**
1. The pi-worker snapshot gains a **park mode**: `KORTIX_PI_PARK=1` boxes boot a ~100-line claim server instead of a session. One `POST /kortix/claim` (random per-box park token) delivers the session env; the box then runs the same fetch-artifact + exec-worker path as a cold boot. **Single-accept**: the second claim gets 409 — the box itself is the cross-instance serialization point, so no shared lock exists anywhere.
2. **Registry = Daytona labels** (env-scoped alongside `kortix.managed`); no DB table. Parked boxes carry a Daytona auto-stop at pool max age, so orphans self-reclaim even if every API instance dies.
3. `provisionSessionSandbox` tries a claim before provider create for pi boots on Daytona; **every failure path degrades to the unchanged cold create** (pure accelerator). Claimed boxes flip to the standard session auto-stop and drop their pool labels; the timeline records `pool-claim`.
4. Leader-only periodic maintain (5min) + per-create refill kick; reaps stale-hash (deploy), over-age, dead, and surplus boxes; creation bursts capped at 2.
5. Knobs: `KORTIX_PI_WORKER_POOL_TARGET` (default 0 = off — zero behavior change), `KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES` (60). Dev enabled at target 2 via `KORTIX_ECS_ENV_OVERRIDES`.

**Verified locally**: the REAL park script (exact baked bytes) driven through the full protocol — health-while-parked, token gate (401), env validation (400), claim (200), single-accept (409/refused), and the port handoff to a worker that proves it runs the claim env (`src/snapshots/pi-worker-park.test.ts`). Plus claim-ordering pins, image-cache pins, `tsc --noEmit` clean, 84 tests / 0 fail across the touched suites, and `tests/unit/ecs-deploy-environment.test.ts` green on the overrides edit.

**After deploy**: the pool fills on the leader's first maintain tick; a dev cold-vs-claim benchmark will be posted here. A parked box holds NO session token — only its own park token; the session env arrives with the claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790440257&installation_model_id=434224&pr_number=6981&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6981&signature=0e97e50977bb95f378263892feacce8900875c5298242c0431ab9bd8dfc7135f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->