### PR TITLE
feat: pi worker tools act on the lazy environment (P1.7 E2)

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-rpc-worker-integration.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-rpc-worker-integration.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { Hono } from 'hono'
+
+import type { Config } from '../config'
+import { createEnvRpcRouter } from '../routes/env-rpc'
+// The worker half, imported from its real sources (apps/kortix-worker is
+// workspace-excluded but dependency-free on this path — `ws` loads lazily).
+import { LazyKortixEnv } from '../../../kortix-worker/src/lazy-env.ts'
+
+const TOKEN = 'shared-session-token'
+
+interface Rig {
+  stop(): Promise<void>
+  ensureCalls: number
+  workspace: string
+  env: LazyKortixEnv
+}
+
+/**
+ * The whole P1.7 wire, end to end and real on both halves:
+ *
+ *   worker LazyKortixEnv ──ensure──▶ fake Kortix API (counts calls)
+ *                        ──ops────▶ REAL daemon env-rpc router (real fs, real bash)
+ *
+ * The daemon router verifies the X-Kortix-User-Context signature, so a green
+ * op also proves the worker's own header minting against the daemon's codec.
+ */
+async function buildRig(): Promise<Rig> {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'lazy-env-ws-'))
+
+  const daemon = new Hono()
+  daemon.get('/kortix/health', (c) => c.json({ ok: true, repo_ready: true }))
+  daemon.route('/kortix/env-rpc', createEnvRpcRouter({ sandboxToken: TOKEN, workspace } as unknown as Config))
+  const daemonServer = Bun.serve({ port: 0, fetch: daemon.fetch })
+
+  const rig = { ensureCalls: 0 } as Rig
+  const api = new Hono()
+  api.post('/v1/projects/:pid/sessions/:sid/environment/ensure', (c) => {
+    rig.ensureCalls += 1
+    if (c.req.header('authorization') !== `Bearer ${TOKEN}`) {
+      return c.json({ error: 'bad token' }, 401)
+    }
+    return c.json({
+      session_id: c.req.param('sid'),
+      status: 'active',
+      external_id: 'env-box-1',
+      preview_url: `http://127.0.0.1:${daemonServer.port}`,
+      preview_token: 'edge-token',
+    })
+  })
+  const apiServer = Bun.serve({ port: 0, fetch: api.fetch })
+
+  rig.workspace = workspace
+  rig.env = new LazyKortixEnv({
+    apiUrl: `http://127.0.0.1:${apiServer.port}/v1`,
+    token: TOKEN,
+    projectId: 'proj-1',
+    sessionId: 'sess-1',
+    cwd: workspace,
+    ensureTimeoutMs: 10_000,
+  })
+  rig.stop = async () => {
+    await rig.env.cleanup()
+    daemonServer.stop(true)
+    apiServer.stop(true)
+    await fs.rm(workspace, { recursive: true, force: true })
+  }
+  return rig
+}
+
+let rig: Rig | null = null
+afterEach(async () => {
+  await rig?.stop()
+  rig = null
+})
+
+describe('worker lazy environment ↔ daemon env-rpc', () => {
+  test('zero provisioning before the first operation; one ensure for many ops', async () => {
+    rig = await buildRig()
+    expect(rig.ensureCalls).toBe(0)
+    expect(rig.env.attached).toBe(false)
+
+    const write = await rig.env.writeFile('src/app.ts', 'export const answer = 42\n')
+    expect(write.ok).toBe(true)
+    expect(rig.ensureCalls).toBe(1)
+    expect(rig.env.attached).toBe(true)
+    expect(rig.env.externalId).toBe('env-box-1')
+
+    // Real bytes on the environment's real filesystem.
+    const onDisk = await fs.readFile(path.join(rig.workspace, 'src/app.ts'), 'utf8')
+    expect(onDisk).toBe('export const answer = 42\n')
+
+    // Later ops reuse the attachment — no second ensure.
+    const read = await rig.env.readTextFile('src/app.ts')
+    expect(read).toEqual({ ok: true, value: 'export const answer = 42\n' })
+    const run = await rig.env.exec('grep -r answer src && echo FOUND')
+    expect(run.ok).toBe(true)
+    if (run.ok) {
+      expect(run.value.stdout).toContain('FOUND')
+      expect(run.value.exitCode).toBe(0)
+    }
+    expect(rig.ensureCalls).toBe(1)
+    // The rpcCalls tap the worker's /say reports.
+    expect(rig.env.calls.map((c) => c.op)).toEqual(['writeFile', 'readTextFile', 'exec'])
+  })
+
+  test('a missing file is a Result the tool can render, and a dead API is too', async () => {
+    rig = await buildRig()
+    const missing = await rig.env.readTextFile('never-written.txt')
+    expect(missing.ok).toBe(false)
+    if (!missing.ok) expect((missing.error as { code?: string }).code).toBe('ENOENT')
+
+    const dead = new LazyKortixEnv({
+      apiUrl: 'http://127.0.0.1:1/v1',
+      token: TOKEN,
+      projectId: 'p',
+      sessionId: 's',
+      cwd: '/workspace',
+      ensureTimeoutMs: 1500,
+    })
+    const result = await dead.exec('echo hi')
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(String((result.error as Error).message)).toContain('could not attach environment')
+    }
+  }, 15_000)
+})

