### PR TITLE
fix(web): remove leftover diff3 base block in session-chat — frontend build was red

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -5228,58 +5228,6 @@ export function SessionChat({
                               promptInbox.prompts.length > 0
                             }
                           />
-||||||| 63db80ad98
-                          <SessionTurn
-                            turn={turn}
-                            isLast={turn.userMessage.info.id === lastUserMessageId}
-                            ownsPlan={turn.userMessage.info.id === planAnchorId}
-                            sessionId={sessionId}
-                            sessionStatus={sessionStatus}
-                            permissions={pendingPermissions}
-                            questions={pendingQuestions}
-                            agentNames={agentNames}
-                            isFirstTurn={turnIndex === 0}
-                            sessionWorking={lastTurnWorking}
-                            isWorkingTurn={turn.userMessage.info.id === workingTurn.workingTurnId}
-                            pending={
-                              lastTurnWorking && pendingTurnIds.has(turn.userMessage.info.id)
-                            }
-                            queueRow={inboxRowsByMessageId.get(turn.userMessage.info.id) ?? null}
-                            queueHeld={queueRows.held}
-                            onQueueRemove={handleRemoveQueuedMessage}
-                            onQueueSendNow={handleQueueSendNow}
-                            onQueueRetry={handleRetryQueuedMessage}
-                            interruptedBeforeRun={interruptedTurnIds.has(turn.userMessage.info.id)}
-                            isCompaction={hasCompaction}
-                            onOpenCompactionSummary={
-                              panel ? handleOpenCompactionSummary : undefined
-                            }
-                            providers={providers}
-                            commandMessages={commandMessagesRef.current}
-                            commands={commands}
-                            disableToolNavigation={disableToolNavigation}
-                            onPermissionReply={handlePermissionReply}
-                            onRewind={handleRewind}
-                            editingText={
-                              rewindTarget?.messageId === turn.userMessage.info.id
-                                ? rewindTarget.text
-                                : null
-                            }
-                            editPending={editSendPending || !!sessionState?.rewindPending}
-                            onEditCancel={handleEditCancel}
-                            onEditSend={handleEditSend}
-                            rewindDisabled={
-                              !!readOnly ||
-                              !sessionState ||
-                              isBusy ||
-                              sessionState.rewindPending ||
-                              // The runtime is not idle while queued prompts
-                              // are still on their way to it — a rewind mid-
-                              // delivery fails downstream with "Session is
-                              // busy" (measured); refuse it up front instead.
-                              promptInbox.prompts.length > 0
-                            }
-                          />
                           )}
                         </TurnViewport>
                       );


### PR DESCRIPTION
Deploy run 33100547747 (tip `31ad856d`) failed its **frontend image build**: `Turbopack … Merge conflict marker encountered` at `session-chat.tsx:5231`. #6987's merge left the `||||||| 63db80ad98` diff3 BASE copy of the `<SessionTurn>` hunk in the file — the `<<<<<<<`/`>>>>>>>` lines were cleaned up, the base section between them was not (grep for `^<<<<<<<` alone misses this shape). The API surface deployed fine; only the frontend image was blocked.

Fix: excised lines 5231–5282 (the stale base copy, which lacks the newer `suppressBusyIndicator` prop); the merged block above it is the survivor. `eslint` parses the file clean (exit 0), no marker patterns remain repo-wide in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790445749&installation_model_id=434224&pr_number=6991&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6991&signature=d57725467b26ec438a58b8f11ce94d13ef9d64e4ba2c3bf89b0f145c31598eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->