### PR TITLE
fix(api): session environments idle-stop at 60min, not the 12h backstop

### DIFF
--- a/apps/api/src/platform/services/session-environment.ts
+++ b/apps/api/src/platform/services/session-environment.ts
@@ -241,6 +241,12 @@ export async function ensureSessionEnvironment(
       name: `env-${input.sessionId.slice(0, 8)}`,
       sandboxId: environmentId,
       snapshot: image.snapshotName,
+      // Environments have no session_sandboxes row, so the box reaper does not
+      // manage them yet: the provider's own idle timer is the ONLY stop. Keep
+      // it tight (a stopped box resumes on the next ensure) instead of the 12h
+      // backstop a reaper-managed session box gets. Metering + reaper tie-in
+      // is the recorded fast-follow.
+      autoStopInterval: 60,
       envVars: {
         ...envVars,
         KORTIX_TOKEN: token,

--- a/apps/api/src/projects/routes/session-environment.test.ts
+++ b/apps/api/src/projects/routes/session-environment.test.ts
@@ -77,3 +77,12 @@ describe('session environment service', () => {
     expect(infoBlock).toContain('previewUrl');
   });
 });
+
+describe('session environment lifecycle bounds', () => {
+  test('an environment box carries a tight idle auto-stop, never the 12h backstop', async () => {
+    const source = await serviceSource();
+    const create = source.indexOf('provider.create({');
+    const block = source.slice(create, source.indexOf('} as never', create));
+    expect(block).toContain('autoStopInterval: 60');
+  });
+});


### PR DESCRIPTION
Follow-up to #6986 caught in the pre-live sweep: `provisionSessionEnvironment` passed no `autoStopInterval`, so env boxes inherited the provider's 12h last-resort backstop — but they have no `session_sandboxes` row, so the box reaper does not manage them and that backstop was their ONLY stop: up to 12h of idle unmetered compute per environment. Now 60min; a stopped box resumes transparently on the next ensure. Pinned in `session-environment.test.ts` (6 pass). Metering + reaper tie-in remains the recorded fast-follow before any prod exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444856&installation_model_id=434224&pr_number=6990&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6990&signature=413628360eb5fd68215032bb69797fdc2a55930eb52536832c2b99f9931deea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->