### PR TITLE
feat(worker): pi sessions render in the product — the Kortix Runtime API on the worker

### DIFF
--- a/apps/api/src/git-proxy/pi-worker-bundle.test.ts
+++ b/apps/api/src/git-proxy/pi-worker-bundle.test.ts
@@ -105,3 +105,131 @@ describe.skipIf(!existsSync(WORKER_DIST))('compiled pi runtime artifact (real bu
     }
   }, 15_000);
 });
+
+// The Kortix Runtime API on the worker (/kortix/opencode/*): the surface the
+// web session page reads since #6987 — /state, paged /messages, the sequenced
+// /events SSE — served by the REAL compiled artifact, driven through a real
+// faux turn. Skipped like the sibling when dist has not been built.
+describe.skipIf(!existsSync(WORKER_DIST))('compiled pi runtime — session read surface', () => {
+  test('a turn renders: transcript, state, sequenced events, health identity', async () => {
+    process.env.KORTIX_PI_WORKER_BUNDLE_PATH = WORKER_DIST;
+    const bundle = await getPiWorkerBundle();
+    const artifact = compilePiRuntime({
+      projectId: 'project-e2e',
+      ref: 'main',
+      sourceSha: 'c'.repeat(40),
+      agentConfig: JSON.stringify({
+        agent: { dev: { prompt: 'You are the compiled dev agent.', model: 'openrouter/anthropic/claude-sonnet-4.5' } },
+      }),
+      defaultAgent: 'dev',
+      workerBundle: bundle.source,
+    });
+    const root = await mkdtemp(join(tmpdir(), 'kortix-pi-read-'));
+    roots.push(root);
+    const runtimePath = join(root, 'worker.mjs');
+    await writeFile(runtimePath, artifact.source, { mode: 0o700 });
+
+    const port = 18900 + Math.floor(Math.random() * 500);
+    const TOKEN = 'read-surface-token';
+    const child = spawn('node', [runtimePath], {
+      env: {
+        ...process.env,
+        PORT: String(port),
+        KORTIX_MODEL_MODE: 'faux',
+        KORTIX_PROJECT_ID: 'project-e2e',
+        KORTIX_SESSION_ID: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        KORTIX_TOKEN: TOKEN,
+        KORTIX_AGENT: 'dev',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const base = `http://127.0.0.1:${port}`;
+    const authed = { headers: { authorization: `Bearer ${TOKEN}` } };
+    try {
+      let up = false;
+      for (let i = 0; i < 100 && !up; i++) {
+        up = await fetch(`${base}/health`).then((r) => r.ok, () => false);
+        if (!up) await new Promise((r) => setTimeout(r, 50));
+      }
+      expect(up).toBe(true);
+
+      // Health advertises the minted pi root as the native conversation id —
+      // the id the whole client transcript machinery keys on (it must not be
+      // a project-session UUID).
+      const health = (await (await fetch(`${base}/kortix/health`)).json()) as {
+        opencode_session_id?: string;
+      };
+      const rootId = health.opencode_session_id ?? '';
+      expect(rootId.startsWith('ses_pi')).toBe(true);
+
+      // Auth: no bearer, no user-context → 401.
+      const denied = await fetch(`${base}/kortix/opencode/state`);
+      expect(denied.status).toBe(401);
+
+      // Drive one scripted faux turn.
+      const turn = await fetch(`${base}/prompt`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text: 'render me', script: [{ text: 'rendered, chief' }] }),
+      });
+      expect(turn.ok).toBe(true);
+
+      // Transcript: user + assistant, ids unique and sorted, text present.
+      const page = (await (
+        await fetch(`${base}/kortix/opencode/messages/${rootId}?limit=20`, authed)
+      ).json()) as {
+        messages: Array<{ info: { id: string; role: string }; parts: Array<{ type: string; text?: string }> }>;
+        has_more: boolean;
+        epoch: string;
+        seq: number;
+      };
+      const roles = page.messages.map((m) => m.info.role);
+      expect(roles).toContain('user');
+      expect(roles).toContain('assistant');
+      const ids = page.messages.map((m) => m.info.id);
+      expect([...ids].sort()).toEqual(ids);
+      expect(new Set(ids).size).toBe(ids.length);
+      const assistant = page.messages.find((m) => m.info.role === 'assistant');
+      expect(assistant?.parts.some((p) => p.type === 'text' && p.text === 'rendered, chief')).toBe(true);
+      expect(page.seq).toBeGreaterThan(0);
+
+      // State: identity + roster + idle status for the root.
+      const state = (await (await fetch(`${base}/kortix/opencode/state`, authed)).json()) as {
+        identity: { opencode_session_id: string };
+        agents: { known: boolean; value: Array<{ name: string; model: { providerID: string } | null }> };
+        sessions: { value: Array<{ id: string; title: string }> };
+        statuses: { value: Record<string, { type: string }> };
+      };
+      expect(state.identity.opencode_session_id).toBe(rootId);
+      expect(state.agents.value.map((a) => a.name)).toEqual(['dev']);
+      expect(state.agents.value[0]?.model?.providerID).toBe('openrouter');
+      expect(state.sessions.value[0]?.id).toBe(rootId);
+      expect(state.statuses.value[rootId]?.type).toBe('idle');
+      // The first user line names the session.
+      expect(state.sessions.value[0]?.title).toBe('render me');
+
+      // Events: full replay from 0 — message frames present, seqs dense-ish
+      // and increasing, hello first.
+      const sse = await fetch(`${base}/kortix/opencode/events?since=0`, authed);
+      expect(sse.headers.get('x-kortix-epoch')).toBe(page.epoch);
+      const reader = sse.body!.getReader();
+      let buffer = '';
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline && !buffer.includes('session.idle')) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += new TextDecoder().decode(value);
+      }
+      await reader.cancel().catch(() => {});
+      expect(buffer.startsWith('event: kortix.hello')).toBe(true);
+      expect(buffer).toContain('event: message.updated');
+      expect(buffer).toContain('event: message.part.updated');
+      expect(buffer).toContain('rendered, chief');
+      const seqs = [...buffer.matchAll(/^id: (\d+)$/gm)].map((m) => Number(m[1]));
+      expect(seqs.length).toBeGreaterThan(2);
+      expect([...seqs].sort((a, b) => a - b)).toEqual(seqs);
+    } finally {
+      child.kill('SIGKILL');
+    }
+  }, 20_000);
+});

