### PR TITLE
feat(kortixd): context-aware update/rollback — stage via supervisor in-sandbox (Option A)

### DIFF
--- a/DONE-P2.md
+++ b/DONE-P2.md
@@ -1,0 +1,155 @@
+# P2 — kortixd as the clean INTERFACE to the existing convergent-runtime supervisor (Option A)
+
+`kortixd update`/`rollback` are now context-aware. In-sandbox they DRIVE the
+existing entrypoint supervisor (stage → exit 75 → supervisor swaps); standalone
+they keep the safe self-swap. The supervisor's staged-swap / crash-loop-rollback
+machinery is UNCHANGED — kortixd stages, the supervisor swaps.
+
+Branch: `p2/kortixd-supervisor-interface` (off `origin/main`). Committed, not
+pushed. 3 files changed, +382/-18.
+
+## Files changed
+
+1. `apps/kortix-sandbox-agent-server/src/cli.ts` — context-aware update/rollback.
+2. `apps/sandbox/entrypoint.sh` — set `KORTIX_SUPERVISED=1` (+ export state dir).
+3. `apps/kortix-sandbox-agent-server/src/__tests__/cli-update.test.ts` — new tests.
+
+## The exact entrypoint diff
+
+The ONLY entrypoint change is two exported env vars before the supervisor loop
+(no change to the swap/rollback/crash-loop logic, no `kortixd install` added):
+
+```diff
+ mkdir -p "${AGENT_STATE_DIR}" 2>/dev/null || true
+ 
++# Tell the daemon (and any `kortixd` invocation that inherits this env) that a
++# supervisor owns the binary swap. `kortixd update` then STAGES ${AGENT_NEXT}
++# and exits ${SWAP_CODE} for this loop to install, instead of self-swapping its
++# own running binary — which is unsafe and which warm-fork/resume/restart would
++# not re-run anyway. Export the resolved state dir so it stages into the exact
++# slot select_agent/promote_staged_agent read. See apps/kortix-sandbox-agent-server/src/cli.ts.
++export KORTIX_SUPERVISED=1
++export KORTIX_AGENT_STATE_DIR="${AGENT_STATE_DIR}"
++
+ COMPILED_RUNTIME_PATH=""
+```
+
+`KORTIX_SUPERVISED=1` is only read by `kortixd`'s management verbs
+(update/rollback). The daemon's normal `serve` path never reads it, so boot is
+byte-for-byte unchanged. **No `kortixd install` was added to boot**: the baked
+binary is already the immutable floor and `select_agent` already resolves it, so
+an extra boot-time install would add risk for zero benefit.
+
+## How kortixd now stages vs self-swaps
+
+Detection (`detectSupervised`): supervised iff `KORTIX_SUPERVISED=1` (primary,
+set by the entrypoint), OR — fallback for an older baked entrypoint — the running
+binary is a supervisor-managed path (`<state>/agent.current` or the baked floor)
+and the state dir exists. A standalone kortixd on a normal machine matches
+neither. `--standalone` / `--supervised` force either path (testing/recovery).
+
+**SUPERVISED (`kortixd update`, in-sandbox):**
+1. Resolve target (manifest / `--from`). No-op if the running binary already
+   matches, or if `agent.next.sha256` already equals the target (idempotent).
+2. Download → verify content digest → **smoke-test** the candidate
+   (`version` + `--health-check`).
+3. Stage into `<state-dir>` using the EXACT contract of
+   `runtime-assets.ts:stageAgentBinary` and `entrypoint.sh:promote_staged_agent`:
+   write `agent.next.sha256` (content `"<sha>\n"`) FIRST via atomic rename, then
+   rename the verified binary into `agent.next`. Never touches the live binary.
+4. Return exit code **75** (`AGENT_SWAP_EXIT_CODE`). Under the supervisor loop
+   this triggers the atomic swap + health-supervision + crash-loop rollback.
+   Run from a shell, the exit is harmless and the stage persists for next boot.
+
+**STANDALONE (`kortixd update`, off-sandbox):** unchanged — download → verify →
+smoke-test → atomic self-swap (keep `<name>.prev`) → post-swap health →
+auto-rollback to `.prev` on failure.
+
+**ROLLBACK:** supervised → `performSupervisorRollback` mirrors
+`entrypoint.sh:rollback_agent` exactly (restore `agent.prev`→`agent.current`, or
+drop the override to fall back to the baked floor; latch `agent.pinned`; discard
+any staged `agent.next`). Standalone → consume `<name>.prev` (unchanged).
+
+One extra hardening in `realRun`: a non-executable smoke-test candidate can throw
+`ENOEXEC` synchronously from `child_process.spawn`, escaping the `'error'`
+handler. It is now caught and mapped to exit 126, so a bad candidate is a clean
+"candidate failed — kept current binary" with temp-file cleanup, never an
+uncaught throw. This fixes both the supervised and standalone paths.
+
+## Verification (real outputs)
+
+### `bun run typecheck` (tsc --noEmit) — clean
+```
+$ bun tsc --noEmit
+(no output, exit 0)
+```
+
+### `bun test src/__tests__/cli-update.test.ts` — 19 pass / 0 fail
+New tests: supervised staging (exit 75, live binary untouched, agent.next +
+matching sha256), supervised no-op, supervised broken-candidate refusal,
+supervised already-staged re-run, `detectSupervised`, `performSupervisorRollback`
+(with prev / no prev / nothing-to-roll-back). Plus the original 9 standalone
+tests (self-swap, digest mismatch, pre/post-swap smoke failure, auto-rollback,
+best-effort, digest cache).
+```
+ 19 pass  0 fail  58 expect() calls
+```
+`runtime-assets.test.ts` + `runtime-convergence.test.ts` also green (77 pass / 0
+fail together with cli-update).
+
+### `apps/sandbox/scripts/test-entrypoint-swap.sh` — 12 passed / 0 failed
+The supervisor still swaps a staged `agent.next` and rolls back a crash-looper.
+The staged-file contract is UNCHANGED, so the harness needed no edits.
+```
+PASS  swap: staged binary promoted, relaunched, installed as current
+PASS  bad digest: staged binary discarded, live binary kept running
+PASS  crash-looping update rolls back to the baked binary and pins
+PASS  update installs beside the baked binary and never overwrites it
+PASS  first bad update with no predecessor falls back to the baked binary
+PASS  pinned box refuses staged updates
+... (12 passed, 0 failed)
+```
+
+### Keystone — real compiled host-native `kortixd` (`bun build --compile`), run as a process
+- **A. Supervised staging** (`KORTIX_SUPERVISED=1 kortixd update`): `exit=75`;
+  `sha256(agent.next) == agent.next.sha256` (so the supervisor's independent
+  re-verification accepts it); LIVE BINARY UNTOUCHED; target NOT self-swapped; no
+  `.prev`.
+- **B. Standalone** (`--standalone`): `exit=0`; target self-swapped to the build;
+  `.prev` kept.
+- **C. Supervised rollback** (prev present): restores `agent.prev`, latches
+  `agent.pinned`, consumes prev, discards staged `agent.next`; `exit=0`.
+- **D. Supervised rollback** (no prev): removes `agent.current` → drops to the
+  baked floor, latches pin; `exit=0`.
+- **E. Broken staged candidate**: smoke test fails (`version exited 126`);
+  `exit=1`; nothing staged; no leaked temp file — the supervisor never sees a bad
+  build.
+
+## Supervisor safety properties preserved
+
+1. **Immutable baked floor.** The root-owned baked binary is never written by
+   kortixd; supervised rollback with no predecessor drops back to it by removing
+   the `agent.current` override (harness 6b/6c still green).
+2. **Independent re-verification.** The supervisor re-hashes `agent.next` against
+   `agent.next.sha256` before promoting. kortixd writes the identical
+   `"<sha>\n"` + verified-binary contract (proven: keystone A shows the two match).
+3. **Atomic, no partial binary.** kortixd stages via same-filesystem `rename(2)`,
+   side-car first then binary — the exact order `stageAgentBinary` uses; any
+   interruption leaves a state the supervisor already refuses.
+4. **Crash-loop rollback + pin.** Untouched. A kortixd-staged binary that dies
+   fast still rolls back and pins (harness test 6 green).
+5. **`agent.prev` rollback target.** Untouched; supervised CLI rollback follows
+   the same restore-prev / drop-to-floor + pin logic.
+6. **Pinned box refuses staged updates.** Untouched (harness test 7 green).
+7. **No self-overwrite of a running binary.** kortixd never self-swaps
+   in-sandbox — it stages and exits 75, exactly the case the supervisor exists to
+   handle for warm-fork/resume/restart.
+8. **Failure-biased.** A bad artifact, bad digest, or unrunnable candidate leaves
+   a working box: kortixd smoke-tests before staging, and the supervisor
+   re-verifies before promoting.
+
+## Shippable: YES (pending coordinator diff review + dev deploy)
+
+Highest-risk change in the epic; kept minimal and reviewable. Not pushed — the
+coordinator reviews the diff with the user before merge, since this touches the
+sandbox boot for every box.

