### PR TITLE
fix(worker): answer the raw /session pin probe; only assistant roles translate

### DIFF
--- a/apps/api/src/git-proxy/pi-worker-bundle.test.ts
+++ b/apps/api/src/git-proxy/pi-worker-bundle.test.ts
@@ -196,6 +196,19 @@ describe.skipIf(!existsSync(WORKER_DIST))('compiled pi runtime — session read 
       expect(assistant?.parts.some((p) => p.type === 'text' && p.text === 'rendered, chief')).toBe(true);
       expect(page.seq).toBeGreaterThan(0);
 
+      // Raw /session list — the control plane's pin probe
+      // (ensureOpencodeSessionPin) reads THIS to resolve /start to 'ready';
+      // without it the healthy box parks at the 90s no-progress budget.
+      const rawList = (await (
+        await fetch(`${base}/session?directory=%2Fworkspace`, authed)
+      ).json()) as Array<{ id: string; title: string }>;
+      expect(rawList.map((s) => s.id)).toEqual([rootId]);
+      const rawDenied = await fetch(`${base}/session`);
+      expect(rawDenied.status).toBe(401);
+      // Only user/assistant roles reach the transcript — pi's toolResult
+      // messages ride as tool PARTS, never as their own rows.
+      expect(new Set(roles).size).toBeLessThanOrEqual(2);
+
       // State: identity + roster + idle status for the root.
       const state = (await (await fetch(`${base}/kortix/opencode/state`, authed)).json()) as {
         identity: { opencode_session_id: string };

--- a/apps/kortix-worker/src/chat-events.ts
+++ b/apps/kortix-worker/src/chat-events.ts
@@ -84,11 +84,12 @@ export class ChatEventAdapter {
         return [{ type: 'session.status', properties: { sessionID, status: { type: 'running' } } }];
 
       case 'message_start': {
-        // The worker publishes the USER message itself at prompt time (with its
-        // real text); translating pi's user message_start too would render an
-        // empty duplicate user bubble — observed live on dev (session ae3a07fc,
-        // roles ['user','user','assistant']).
-        if ((event.message?.role ?? 'assistant') === 'user') return [];
+        // Only ASSISTANT messages translate. The worker publishes the USER
+        // message itself at prompt time (pi's user message_start rendered an
+        // empty duplicate bubble — dev session ae3a07fc), and pi's 'toolResult'
+        // messages are already carried as tool PARTS on the assistant message
+        // (dev session 7f218b0a rendered a stray toolResult row).
+        if ((event.message?.role ?? 'assistant') !== 'assistant') return [];
         this.currentMessageId = this.mint ? this.mint() : `msg-${++this.messageSeq}`;
         this.partCount = 0;
         this.textIndex.clear();
@@ -185,7 +186,7 @@ export class ChatEventAdapter {
       }
 
       case 'message_end': {
-        if ((event.message?.role ?? 'assistant') === 'user') return [];
+        if ((event.message?.role ?? 'assistant') !== 'assistant') return [];
         const stop = event.message?.stopReason;
         const out: Wire[] = [
           {

--- a/apps/kortix-worker/src/runtime-surface.ts
+++ b/apps/kortix-worker/src/runtime-surface.ts
@@ -359,6 +359,43 @@ export class RuntimeSurface {
     };
   }
 
+  private opencodeSessionObject() {
+    const s = this.sessionProjection();
+    return {
+      id: s.id,
+      title: s.title,
+      directory: s.directory,
+      time: { created: s.time.created, updated: s.time.updated },
+      version: 'pi',
+    };
+  }
+
+  /**
+   * The RAW OpenCode list the control plane still probes:
+   * `ensureOpencodeSessionPin` resolves the canonical pin from
+   * `GET /session?directory=…` (apps/api/src/projects/opencode-mapping.ts),
+   * and /start reports `starting` forever — then PARKS the healthy box at
+   * the 90s no-progress budget — until that list answers. One root, same
+   * auth posture as the namespace routes.
+   */
+  handleRawSessionList(req: IncomingMessage, res: ServerResponse, url: URL): boolean {
+    if (req.method !== 'GET') return false;
+    if (!this.authorized(req, url)) {
+      res.writeHead(401, { 'content-type': 'application/json' }).end(JSON.stringify({ error: 'unauthorized' }));
+      return true;
+    }
+    if (url.pathname === '/session') {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify([this.opencodeSessionObject()]));
+      return true;
+    }
+    const m = url.pathname.match(/^\/session\/([^/]+)$/);
+    if (m && decodeURIComponent(m[1]!) === this.rootId) {
+      res.writeHead(200, { 'content-type': 'application/json' }).end(JSON.stringify(this.opencodeSessionObject()));
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Serve one `/kortix/opencode/*` request. Returns false when the subpath is
    * not part of this surface (the caller then 404s it).
@@ -424,15 +461,8 @@ export class RuntimeSurface {
     if (sub.startsWith('session/') && req.method === 'GET') {
       const sessionId = decodeURIComponent(sub.slice('session/'.length));
       if (sessionId !== this.rootId) return json(404, { error: 'unknown session' });
-      const s = this.sessionProjection();
       // OpenCode's own Session shape, minimally: id, title, time.
-      return json(200, {
-        id: s.id,
-        title: s.title,
-        directory: s.directory,
-        time: { created: s.time.created, updated: s.time.updated },
-        version: 'pi',
-      });
+      return json(200, this.opencodeSessionObject());
     }
 
     if (sub === 'events' && req.method === 'GET') {

--- a/apps/kortix-worker/src/worker.ts
+++ b/apps/kortix-worker/src/worker.ts
@@ -413,6 +413,9 @@ export async function startWorker(cfg = configFromEnv()) {
     if (url.pathname.startsWith('/kortix/opencode/')) {
       if (surface.handle(req, res, url)) return;
     }
+    if (url.pathname === '/session' || url.pathname.startsWith('/session/')) {
+      if (surface.handleRawSessionList(req, res, url)) return;
+    }
 
     // ── Platform compatibility surface ─────────────────────────────────────
     // The session lifecycle (start envelope, wake fences, env fan-out) speaks


### PR DESCRIPTION
Two live-caught fixes from the first post-#6994 dev proof (session `7f218b0a`):

1. **`/start` never reached `ready`** — `ensureOpencodeSessionPin` resolves the canonical pin from the RAW `GET /session?directory=…` list (`opencode-mapping.ts`), the one OpenCode route the worker did not serve. Worse than cosmetic: the start path's 90s no-progress budget would eventually **park the healthy worker box** as `runtime_boot_failed` under normal web polling. The worker now serves `/session` + `/session/:id` (single root, same Bearer/HMAC posture as the namespace routes); `/start` resolves to `ready` with the `ses_pi…` pin.
2. **Stray `toolResult` transcript rows** — pi emits its own `toolResult` messages; their content already rides as tool PARTS on the assistant message. The adapter now translates message frames for ASSISTANT roles only (user turns stay worker-published, per #6994).

e2e on the rebuilt artifact pins both: the raw list answers `[rootId]` (401 unauthenticated), and transcript roles are user/assistant only (`pi-worker-bundle.test.ts`, 4 pass / 32 asserts). `tsc` clean on apps/api.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790449947&installation_model_id=434224&pr_number=6995&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6995&signature=de9ef167d1f58da1cc5a8fe82b3490e99506975a827e83c11fd83637876569cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->