### PR TITLE
fix(api): defer the ensurePiWorkerImage import so builder mocks cannot SyntaxError

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -77,8 +77,20 @@ failed:` followed by nothing, is this. Read the `Unhandled error` block, not the
 failing test name.
 *Near-miss:* PR #6963 (the Apps viewer token). Cost two CI rounds and a wrong
 "it's a pre-existing flake" call before the real cause was read.
+*Recurrence, same day:* `d990e122aa` added `ensurePiWorkerImage` to the static
+import from `snapshots/builder` in `platform/services/session-sandbox.ts`. The
+module edge already existed — only the NAME was new — and that was enough: all
+eleven suites that stub `snapshots/builder` by listing its exports died at
+import. It reddened the packages lane on two unrelated PRs (#6978, and #6957 on
+different tests) before anyone read the cause. Fixed in #6982 by deferring that
+one name to a dynamic import at its single call site: zero mock churn.
+**It does not reproduce locally** — the full `apps/api` suite passes 8745/0 both
+with and without the fix. Only CI's worker count and interleaving surface it, so
+"it passes on my machine" proves nothing about this class. Read the CI
+`Unhandled error` block.
 *Enforcer:* none. A lint that flags `mock.module` factories which do not spread
-the real module would catch the mocks; nothing catches the import edge.
+the real module would catch the mocks; nothing catches the import edge. Worth
+building — this rule has now been paid for twice in one day.
 
 ### Two migrations generated from the same parent fork the drizzle chain, and main then cannot generate ANY migration (2026-08-27)
 

--- a/apps/api/src/platform/services/session-sandbox.ts
+++ b/apps/api/src/platform/services/session-sandbox.ts
@@ -43,7 +43,6 @@ import {
 import {
   ensureSandboxImage,
   ensureMetaSandboxImage,
-  ensurePiWorkerImage,
   deleteSandboxImage,
   resolveTemplate,
   DEFAULT_SANDBOX_SLUG,
@@ -374,7 +373,21 @@ export async function provisionSessionSandbox(opts: {
         ? // The pi worker is a shared content-hashed image like meta — never a
           // project template. Its harness arrives at boot as the compiled
           // artifact (KORTIX_PI_RUNTIME_REF/SHA in extraEnvVars).
-          ensurePiWorkerImage({ source: 'session-start', provider: targetProvider })
+          //
+          // Imported lazily, and ONLY this name. `mock.module` replaces a
+          // module wholesale, so every suite that stubs `snapshots/builder` by
+          // listing its exports drops the ones it did not name. Adding
+          // `ensurePiWorkerImage` to the static import above made all eleven of
+          // those suites die at import with `SyntaxError: Export named
+          // 'ensurePiWorkerImage' not found` — attributed to no test, and it
+          // takes an unrelated parallel worker down with it. The register's
+          // rule is "fix the import, not the mocks"
+          // (.claude/skills/learnings/SKILL.md:39). This edge is reached once,
+          // on the pi-worker branch only, so deferring it costs nothing and
+          // needs no test churn.
+          import('../../snapshots/builder').then(({ ensurePiWorkerImage }) =>
+            ensurePiWorkerImage({ source: 'session-start', provider: targetProvider }),
+          )
         : ensureSandboxImage(gitProject, {
           slug,
           accountId,


### PR DESCRIPTION
## What broke

`main` commit `d990e122aa` ("sessions boot the pi worker when pi_worker flag + manifest runtime: pi") added `ensurePiWorkerImage` to the **static** import from `snapshots/builder` in `apps/api/src/platform/services/session-sandbox.ts:46`.

Eleven suites stub that module with `mock.module` by listing its exports:

```
src/projects/maintenance.test.ts
src/projects/routes/r2-glyph-wiring.test.ts
src/projects/routes/r2-icon-wiring.test.ts
src/platform/services/session-sandbox.test.ts
src/__tests__/e2e-project-session-contract.test.ts
src/__tests__/e2e-create-repo-starter.test.ts
src/__tests__/e2e-projects-provision.test.ts
src/__tests__/e2e-projects-contract.test.ts
src/__tests__/e2e-project-limit.test.ts
src/__tests__/e2e-project-triggers.test.ts
src/__tests__/unit-warm-bake-cooldown.test.ts
```

`mock.module` replaces a module **wholesale**, so a stub that does not name `ensurePiWorkerImage` deletes it. CI's packages lane then dies with

```
SyntaxError: Export named 'ensurePiWorkerImage' not found in module
'apps/api/src/snapshots/builder.ts'
```

attributed to **no test**, taking an unrelated parallel worker down with it. Observed on PR #6978's packages lane (run `33091892424`).

## The change

One line. The import is reached once, on the pi-worker branch only, so deferring it costs nothing and needs no mock edits.

This follows the register's rule for this exact failure class — **"fix the import, not the mocks"** (`.claude/skills/learnings/SKILL.md:39`). That entry was added the same day, for the same shape, and records `Enforcer: none` — this is its first recurrence.

## Honest status: hardening, not a proven fix

The failure **does not reproduce locally**. The full `apps/api` suite passes **8745 / 0 on unmodified `main`** and **8745 / 0 with this change**. CI is the only environment that has reproduced it, presumably through a different worker count and interleaving.

A single green CI run on this PR would be **weak evidence**, because the packages lane is independently flaky:
- PR #6957 fails the same lane on unrelated timing tests (`upstreamTiming`, `sessions new CLI flow` 30s timeouts).
- `main`'s own recent `Tests - PR` runs flip this lane between success and failure across commits.

So: this removes a real, identified fragility and is zero-risk, but I am not claiming it is the whole story on that lane.

## Verified

- `tsc --noEmit` on `apps/api`: clean.
- Full `apps/api` suite: 8745 pass, 0 fail.

cc the author of `d990e122aa` — worth a look in case the pi-worker path wants the static edge back with the mocks updated instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790440669&installation_model_id=434224&pr_number=6982&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6982&signature=f2a7eea474317e18b51a881aeb39a2725256294df7458db2f5d659d53cd5d0d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->