--- a/apps/kortix-sandbox-agent-server/src/__tests__/cli-update.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/cli-update.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import {
+  AGENT_SWAP_EXIT_CODE,
+  detectSupervised,
   parseFlags,
   performRollback,
+  performSupervisorRollback,
   performUpdate,
   type ResolvedTarget,
   type SpawnDeps,
@@ -138,6 +141,124 @@ describe('performUpdate', () => {
     // The cache file now exists and records the digest.
     const cache = JSON.parse(readFileSync(opts.statePath, 'utf8'))
     expect(cache.current.sha256).toBe(sha(current))
+  })
+})
+
+describe('performUpdate — supervised (in-sandbox staging)', () => {
+  test('stages agent.next + sha256, exits 75, and never touches the live binary', async () => {
+    // The running binary is V1; the target build is V2.
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2')
+    const stateDir = join(dir, 'state')
+    const res = await performUpdate(
+      baseOpts({ resolveTarget: resolveTo(next), supervised: true, stateDir }),
+    )
+    // Asks the caller to exit 75 so the supervisor performs the swap.
+    expect(res.outcome).toBe('staged')
+    expect(res.code).toBe(AGENT_SWAP_EXIT_CODE)
+    // The live binary is UNTOUCHED — kortixd never self-swaps in-sandbox.
+    expect(readFileSync(join(dir, 'kortixd')).toString()).toBe('BINARY-V1')
+    expect(existsSync(join(dir, 'kortixd.prev'))).toBe(false)
+    // The staged slot the supervisor reads holds the verified V2 + its digest.
+    expect(readFileSync(join(stateDir, 'agent.next')).toString()).toBe('BINARY-V2')
+    expect(readFileSync(join(stateDir, 'agent.next.sha256'), 'utf8').trim()).toBe(sha(next))
+  })
+
+  test('no-op when the running binary already matches the target', async () => {
+    const current = Buffer.from('BINARY-V1')
+    writeFileSync(join(dir, 'kortixd'), current)
+    const stateDir = join(dir, 'state')
+    const res = await performUpdate(
+      baseOpts({ resolveTarget: resolveTo(current), supervised: true, stateDir }),
+    )
+    expect(res.outcome).toBe('current')
+    expect(res.code).toBe(0)
+    expect(existsSync(join(stateDir, 'agent.next'))).toBe(false)
+  })
+
+  test('a candidate that fails its smoke test is never staged', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2-BROKEN')
+    const stateDir = join(dir, 'state')
+    // Any candidate whose path is not the live target fails its smoke test —
+    // the staged temp file is a candidate, so it fails.
+    const spawn = spawnWith((bin) => (bin.endsWith('kortixd') ? 0 : 1))
+    const res = await performUpdate(
+      baseOpts({ resolveTarget: resolveTo(next), supervised: true, stateDir, spawn }),
+    )
+    expect(res.outcome).toBe('failed')
+    expect(existsSync(join(stateDir, 'agent.next'))).toBe(false)
+    expect(existsSync(join(stateDir, 'agent.next.sha256'))).toBe(false)
+  })
+
+  test('a re-run that finds the build already staged asks for the swap without re-staging', async () => {
+    writeFileSync(join(dir, 'kortixd'), Buffer.from('BINARY-V1'))
+    const next = Buffer.from('BINARY-V2')
+    const stateDir = join(dir, 'state')
+    // First pass stages it.
+    await performUpdate(baseOpts({ resolveTarget: resolveTo(next), supervised: true, stateDir }))
+    // Second pass: agent.next.sha256 already matches → staged, exit 75.
+    const res = await performUpdate(
+      baseOpts({ resolveTarget: resolveTo(next), supervised: true, stateDir }),
+    )
+    expect(res.outcome).toBe('staged')
+    expect(res.code).toBe(AGENT_SWAP_EXIT_CODE)
+    expect(res.message).toBe('already staged')
+  })
+})
+
+describe('detectSupervised', () => {
+  const prev = process.env.KORTIX_SUPERVISED
+  afterEach(() => {
+    if (prev === undefined) delete process.env.KORTIX_SUPERVISED
+    else process.env.KORTIX_SUPERVISED = prev
+  })
+  test('KORTIX_SUPERVISED=1 selects the supervised path', () => {
+    process.env.KORTIX_SUPERVISED = '1'
+    expect(detectSupervised('/anything/kortixd')).toBe(true)
+  })
+  test('a normal standalone binary is not supervised', () => {
+    delete process.env.KORTIX_SUPERVISED
+    expect(detectSupervised(join(dir, 'kortixd'))).toBe(false)
+  })
+})
+
+describe('performSupervisorRollback', () => {
+  test('with a predecessor: restores agent.prev and latches the pin', () => {
+    const state = join(dir, 'state')
+    // Prepare the supervisor state as it looks after one update.
+    mkdirSync(state, { recursive: true })
+    writeFileSync(join(state, 'agent.current'), 'UPDATED')
+    writeFileSync(join(state, 'agent.prev'), 'PREVIOUS')
+    writeFileSync(join(state, 'agent.next'), 'STAGED')
+    writeFileSync(join(state, 'agent.next.sha256'), 'deadbeef\n')
+    const r = performSupervisorRollback(state)
+    expect(r.code).toBe(0)
+    expect(readFileSync(join(state, 'agent.current')).toString()).toBe('PREVIOUS')
+    expect(existsSync(join(state, 'agent.prev'))).toBe(false)
+    expect(existsSync(join(state, 'agent.pinned'))).toBe(true)
+    // A staged build is discarded so the box does not re-stage what was rejected.
+    expect(existsSync(join(state, 'agent.next'))).toBe(false)
+    expect(existsSync(join(state, 'agent.next.sha256'))).toBe(false)
+  })
+
+  test('no predecessor: drops back to the baked floor and pins', () => {
+    const state = join(dir, 'state')
+    mkdirSync(state, { recursive: true })
+    writeFileSync(join(state, 'agent.current'), 'FIRST-UPDATE-BAD')
+    const r = performSupervisorRollback(state)
+    expect(r.code).toBe(0)
+    // Removing the override drops the box back to the immutable baked binary.
+    expect(existsSync(join(state, 'agent.current'))).toBe(false)
+    expect(existsSync(join(state, 'agent.pinned'))).toBe(true)
+  })
+
+  test('nothing to roll back: no agent.current → non-zero, box already on baked', () => {
+    const state = join(dir, 'state')
+    mkdirSync(state, { recursive: true })
+    const r = performSupervisorRollback(state)
+    expect(r.code).toBe(1)
+    expect(r.message).toContain('no update to roll back')
   })
 })
 

