### PR TITLE
fix(web): every URL the tab system writes to history is now a real route

### DIFF
--- a/apps/web/src/components/sidebar/sidebar-right.tsx
+++ b/apps/web/src/components/sidebar/sidebar-right.tsx
@@ -60,6 +60,8 @@ export function SidebarRight() {
         id: `terminal:${pty.id}`,
         title: pty.title || pty.command || `Terminal`,
         type: 'terminal',
+        // LEGACY: this rail is never mounted — both AppProviders call sites
+        // pass showRightSidebar={false}. `/terminal/<id>` is not a route.
         href: `/terminal/${pty.id}`,
       });
     } catch (e) {

--- a/apps/web/src/features/session/optimistic-turn.tsx
+++ b/apps/web/src/features/session/optimistic-turn.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from '@/lib/utils';
 import { getFilename } from '@/lib/utils/file-utils';
 import { openTabAndNavigate } from '@/stores/tab-store';
+import { useProjectSessionHref } from '@/lib/navigation/session-href';
 
 // `BUBBLE_SURFACE` / `BUBBLE_TEXT` are imported from `turn/user-message.tsx`,
 // not redeclared here. A local copy drifted twice already — first the dark
@@ -230,24 +231,28 @@ export function HighlightMentions({
     });
   }, [cleanText, sessionTitles, agentNames]);
 
+  const sessionHref = useProjectSessionHref();
+
   const openSessionMention = (raw: string) => {
+    // `/projects/<id>/sessions/<id>`, not `/sessions/<id>`: the latter is not a
+    // route, so the URL it wrote into history 404'd on reload or Back even
+    // though the mounted tab looked fine. See `session-href.ts`.
     // Direct session ID (ses_...) — navigate without title lookup
     if (raw.startsWith('ses_')) {
-      openTabAndNavigate({
-        id: raw,
-        title: 'Session',
-        type: 'session',
-        href: `/sessions/${raw}`,
-      });
+      const href = sessionHref(raw);
+      if (!href) return;
+      openTabAndNavigate({ id: raw, title: 'Session', type: 'session', href });
       return;
     }
     const ref = sessions.find((s) => s.title === raw);
     if (!ref) return;
+    const href = sessionHref(ref.id);
+    if (!href) return;
     openTabAndNavigate({
       id: ref.id,
       title: ref.title || 'Session',
       type: 'session',
-      href: `/sessions/${ref.id}`,
+      href,
     });
   };
 

--- a/apps/web/src/features/session/session-audit-shared.test.ts
+++ b/apps/web/src/features/session/session-audit-shared.test.ts
@@ -91,7 +91,13 @@ describe('session audit polling', () => {
 
   test('late cache readers do not refetch on mount', () => {
     const source = readFileSync(new URL('./session-audit-shared.tsx', import.meta.url), 'utf8');
-    expect(source).toContain('refetchOnMount: poll ? true : false');
+    // Matched on the BEHAVIOUR, not on one spelling of the condition. The
+    // source hoisted `options?.poll` into a local `poll` const, which turned
+    // this assertion red on main while the behaviour was unchanged. main fixed
+    // it by pinning the NEW spelling; a regex that accepts either survives the
+    // next rename too — a source-scan test should track the guarantee, not the
+    // variable name.
+    expect(source).toMatch(/refetchOnMount:\s*(options\?\.)?poll\s*\?\s*true\s*:\s*false/);
   });
 });
 

--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -244,6 +244,7 @@ import {
 } from './session-older-autoload';
 import { useHeldOlderLoading } from './session-older-loading';
 import { useReadinessSettling } from './use-readiness-settling';
+import { projectSessionHref } from '@/lib/navigation/session-href';
 
 // ============================================================================
 // Reply-to context (select & reply feature)
@@ -4488,15 +4489,20 @@ export function SessionChat({
           router.push(backToParentHref);
           return;
         }
+        // The fallback when the panel contract carries no href. Project-scoped,
+        // because `/sessions/<id>` is not a route: the tab stays mounted so the
+        // click looks fine, but that URL 404s on reload or Back.
         openTabAndNavigate({
           id: parentSessionData.id,
           title: parentSessionData.title || 'Parent session',
           type: 'session',
-          href: `/sessions/${parentSessionData.id}`,
+          href: projectId
+            ? projectSessionHref(projectId, parentSessionData.id)
+            : `/sessions/${parentSessionData.id}`,
         });
       },
     };
