### PR TITLE
perf(web): stop blurring text the user is trying to read

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1170,23 +1170,6 @@ a.prose code {
    inline style beats a stylesheet declaration, which meant the stagger
    survived `prefers-reduced-motion` on `.kx-fade-up` — the movement stopped
    but the staged reveal did not. */
-@keyframes blur-fade-in {
-  from {
-    opacity: 0;
-    filter: blur(8px);
-    transform: translateY(2px);
-  }
-  50% {
-    opacity: 0.7;
-    filter: blur(3px);
-    transform: translateY(1px);
-  }
-  to {
-    opacity: 1;
-    filter: blur(0);
-    transform: translateY(0);
-  }
-}
 
 .kortix-markdown.streaming-active {
   position: relative;
@@ -1210,10 +1193,6 @@ a.prose code {
   font-size: 1.05em;
 }
 
-.kortix-markdown[data-streaming='true'] > *:last-child {
-  animation: stream-fade-in 180ms ease-out;
-}
-
 @keyframes text-shimmer {
   0% {
     background-position: -200% center;
@@ -1223,9 +1202,17 @@ a.prose code {
   }
 }
 
-.kortix-markdown[data-streaming='true'] > *:last-child {
-  animation: blur-fade-in 0.3s ease-out forwards;
-}
+/* Streaming text is NOT animated.
+ *
+ * This used to run `blur-fade-in` (blur 8px -> 3px -> 0) on the last child of a
+ * streaming block. `filter: blur()` promotes the element to its own layer and
+ * re-rasterises it every frame, and during a stream the last child changes on
+ * every token append — so the animation restarted continuously over live text.
+ * On refresh it read as the whole reply arriving blurred and then sharpening.
+ *
+ * Text that is being read as it arrives must be legible the instant it lands.
+ * If a reveal is ever wanted here it has to be opacity-only: no filter, no
+ * transform, nothing that forces a repaint of glyphs mid-stream. */
 
 /* Pulse heartbeat animation for reasoning section Kortix icon */
 @keyframes pulse-heartbeat {
@@ -1294,22 +1281,18 @@ html:not(.consent-enabled) #cookieyes {
   mix-blend-mode: normal;
 }
 
-::view-transition-new(root) {
-  filter: blur(20px);
-  animation: view-transition-sharpen 400ms ease-in-out forwards;
-}
-
-@keyframes view-transition-sharpen {
-  0% {
-    filter: blur(20px);
-  }
-  60% {
-    filter: blur(6px);
-  }
-  100% {
-    filter: blur(0px);
-  }
-}
+/* The incoming view is NOT blurred.
+ *
+ * This ran `blur(20px) -> 6px -> 0` over 400ms across the ENTIRE page root on
+ * every view transition. A root-level filter rasterises the whole viewport on
+ * every frame of that animation, and it sits directly between the navigation
+ * and the first legible paint — so the reply you navigated to arrived blurred
+ * and stayed unreadable for 400ms while the compositor worked.
+ *
+ * The rule above already sets `animation: none` on both halves, which is the
+ * behaviour we want: the new view simply appears. Nothing here should reach for
+ * `filter` again — a full-viewport blur is the most expensive way to spend the
+ * exact moment the user is waiting to read. */
 
 @keyframes kortix-spin {
   to {


### PR DESCRIPTION
## Summary

Removes the two `filter: blur()` animations that sat between a navigation and the first legible paint in `apps/web/src/app/globals.css`.

- **Streaming blur** — `.kortix-markdown[data-streaming='true'] > *:last-child` ran `blur-fade-in` (8px → 3px → 0). `filter: blur()` promotes the element to its own layer and re-rasterises it every frame; during a stream the last child changes on every token append, so the animation restarted continuously over live text. It read as the whole reply arriving blurred and then sharpening.
- **View-transition blur** — `::view-transition-new(root)` applied `blur(20px)` for 400ms to the entire page root. A root-level filter rasterises the whole viewport per frame, at exactly the moment the user is waiting to read.
- Also drops `@keyframes blur-fade-in` and a dead rule referencing `stream-fade-in`, an animation not defined anywhere in the repo.

Both removals are replaced by comments explaining why the rules must not come back, and that any future reveal here has to be opacity-only.

Net: 23 insertions, 40 deletions, one file.

## Test plan

- `apps/web/src/app/globals.css` is the only file touched; no TS/JS surface changes.
- `grep -rn "@keyframes blur-fade-in" apps/web/src/` → no hits, so no rule is left pointing at a removed animation.
- `grep -rn "@keyframes stream-fade-in" apps/web/src/` → no hits before or after; the removed rule was already a no-op.
- Visual check on dev after deploy: navigate between sessions and stream a reply. Text must be sharp on the frame it lands; the incoming view must appear without a blur ramp.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790442478&installation_model_id=434224&pr_number=6984&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6984&signature=4453fb3ca55d5acfa27c1f6bc0d79cdc3538b1c090948a5b556ecfcf866b49cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->