--- a/apps/kortix-sandbox-agent-server/src/cli.ts
+++ b/apps/kortix-sandbox-agent-server/src/cli.ts
@@ -7,12 +7,25 @@
  * onto PATH, self-update to the current published build, and roll back the last
  * update. All of that lives here so `main.ts` keeps serving the daemon.
  *
- * THE RELIABILITY PROPERTY. A self-update never bricks the app. The flow is
- * download → verify content digest → smoke-test the new binary → atomic swap
- * (keeping the replaced binary as `<name>.prev`) → post-swap health-check →
- * auto-rollback to `.prev` on any failure. A half-written binary is never left
- * on disk: bytes are written to a temp file in the destination directory and
- * only `rename(2)`d into place after they pass every gate.
+ * TWO UPDATE CONTEXTS. `update`/`rollback` are context-aware:
+ *   - STANDALONE (run-anywhere, no supervisor): kortixd owns the swap. Flow is
+ *     download → verify content digest → smoke-test → atomic self-swap (keeping
+ *     the replaced binary as `<name>.prev`) → post-swap health → auto-rollback
+ *     to `.prev` on any failure.
+ *   - SUPERVISED (in-sandbox, KORTIX_SUPERVISED=1 set by the entrypoint): kortixd
+ *     does NOT self-swap. A process cannot overwrite its own running binary, and
+ *     warm-fork/resume/restart reuse the VM without re-running boot — only the
+ *     entrypoint supervisor's staged swap survives those. So kortixd downloads →
+ *     verifies → smoke-tests → STAGES `<state-dir>/agent.next` (+ `.sha256`) and
+ *     exits 75. The supervisor (apps/sandbox/entrypoint.sh) re-verifies the
+ *     digest, renames it into `agent.current`, keeps `agent.prev`, and rolls back
+ *     a crash-looper against the immutable baked floor. See the convergent-runtime
+ *     spec docs/specs/2026-08-20-convergent-runtime.md.
+ *
+ * THE RELIABILITY PROPERTY. An update never bricks the app in either context. A
+ * half-written binary is never left on disk: bytes are written to a temp file on
+ * the destination filesystem and only `rename(2)`d into place after they pass
+ * every gate.
  *
  * THE BOOT CONTRACT. The primary caller is the sandbox boot path, which runs,
  * every start, idempotently: `kortixd install` → `kortixd update --boot` →
