### PR TITLE
fix(worker): skip pi's user-role message frames — the worker publishes the user turn itself

### DIFF
--- a/apps/api/src/git-proxy/pi-worker-bundle.test.ts
+++ b/apps/api/src/git-proxy/pi-worker-bundle.test.ts
@@ -184,7 +184,10 @@ describe.skipIf(!existsSync(WORKER_DIST))('compiled pi runtime — session read 
         seq: number;
       };
       const roles = page.messages.map((m) => m.info.role);
-      expect(roles).toContain('user');
+      // EXACTLY one user message: pi emits its own user message_start, which
+      // the adapter must skip (the worker publishes the user turn itself) —
+      // the duplicate rendered as an empty second bubble on dev.
+      expect(roles.filter((r) => r === 'user')).toEqual(['user']);
       expect(roles).toContain('assistant');
       const ids = page.messages.map((m) => m.info.id);
       expect([...ids].sort()).toEqual(ids);

--- a/apps/kortix-worker/src/chat-events.ts
+++ b/apps/kortix-worker/src/chat-events.ts
@@ -84,6 +84,11 @@ export class ChatEventAdapter {
         return [{ type: 'session.status', properties: { sessionID, status: { type: 'running' } } }];
 
       case 'message_start': {
+        // The worker publishes the USER message itself at prompt time (with its
+        // real text); translating pi's user message_start too would render an
+        // empty duplicate user bubble — observed live on dev (session ae3a07fc,
+        // roles ['user','user','assistant']).
+        if ((event.message?.role ?? 'assistant') === 'user') return [];
         this.currentMessageId = this.mint ? this.mint() : `msg-${++this.messageSeq}`;
         this.partCount = 0;
         this.textIndex.clear();
@@ -180,6 +185,7 @@ export class ChatEventAdapter {
       }
 
       case 'message_end': {
+        if ((event.message?.role ?? 'assistant') === 'user') return [];
         const stop = event.message?.stopReason;
         const out: Wire[] = [
           {


### PR DESCRIPTION
Live-caught on the first #6993 dev proof (session `ae3a07fc`): the transcript read `roles=['user','user','assistant']`. pi's Agent stream emits `message_start` for the USER message as well; the adapter translated it into a second, EMPTY user message beside the worker's own prompt-time publication (which carries the real text). The adapter now skips user-role `message_start`/`message_end`; the artifact e2e pins exactly one user message per turn (`pi-worker-bundle.test.ts`, 4 pass on the rebuilt bundle).

Everything else in that proof was green: `/kortix/opencode/state` and `/messages` render through the proxy with the signed user context, identity `ses_pi…`, roster, idle status, and the first-user-line title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790449053&installation_model_id=434224&pr_number=6994&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6994&signature=4199f35348818e106a42f12ea3aa510fb4c18f14cbf38e8844506b7ae4021255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->