### PR TITLE
fix(api): pi worker env — only an explicit session model overrides the bake

### DIFF
--- a/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
+++ b/apps/api/src/projects/lib/sessions.fast-boot-git-hint.test.ts
@@ -94,3 +94,16 @@ describe('pi worker boot skips the OpenCode boot chain', () => {
     expect(block).toContain('resolveCommitSha(authedProject, ref).catch(() => null)');
   });
 });
+
+describe('pi worker env model override', () => {
+  test('only an explicit session model overrides the baked agent model', async () => {
+    const source = await sessionsSource();
+    const fork = source.indexOf('const envPromise = piWorkerBoot');
+    const slim = source.indexOf('buildPiWorkerSessionEnvVars({', fork);
+    const block = source.slice(slim, source.indexOf('apiUrl:', slim));
+    expect(block).toContain("opencodeModelSource === 'explicit'");
+    // Env refs reach the worker verbatim, so the gateway prefix is stripped
+    // server-side (the baked path de-prefixes inside the worker).
+    expect(block).toContain("replace(/^kortix\\//, '')");
+  });
+});

--- a/apps/api/src/projects/lib/sessions.ts
+++ b/apps/api/src/projects/lib/sessions.ts
@@ -1773,7 +1773,16 @@ export async function createProjectSession(input: {
               projectId,
               sessionId,
               agentName,
-              opencodeModel,
+              // Only an EXPLICIT session model may override the baked agent
+              // model — the platform/project fallback resolution exists for
+              // the OpenCode path and must not clobber the artifact's own
+              // model (KORTIX_MODEL wins over the bake inside the worker).
+              // Stripped to the native ref: the worker's env path takes the
+              // value verbatim, unlike the baked path which de-prefixes.
+              opencodeModel:
+                opencodeModelSource === 'explicit' && opencodeModel
+                  ? opencodeModel.replace(/^kortix\//, '')
+                  : null,
               apiUrl: deriveKortixApiBase(),
               frontendUrl: sandboxFrontendBaseUrl(),
             }),


### PR DESCRIPTION
Live-behavior fix caught during the P1.8 pool verification on dev (session `90232bdc`): the slim pi env from #6980 passed the session's RESOLVED `opencode_model` (which falls back to project/platform defaults) as `KORTIX_MODEL`. Inside the worker, env wins over bake — so every pi session ran `kortix/openrouter/z-ai/glm-5.3-flash` (the platform default, gateway prefix unstripped ⇒ zero tokens) instead of its agent's baked model.

Fix: pass `KORTIX_MODEL` only when `opencode_model_source === 'explicit'`, stripped to the native ref. Bake wins otherwise — the pre-#6980 behavior.

Verified: pinned by a source test (`sessions.fast-boot-git-hint.test.ts`, 7 pass), `tsc --noEmit` clean. Post-deploy the live re-run on the bench project must answer from `openrouter/anthropic/claude-sonnet-4.5` again — will be posted on #6981 with the pool benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790442019&installation_model_id=434224&pr_number=6983&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6983&signature=60477dfb0acee433c37ccd2d89c6f92a76f9cf13635c4e23ce3ddf1921a9346a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->