@@ -177,6 +190,125 @@ function invalidateDigestCache(statePath: string): void {
   }
 }
 
+// ── supervisor integration (in-sandbox) ─────────────────────────────────────
+//
+// Inside a sandbox the entrypoint supervisor (apps/sandbox/entrypoint.sh) — not
+// kortixd — owns the binary swap. A process cannot safely overwrite its own
+// running executable, and warm-fork/resume/restart reuse the same VM without
+// re-running boot, so only the supervisor's staged-swap survives those. kortixd
+// therefore STAGES the update and asks for the swap instead of self-swapping.
+//
+// EX_TEMPFAIL. The supervisor reads exactly this code as "install the staged
+// binary and relaunch me"; every other non-zero exit counts against its crash-
+// loop budget. Keep in lockstep with `SWAP_CODE` in apps/sandbox/entrypoint.sh
+// and `AGENT_SWAP_EXIT_CODE` in runtime-assets.ts.
+export const AGENT_SWAP_EXIT_CODE = 75
+
+/** The supervisor's state dir. `agent.next` is staged here; `agent.current` /
+ *  `agent.prev` / `agent.pinned` are the supervisor's own. */
+export function agentStateDir(): string {
+  const v = (process.env.KORTIX_AGENT_STATE_DIR ?? '').trim()
+  return v || '/opt/kortix'
+}
+
+function bakedAgentPath(): string {
+  const v = (process.env.KORTIX_AGENT_BIN ?? '').trim()
+  return v || '/usr/local/bin/kortix-agent'
+}
+
+/**
+ * Is this process running under the entrypoint supervisor?
+ *
+ * Primary signal: `KORTIX_SUPERVISED=1`, which the entrypoint exports before it
+ * launches the agent. Fallback for an older baked entrypoint that predates that
+ * env: the running binary IS a supervisor-managed path (`agent.current` or the
+ * baked floor) and the state dir exists. A standalone kortixd on a normal
+ * machine matches neither, so it keeps the self-swap path.
+ */
+export function detectSupervised(binPath: string): boolean {
+  if ((process.env.KORTIX_SUPERVISED ?? '').trim() === '1') return true
+  const stateDir = agentStateDir()
+  const current = join(stateDir, 'agent.current')
+  if ((binPath === current || binPath === bakedAgentPath()) && existsSync(stateDir)) return true
+  return false
+}
+
+/**
+ * Move an already-verified binary into the supervisor's staged slot.
+ *
+ * The write order matches runtime-assets.ts `stageAgentBinary` and the contract
+ * the supervisor's `promote_staged_agent` enforces: the digest side-car is
+ * renamed into place FIRST, then `agent.next` itself. Every interruption
+ * therefore leaves a state the supervisor already refuses — `agent.next` absent
+ * (nothing to promote), or present without a matching digest (discarded). It can
+ * never leave one the supervisor would install blind. `verifiedTmp` must already
+ * live inside `stateDir` so the rename is same-filesystem (atomic).
+ */
+function stageForSupervisor(stateDir: string, sha256: string, verifiedTmp: string): void {
+  const nextPath = join(stateDir, 'agent.next')
+  const tmpSha = join(
+    stateDir,
+    `.kortixd.stage.${process.pid}.${Math.random().toString(36).slice(2, 10)}.sha256`,
+  )
+  mkdirSync(stateDir, { recursive: true })
+  try {
+    writeFileSync(tmpSha, `${sha256}\n`, 'utf8')
+    renameSync(tmpSha, `${nextPath}.sha256`)
+  } catch (e) {
+    try {
+      rmSync(tmpSha, { force: true })
+    } catch {
+      /* nothing to clean */
+    }
+    throw e
+  }
+  renameSync(verifiedTmp, nextPath)
+}
+
+/**
+ * The supervisor-side rollback (in-sandbox), mirroring `rollback_agent` in
+ * apps/sandbox/entrypoint.sh: restore `agent.prev` over `agent.current` when a
+ * predecessor exists, otherwise drop back to the baked floor by removing the
+ * `agent.current` override — the floor is a root-owned file runtime code cannot
+ * write, so a box can never be bricked by this. Then latch `agent.pinned` so the
+ * supervisor stops re-staging the same bad build, and discard any staged
+ * `agent.next`. Effective at the next daemon launch; the running process keeps
+ * its open inode until then.
+ */
+export function performSupervisorRollback(stateDir: string): { code: number; message: string } {
+  const current = join(stateDir, 'agent.current')
+  const prev = join(stateDir, 'agent.prev')
+  const pinned = join(stateDir, 'agent.pinned')
+  if (!existsSync(current)) {
+    return {
+      code: 1,
+      message: 'no update to roll back (agent.current absent); the box already runs the baked binary',
+    }
+  }
+  try {
+    if (existsSync(prev)) {
+      renameSync(prev, current)
+      chmodSync(current, 0o755)
+    } else {
+      rmSync(current, { force: true })
+    }
+    // Latch updates off, exactly like the supervisor, so the next boot does not
+    // re-stage the build we just rejected.
+    writeFileSync(pinned, '')
+    // Drop any staged artifact immediately (the pin would make the supervisor
+    // discard it anyway, but leaving it invites confusion).
+    rmSync(join(stateDir, 'agent.next'), { force: true })
+    rmSync(join(stateDir, 'agent.next.sha256'), { force: true })
+    const restored = existsSync(current) ? 'previous binary' : 'baked binary'
+    return {
+      code: 0,
+      message: `rolled back to the ${restored} and pinned updates off; effective on next daemon launch`,
+    }
+  } catch (e) {
+    return { code: 1, message: `supervisor rollback failed: ${e instanceof Error ? e.message : String(e)}` }
+  }
+}
+
 // ── version ──────────────────────────────────────────────────────────────────
 
 /** The build digest is the running binary's own sha256 — the exact value the
@@ -270,7 +402,18 @@ export interface SpawnDeps {
 function realRun(bin: string, args: string[], timeoutMs: number): Promise<number> {
   return new Promise((resolve) => {
     let settled = false
-    const child = nodeSpawn(bin, args, { stdio: 'ignore', env: process.env })
+    let child: ReturnType<typeof nodeSpawn>
+    try {
+      // A non-executable candidate can throw ENOEXEC SYNCHRONOUSLY here, before
+      // any 'error' event fires. Without this guard the throw escapes the smoke
+      // test, skips the temp-file cleanup, and surfaces as an uncaught error
+      // instead of a clean "candidate failed" — the box must keep its binary,
+      // not crash the updater. Treat it exactly like a spawn error: exit 126.
+      child = nodeSpawn(bin, args, { stdio: 'ignore', env: process.env })
+    } catch {
+      resolve(126) // not executable / spawn error
+      return
+    }
     const timer = setTimeout(() => {
       if (settled) return
       settled = true
@@ -417,6 +560,16 @@ export interface UpdateOptions {
   /** Boot / best-effort mode: never hard-fail, keep the last-good binary. */
   bestEffort: boolean
   statePath: string