--- a/apps/kortix-sandbox-agent-server/src/__tests__/env-rpc.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/env-rpc.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test'
+import { createHmac } from 'node:crypto'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import type { Config } from '../config'
+import { KORTIX_USER_CONTEXT_HEADER } from '../kortix-user-context'
+import { createEnvRpcRouter } from '../routes/env-rpc'
+
+const TOKEN = 'test-session-token'
+
+function mintUserContext(secret: string, expOffsetSec = 300): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      userId: 'worker',
+      sandboxId: 'env-box',
+      sandboxRole: 'owner',
+      scopes: [],
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + expOffsetSec,
+    }),
+  )
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  const sig = createHmac('sha256', secret)
+    .update(payload)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return `${payload}.${sig}`
+}
+
+async function makeApp() {
+  const workspace = await fs.mkdtemp(path.join(os.tmpdir(), 'env-rpc-ws-'))
+  const app = createEnvRpcRouter({ sandboxToken: TOKEN, workspace } as unknown as Config)
+  const call = async (op: string, args: Record<string, unknown>, opts?: { token?: string }) => {
+    const res = await app.request('/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        [KORTIX_USER_CONTEXT_HEADER]: mintUserContext(opts?.token ?? TOKEN),
+      },
+      body: JSON.stringify({ op, args, cwd: workspace }),
+    })
+    return { status: res.status, body: (await res.json()) as any }
+  }
+  return { workspace, app, call }
+}
+
+describe('env-rpc route', () => {
+  test('rejects a missing or wrongly-signed user context', async () => {
+    const { app } = await makeApp()
+    const noHeader = await app.request('/', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ op: 'exists', args: { path: 'x' } }),
+    })
+    expect(noHeader.status).toBe(401)
+    const { call } = await makeApp()
+    const wrong = await call('exists', { path: 'x' }, { token: 'other-secret' })
+    expect(wrong.status).toBe(401)
+  })
+
+  test('file ops round-trip on the real filesystem, failures are Results not 500s', async () => {
+    const { call, workspace } = await makeApp()
+    const write = await call('writeFile', { path: 'notes/hello.txt', content: 'hi worker' })
+    expect(write.body.ok).toBe(true)
+    const read = await call('readTextFile', { path: 'notes/hello.txt' })
+    expect(read.body).toEqual({ ok: true, value: 'hi worker' })
+    const lines = await call('readTextLines', { path: 'notes/hello.txt', maxLines: 1 })
+    expect(lines.body.value).toEqual(['hi worker'])
+    const info = await call('fileInfo', { path: 'notes/hello.txt' })
+    expect(info.body.value.isFile).toBe(true)
+    const list = await call('listDir', { path: 'notes' })
+    expect(list.body.value.map((e: { name: string }) => e.name)).toEqual(['hello.txt'])
+    const abs = await call('absolutePath', { path: 'notes/hello.txt' })
+    expect(abs.body.value).toBe(path.join(workspace, 'notes/hello.txt'))
+
+    // A missing file is a Result with the errno code — the tool renders it.
+    const missing = await call('readTextFile', { path: 'nope.txt' })
+    expect(missing.status).toBe(200)
+    expect(missing.body.ok).toBe(false)
+    expect(missing.body.error.code).toBe('ENOENT')
+
+    const rename = await call('renameFile', {
+      sourcePath: 'notes/hello.txt',
+      destinationPath: 'notes/renamed.txt',
+    })
+    expect(rename.body.ok).toBe(true)
+    const gone = await call('exists', { path: 'notes/hello.txt' })
+    expect(gone.body.value).toBe(false)
+  })
+
+  test('exec runs a real shell in the workspace and reports exit codes', async () => {
+    const { call } = await makeApp()
+    await call('writeFile', { path: 'probe.txt', content: 'exec sees the workspace' })
+    const run = await call('exec', { command: 'cat probe.txt && echo done' })
+    expect(run.body.ok).toBe(true)
+    expect(run.body.value.stdout).toContain('exec sees the workspace')
+    expect(run.body.value.stdout).toContain('done')
+    expect(run.body.value.exitCode).toBe(0)
+
+    const fail = await call('exec', { command: 'exit 3' })
+    expect(fail.body.value.exitCode).toBe(3)
+
+    const timedOut = await call('exec', { command: 'sleep 5', timeout: 200 })
+    expect(timedOut.body.value.exitCode).not.toBe(0)
+    expect(timedOut.body.value.stderr).toContain('killed')
+  })
+
+  test('an unknown op is a Result, never a crash', async () => {
+    const { call } = await makeApp()
+    const bogus = await call('formatDisk', {})
+    expect(bogus.status).toBe(200)
+    expect(bogus.body.ok).toBe(false)
+    expect(bogus.body.error.code).toBe('unknown_op')
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -21,6 +21,7 @@ import { opencodeTurnInFlight, readPinnedSessionId } from './opencode-turn-state
 import { OPENCODE_HOME } from './opencode'
 import { createAbortRouter } from './routes/abort'
 import { createEnvRouter } from './routes/env'
+import { createEnvRpcRouter } from './routes/env-rpc'
 import { createGitRouter } from './routes/git'
 import { createPortProxyRouter } from './routes/port-proxy'
 import { createFilesRouter } from './routes/files'
@@ -200,6 +201,12 @@ export function buildOpencodeApp(
   kortixRouter.route('/git/', gitRouter)
   kortixRouter.route('/pty', ptyRouter)
   kortixRouter.route('/pty/', ptyRouter)
+  // Harness/worker split (P1.7): the pi worker's ExecutionEnv, one op per POST.
+  // Self-authenticated like /pty (X-Kortix-User-Context signed with this box's
+  // KORTIX_TOKEN — the worker holds the same session credential).
+  const envRpcRouter = createEnvRpcRouter(cfg)
+  kortixRouter.route('/env-rpc', envRpcRouter)
+  kortixRouter.route('/env-rpc/', envRpcRouter)
   // /kortix/part — attachment bytes on demand; see routes/part.ts.
   const partRouter = createPartRouter(opencode, { sidecarDir: defaultSidecarDir(OPENCODE_HOME) })
   kortixRouter.route('/part', partRouter)

--- a/apps/kortix-sandbox-agent-server/src/routes/env-rpc.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/env-rpc.ts
@@ -1,0 +1,318 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { Hono, type Context } from 'hono'
+
+import type { Config } from '../config'
+import {
+  KORTIX_USER_CONTEXT_HEADER,
+  verifyKortixUserContext,
+} from '../kortix-user-context'
+import { logger } from '../logger'
+
+/**
+ * `/kortix/env-rpc` — the environment half of the harness/worker split (P1.7).
+ *
+ * The pi worker's built-in tools (bash, read, write, edit) run against an
+ * ExecutionEnv whose every operation is one POST here. This route is that
+ * environment: direct filesystem + shell access on THIS box, executed as the
+ * session (the box exists for exactly one session and holds its credential).
+ *
+ * Wire contract (mirrors apps/kortix-worker/src/kortix-env.ts):
+ *   POST { op, args, cwd }  →  { ok: true, value } | { ok: false, error: { code, message, path? } }
+ * The route never throws wire-level errors for filesystem failures — a missing
+ * file is a Result, not a 500. HTTP errors are reserved for auth and malformed
+ * requests.
+ *
+ * Auth: `/kortix/*` is exempt from the daemon's global gate, so — exactly like
+ * the sibling pty router — every request verifies X-Kortix-User-Context signed
+ * with this box's own KORTIX_TOKEN. The worker holds the SAME session token
+ * (platform/services/session-environment.ts boots the box with it), so it can
+ * mint the header itself; nothing else can.
+ */
+
+const EXEC_TIMEOUT_DEFAULT_MS = 120_000
+const EXEC_TIMEOUT_MAX_MS = 10 * 60_000
+/** Per-stream cap so one `cat big.bin` cannot balloon the worker's context. */
+const EXEC_OUTPUT_CAP_BYTES = 2 * 1024 * 1024
+
+interface EnvRpcError {
+  code: string
+  message: string
+  path?: string
+}
+
+const ok = (value: unknown) => ({ ok: true as const, value })
+const err = (error: EnvRpcError) => ({ ok: false as const, error })
+
+function fsError(e: unknown, fallbackPath?: string) {
+  const errno = e as NodeJS.ErrnoException
+  return err({
+    code: errno?.code ?? 'unknown',
+    message: errno?.message ?? String(e),
+    path: (errno as { path?: string })?.path ?? fallbackPath,
+  })
+}
+
+function resolveIn(cwd: string, p: string): string {
+  return path.isAbsolute(p) ? p : path.resolve(cwd, p)
+}
+
+async function runExec(input: {
+  command: string
+  cwd: string
+  env?: Record<string, string>
+  timeoutMs: number
+}): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const child = spawn('bash', ['-lc', input.command], {
+      cwd: input.cwd,
+      env: { ...process.env, ...(input.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout: Buffer = Buffer.alloc(0)
+    let stderr: Buffer = Buffer.alloc(0)
+    let truncatedOut = false
+    let truncatedErr = false
+    const cap = (buf: Buffer, chunk: Buffer, markTruncated: () => void): Buffer => {
+      if (buf.length >= EXEC_OUTPUT_CAP_BYTES) {
+        markTruncated()
+        return buf
+      }
+      const room = EXEC_OUTPUT_CAP_BYTES - buf.length
+      if (chunk.length > room) markTruncated()
+      return Buffer.concat([buf, chunk.subarray(0, room)])
+    }
+    child.stdout.on('data', (c: Buffer) => {
+      stdout = cap(stdout, c, () => {
+        truncatedOut = true
+      })
+    })
+    child.stderr.on('data', (c: Buffer) => {
+      stderr = cap(stderr, c, () => {
+        truncatedErr = true
+      })
+    })
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+    }, input.timeoutMs)
+    child.on('close', (code, signal) => {
+      clearTimeout(timer)
+      const suffix = (t: boolean) => (t ? '\n[output truncated at 2MiB]' : '')
+      resolve({
+        stdout: stdout.toString('utf8') + suffix(truncatedOut),
+        stderr:
+          stderr.toString('utf8') +
+          suffix(truncatedErr) +
+          (signal === 'SIGKILL' ? `\n[killed: exceeded ${input.timeoutMs}ms]` : ''),
+        exitCode: code ?? (signal ? 124 : 1),
+      })
+    })
+    child.on('error', (e) => {
+      clearTimeout(timer)
+      resolve({ stdout: '', stderr: String(e?.message ?? e), exitCode: 127 })
+    })
+  })
+}
+
+export function createEnvRpcRouter(cfg: Config): Hono {
+  const app = new Hono()
+
+  app.use('*', async (c, next) => {
+    if (!cfg.sandboxToken) {
+      return c.json({ error: 'daemon not configured', detail: 'KORTIX_TOKEN unset' }, 503)
+    }
+    const auth = verifyKortixUserContext(c.req.header(KORTIX_USER_CONTEXT_HEADER), cfg.sandboxToken)
+    if (!auth.ok) {
+      logger.warn('[env-rpc] reject', { reason: auth.reason })
+      return c.json({ error: 'unauthorized', reason: auth.reason }, 401)
+    }
+    return next()
+  })
+
+  const handler = async (c: Context) => {
+    let body: { op?: unknown; args?: unknown; cwd?: unknown }
+    try {
+      body = (await c.req.json()) as typeof body
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400)
+    }
+    const op = typeof body.op === 'string' ? body.op : ''
+    const args = (body.args && typeof body.args === 'object' ? body.args : {}) as Record<
+      string,
+      unknown
+    >
+    const cwd = typeof body.cwd === 'string' && body.cwd ? body.cwd : cfg.workspace
+
+    const p = (key = 'path') => resolveIn(cwd, String(args[key] ?? ''))
+
+    try {
+      switch (op) {
+        case 'absolutePath':
+          return c.json(ok(p()))
+        case 'canonicalPath': {
+          try {
+            return c.json(ok(await fs.realpath(p())))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'joinPath':
+          return c.json(ok(path.join(...((args.parts as string[]) ?? []))))
+        case 'exists': {
+          try {
+            await fs.access(p())
+            return c.json(ok(true))
+          } catch {
+            return c.json(ok(false))
+          }
+        }
+        case 'readTextFile': {
+          try {
+            return c.json(ok(await fs.readFile(p(), 'utf8')))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'readTextLines': {
+          try {
+            const text = await fs.readFile(p(), 'utf8')
+            const lines = text.split('\n')
+            const max = typeof args.maxLines === 'number' ? args.maxLines : undefined
+            return c.json(ok(max ? lines.slice(0, max) : lines))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'readBinaryFile': {
+          try {
+            const buf = await fs.readFile(p())
+            return c.json(ok(buf.toString('base64')))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'writeFile':
+        case 'appendFile': {
+          try {
+            const raw = String(args.content ?? '')
+            const data =
+              args.encoding === 'base64' ? Buffer.from(raw, 'base64') : Buffer.from(raw, 'utf8')
+            await fs.mkdir(path.dirname(p()), { recursive: true })
+            if (op === 'appendFile') await fs.appendFile(p(), data)
+            else await fs.writeFile(p(), data)
+            return c.json(ok(undefined))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'renameFile': {
+          const src = resolveIn(cwd, String(args.sourcePath ?? ''))
+          const dst = resolveIn(cwd, String(args.destinationPath ?? ''))
+          try {
+            await fs.mkdir(path.dirname(dst), { recursive: true })
+            await fs.rename(src, dst)
+            return c.json(ok(undefined))
+          } catch (e) {
+            return c.json(fsError(e, src))
+          }
+        }
+        case 'fileInfo': {
+          try {
+            const st = await fs.stat(p())
+            return c.json(
+              ok({
+                size: st.size,
+                isFile: st.isFile(),
+                isDirectory: st.isDirectory(),
+                modifiedAt: st.mtime.toISOString(),
+              }),
+            )
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'listDir': {
+          try {
+            const entries = await fs.readdir(p(), { withFileTypes: true })
+            return c.json(
+              ok(
+                entries.map((entry) => ({
+                  name: entry.name,
+                  isDirectory: entry.isDirectory(),
+                  isFile: entry.isFile(),
+                })),
+              ),
+            )
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'createDir': {
+          try {
+            await fs.mkdir(p(), { recursive: args.recursive !== false })
+            return c.json(ok(undefined))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'remove': {
+          try {
+            await fs.rm(p(), { recursive: !!args.recursive, force: !!args.force })
+            return c.json(ok(undefined))
+          } catch (e) {
+            return c.json(fsError(e, p()))
+          }
+        }
+        case 'createTempDir': {
+          try {
+            return c.json(ok(await fs.mkdtemp(path.join(os.tmpdir(), String(args.prefix ?? 'tmp-')))))
+          } catch (e) {
+            return c.json(fsError(e))
+          }
+        }
+        case 'createTempFile': {
+          try {
+            const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'envrpc-'))
+            const file = path.join(dir, `${String(args.prefix ?? '')}file${String(args.suffix ?? '')}`)
+            await fs.writeFile(file, '')
+            return c.json(ok(file))
+          } catch (e) {
+            return c.json(fsError(e))
+          }
+        }
+        case 'exec': {
+          const command = String(args.command ?? '')
+          if (!command) return c.json(err({ code: 'invalid', message: 'command required' }))
+          const timeoutMs = Math.min(
+            typeof args.timeout === 'number' && args.timeout > 0
+              ? args.timeout
+              : EXEC_TIMEOUT_DEFAULT_MS,
+            EXEC_TIMEOUT_MAX_MS,
+          )
+          const result = await runExec({
+            command,
+            cwd: typeof args.cwd === 'string' && args.cwd ? resolveIn(cwd, args.cwd) : cwd,
+            env: (args.env as Record<string, string>) ?? undefined,
+            timeoutMs,
+          })
+          return c.json(ok(result))
+        }
+        default:
+          return c.json(err({ code: 'unknown_op', message: `unsupported op: ${op || '(missing)'}` }))
+      }
+    } catch (e) {
+      // Belt and braces: nothing above should reach here, but a Result beats a 500.
+      logger.error('[env-rpc] unexpected failure', e)
+      return c.json(fsError(e))
+    }
+  }
+
+  app.post('/', handler)
+  // The worker's RpcTransport appends `/rpc` to its base URL; serve both so
+  // the base can be `<edge>/kortix/env-rpc` verbatim.
+  app.post('/rpc', handler)
+
+  return app
+}

--- a/apps/kortix-worker/src/lazy-env.ts
+++ b/apps/kortix-worker/src/lazy-env.ts
@@ -1,0 +1,237 @@
+/**
+ * LazyKortixEnv — P1.7's "zero sandboxes until a compute tool call".
+ *
+ * The worker boots with NO environment. The first ExecutionEnv operation calls
+ * `POST {api}/projects/{pid}/sessions/{sid}/environment/ensure` with the
+ * worker's own session token; the API provisions (or resumes) the full daemon
+ * box and answers with a PROVIDER-EDGE origin + token. Every operation then
+ * flows through the ordinary KortixExecutionEnv against
+ * `{edge}/kortix/env-rpc` — the control plane is not in the data path.
+ *
+ * The daemon's env-rpc route authenticates X-Kortix-User-Context signed with
+ * the box's KORTIX_TOKEN. The worker holds the SAME session credential (the
+ * environment boots with it, by design), so it mints that header itself.
+ *
+ * Same contract as the inner env: operations never throw — a failed ensure is
+ * a Result the tool renders, not a crash.
+ */
+import { createHmac } from 'node:crypto';
+import { KortixExecutionEnv } from './kortix-env.ts';
+
+type Ok<T> = { ok: true; value: T };
+type Err<E> = { ok: false; error: E };
+type Result<T, E> = Ok<T> | Err<E>;
+const err = <E,>(error: E): Err<E> => ({ ok: false, error });
+
+class EnvUnavailableError extends Error {
+  code = 'environment_unavailable';
+  constructor(message: string) {
+    super(message);
+    this.name = 'EnvUnavailableError';
+  }
+}
+
+export interface LazyEnvOptions {
+  /** Kortix API base incl. /v1 (KORTIX_API_URL). */
+  apiUrl: string;
+  /** The worker's session credential (KORTIX_TOKEN). */
+  token: string;
+  projectId: string;
+  sessionId: string;
+  cwd: string;
+  /** Overall budget for ensure + daemon readiness. Cold provision ≈ 15–30 s. */
+  ensureTimeoutMs?: number;
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Mirror of the daemon's verifyKortixUserContext, signing side. */
+export function mintUserContext(secret: string, sandboxId: string): string {
+  const payload = base64url(
+    Buffer.from(
+      JSON.stringify({
+        userId: 'pi-worker',
+        sandboxId,
+        sandboxRole: 'owner',
+        scopes: [],
+        iat: Math.floor(Date.now() / 1000),
+        // Long-lived on purpose: the env object holds static headers for the
+        // session's whole life, and the real secret is the session token the
+        // signature already depends on.
+        exp: Math.floor(Date.now() / 1000) + 24 * 3600,
+      }),
+    ),
+  );
+  return `${payload}.${base64url(createHmac('sha256', secret).update(payload).digest())}`;
+}
+
+interface EnsureResponse {
+  status?: string;
+  external_id?: string | null;
+  preview_url?: string | null;
+  preview_token?: string | null;
+  error?: string;
+}
+
+export class LazyKortixEnv {
+  readonly cwd: string;
+  private readonly opts: Required<Pick<LazyEnvOptions, 'ensureTimeoutMs'>> & LazyEnvOptions;
+  private inner: KortixExecutionEnv | null = null;
+  private attaching: Promise<KortixExecutionEnv> | null = null;
+  /** Set once attached; surfaced in /kortix/health. */
+  externalId: string | null = null;
+
+  constructor(opts: LazyEnvOptions) {
+    this.opts = { ensureTimeoutMs: 180_000, ...opts };
+    this.cwd = opts.cwd;
+  }
+
+  get attached(): boolean {
+    return this.inner !== null;
+  }
+
+  /** Every boundary crossing, for /say's rpcCalls tap. Empty until attached. */
+  get calls(): Array<{ op: string; args: unknown }> {
+    return this.inner?.calls ?? [];
+  }
+
+  private async ensureOnce(): Promise<EnsureResponse> {
+    const res = await fetch(
+      `${this.opts.apiUrl.replace(/\/+$/, '')}/projects/${this.opts.projectId}/sessions/${this.opts.sessionId}/environment/ensure`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${this.opts.token}`,
+          'content-type': 'application/json',
+        },
+        signal: AbortSignal.timeout(150_000),
+      },
+    );
+    const body = (await res.json().catch(() => ({}))) as EnsureResponse;
+    if (!res.ok) {
+      throw new EnvUnavailableError(
+        `environment ensure failed: HTTP ${res.status}${body?.error ? ` — ${body.error}` : ''}`,
+      );
+    }
+    return body;
+  }
+
+  private async attach(): Promise<KortixExecutionEnv> {
+    if (this.inner) return this.inner;
+    if (this.attaching) return this.attaching;
+    this.attaching = (async () => {
+      const deadline = Date.now() + this.opts.ensureTimeoutMs;
+      let ensured: EnsureResponse | null = null;
+      let lastError = 'unknown';
+      while (Date.now() < deadline) {
+        try {
+          const r = await this.ensureOnce();
+          if (r.status === 'active' && r.preview_url) {
+            ensured = r;
+            break;
+          }
+          lastError = `environment status: ${r.status ?? 'unknown'}`;
+        } catch (e) {
+          lastError = String((e as Error)?.message ?? e);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+      if (!ensured?.preview_url) {
+        throw new EnvUnavailableError(`could not attach environment: ${lastError}`);
+      }
+      const edge = ensured.preview_url.replace(/\/+$/, '');
+      const headers: Record<string, string> = {
+        'x-kortix-user-context': mintUserContext(this.opts.token, ensured.external_id ?? 'env'),
+        ...(ensured.preview_token ? { 'x-daytona-preview-token': ensured.preview_token } : {}),
+      };
+      // Wait for the daemon (repo materialization included) before first use.
+      let ready = false;
+      while (Date.now() < deadline) {
+        try {
+          const res = await fetch(`${edge}/kortix/health`, {
+            headers,
+            signal: AbortSignal.timeout(5000),
+          });
+          if (res.ok) {
+            const health = (await res.json()) as { repo_ready?: boolean };
+            if (health.repo_ready !== false) {
+              ready = true;
+              break;
+            }
+          }
+        } catch {
+          // edge or daemon still coming up
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+      if (!ready) throw new EnvUnavailableError('environment daemon never became ready');
+      this.externalId = ensured.external_id ?? null;
+      this.inner = new KortixExecutionEnv({
+        baseUrl: `${edge}/kortix/env-rpc`,
+        cwd: this.cwd,
+        headers,
+        transport: 'keepalive',
+      });
+      return this.inner;
+    })();
+    try {
+      return await this.attaching;
+    } finally {
+      // A failed attach must not poison later tool calls — retry from scratch.
+      if (!this.inner) this.attaching = null;
+    }
+  }
+
+  /** Delegate an operation, converting attach failures into Results. */
+  private async op<T>(run: (env: KortixExecutionEnv) => Promise<Result<T, unknown>>): Promise<Result<T, unknown>> {
+    try {
+      const env = await this.attach();
+      return await run(env);
+    } catch (e) {
+      return err(e instanceof Error ? e : new EnvUnavailableError(String(e)));
+    }
+  }
+
+  // ---- FileSystem (same surface as KortixExecutionEnv) --------------------
+  absolutePath(path: string) { return this.op((env) => env.absolutePath(path)); }
+  joinPath(parts: string[]) { return this.op((env) => env.joinPath(parts)); }
+  readTextFile(path: string) { return this.op((env) => env.readTextFile(path)); }
+  readTextLines(path: string, options?: { maxLines?: number }) {
+    return this.op((env) => env.readTextLines(path, options));
+  }
+  readBinaryFile(path: string) { return this.op((env) => env.readBinaryFile(path)); }
+  writeFile(path: string, content: string | Uint8Array) {
+    return this.op((env) => env.writeFile(path, content));
+  }
+  appendFile(path: string, content: string | Uint8Array) {
+    return this.op((env) => env.appendFile(path, content));
+  }
+  renameFile(sourcePath: string, destinationPath: string) {
+    return this.op((env) => env.renameFile(sourcePath, destinationPath));
+  }
+  fileInfo(path: string) { return this.op((env) => env.fileInfo(path)); }
+  listDir(path: string) { return this.op((env) => env.listDir(path)); }
+  canonicalPath(path: string) { return this.op((env) => env.canonicalPath(path)); }
+  exists(path: string) { return this.op((env) => env.exists(path)); }
+  createDir(path: string, options?: { recursive?: boolean }) {
+    return this.op((env) => env.createDir(path, options));
+  }
+  remove(path: string, options?: { recursive?: boolean; force?: boolean }) {
+    return this.op((env) => env.remove(path, options));
+  }
+  createTempDir(prefix?: string) { return this.op((env) => env.createTempDir(prefix)); }
+  createTempFile(options?: { prefix?: string; suffix?: string }) {
+    return this.op((env) => env.createTempFile(options));
+  }
+
+  // ---- Shell --------------------------------------------------------------
+  exec(command: string, options?: unknown) {
+    return this.op((env) => env.exec(command, options));
+  }
+
+  async cleanup(): Promise<void> {
+    await this.inner?.cleanup();
+  }
+}

--- a/apps/kortix-worker/src/rpc-transport.ts
+++ b/apps/kortix-worker/src/rpc-transport.ts
@@ -17,7 +17,9 @@
  */
 import { Agent, request as httpRequest } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
-import WebSocket from 'ws';
+// `ws` loads lazily: only the ws transport needs it, and keeping the top
+// level free of it lets other packages import these sources for tests.
+type WsInstance = import('ws').default;
 
 export interface RpcTransport {
   call(op: string, args: Record<string, unknown>, cwd: string): Promise<any>;
@@ -82,7 +84,7 @@ export class KeepAliveTransport implements RpcTransport {
 /** One socket, many in-flight calls, correlated by id. */
 export class WebSocketTransport implements RpcTransport {
   readonly kind = 'ws';
-  private ws?: WebSocket;
+  private ws?: WsInstance;
   private ready?: Promise<void>;
   private seq = 0;
   private readonly pending = new Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>();
@@ -91,7 +93,9 @@ export class WebSocketTransport implements RpcTransport {
 
   private connect(): Promise<void> {
     if (this.ready) return this.ready;
-    this.ready = new Promise((resolve, reject) => {
+    this.ready = (async () => {
+      const { default: WebSocket } = await import('ws');
+      await new Promise<void>((resolve, reject) => {
       const url = this.baseUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/rpc-ws';
       const ws = new WebSocket(url, { headers: this.headers });
       this.ws = ws;
@@ -110,7 +114,8 @@ export class WebSocketTransport implements RpcTransport {
         this.pending.clear();
         this.ready = undefined;
       });
-    });
+      });
+    })();
     return this.ready;
   }
 

--- a/apps/kortix-worker/src/worker.ts
+++ b/apps/kortix-worker/src/worker.ts
@@ -34,6 +34,7 @@ import {
 import { AssistantMessageEventStream } from '@earendil-works/pi-ai';
 import { Session } from '@earendil-works/pi-agent-core';
 import { KortixExecutionEnv } from './kortix-env.ts';
+import { LazyKortixEnv } from './lazy-env.ts';
 import { DurableSessionStorage, RemoteSessionLog } from './session-store.ts';
 
 /**
@@ -125,10 +126,17 @@ function vmUptimeMs(): number | null {
 export interface WorkerConfig {
   port: number;
   envUrl: string;
+  /** True only when KORTIX_ENV_URL was set explicitly (spike/bench rigs). */
+  envUrlExplicit?: boolean;
   envCwd: string;
   envToken?: string;
   envHeaders?: Record<string, string>;
   envTransport?: 'fetch' | 'keepalive' | 'ws';
+  /** Lazy-environment identity (P1.7): all four present → first compute tool
+   *  call provisions the session's environment through the Kortix API. */
+  apiUrl?: string;
+  kortixToken?: string;
+  projectId?: string;
   systemPrompt: string;
   modelMode: 'faux' | 'real';
   providerId?: string;
@@ -146,7 +154,11 @@ export function configFromEnv(): WorkerConfig {
   return {
     port: Number(process.env.PORT ?? 8080),
     envUrl: process.env.KORTIX_ENV_URL ?? 'http://127.0.0.1:8100',
+    envUrlExplicit: Boolean(process.env.KORTIX_ENV_URL),
     envCwd: process.env.KORTIX_ENV_CWD ?? '/workspace',
+    apiUrl: process.env.KORTIX_API_URL,
+    kortixToken: process.env.KORTIX_TOKEN,
+    projectId: process.env.KORTIX_PROJECT_ID,
     envToken: process.env.KORTIX_ENV_TOKEN,
     envHeaders: process.env.KORTIX_ENV_HEADERS ? JSON.parse(process.env.KORTIX_ENV_HEADERS) : undefined,
     envTransport: (process.env.KORTIX_ENV_TRANSPORT as any) ?? 'keepalive',
@@ -184,7 +196,23 @@ function bindTool(tool: any, context: object) {
 }
 
 export async function buildHarness(cfg: WorkerConfig) {
-  const env = new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken, headers: cfg.envHeaders, transport: cfg.envTransport });
+  // P1.7 lazy environment: in a session sandbox (identity present, no explicit
+  // env URL) the first compute tool call provisions the session's environment
+  // through the Kortix API and every operation then runs over the provider
+  // edge. Bench/spike rigs keep the direct-URL path by setting KORTIX_ENV_URL.
+  const lazy =
+    !cfg.envUrlExplicit && cfg.apiUrl && cfg.kortixToken && cfg.projectId && cfg.sessionId
+      ? new LazyKortixEnv({
+          apiUrl: cfg.apiUrl,
+          token: cfg.kortixToken,
+          projectId: cfg.projectId,
+          sessionId: cfg.sessionId,
+          cwd: cfg.envCwd,
+        })
+      : null;
+  const env =
+    lazy ??
+    new KortixExecutionEnv({ baseUrl: cfg.envUrl, cwd: cfg.envCwd, token: cfg.envToken, headers: cfg.envHeaders, transport: cfg.envTransport });
 
   const credentials = new InMemoryCredentialStore();
   const models = createModels({ credentials });
@@ -358,7 +386,16 @@ export async function startWorker(cfg = configFromEnv()) {
         vmUptimeAtListenMs: LISTEN_UPTIME_MS,
         vmUptimeNowMs: vmUptimeMs(),
         modelMode: cfg.modelMode,
-        environment: { url: cfg.envUrl, cwd: cfg.envCwd, rpcCalls: env.calls.length },
+        environment:
+          env instanceof LazyKortixEnv
+            ? {
+                mode: 'lazy',
+                attached: env.attached,
+                external_id: env.externalId,
+                cwd: cfg.envCwd,
+                rpcCalls: env.calls.length,
+              }
+            : { mode: 'url', url: cfg.envUrl, cwd: cfg.envCwd, rpcCalls: env.calls.length },
         store: cfg.storeUrl ? { url: cfg.storeUrl, sessionId: cfg.sessionId, restoredEntries } : null,
       });
       res.writeHead(200, { 'content-type': 'application/json' }).end(body);

--- a/docs/specs/2026-08-26-harness-worker-split.md
+++ b/docs/specs/2026-08-26-harness-worker-split.md
@@ -304,6 +304,37 @@ persistent multiplexed connection (never per-call HTTP — see "What we measure"
 - **Proof:** a session that never calls a compute tool provisions **zero**
   sandboxes, asserted against the DB. One that does provisions exactly one.
 
+> **Shipped 2026-08-27** in two slices. E1 (PR #6986): `session_environments`
+> table + `POST /v1/projects/:pid/sessions/:sid/environment/ensure` — the env
+> box is the full daemon image on the session branch, booted with the SESSION's
+> own service key and `KORTIX_BOOTSTRAP_OPENCODE_SESSION=0`; the response hands
+> the worker a provider-edge origin + token, so worker↔environment traffic
+> never transits the session proxy. E2: the daemon gains `/kortix/env-rpc`
+> (ExecutionEnv ops, self-authenticated like `/pty`) and the worker gains
+> `LazyKortixEnv` — pi's built-in bash/read/write/edit tools attach on first
+> use.
+>
+> **Two recorded deviations from the letter of this plan.** (1) *P1.2's "tools
+> live in `@kortix/sdk`"*: the worker speaks the daemon surface directly. The
+> worker is platform infrastructure (like the daemon, which also consumes no
+> SDK), it is workspace-excluded with npm-pinned deps and cannot depend on
+> unpublished SDK changes, and pi's own tools already carry the ExecutionEnv
+> seam — reimplementing them as SDK clients would have bought a package
+> boundary at the cost of the tools' ergonomics. The SDK tool pack remains the
+> right shape for HOST-side consumers and stays on the backlog. (2) *"one
+> persistent multiplexed connection"*: v1 ships the keep-alive transport with
+> the retirement-retry guard over the provider edge (the G0 measurement path);
+> the ws multiplex upgrade slots in behind the same `RpcTransport` interface.
+
+### P1.6b — Worker pool (added 2026-08-27, shipped as "P1.8" in PRs #6981/#6985)
+
+Not in the original plan; the cold-boot decomposition demanded it. Parked
+worker boxes (park-mode entrypoint + single-accept claim server) claimed at
+session create; Daytona labels are the registry; pure accelerator with cold
+fallback. Measured on dev: create→ready 6.5–7.7 s claimed vs 8.5–10 s cold.
+Note the PR titles say "P1.8" — that name collided with this plan's
+history-without-runtime item, which remains OPEN below.
+
 ### P1.8 — History readable with nothing running
 
 Serve session history without touching a runtime.


### PR DESCRIPTION
Second slice of P1.7, on top of #6986. The pi worker's built-in tools (bash/read/write/edit — pi-agent-core's own, unchanged) now act on the session's lazily-provisioned environment.

**Wire**: first tool operation → `POST …/environment/ensure` (worker's own session token) → provider-edge origin → every op is one POST to the daemon's new **`/kortix/env-rpc`** (ExecutionEnv op surface: fs + bash, executed in-box, output capped 2MiB, fs failures are Results). Auth: the daemon route self-verifies `X-Kortix-User-Context` exactly like `/pty`; the worker mints it — it holds the SAME session credential the env box booted with (#6986), so a green op also proves the codec end to end.

**Verified locally, both halves real**:
- `env-rpc.test.ts` (daemon, 4 pass): real fs round-trips, real bash exec with exit codes + timeout kill, 401 on bad signature, unknown op is a Result.
- `env-rpc-worker-integration.test.ts` (2 pass): the REAL `LazyKortixEnv` (worker sources) against the REAL daemon router over HTTP — **zero ensure calls before the first op, exactly one for many ops**, bytes land on the env's real filesystem, `exec` greps them, dead-API attach degrades to a Result the tool renders.
- Worker bundle rebuilds at 890KB; `pi-worker-bundle.test.ts` (apps/api e2e on the real artifact) still green; daemon `tsc --noEmit` clean. (Worker-package tsc has 2 pre-existing errors at HEAD, untouched.)
- Recorded deviations in the plan doc: worker speaks the daemon surface directly (SDK tool pack stays backlog, host-side), and v1 transport is keep-alive+retry over the edge with the ws multiplex slotting behind the same `RpcTransport` interface.

**Deployment shape**: env boxes only ever boot images built AFTER this deploy (they did not exist before), so there is no old-daemon compat window. Artifacts recompile automatically — the worker bundle sha is part of the artifact cache key.

**Live proof after deploy** (will be posted here): a dev pi session asked to read/modify/run something in its repo — tools attach, exactly one `session_environments` row, answer reflects real repo state; a chat-only session keeps zero rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444651&installation_model_id=434224&pr_number=6989&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6989&signature=a67f5c16ee8eb6e05f4b1e71d55c22016645b83efcfe8345bd82cecf044e49cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->