--- a/apps/kortix-worker/src/chat-events.ts
+++ b/apps/kortix-worker/src/chat-events.ts
@@ -41,6 +41,14 @@ export interface AdapterOptions {
   sessionID: string;
   /** Stable id for the assistant message currently being streamed. */
   messageId?: () => string;
+  /**
+   * Session-scoped id mint. Without it ids restart at `msg-1` per adapter
+   * instance, so two turns through two adapters collide — and the id ORDER is
+   * load-bearing (the transcript sorts by it, and OpenCode's own id order is
+   * how an answered prompt is detected). The worker passes its surface's
+   * zero-padded counter.
+   */
+  mintMessageId?: () => string;
 }
 
 /**
@@ -52,6 +60,7 @@ export interface AdapterOptions {
  */
 export class ChatEventAdapter {
   private readonly sessionID: string;
+  private readonly mint?: () => string;
   private messageSeq = 0;
   private currentMessageId = '';
   private textIndex = new Map<string, number>();
@@ -61,6 +70,7 @@ export class ChatEventAdapter {
 
   constructor(opts: AdapterOptions) {
     this.sessionID = opts.sessionID;
+    this.mint = opts.mintMessageId;
   }
 
   private nextPart(): string {
@@ -74,7 +84,7 @@ export class ChatEventAdapter {
         return [{ type: 'session.status', properties: { sessionID, status: { type: 'running' } } }];
 
       case 'message_start': {
-        this.currentMessageId = `msg-${++this.messageSeq}`;
+        this.currentMessageId = this.mint ? this.mint() : `msg-${++this.messageSeq}`;
         this.partCount = 0;
         this.textIndex.clear();
         this.accum.clear();

--- a/apps/kortix-worker/src/runtime-surface.ts
+++ b/apps/kortix-worker/src/runtime-surface.ts
@@ -1,0 +1,515 @@
+/**
+ * The Kortix Runtime API, pi-worker half — `/kortix/opencode/*` served by the
+ * WORKER so the product's session surface renders a pi session unchanged.
+ *
+ * The web client speaks ONLY this namespace since #6987: one `/state`
+ * projection, a paged `/messages/:sessionId` transcript, and ONE sequenced
+ * `/events` SSE that the API attaches to and relays. The daemon documents the
+ * namespace as "the runtime OpenCode manages" with a future harness getting
+ * `/kortix/<harness>/*`; the client is not namespace-parameterized yet, so the
+ * worker serves the SAME five-shape contract verbatim — the bodies are
+ * OpenCode wire shapes, which is exactly what the S0.5 adapter emits. When the
+ * SDK grows engine-aware namespacing this mounts at `/kortix/pi/*` too and the
+ * alias retires.
+ *
+ * Everything here mirrors the daemon implementation deliberately
+ * (apps/kortix-sandbox-agent-server: kortix-event-bus.ts, opencode-runtime.ts,
+ * runtime-state-projection.ts) — same seq/epoch semantics, same hello/resync/
+ * heartbeat framing, same auth posture (Bearer KORTIX_TOKEN for service calls,
+ * HMAC X-Kortix-User-Context — header or `__kortix_user_context` query — for
+ * user calls). Copied, not imported: the worker is standalone by design.
+ *
+ * ONE SOURCE OF TRUTH for list AND stream: every wire event the adapter emits
+ * is (a) sequenced onto the bus and (b) applied to the transcript store, so
+ * `/messages` always says exactly what `/events` said and ids can never
+ * disagree between the two.
+ */
+import { createHash, createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+// ---------------------------------------------------------------------------
+// Auth — the daemon's user-context codec, verify side.
+// ---------------------------------------------------------------------------
+
+export const KORTIX_USER_CONTEXT_HEADER = 'x-kortix-user-context';
+export const KORTIX_USER_CONTEXT_QUERY_PARAM = '__kortix_user_context';
+
+function base64urlDecode(s: string): Buffer {
+  const pad = 4 - (s.length % 4);
+  const padded = pad < 4 ? s + '='.repeat(pad) : s;
+  return Buffer.from(padded.replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+}
+
+function base64urlEncode(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function verifyUserContext(token: string | undefined | null, secret: string): boolean {
+  if (!token || typeof token !== 'string') return false;
+  const parts = token.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
+  const expected = base64urlEncode(createHmac('sha256', secret).update(parts[0]).digest());
+  const a = Buffer.from(parts[1]);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return false;
+  try {
+    const payload = JSON.parse(base64urlDecode(parts[0]).toString('utf8')) as { exp?: unknown };
+    return typeof payload.exp === 'number' && payload.exp > Math.floor(Date.now() / 1000);
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event bus — the daemon's seq/epoch/ring semantics, compact.
+// ---------------------------------------------------------------------------
+
+export const RING_CAPACITY = 2_000;
+export const EVENT_HEARTBEAT_MS = 15_000;
+
+export interface WireEvent {
+  seq: number;
+  type: string;
+  at: number;
+  payload: unknown;
+  session?: string;
+}
+
+interface Resync {
+  reason: 'epoch-changed' | 'gap-too-old' | 'ahead-of-head';
+  epoch: string;
+  first_seq: number;
+  head_seq: number;
+  requested_since: number | null;
+  recover: string[];
+}
+
+const RECOVER_RECIPE = ['GET /kortix/opencode/state', 'GET /kortix/opencode/messages/:sessionId'];
+
+export class WorkerEventBus {
+  private seq = 0;
+  private ring: WireEvent[] = [];
+  private readonly listeners = new Set<(e: WireEvent) => void>();
+  readonly epoch = `p${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+  get headSeq(): number {
+    return this.seq;
+  }
+  get firstSeq(): number {
+    return this.ring.length > 0 ? this.ring[0]!.seq : this.seq;
+  }
+
+  publish(type: string, payload: unknown, session?: string): WireEvent {
+    const event: WireEvent = {
+      seq: ++this.seq,
+      type,
+      at: Date.now(),
+      payload,
+      ...(session ? { session } : {}),
+    };
+    this.ring.push(event);
+    if (this.ring.length > RING_CAPACITY) this.ring.splice(0, this.ring.length - RING_CAPACITY);
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // one broken consumer must never stop the stream for the others
+      }
+    }
+    return event;
+  }
+
+  subscribe(
+    listener: (e: WireEvent) => void,
+    opts: { since: number | null; epoch: string | null },
+  ): { replay: WireEvent[]; resync: Resync | null; unsubscribe: () => void } {
+    // Snapshot + attach in one synchronous tick — the atomic handoff the
+    // daemon's bus documents. Nothing can publish between these lines.
+    let replay: WireEvent[] = [];
+    let resync: Resync | null = null;
+    if (opts.since !== null) {
+      const mkResync = (reason: Resync['reason']): Resync => ({
+        reason,
+        epoch: this.epoch,
+        first_seq: this.firstSeq,
+        head_seq: this.headSeq,
+        requested_since: opts.since,
+        recover: RECOVER_RECIPE,
+      });
+      if (opts.epoch && opts.epoch !== this.epoch) resync = mkResync('epoch-changed');
+      else if (opts.since > this.headSeq) resync = mkResync('ahead-of-head');
+      else if (opts.since < this.firstSeq - 1 && this.ring.length > 0 && opts.since < this.ring[0]!.seq - 1)
+        resync = mkResync('gap-too-old');
+      else replay = this.ring.filter((e) => e.seq > (opts.since as number));
+    }
+    this.listeners.add(listener);
+    return {
+      replay,
+      resync,
+      unsubscribe: () => this.listeners.delete(listener),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Transcript store — /messages serves exactly what /events said.
+// ---------------------------------------------------------------------------
+
+interface StoredMessage {
+  info: Record<string, unknown> & { id: string };
+  parts: Map<string, Record<string, unknown>>;
+  order: string[];
+}
+
+export class WireTranscript {
+  private readonly messages = new Map<string, StoredMessage>();
+  private order: string[] = [];
+
+  apply(wire: { type: string; properties: Record<string, unknown> }): void {
+    if (wire.type === 'message.updated') {
+      const info = wire.properties.info as (Record<string, unknown> & { id?: string }) | undefined;
+      if (!info?.id) return;
+      const existing = this.messages.get(info.id);
+      if (existing) {
+        existing.info = { ...existing.info, ...info, id: info.id };
+      } else {
+        this.messages.set(info.id, { info: { ...info, id: info.id }, parts: new Map(), order: [] });
+        this.order.push(info.id);
+        this.order.sort();
+      }
+      return;
+    }
+    if (wire.type === 'message.part.updated') {
+      const part = wire.properties.part as
+        | (Record<string, unknown> & { id?: string; messageID?: string })
+        | undefined;
+      if (!part?.id || !part.messageID) return;
+      let message = this.messages.get(part.messageID);
+      if (!message) {
+        // A part can outrun its message frame on a hot stream — hold the slot.
+        message = {
+          info: { id: part.messageID, role: 'assistant', sessionID: part.sessionID },
+          parts: new Map(),
+          order: [],
+        } as StoredMessage;
+        this.messages.set(part.messageID, message);
+        this.order.push(part.messageID);
+        this.order.sort();
+      }
+      if (!message.parts.has(part.id)) message.order.push(part.id);
+      message.parts.set(part.id, part);
+    }
+  }
+
+  page(opts: { limit: number; before: string | null }): {
+    messages: Array<{ info: Record<string, unknown>; parts: Record<string, unknown>[] }>;
+    hasMore: boolean;
+  } {
+    const eligible = opts.before ? this.order.filter((id) => id < (opts.before as string)) : this.order;
+    const window = eligible.slice(-opts.limit);
+    return {
+      messages: window.map((id) => {
+        const m = this.messages.get(id)!;
+        return { info: m.info, parts: m.order.map((pid) => m.parts.get(pid)!) };
+      }),
+      hasMore: eligible.length > window.length,
+    };
+  }
+
+  get count(): number {
+    return this.order.length;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The surface.
+// ---------------------------------------------------------------------------
+
+/** Deterministic, opencode-shaped, never a project-session UUID. */
+export function mintRootId(sessionId: string): string {
+  const digest = createHash('sha256').update(`pi-root\0${sessionId}`).digest('hex');
+  return `ses_pi${digest.slice(0, 24)}`;
+}
+
+export const DEFAULT_MESSAGE_PAGE = 20;
+export const MAX_MESSAGE_PAGE = 200;
+
+export interface RuntimeSurfaceOptions {
+  sessionId: string;
+  /** The worker's own KORTIX_TOKEN — service bearer AND user-context secret. */
+  token?: string;
+  agentName?: string;
+  agentConfigEtag?: string | null;
+  agents?: Record<string, { description?: string; model?: string }>;
+  defaultModel?: string | null;
+  workspace?: string;
+}
+
+function agentModel(ref: string | undefined): { providerID: string; modelID: string } | null {
+  if (!ref || !ref.includes('/')) return null;
+  const native = ref.startsWith('kortix/') ? ref.slice('kortix/'.length) : ref;
+  const slash = native.indexOf('/');
+  return { providerID: native.slice(0, slash), modelID: native.slice(slash + 1) };
+}
+
+export class RuntimeSurface {
+  readonly rootId: string;
+  readonly bus = new WorkerEventBus();
+  readonly transcript = new WireTranscript();
+  private status: { type: string } = { type: 'idle' };
+  private messageSeq = 0;
+  private readonly createdAt = Date.now();
+  private updatedAt = Date.now();
+  private title: string;
+
+  constructor(private readonly opts: RuntimeSurfaceOptions) {
+    this.rootId = mintRootId(opts.sessionId);
+    this.title = opts.agentName ? `${opts.agentName} session` : 'Pi session';
+  }
+
+  /** Zero-padded so message ids sort in mint order — the id ORDER is load-bearing. */
+  mintMessageId = (): string => `msg_pi${String(++this.messageSeq).padStart(8, '0')}`;
+
+  /** Sequence one adapter wire event AND fold it into the transcript. */
+  publishWire(wire: { type: string; properties: Record<string, unknown> }): void {
+    this.updatedAt = Date.now();
+    if (wire.type === 'session.status') {
+      const status = wire.properties.status as { type?: string } | undefined;
+      if (status?.type) this.status = { type: status.type };
+    }
+    this.transcript.apply(wire);
+    const session =
+      (wire.properties.sessionID as string | undefined) ??
+      ((wire.properties.info as { sessionID?: string } | undefined)?.sessionID ??
+        (wire.properties.part as { sessionID?: string } | undefined)?.sessionID);
+    this.bus.publish(wire.type, wire.properties, session);
+  }
+
+  /** The first user text names the session, like OpenCode's title adoption. */
+  noteUserText(text: string): void {
+    if (this.title.endsWith(' session') || this.title === 'Pi session') {
+      const line = text.trim().split('\n')[0] ?? '';
+      if (line) this.title = line.length > 80 ? `${line.slice(0, 77)}…` : line;
+    }
+  }
+
+  private authorized(req: IncomingMessage, url: URL): boolean {
+    const token = this.opts.token;
+    if (!token) return false;
+    const auth = req.headers.authorization;
+    if (auth === `Bearer ${token}`) return true;
+    const header =
+      (req.headers[KORTIX_USER_CONTEXT_HEADER] as string | undefined) ??
+      url.searchParams.get(KORTIX_USER_CONTEXT_QUERY_PARAM) ??
+      undefined;
+    return verifyUserContext(header, token);
+  }
+
+  private sessionProjection() {
+    return {
+      id: this.rootId,
+      title: this.title,
+      parent_id: null,
+      directory: this.opts.workspace ?? '/workspace',
+      time: { created: this.createdAt, updated: this.updatedAt, compacting: null },
+      revert: null,
+    };
+  }
+
+  private stateDoc() {
+    const agents = Object.entries(this.opts.agents ?? {}).map(([name, agent]) => ({
+      name,
+      description: agent.description ?? null,
+      mode: null,
+      native: false,
+      hidden: null,
+      color: null,
+      variant: null,
+      source: 'config' as const,
+      model: agentModel(agent.model ?? this.opts.defaultModel ?? undefined),
+    }));
+    return {
+      epoch: this.bus.epoch,
+      seq: this.bus.headSeq,
+      built_at: new Date().toISOString(),
+      identity: {
+        opencode_session_id: this.rootId,
+        opencode_version: null,
+        daemon_build: null,
+        agent_config_etag: this.opts.agentConfigEtag ?? null,
+        head_seq: null,
+      },
+      agents: { known: true, value: agents },
+      commands: { known: true, value: [] },
+      config: {
+        known: true,
+        value: {
+          model: this.opts.defaultModel ?? null,
+          small_model: null,
+          default_agent: this.opts.agentName ?? null,
+          permission: null,
+          instructions: null,
+          enabled_providers: null,
+        },
+      },
+      sessions: { known: true, value: [this.sessionProjection()] },
+      statuses: { known: true, value: { [this.rootId]: this.status } },
+      permissions: { known: true, value: [] },
+      questions: { known: true, value: [] },
+    };
+  }
+
+  /**
+   * Serve one `/kortix/opencode/*` request. Returns false when the subpath is
+   * not part of this surface (the caller then 404s it).
+   */
+  handle(req: IncomingMessage, res: ServerResponse, url: URL): boolean {
+    const sub = url.pathname.slice('/kortix/opencode/'.length).replace(/\/+$/, '');
+    const json = (status: number, body: unknown, headers: Record<string, string> = {}) => {
+      res
+        .writeHead(status, { 'content-type': 'application/json', ...headers })
+        .end(JSON.stringify(body));
+      return true;
+    };
+    if (!this.authorized(req, url)) {
+      return json(401, { error: 'unauthorized' });
+    }
+
+    if (sub === 'state' && req.method === 'GET') {
+      const doc = this.stateDoc();
+      const body = JSON.stringify(doc);
+      const etag = `"${createHash('sha256').update(body).digest('hex').slice(0, 16)}"`;
+      if (req.headers['if-none-match'] === etag) {
+        res.writeHead(304, { etag }).end();
+        return true;
+      }
+      res.writeHead(200, { 'content-type': 'application/json', etag }).end(body);
+      return true;
+    }
+
+    if (sub.startsWith('messages/') && req.method === 'GET') {
+      const sessionId = decodeURIComponent(sub.slice('messages/'.length));
+      const limitRaw = Number(url.searchParams.get('limit'));
+      const limit =
+        Number.isFinite(limitRaw) && limitRaw > 0
+          ? Math.min(Math.floor(limitRaw), MAX_MESSAGE_PAGE)
+          : DEFAULT_MESSAGE_PAGE;
+      const before = url.searchParams.get('before')?.trim() || null;
+      // One root per worker: an unknown id is an empty transcript, not an error
+      // — the client may probe with a stale id across a restart.
+      const page =
+        sessionId === this.rootId
+          ? this.transcript.page({ limit, before })
+          : { messages: [], hasMore: false };
+      const first = page.messages[0]?.info as { id?: string } | undefined;
+      const last = page.messages[page.messages.length - 1]?.info as { id?: string } | undefined;
+      return json(200, {
+        session_id: sessionId,
+        epoch: this.bus.epoch,
+        seq: this.bus.headSeq,
+        head_seq: null,
+        source: 'pi-worker',
+        count: page.messages.length,
+        has_more: page.hasMore,
+        first_message_id: first?.id ?? null,
+        last_message_id: last?.id ?? null,
+        dropped: 0,
+        attachments_referenced: 0,
+        attachment_bytes_saved: 0,
+        tool_outputs_truncated: 0,
+        messages: page.messages,
+      });
+    }
+
+    if (sub.startsWith('session/') && req.method === 'GET') {
+      const sessionId = decodeURIComponent(sub.slice('session/'.length));
+      if (sessionId !== this.rootId) return json(404, { error: 'unknown session' });
+      const s = this.sessionProjection();
+      // OpenCode's own Session shape, minimally: id, title, time.
+      return json(200, {
+        id: s.id,
+        title: s.title,
+        directory: s.directory,
+        time: { created: s.time.created, updated: s.time.updated },
+        version: 'pi',
+      });
+    }
+
+    if (sub === 'events' && req.method === 'GET') {
+      const sinceRaw = url.searchParams.get('since');
+      const since = sinceRaw !== null && /^\d+$/.test(sinceRaw) ? Number(sinceRaw) : null;
+      const epoch = url.searchParams.get('epoch')?.trim() || null;
+      res.writeHead(200, {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache, no-transform',
+        connection: 'keep-alive',
+        'x-accel-buffering': 'no',
+        'x-kortix-epoch': this.bus.epoch,
+      });
+      let closed = false;
+      let lastSent = -1;
+      const write = (chunk: string) => {
+        if (closed) return;
+        try {
+          res.write(chunk);
+        } catch {
+          closed = true;
+        }
+      };
+      const send = (event: WireEvent) => {
+        if (event.seq <= lastSent) return;
+        lastSent = event.seq;
+        write(`event: ${event.type}\nid: ${event.seq}\ndata: ${JSON.stringify(event)}\n\n`);
+      };
+      let replaying = true;
+      const pending: WireEvent[] = [];
+      const subscription = this.bus.subscribe(
+        (event) => {
+          if (replaying) pending.push(event);
+          else send(event);
+        },
+        { since, epoch },
+      );
+      write(
+        `event: kortix.hello\ndata: ${JSON.stringify({
+          type: 'kortix.hello',
+          epoch: this.bus.epoch,
+          head_seq: this.bus.headSeq,
+          first_seq: this.bus.firstSeq,
+          since,
+          at: Date.now(),
+        })}\n\n`,
+      );
+      if (subscription.resync) {
+        write(
+          `event: kortix.resync\ndata: ${JSON.stringify({ type: 'kortix.resync', ...subscription.resync })}\n\n`,
+        );
+        lastSent = this.bus.headSeq;
+      }
+      for (const event of subscription.replay) send(event);
+      replaying = false;
+      for (const event of pending) send(event);
+      pending.length = 0;
+      const heartbeat = setInterval(() => {
+        write(
+          `event: kortix.heartbeat\ndata: ${JSON.stringify({
+            type: 'kortix.heartbeat',
+            at: Date.now(),
+            head_seq: this.bus.headSeq,
+          })}\n\n`,
+        );
+      }, EVENT_HEARTBEAT_MS);
+      heartbeat.unref?.();
+      req.on('close', () => {
+        closed = true;
+        clearInterval(heartbeat);
+        subscription.unsubscribe();
+      });
+      return true;
+    }
+
+    // Lazy passthroughs the worker has no upstream for (vcs-diff, config,
+    // todo, …): an honest 404 — the product degrades those panels gracefully.
+    return json(404, { error: `no pi handler for /kortix/opencode/${sub}` });
+  }
+}

--- a/apps/kortix-worker/src/worker.ts
+++ b/apps/kortix-worker/src/worker.ts
@@ -33,8 +33,10 @@ import {
 } from '@earendil-works/pi-ai';
 import { AssistantMessageEventStream } from '@earendil-works/pi-ai';
 import { Session } from '@earendil-works/pi-agent-core';
+import { ChatEventAdapter } from './chat-events.ts';
 import { KortixExecutionEnv } from './kortix-env.ts';
 import { LazyKortixEnv } from './lazy-env.ts';
+import { RuntimeSurface } from './runtime-surface.ts';
 import { DurableSessionStorage, RemoteSessionLog } from './session-store.ts';
 
 /**
@@ -332,8 +334,85 @@ export async function startWorker(cfg = configFromEnv()) {
     for (const l of listeners) l(line);
   });
 
+  // ── Kortix Runtime API (/kortix/opencode/*) ─────────────────────────────
+  // The product's session surface: /state, paged /messages, ONE sequenced
+  // /events SSE the API relays. One PERSISTENT adapter feeds one surface — the
+  // stream and the transcript can never disagree, and message ids stay unique
+  // and lexicographically ordered across the whole session.
+  const compiledPayload = (globalThis as Record<string, unknown>).__KORTIX_COMPILED__ as
+    | {
+        manifest?: { agent_config_etag?: string | null; default_agent?: string | null };
+        agentConfig?: {
+          model?: string;
+          agent?: Record<string, { description?: string; model?: string }>;
+        } | null;
+      }
+    | undefined;
+  const surface = new RuntimeSurface({
+    sessionId: cfg.sessionId ?? 'session-local',
+    token: cfg.kortixToken,
+    agentName:
+      process.env.KORTIX_AGENT ??
+      compiledPayload?.manifest?.default_agent ??
+      undefined,
+    agentConfigEtag: compiledPayload?.manifest?.agent_config_etag ?? null,
+    agents: compiledPayload?.agentConfig?.agent ?? {},
+    defaultModel: cfg.modelId ?? compiledPayload?.agentConfig?.model ?? null,
+    workspace: cfg.envCwd,
+  });
+  const wireAdapter = new ChatEventAdapter({
+    sessionID: surface.rootId,
+    mintMessageId: surface.mintMessageId,
+  });
+  agent.subscribe((event: any) => {
+    try {
+      for (const wire of wireAdapter.translate(event)) surface.publishWire(wire);
+    } catch (e: any) {
+      console.error(JSON.stringify({ msg: 'wire adapter failed', error: String(e?.message ?? e) }));
+    }
+  });
+  // pi's stream carries the assistant; the USER message is published at prompt
+  // time so the transcript shows the turn the moment it starts.
+  const publishUserMessage = (text: string) => {
+    surface.noteUserText(text);
+    const id = surface.mintMessageId();
+    surface.publishWire({
+      type: 'message.updated',
+      properties: {
+        sessionID: surface.rootId,
+        info: {
+          id,
+          role: 'user',
+          sessionID: surface.rootId,
+          time: { created: Date.now() },
+        },
+      },
+    });
+    surface.publishWire({
+      type: 'message.part.updated',
+      properties: {
+        sessionID: surface.rootId,
+        part: {
+          id: `${id}-p0`,
+          messageID: id,
+          sessionID: surface.rootId,
+          type: 'text',
+          text,
+        },
+      },
+    });
+  };
+  const runTurn = async (text: string) => {
+    publishUserMessage(text);
+    await agent.prompt(text);
+  };
+
   const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://x');
+
+    if (url.pathname.startsWith('/kortix/opencode/')) {
+      if (surface.handle(req, res, url)) return;
+    }
 
     // ── Platform compatibility surface ─────────────────────────────────────
     // The session lifecycle (start envelope, wake fences, env fan-out) speaks
@@ -356,7 +435,7 @@ export async function startWorker(cfg = configFromEnv()) {
         boot_error: null,
         // The pi worker has no OpenCode store to pin — the start path must not
         // wait for one.
-        opencode_session_id: null,
+        opencode_session_id: surface.rootId,
         opencode_session_required: false,
         agent_config_etag: compiled?.manifest?.agent_config_etag ?? null,
         commit_sha: compiled?.manifest?.source_sha ?? null,
@@ -428,7 +507,7 @@ export async function startWorker(cfg = configFromEnv()) {
               ),
             );
           }
-          await agent.prompt(String(text ?? ''));
+          await runTurn(String(text ?? ''));
           const result = { messages: agent.state.messages.length };
           const payload = JSON.stringify({ ok: true, result, rpcCalls: env.calls.map((c) => c.op) });
           res.writeHead(200, { 'content-type': 'application/json' }).end(payload);
@@ -462,7 +541,7 @@ export async function startWorker(cfg = configFromEnv()) {
           res.write(`data: ${JSON.stringify(event)}\n\n`);
         });
         try {
-          await agent.prompt(String(text ?? ''));
+          await runTurn(String(text ?? ''));
           res.write(`event: done\ndata: ${JSON.stringify({ rpcCalls: env.calls.map((c) => c.op) })}\n\n`);
         } catch (e: any) {
           res.write(`event: error\ndata: ${JSON.stringify({ error: String(e?.message ?? e) })}\n\n`);
@@ -484,7 +563,7 @@ export async function startWorker(cfg = configFromEnv()) {
           const { text } = JSON.parse(body || '{}');
           timing.firstTokenMs = null;
           const t0 = process.hrtime.bigint();
-          await agent.prompt(String(text ?? ''));
+          await runTurn(String(text ?? ''));
           const totalMs = Number(process.hrtime.bigint() - t0) / 1e6;
           const last = agent.state.messages.filter((m: any) => m.role === 'assistant').pop();
           const answer = (last?.content ?? [])


### PR DESCRIPTION
Slice 1 of frontend rendering for pi sessions. Since #6987 the web speaks ONLY the `/kortix/*` surface to the box — `/state`, paged `/messages`, ONE sequenced `/events` SSE that the API attaches to and relays (`session-runtime-transport.ts` is box-generic). This PR serves that exact contract from the WORKER, so a pi session renders in dev.kortix.com with **zero SDK or web changes**.

**How**
1. `runtime-surface.ts` mirrors the daemon deliberately: same seq/epoch/ring semantics (`kortix.hello` first, `kortix.resync` on epoch/gap, typed heartbeat, atomic replay handoff), same `RuntimeStateDoc` shape, same auth posture (Bearer `KORTIX_TOKEN` for the API's attach, HMAC `X-Kortix-User-Context` — header or query — for proxied user reads; the signing key IS the worker's session token, which is also the service key the API signs with).
2. **One source of truth**: every wire event the S0.5 adapter emits is sequenced onto the bus AND folded into the transcript store — `/messages` can never disagree with `/events`, and ids can't collide (session-wide zero-padded mint; id order is load-bearing per the OpenCode-ids learning). User messages publish at prompt time; the first user line titles the session.
3. `/kortix/health` now advertises the minted pi root (`ses_pi<sha>`) as `opencode_session_id` — `canQueryOpenCodeSession` gates the whole client transcript machinery on a native (non-UUID) id.
4. Namespace note: the daemon documents `/kortix/<harness>/*` as the future shape; the client isn't namespace-parameterized yet, so the worker serves `/kortix/opencode/*` verbatim (the bodies ARE OpenCode wire shapes). When the SDK grows engine-aware namespacing this mounts at `/kortix/pi/*` and the alias retires.
5. Not in this slice: sends from the composer (prompt delivery branches for engine:pi — slice 2), `act`/`turn` oracle routes, vcs-diff/config passthroughs (honest 404s; panels degrade).

**Verified**: e2e on the REAL compiled artifact (`pi-worker-bundle.test.ts`, 4 pass) — boot, 401 without auth, scripted turn, transcript with user+assistant / sorted unique ids / exact text, state with identity+roster+idle+title, SSE with hello-first framing, matching epoch header, monotonically increasing seqs, content present. `tsc` clean on apps/api; worker package carries only its 2 pre-existing errors. Live browser proof on dev lands after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790448175&installation_model_id=434224&pr_number=6993&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6993&signature=f63e708b5a1b2161acf0ef5efe342885228fc0220bd2f8164582e33f38d6628e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->