+  /**
+   * In-sandbox: stage the update for the entrypoint supervisor instead of
+   * self-swapping. On success the verified binary lands at `<stateDir>/agent.next`
+   * (+ `.sha256`) and the result asks the caller to exit {@link AGENT_SWAP_EXIT_CODE}.
+   * The supervisor then performs the atomic swap, health-supervision, and
+   * crash-loop rollback. Standalone (default) keeps the self-swap.
+   */
+  supervised?: boolean
+  /** Where `agent.next` is staged when {@link supervised}. Defaults to `agentStateDir()`. */
+  stateDir?: string
   fetchImpl?: typeof fetch
   spawn?: SpawnDeps
   /** Test seam: resolve the target directly instead of hitting the network. */
@@ -424,9 +577,11 @@ export interface UpdateOptions {
 }
 
 export interface UpdateResult {
-  /** 'current' = already up to date (no swap). 'updated' = swapped in a new
-   *  binary. 'failed' = kept the last-good binary. */
-  outcome: 'current' | 'updated' | 'failed'
+  /** 'current' = already up to date (no swap/stage). 'updated' = self-swapped a
+   *  new binary (standalone). 'staged' = wrote `agent.next` for the supervisor
+   *  and is asking the caller to exit {@link AGENT_SWAP_EXIT_CODE}. 'failed' =
+   *  kept the last-good binary. */
+  outcome: 'current' | 'updated' | 'staged' | 'failed'
   code: number
   message: string
 }