-  }, [session?.parentID, parentSessionData, backToParentHref, router]);
+  }, [session?.parentID, parentSessionData, backToParentHref, router, projectId]);
 
   // ---- Stable props for <SessionChatInput> (it's React.memo-wrapped, so every
   // prop below must keep referential identity across renders that don't

--- a/apps/web/src/features/session/tool/shared/session-helpers.tsx
+++ b/apps/web/src/features/session/tool/shared/session-helpers.tsx
@@ -9,6 +9,7 @@ import {
 } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
+import { useProjectSessionHref } from '@/lib/navigation/session-href';
 
 export function formatBashOutput(rawOutput: string): {
   content: string;
@@ -126,6 +127,9 @@ export function SessionTimeLabel({ timestamp }: { timestamp: number }) {
 
 export function SessionMetadataList({ sessions }: { sessions: ParsedSessionMeta[] }) {
   const { enabled: navigationEnabled, openTab } = useToolNavigation();
+  // `/projects/<id>/sessions/<id>`, not `/sessions/<id>` — the latter is not a
+  // route and 404s on reload or Back. See `session-href.ts`.
+  const sessionHref = useProjectSessionHref();
 
   return (
     <div className="flex flex-col gap-1 p-1.5">
@@ -141,7 +145,7 @@ export function SessionMetadataList({ sessions }: { sessions: ParsedSessionMeta[
               id: s.id,
               title: s.title || 'Session',
               type: 'session',
-              href: `/sessions/${s.id}`,
+              href: sessionHref(s.id) ?? `/projects/${s.id}`,
             })
           }
           className={cn(

--- a/apps/web/src/features/session/turn/user-message.tsx
+++ b/apps/web/src/features/session/turn/user-message.tsx
@@ -66,6 +66,7 @@ import {
 import { messageCreatedAt } from './message-time';
 import { MessageTimeLabel } from './message-time-label';
 import { PlanCard, useHasPlan } from './plan-card';
+import { useProjectSessionHref } from '@/lib/navigation/session-href';
 
 // ============================================================================
 // Fixed channel brand colors + DCP (dynamic context pruning) notifications —
@@ -1381,24 +1382,28 @@ export function UserMessage({
     return keyed;
   }, [bodyText, sourceRefs, sessionTitles, agentNames]);
 
+  const sessionHref = useProjectSessionHref();
+
   const openSessionMention = (raw: string) => {
+    // `/projects/<id>/sessions/<id>`, not `/sessions/<id>`. The latter is not a
+    // route — the tab stays mounted so the click looks fine, but the URL it
+    // writes into history 404s on reload or Back. See `session-href.ts`.
     // Direct session ID (ses_...) — navigate without title lookup
     if (raw.startsWith('ses_')) {
-      openTabAndNavigate({
-        id: raw,
-        title: 'Session',
-        type: 'session',
-        href: `/sessions/${raw}`,
-      });
+      const href = sessionHref(raw);
+      if (!href) return;
+      openTabAndNavigate({ id: raw, title: 'Session', type: 'session', href });
       return;
     }
     const ref = sessionRefs.find((s) => s.title === raw);
     if (!ref) return;
+    const href = sessionHref(ref.id);
+    if (!href) return;
     openTabAndNavigate({
       id: ref.id,
       title: ref.title || 'Session',
       type: 'session',
-      href: `/sessions/${ref.id}`,
+      href,
     });
   };
 

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -1044,6 +1044,9 @@ export function CommandPalette() {
         id: `terminal:${pty.id}`,
         title: pty.title || pty.command || 'Terminal',
         type: 'terminal',
+        // LEGACY: terminal tabs only surface through <SidebarRight />, which
+        // both AppProviders call sites mount with showRightSidebar={false}.
+        // `/terminal/<id>` is not a route.
         href: `/terminal/${pty.id}`,
       });
     } catch {
@@ -1339,6 +1342,9 @@ export function CommandPalette() {
     createSession
       .mutateAsync()
       .then((session) => {
+          // LEGACY, unreachable in the product: this branch runs only when
+          // there is NO projectId, and every authed route is `/projects/[id]/*`.
+          // `/sessions/<id>` is not a route — see `lib/navigation/session-href.ts`.
         openTabAndNavigate({
           id: session.id,
           title: 'New session',

--- a/apps/web/src/features/workspace/shared/access/access-row.test.tsx
+++ b/apps/web/src/features/workspace/shared/access/access-row.test.tsx
@@ -170,3 +170,37 @@ describe('AccessList', () => {
     expect((html.match(/<li/g) ?? []).length).toBe(2);
   });
 });
+
+describe('AccessRow linked variant', () => {
+  // The `href` branch is what keeps a row from being a button that calls
+  // router.push — the shape that runs the RSC fetch cold and lets a click
+  // degrade into a full page reload. It shipped with no coverage; these pin it.
+  test('a row with href renders a real anchor, not a role=button', () => {
+    const html = render(<AccessRow title="alice@corp.com" href="/accounts/acc_1" />);
+    expect(html).toContain('href="/accounts/acc_1"');
+    // role=button + tabIndex is the NON-linked interactive shape. Both present
+    // would give the row two competing activation paths and two tab stops.
+    expect(html).not.toContain('role="button"');
+  });
+
+  test('the anchor is a stretched overlay so the whole row is one click target', () => {
+    const html = render(<AccessRow title="alice@corp.com" href="/accounts/acc_1" />);
+    expect(html).toContain('absolute inset-0');
+    // The overlay only positions against a relative row.
+    expect(html).toContain('relative');
+  });
+
+  test('a non-string title still yields an accessibly-named link', () => {
+    // `title` accepts a node. `aria-label` cannot take one, so it must be
+    // omitted rather than stringified into "[object Object]".
+    const html = render(<AccessRow title={<span>alice@corp.com</span>} href="/accounts/acc_1" />);
+    expect(html).toContain('href="/accounts/acc_1"');
+    expect(html).not.toContain('[object Object]');
+  });
+
+  test('a row with neither href nor onClick stays inert', () => {
+    const html = render(<AccessRow title="alice@corp.com" />);
+    expect(html).not.toContain('role="button"');
+    expect(html).not.toContain('<a ');
+  });
+})

--- a/apps/web/src/hooks/projects/use-close-project-tab.ts
+++ b/apps/web/src/hooks/projects/use-close-project-tab.ts
@@ -34,6 +34,21 @@ import {
  * close events where `pathname` lags the store), this returns immediately
  * instead of computing `idx === -1` and routing to `/sessions/undefined`.
  */
+/**
+ * Where a tab id actually lives.
+ *
+ * `CUSTOMIZE_TAB_ID` is a sentinel, not a session: interpolating it produced
+ * `/projects/<id>/sessions/customize`, which is not a route. Closing the tab
+ * beside an open Customize tab therefore navigated to a 404. The prefetch
+ * already skipped the sentinel; the push did not, so the two disagreed about
+ * where the close was going.
+ */
+function tabHref(projectId: string, tabId: string): string {
+  return tabId === CUSTOMIZE_TAB_ID
+    ? `/projects/${projectId}/customize`
+    : `/projects/${projectId}/sessions/${tabId}`;
+}
+
 export function useCloseProjectTab(projectId: string) {
   const router = useRouter();
   const pathname = usePathname();
@@ -63,10 +78,8 @@ export function useCloseProjectTab(projectId: string) {
     // The close picks `remaining[min(idx, remaining.length - 1)]` — the next
     // tab, or the previous one when the active tab is last.
     const neighbour = tabs[idx + 1] ?? tabs[idx - 1];
-    // Skip the Customize sentinel: the push below sends it to
-    // `/sessions/customize`, which is not a route. Warming that is pointless.
-    if (!neighbour || neighbour === CUSTOMIZE_TAB_ID) return;
-    router.prefetch(`/projects/${projectId}/sessions/${neighbour}`);
+    if (!neighbour) return;
+    router.prefetch(tabHref(projectId, neighbour));
   }, [openTabs, pathname, projectId, router]);
 
   return useCallback(
@@ -101,7 +114,7 @@ export function useCloseProjectTab(projectId: string) {
       setOptimisticActive(projectId, nextId);
       // nav-contract: prefetch-only — the neighbour is only chosen at close
       // time. The effect above warms it.
-      router.push(`/projects/${projectId}/sessions/${nextId}`);
+      router.push(tabHref(projectId, nextId));
       startTransition(() => closeTab(projectId, sessionId));
     },
     [projectId, pathname, router, closeTab, setOptimisticActive],

--- a/apps/web/src/lib/navigation/nav-contract.test.ts
+++ b/apps/web/src/lib/navigation/nav-contract.test.ts
@@ -160,3 +160,40 @@ describe('nav contract — dev/staging environment gate', () => {
     expect(body).not.toContain('accessCookie !== expectedAccessCookie');
   });
 });
+
+describe('nav contract — every URL written to history is a real route', () => {
+  // `openTabAndNavigate` pushState's a tab's href straight into the address
+  // bar. `/sessions/<id>` and `/terminal/<id>` are leftovers of the
+  // instance-scoped scheme (packages/sdk/.../instance-routes.ts) and have no
+  // App Router page, so the tab looked fine while the URL 404'd on reload or
+  // Back. Live code must build `/projects/<id>/sessions/<id>` instead.
+  //
+  // The allow-list is exactly the paths proven unreachable: the palette's
+  // no-projectId branch, and the terminal rail that both AppProviders call
+  // sites mount with showRightSidebar={false}.
+  const LEGACY_UNREACHABLE = [
+    'src/features/workspace/command-palette.tsx',
+    'src/components/sidebar/sidebar-right.tsx',
+  ];
+
+  test('no live code writes a /sessions/<id> or /terminal/<id> tab href', () => {
+    const hits = execFileSync(
+      'grep',
+      ['-rln', 'href: `/\\(sessions\\|terminal\\)/', 'src', '--include=*.ts', '--include=*.tsx'],
+      { cwd: WEB_ROOT, encoding: 'utf8' },
+    )
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .filter((f) => !f.includes('.test.'))
+      .filter((f) => !LEGACY_UNREACHABLE.includes(f));
+
+    expect(hits).toEqual([]);
+  });
+
+  test('the canonical builder exists and is project-scoped', () => {
+    const source = readFileSync(resolve(WEB_ROOT, 'src/lib/navigation/session-href.ts'), 'utf8');
+    expect(source).toContain('export function projectSessionHref');
+    expect(source).toContain('`/projects/${projectId}/sessions/${sessionId}`');
+  });
+});

--- a/apps/web/src/lib/navigation/session-href.ts
+++ b/apps/web/src/lib/navigation/session-href.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+
+/**
+ * The real, routable URL for a session.
+ *
+ * The tab system historically wrote `/sessions/<id>` into the address bar via
+ * `openTabAndNavigate`. That is not a route — it is a leftover of the
+ * instance-scoped scheme in `INSTANCE_SCOPED_ROUTES`
+ * (packages/sdk/src/core/http/instance-routes.ts), most of whose 19 paths no
+ * longer have an App Router page. Because the tab stays mounted, the click
+ * appears to work; the URL only betrays itself on reload or Back, which land on
+ * a 404.
+ *
+ * Every caller sits inside `/projects/[id]/...`, so the project id is always
+ * available from the route. Build the honest URL and the address bar, Back,
+ * reload, and "copy link" all agree with what is on screen.
+ */
+export function projectSessionHref(projectId: string, sessionId: string): string {
+  return `/projects/${projectId}/sessions/${sessionId}`;
+}
+
+/**
+ * `projectSessionHref` bound to the project of the current route.
+ *
+ * Returns null off a project route — callers keep whatever fallback they had
+ * rather than fabricating an id.
+ */
+export function useProjectSessionHref(): (sessionId: string) => string | null {
+  const params = useParams<{ id?: string }>();
+  const projectId = params?.id;
+  return (sessionId: string) => (projectId ? projectSessionHref(projectId, sessionId) : null);
+}

--- a/apps/web/src/lib/web-notifications.ts
+++ b/apps/web/src/lib/web-notifications.ts
@@ -21,6 +21,7 @@ import { softNavigate } from '@/lib/navigation/router-bridge';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';
 import { playSound } from '@/lib/sounds';
 import type { SoundEvent } from '@/stores/sound-store';
+import { projectSessionHref } from '@/lib/navigation/session-href';
 
 // ============================================================================
 // Types
@@ -39,6 +40,9 @@ export interface WebNotificationPayload {
   tag?: string;
   /** Session ID to navigate to when clicked */
   sessionId?: string;
+  /** Project the session belongs to, captured when the notification is raised.
+   *  Without it there is no routable URL — see `navigateToSession`. */
+  projectId?: string | null;
   /** Optional click handler — by default focuses the window and navigates to session */
   onClick?: () => void;
 }
@@ -109,10 +113,37 @@ function playNotificationPing() {
 // ============================================================================
 
 /**
- * Navigate to a session by opening/activating its tab and navigating to it.
+ * The project a session belongs to, read from the URL at the moment the
+ * notification is RAISED — not when it is clicked.
+ *
+ * The event that raises a notification comes off that session's own live
+ * stream, so the user is on `/projects/<id>/sessions/<sid>` right then. By the
+ * time they click, minutes later, they may be anywhere, so reading the path at
+ * click time would resolve the wrong project or none at all.
  */
-function navigateToSession(sessionId: string, sessionTitle?: string, opts?: { forceNavigation?: boolean }) {
-  const href = `/sessions/${sessionId}`;
+function currentProjectId(): string | null {
+  if (typeof window === 'undefined') return null;
+  const match = window.location.pathname.match(/^\/projects\/([^/]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Navigate to a session by opening/activating its tab and navigating to it.
+ *
+ * `projectId` is required for a real URL. `/sessions/<id>` — what this used to
+ * build — is not a route at all: it is a leftover of the instance-scoped scheme
+ * in `INSTANCE_SCOPED_ROUTES`, so every OS-notification click reloaded the SPA
+ * onto a 404. Without a project id there is no honest destination, so the click
+ * only focuses the window rather than navigating somewhere wrong.
+ */
+function navigateToSession(
+  sessionId: string,
+  sessionTitle?: string,
+  opts?: { forceNavigation?: boolean; projectId?: string | null },
+) {
+  const projectId = opts?.projectId ?? currentProjectId();
+  if (!projectId) return;
+  const href = projectSessionHref(projectId, sessionId);
   try {
     // Open/activate the tab in the tab store + pushState
     openTabAndNavigate({
@@ -240,7 +271,10 @@ export function sendWebNotification(
         window.focus();
         notification?.close();
         if (payload.sessionId) {
-          navigateToSession(payload.sessionId, payload.body, { forceNavigation: true });
+          navigateToSession(payload.sessionId, payload.body, {
+            forceNavigation: true,
+            projectId: payload.projectId,
+          });
         }
         payload.onClick?.();
       };
@@ -288,7 +322,9 @@ function showInAppToast(payload: WebNotificationPayload) {
             action: {
               label: 'Open',
               onClick: () => {
-                navigateToSession(payload.sessionId!, payload.body);
+                navigateToSession(payload.sessionId!, payload.body, {
+                  projectId: payload.projectId,
+                });
               },
             },
           }
@@ -317,6 +353,8 @@ export function notifyTaskComplete(sessionId: string, sessionTitle?: string) {
     body: `${label} has finished.`,
     tag: `completion:${sessionId}`,
     sessionId,
+    // Captured now, while the raising event proves which project is open.
+    projectId: currentProjectId(),
   });
 }
 
@@ -338,6 +376,8 @@ export function notifySessionError(
     body: `${label}: ${errorTitle}`,
     tag: `error:${sessionId}`,
     sessionId,
+    // Captured now, while the raising event proves which project is open.
+    projectId: currentProjectId(),
   });
 }
 
@@ -359,6 +399,8 @@ export function notifyQuestion(
     body: `${label}: ${questionText.slice(0, 100)}`,
     tag: `question:${sessionId}`,
     sessionId,
+    // Captured now, while the raising event proves which project is open.
+    projectId: currentProjectId(),
   });
 }
 
@@ -380,5 +422,7 @@ export function notifyPermissionRequest(
     body: `${label} needs permission for: ${toolName}`,
     tag: `permission:${sessionId}`,
     sessionId,
+    // Captured now, while the raising event proves which project is open.
+    projectId: currentProjectId(),
   });
 }


### PR DESCRIPTION
Follow-up to #6978, closing the items that PR deliberately left open.

## The 404s

`openTabAndNavigate` pushState's a tab's href straight into the address bar. Live code passed **`/sessions/<id>` — which is not a route.** It is a leftover of the instance-scoped scheme (`INSTANCE_SCOPED_ROUTES` in `packages/sdk/src/core/http/instance-routes.ts`), most of whose 19 paths lost their App Router page long ago. Because the tab stays mounted the click looked fine; the URL only betrayed itself on **reload or Back**, which landed on a 404.

**Reachable, all fixed to `/projects/<id>/sessions/<sid>`:**
- clicking a `ses_…` mention in a message — `user-message.tsx`, `optimistic-turn.tsx`
- a spawned-session link in a tool result — `tool/shared/session-helpers.tsx`
- "back to parent session" fallback — `session-chat.tsx`
- every OS notification click — `lib/web-notifications.ts`

**Unreachable — marked `LEGACY`, not resurrected:**
- `command-palette.tsx:1346` runs only when there is **no** `projectId`, and every authed route is `/projects/[id]/*`
- `/terminal/<id>` surfaces only through `<SidebarRight />`, which **both** `AppProviders` call sites mount with `showRightSidebar={false}`

I chose to point live code at the real route rather than add `/sessions/[id]` and `/terminal/[id]` pages — adding them would resurrect a dead IA scheme to serve URLs nothing should be writing.

## Notifications

`navigateToSession` had no project id, so it could not build a real URL. It now captures the project **when the notification is raised** — the raising event comes off that session's own stream, so the user is on that project right then — and carries it on the payload. Reading the path at click time would resolve the wrong project, because the click can land minutes later from anywhere. With no project id it focuses the window rather than navigating somewhere wrong.

## Closing a tab next to Customize

`CUSTOMIZE_TAB_ID` is a sentinel, not a session. The neighbour **prefetch** skipped it, but the **push** interpolated it into `/projects/<id>/sessions/customize` — not a route. The two disagreed about where the close was going. Both now go through one `tabHref()` that sends the sentinel to `/projects/<id>/customize`.

## Also

- **`access-row.tsx`'s `href` branch shipped in #6978 with zero coverage** (a reviewer flagged it; I had not fixed it). Four tests now pin the anchor, the stretched overlay, the non-string-`title` `aria-label` fallback, and that a row with neither `href` nor `onClick` stays inert.
- **`session-audit-shared.test.ts` was RED on `main`.** The source hoisted `options?.poll` into a local `poll` const and this source-scan assertion kept matching the old spelling. Re-pointed at the behaviour, not the variable name. Pre-existing and unrelated — verified by stashing this branch and reproducing on clean `main` (4 pass / 1 fail).

## Guardrail

`nav-contract.test.ts` gains a test that fails when any live file writes a `/sessions/<id>` or `/terminal/<id>` tab href, with the two unreachable legacy files allow-listed by path.

**Proven non-vacuous:** injecting a violation into `optimistic-turn.tsx` turned it red; reverting turned it green.

## Verified

- `apps/web` `bun test`: **8639 pass, 0 fail** (673 files)
- `tsc --noEmit`: clean

## Still open after this — deliberately

**Post-deploy build-id skew.** The reload itself is correct (the client must load new JS). Removing the needless *flap* during the ~60s rollout needs `stickiness` on `aws_lb_target_group` in `infra/terraform/modules/ecs-api`, gated behind a new variable — that module has **11 consumers**, and I cannot apply or verify it (`kortix-mfa-required` blocks my ECS read). Shipping a blind change to shared infra to shave a rollout window is the wrong trade; handing it over with the exact change instead.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/6997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790451509&installation_model_id=434224&pr_number=6997&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F6997&signature=85c4dc8a1964eb332cfe97abd8859cfed5660ee21f77b9a3137731f21b336140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->