### PR TITLE
fix(api): pi pool — never trust the Daytona list's labels for reap or claim

### DIFF
--- a/apps/api/src/platform/services/pi-worker-pool.ts
+++ b/apps/api/src/platform/services/pi-worker-pool.ts
@@ -175,6 +175,12 @@ export async function claimParkedPiWorkerBox(
         PROVIDER_CALL_TIMEOUT_MS,
         `Daytona get(${box.externalId})`,
       );
+      // The list can serve stale labels (see verifyStillParked). The direct
+      // object is authoritative — a box already claimed by another session
+      // has lost its park label and must not be dialled.
+      const liveLabels =
+        (sandbox as unknown as { labels?: Record<string, string> }).labels ?? {};
+      if (liveLabels[PARK_LABEL] !== '1') continue;
       const preview = await withTimeout(
         (sandbox as unknown as {
           getPreviewLink(port: number): Promise<{ url: string; token?: string }>;
@@ -229,6 +235,29 @@ export async function claimParkedPiWorkerBox(
 let maintainInFlight: Promise<void> | null = null;
 
 /**
+ * The paginated Daytona list can serve STALE labels: observed live on dev
+ * 2026-08-27, a claimed box (park labels correctly replaced — the direct GET
+ * proved it) still appeared park-labeled in the list minutes later. A reap
+ * decided on that view would delete a LIVE SESSION box. So before any
+ * destructive action, re-read the box directly — the direct GET is the
+ * authority. A box that no longer carries the park label is simply not ours.
+ */
+async function verifyStillParked(externalId: string): Promise<boolean> {
+  try {
+    const sandbox = await withTimeout(
+      getDaytona().get(externalId),
+      PROVIDER_CALL_TIMEOUT_MS,
+      `Daytona get(${externalId})`,
+    );
+    const labels = (sandbox as unknown as { labels?: Record<string, string> }).labels ?? {};
+    return labels[PARK_LABEL] === '1';
+  } catch {
+    // Unknowable ≠ reapable. Skip this round; the next tick retries.
+    return false;
+  }
+}
+
+/**
  * Reconcile the pool toward the target: reap stale-hash / over-age / dead /
  * surplus parked boxes, then create up to MAX_CREATES_PER_MAINTAIN missing
  * ones. Concurrent invocations coalesce; every error is contained (the pool
@@ -241,7 +270,13 @@ export function maintainPiWorkerPool(): Promise<void> {
     const target = config.KORTIX_PI_WORKER_POOL_TARGET;
     const maxAgeMs = config.KORTIX_PI_WORKER_POOL_MAX_AGE_MINUTES * 60_000;
     const image = await ensurePiWorkerImage({ provider: 'daytona' });
-    const parked = await listParkedBoxes();
+    const listed = await listParkedBoxes();
+    // Re-verify every listed box against the direct GET (stale-label hazard
+    // above). Claimed boxes drop out here instead of polluting the counts.
+    const parked: ParkedBox[] = [];
+    for (const box of listed) {
+      if (await verifyStillParked(box.externalId)) parked.push(box);
+    }
     const now = Date.now();
     const alive: ParkedBox[] = [];
     const reap: ParkedBox[] = [];

--- a/apps/api/src/platform/services/session-sandbox.test.ts
+++ b/apps/api/src/platform/services/session-sandbox.test.ts
@@ -1059,3 +1059,27 @@ describe('pi worker pool claim (P1.8)', () => {
     expect(mark).toBeLessThan(elseBranch);
   });
 });
+
+describe('pi worker pool — stale-label hazard', () => {
+  test('reap and claim both re-verify the park label on the direct object', async () => {
+    const source = await Bun.file(new URL('./pi-worker-pool.ts', import.meta.url)).text();
+    // Maintain: every listed box passes verifyStillParked BEFORE the
+    // dead/stale/over-age triage that feeds the reap list.
+    const verify = source.indexOf('async function verifyStillParked');
+    const maintain = source.indexOf('export function maintainPiWorkerPool');
+    const verifyCall = source.indexOf('await verifyStillParked(box.externalId)', maintain);
+    const triage = source.indexOf("state === 'stopped'", maintain);
+    expect(verify).toBeGreaterThan(-1);
+    expect(verifyCall).toBeGreaterThan(maintain);
+    expect(verifyCall).toBeLessThan(triage);
+    // An unknowable box is never reapable.
+    const verifyBody = source.slice(verify, source.indexOf('}', source.indexOf('catch', verify)));
+    expect(verifyBody).toContain('return false');
+    // Claim: the direct object's labels gate the dial.
+    const claim = source.indexOf('export async function claimParkedPiWorkerBox');
+    const gate = source.indexOf("liveLabels[PARK_LABEL] !== '1'", claim);
+    const dial = source.indexOf('/kortix/claim', claim);
+    expect(gate).toBeGreaterThan(claim);
+    expect(gate).toBeLessThan(dial);
+  });
+});


### PR DESCRIPTION
Hazard found during live P1.8 verification on dev (#6981): box `447f611e` was claimed by session `90232bdc` — its labels were correctly replaced (direct `GET /sandbox/:id` proves it: only `kortix.piworker-claimed`) and its autostop correctly reset to 720 — yet Daytona's paginated LIST still served the OLD park labels minutes later. Once the session idled and the platform deadline reaper stopped the box, my pool reaper's next tick would have seen: park-labeled (stale) + stopped + over max age ⇒ **deleted a resumable live-session box**.

Fix:
1. `maintainPiWorkerPool` re-verifies every listed box with a direct GET before the dead/stale/over-age triage; a box whose live labels lack `kortix.piworker-park` is simply not ours. An unknowable box (GET failed) is never reapable.
2. The claim loop gates the dial on the direct object's labels, so an already-claimed box is skipped instead of dialled (its park server is gone; the worker owns the port).

Cost: ≤ pool-target extra GETs per maintain tick (target is 2 on dev). Pinned by source test (`session-sandbox.test.ts`, 31 pass), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790443279&installation_model_id=434224&pr_number=6985&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6985&signature=0fd7578c41ce8ea450f2b72b110c0eae7e53efd95b91408fd2d0415d2f3911ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->