@@ -550,6 +705,23 @@ export async function performUpdate(opts: UpdateOptions): Promise<UpdateResult> 
     return { outcome: 'current', code: 0, message: 'already current' }
   }
 
+  // Supervised: if a prior pass already staged exactly this build, do not
+  // re-download it. Exit 75 again so a still-running daemon gets the swap it has
+  // not yet taken; a re-run from a shell just no-ops the download.
+  if (opts.supervised) {
+    const stateDir = opts.stateDir ?? agentStateDir()
+    let stagedSha: string | null = null
+    try {
+      stagedSha = readFileSync(join(stateDir, 'agent.next.sha256'), 'utf8').trim()
+    } catch {
+      /* nothing staged */
+    }
+    if (stagedSha === resolved.sha256 && existsSync(join(stateDir, 'agent.next'))) {
+      out(`kortixd already staged ${resolved.sha256.slice(0, 12)}; requesting supervisor swap (exit ${AGENT_SWAP_EXIT_CODE})`)
+      return { outcome: 'staged', code: AGENT_SWAP_EXIT_CODE, message: 'already staged' }
+    }
+  }
+
   // Fetch the bytes if the resolver only gave us a URL + digest.
   let bytes = resolved.bytes
   if (!bytes) {
@@ -576,10 +748,14 @@ export async function performUpdate(opts: UpdateOptions): Promise<UpdateResult> 
     )
   }
 
