### PR TITLE
perf(daemon): decompose opencode-ready into named marks; prefetch the initial-turn claim

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, test } from 'bun:test'
+
+// Shape assertions over the boot sequence (a unit suite cannot boot OpenCode).
+// They keep the sub-marks that decompose `opencode-ready` — and the early
+// initial-turn claim — from being quietly dropped.
+const MAIN = readFileSync(join(import.meta.dir, '..', 'main.ts'), 'utf8')
+const OPENCODE = readFileSync(join(import.meta.dir, '..', 'opencode.ts'), 'utf8')
+
+describe('boot instrumentation', () => {
+  test('the initial-turn claim is prefetched at proxy-up, before the clone is awaited', () => {
+    const proxyUp = MAIN.indexOf("bootMark('proxy-up')")
+    const earlyClaim = MAIN.indexOf('void claimInitialTurnFromApi()', proxyUp)
+    const repoAwait = MAIN.indexOf('await repoMaterializePromise', proxyUp)
+    expect(proxyUp).toBeGreaterThan(-1)
+    expect(earlyClaim).toBeGreaterThan(proxyUp)
+    expect(repoAwait).toBeGreaterThan(earlyClaim)
+  })
+
+  test('every stage of the initial-session path has its own mark, in order', () => {
+    const start = MAIN.indexOf('async function maybeCreateInitialOpencodeSession')
+    const order = [
+      "bootMark('initial-turn-claimed')",
+      "bootMark('opencode-answering')",
+      "bootMark('opencode-root-created')",
+      "bootMark('opencode-root-ready')",
+      "bootMark('initial-prompt-delivered')",
+    ]
+    let cursor = start
+    for (const mark of order) {
+      const at = MAIN.indexOf(mark, cursor)
+      expect(at, mark).toBeGreaterThan(cursor)
+      cursor = at
+    }
+    const finalize = MAIN.indexOf('const finalizeInitialSession = async () => {')
+    const accepted = MAIN.indexOf("bootMark('initial-turn-accepted')", finalize)
+    const ready = MAIN.indexOf("bootMark('opencode-ready')", finalize)
+    expect(accepted).toBeGreaterThan(finalize)
+    expect(ready).toBeGreaterThan(accepted)
+  })
+
+  test('the supervisor reports the first HTTP response separately from the first 200', () => {
+    expect(OPENCODE).toContain('onFirstListeningResponse?: () => void')
+    const probe = OPENCODE.indexOf("const probe = await probeOpencodeReadiness(")
+    const report = OPENCODE.indexOf('options.onFirstListeningResponse?.()', probe)
+    expect(probe).toBeGreaterThan(-1)
+    expect(report).toBeGreaterThan(probe)
+    expect(MAIN).toContain("bootMark('opencode-http-listening')")
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -209,6 +209,10 @@ async function main() {
   const opencodeBinaryPrefetchEnabled = process.env.KORTIX_OPENCODE_BINARY_PREFETCH === '1'
   const opencode = createOpencodeSupervisor(cfg, cfg.defaultOpencodeConfigDir, projectEnv, {
     onStartupMark: bootMark,
+    onFirstListeningResponse: () => {
+      if (bootState.timeline.some((mark) => mark.label === 'opencode-http-listening')) return
+      bootMark('opencode-http-listening')
+    },
     onFirstReadyResponse: () => {
       if (bootState.timeline.some((mark) => mark.label === 'opencode-session-api-ready')) return
       bootMark('opencode-session-api-ready')
@@ -258,6 +262,24 @@ async function main() {
     exit: (code) => shutdown({ reason: 'agent-swap', exitCode: code }),
   })
   bootMark('proxy-up')
+
+  // The initial-turn claim is a read (it returns the API's `delivering` record
+  // for this session; nothing server-side changes). It used to run only after
+  // OpenCode answered, costing one control-plane round trip on the critical
+  // path. Prefetch it now — memoized in claimInitialTurnFromApi — so the
+  // initial-session path finds it resolved.
+  if (bootstrapSession && (process.env.KORTIX_SESSION_ID ?? '').trim()) {
+    void claimInitialTurnFromApi()
+      .then(() => {
+        if (bootState.timeline.some((mark) => mark.label === 'initial-turn-claimed')) return
+        bootMark('initial-turn-claimed')
+      })
+      .catch((err) => {
+        logger.warn('[boot] early initial-turn claim failed; the session path retries', {
+          err: err instanceof Error ? err.message : String(err),
+        })
+      })
+  }
 
   // Learn the CURRENT managed lineup from the gateway this session bills
   // against, concurrently with the repo clone. The managed set is deployment
@@ -899,6 +921,7 @@ async function startSessionRuntime(
     loopStarted = true
     const finalizeInitialSession = async () => {
       await reconcileInitialTurnAcceptance()
+      bootMark('initial-turn-accepted')
       opencode.markReady()
       bootMark('opencode-ready')
       logger.info('[boot] opencode ready via initial session', {
@@ -1471,6 +1494,9 @@ async function maybeCreateInitialOpencodeSession(
   onListening?: () => void,
 ): Promise<void> {
   const claimedTurn = await claimInitialTurnFromApi()
+  if (!bootState.timeline.some((mark) => mark.label === 'initial-turn-claimed')) {
+    bootMark('initial-turn-claimed')
+  }
   const prompt = claimedTurn?.prompt ?? ''
   const bootstrapSession = (process.env.KORTIX_BOOTSTRAP_OPENCODE_SESSION ?? '').trim() === '1'
   if (!prompt && !bootstrapSession) return
@@ -1572,6 +1598,7 @@ async function maybeCreateInitialOpencodeSession(
     bootMark('runtime-session-new-requested')
     const session = await createInitialOpenCodeSession(opencode, workspace)
     if (!session.id) throw new Error('opencode session create returned no id')
+    bootMark('opencode-root-created')
     sessionId = session.id
   }
 
@@ -1604,6 +1631,7 @@ async function maybeCreateInitialOpencodeSession(
     // skips this line) — the durable receipt `reusedRootAlreadyDelivered`
     // trusts unconditionally on every later boot of this sandbox.
     markInitialPromptDelivered()
+    bootMark('initial-prompt-delivered')
     logger.info('[boot] initial prompt delivered', { sessionId })
   } else if (prompt) {
     bootState.initialOpenCodeSessionId = sessionId

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1732,6 +1732,12 @@ export type Opencode = {
 export interface OpencodeSupervisorOptions {
   onStartupMark?: (label: string) => void
   onFirstReadyResponse?: () => void
+  /**
+   * First HTTP response of ANY status from the spawned process: the port is
+   * bound and bun has finished loading the binary. The gap to
+   * onFirstReadyResponse is then OpenCode's Instance init for the workspace.
+   */
+  onFirstListeningResponse?: () => void
   binaryPathOverride?: string
   binaryPathResolverOverride?: () => Promise<string | null>
   nativeBinaryFastPathEnabled?: boolean
@@ -1790,6 +1796,7 @@ export function createOpencodeSupervisor(
   let livenessFailures = 0
   let readinessTimer: ReturnType<typeof setTimeout> | null = null
   let firstReadyResponseReported = false
+  let firstListeningResponseReported = false
   let readyResponseProcess: ChildProcess | null = null
   const readyResponseWaiters = new Set<() => void>()
   let opencodeCwd = cfg.workspace
@@ -2379,7 +2386,12 @@ export function createOpencodeSupervisor(
       if (stopping) return
       const probedPort = livePort()
       const probedChild = child
-      const ready = await checkReady(probedPort)
+      const probe = await probeOpencodeReadiness(`http://127.0.0.1:${probedPort}`, currentCfg.projectTarget, 2_000)
+      const ready = probe === 'ready'
+      if (probe !== 'down' && !firstListeningResponseReported && probedChild === child) {
+        firstListeningResponseReported = true
+        options.onFirstListeningResponse?.()
+      }
       if (stopping) return
       if (probedPort !== livePort()) {
         scheduleReadinessProbe()


### PR DESCRIPTION
Follow-up to #6964: with the clone at ~0.2 s, `opencode-ready` is the boot. Dev telemetry (14 d, Platinum): `opencode-spawned → session-api-ready` p50 4.8 s; `session-api-ready → opencode-answering` a near-constant 2.1 s (p90 2.25 s); the 10 s `event-loop-connected` stall seen in 60/550 sessions ended 2026-08-22 (removed by `b99304b97e`).

**New marks** (all in the guest `boot_timeline`, relayed to `provider_events`):
- `opencode-http-listening` — first HTTP response of any status from the spawned process (port bound, bun done loading). Gap to `opencode-session-api-ready` = OpenCode's Instance init for `/workspace`.
- `initial-turn-claimed`, `opencode-root-created`, `initial-prompt-delivered`, `initial-turn-accepted` — the initial-session path, stage by stage.

**Overlap:** `claimInitialTurnFromApi()` is a read of the API's `delivering` record (no state change, no timer — `r4.ts` `initial_turn_claim`). It now runs at `proxy-up` (memoized) instead of after OpenCode answers, removing one control-plane round trip from the critical path.

**Verification:** new `boot-instrumentation.test.ts` (shape: claim before the clone await, marks in order, first-listening reported separately) + boot/dispose/fast-boot/event-loop suites → 83 pass; daemon `tsc --noEmit` clean (the `apps/kortix-worker` `ws` typings error is main's, unrelated). Dev decomposition will be posted here after deploy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790451341&installation_model_id=434224&pr_number=6996&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6996&signature=7c6c3f0975387c560c70314ce2c82adf7510d7aab3819bc8431e4da0666e7af4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->