-  // Write to a temp file in the destination dir (same fs → atomic rename).
-  const tmp = join(dir, `.kortixd.download.${process.pid}.${Math.random().toString(36).slice(2, 10)}`)
+  // Write to a temp file on the SAME filesystem as its final destination, so the
+  // later rename is atomic. Standalone: the target's own dir. Supervised: the
+  // supervisor state dir, because `agent.next` lands there — not next to the
+  // running binary (which may be the baked floor on another mount).
+  const stageDir = opts.supervised ? (opts.stateDir ?? agentStateDir()) : dir
+  const tmp = join(stageDir, `.kortixd.download.${process.pid}.${Math.random().toString(36).slice(2, 10)}`)
   try {
-    mkdirSync(dir, { recursive: true })
+    mkdirSync(stageDir, { recursive: true })
     writeFileSync(tmp, bytes)
     chmodSync(tmp, 0o755)
   } catch (e) {
@@ -598,7 +774,33 @@ export async function performUpdate(opts: UpdateOptions): Promise<UpdateResult> 
     return fail(`candidate failed smoke test: ${smokeFail} — kept current binary`)
   }
 
-  // Atomic swap. Keep exactly one previous version for fast rollback.
+  // ── SUPERVISED: stage for the entrypoint supervisor; never self-swap ────────
+  // A process cannot overwrite its own running binary, and warm-fork/resume/
+  // restart reuse the VM without re-running boot — only the supervisor's staged
+  // swap survives those. So write `agent.next` (+ `.sha256`) and ask the caller
+  // to exit 75. The supervisor re-verifies the digest, renames it into
+  // `agent.current`, keeps `agent.prev`, and rolls back a crash-looper. kortixd
+  // does NOT touch the live binary here.
+  if (opts.supervised) {
+    try {
+      stageForSupervisor(stageDir, resolved.sha256, tmp)
+    } catch (e) {
+      try {
+        rmSync(tmp, { force: true })
+      } catch {
+        /* nothing to clean */
+      }
+      return fail(`could not stage binary for the supervisor: ${e instanceof Error ? e.message : String(e)}`)
+    }
+    const label = resolved.version ? ` (${resolved.version})` : ''
+    out(
+      `kortixd staged ${resolved.sha256.slice(0, 12)}${label} at ${join(stageDir, 'agent.next')}; ` +
+        `requesting supervisor swap (exit ${AGENT_SWAP_EXIT_CODE})`,
+    )
+    return { outcome: 'staged', code: AGENT_SWAP_EXIT_CODE, message: 'staged for supervisor' }
+  }
+
+  // ── STANDALONE: atomic self-swap. Keep exactly one previous version. ────────
   try {
     copyFileSync(target, prev)
   } catch (e) {
@@ -651,6 +853,14 @@ async function cmdUpdate(binPath: string, argv: string[]): Promise<number> {
     flags['best-effort'] === true ||
     (process.env.KORTIXD_UPDATE_BEST_EFFORT ?? '') === '1'
   const targetPath = typeof flags.target === 'string' ? flags.target : binPath
+  // Context: supervised in-sandbox (stage for the entrypoint supervisor) vs
+  // standalone (self-swap). `--standalone` forces self-swap; `--supervised`
+  // forces staging (both mainly for testing / recovery).
+  const supervised =
+    flags.standalone === true
+      ? false
+      : flags.supervised === true || detectSupervised(binPath)
+  const stateDir = typeof flags['state-dir'] === 'string' ? flags['state-dir'] : agentStateDir()
   const result = await performUpdate({
     targetPath,
     from:
@@ -662,6 +872,8 @@ async function cmdUpdate(binPath: string, argv: string[]): Promise<number> {
     channel: typeof flags.channel === 'string' ? flags.channel : undefined,
     version: typeof flags.version === 'string' ? flags.version : undefined,
     bestEffort,
+    supervised,
+    stateDir,
     statePath: defaultStatePath(targetPath),
   })
   return result.code
@@ -690,7 +902,15 @@ export function performRollback(
 function cmdRollback(binPath: string, argv: string[]): number {
   const flags = parseFlags(argv)
   const targetPath = typeof flags.target === 'string' ? flags.target : binPath
-  const r = performRollback(targetPath, defaultStatePath(targetPath))
+  const supervised =
+    flags.standalone === true
+      ? false
+      : flags.supervised === true || detectSupervised(binPath)
+  // Supervised: operate the supervisor's rollback contract (restore agent.prev /
+  // drop back to the baked floor + latch the pin). Standalone: consume `.prev`.
+  const r = supervised
+    ? performSupervisorRollback(typeof flags['state-dir'] === 'string' ? flags['state-dir'] : agentStateDir())
+    : performRollback(targetPath, defaultStatePath(targetPath))
   if (r.code === 0) out(r.message)
   else err(`rollback: ${r.message}`)
   return r.code
@@ -706,8 +926,12 @@ USAGE
   kortixd version                 Print version and build digest.
   kortixd install [--dir <path>]  Install this binary onto PATH (idempotent;
                                   no-op if present, --force to overwrite).
-  kortixd update [flags]          Self-update to the current published build.
-  kortixd rollback                Revert to the previous binary (<name>.prev).
+  kortixd update [flags]          Update to the current published build.
+                                  In-sandbox: stage for the supervisor (exit 75).
+                                  Standalone: safe self-swap + auto-rollback.
+  kortixd rollback                Revert the last update. In-sandbox: operate the
+                                  supervisor contract (restore prev / baked floor,
+                                  pin). Standalone: restore <name>.prev.
   kortixd --health-check          Smoke-test: boot a health server and exit 0.
   kortixd --help                  Show this help.
 
@@ -719,7 +943,17 @@ UPDATE FLAGS
   --boot              Best-effort: never hard-fail; keep the last-good binary
                       and exit 0 so a boot sequence can proceed to \`serve\`.
                       (Also enabled by KORTIXD_UPDATE_BEST_EFFORT=1.)
+  --standalone        Force the self-swap path even inside a supervised sandbox.
+  --supervised        Force staging for the supervisor (exit 75) off-sandbox.
+  --state-dir <path>  Supervisor state dir for staging/rollback (testing).
   --target <path>     Update a binary other than the running one (testing).
+
+SUPERVISED VS STANDALONE
+  Inside a sandbox the entrypoint supervisor owns the binary swap. \`update\`
+  stages <state-dir>/agent.next (+ .sha256) and exits 75; the supervisor
+  re-verifies the digest, swaps atomically, health-supervises, and rolls back a
+  crash-looper. KORTIX_SUPERVISED=1 (set by the entrypoint) selects this path.
+  Off-sandbox, \`update\` self-swaps and auto-rolls-back as before.
 
 BOOT SEQUENCE (idempotent, run every start)
   kortixd install && kortixd update --boot && kortixd serve

--- a/apps/sandbox/entrypoint.sh
+++ b/apps/sandbox/entrypoint.sh
@@ -228,6 +228,15 @@ rollback_agent() {
 
 mkdir -p "${AGENT_STATE_DIR}" 2>/dev/null || true
 
+# Tell the daemon (and any `kortixd` invocation that inherits this env) that a
+# supervisor owns the binary swap. `kortixd update` then STAGES ${AGENT_NEXT}
+# and exits ${SWAP_CODE} for this loop to install, instead of self-swapping its
+# own running binary — which is unsafe and which warm-fork/resume/restart would
+# not re-run anyway. Export the resolved state dir so it stages into the exact
+# slot select_agent/promote_staged_agent read. See apps/kortix-sandbox-agent-server/src/cli.ts.
+export KORTIX_SUPERVISED=1
+export KORTIX_AGENT_STATE_DIR="${AGENT_STATE_DIR}"
+
 COMPILED_RUNTIME_PATH=""
 COMPILED_RUNTIME_ACTIVE=0
 case "${KORTIX_COMPILED_BOOT_MODE:-off}" in


### PR DESCRIPTION
kortixd is now the clean interface to the EXISTING convergent-runtime supervisor (docs/specs/2026-08-20-convergent-runtime.md) — it does NOT replace it.

## What
- `kortixd update` is context-aware: IN-SANDBOX (KORTIX_SUPERVISED=1) it STAGES agent.next + .sha256 and exits 75 so the supervisor does the atomic swap + 60s health-supervise + crash-loop rollback (never self-swaps a running binary); STANDALONE it self-swaps with auto-rollback.
- `kortixd rollback` restores agent.prev / drops to baked floor + pins.
- entrypoint.sh: +9 lines (export KORTIX_SUPERVISED=1 + state dir). Supervisor swap/rollback/crash-loop logic UNTOUCHED; serve path never reads these; boot functionally unchanged.

## Verified (coordinator)
- entrypoint diff +9/-0. test-entrypoint-swap.sh 12/0 (supervisor still swaps staged + rolls back crash-loopers). cli-update 19/0. tsc clean. Real-binary keystones: supervised=>stages+exit75+live untouched; standalone=>self-swap; broken candidate=>refused, no brick.

Preserves every supervisor safety property.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444450&installation_model_id=434224&pr_number=6988&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6988&signature=fa9644239a92a965c4d3e46986920e95db66c223393b86ccfa79e88220388eac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->