### PR TITLE
docs(learnings): deployed configuration has one truth, and it is not the file in git

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3494,3 +3494,45 @@ regions).
 - **Incident (2026-08-27, Essentia self-host, web `39685da4`):** the composer model picker looked dead — every click left the chip on "Claude Opus 5 (Global)" and every prompt was sent with it. The click DID persist the pick; `healBedrockModelKey` (#6915, 2026-08-26) then replaced it at resolution time. The heal finds "the key's own provider" by `providerID` equality and detects Bedrock by any sibling ranking as an inference profile. On the gateway all 481 catalog models share `providerID: 'kortix'`, `bedrockInferenceProfileRank` strips the `amazon-bedrock/` prefix so `amazon-bedrock/global.anthropic.claude-opus-5` still ranks 2, and OpenRouter/Codex/bare-Bedrock picks (no `global.` twin) fell through to the auto-seed fallback = the newest profile in the whole catalog. The unit suite (16/0) was green because every fixture used native ids (`amazon-bedrock` / `xai.grok-4.6`); no test flattened a gateway catalog.
 - **Rule:** any SDK/web logic that groups, filters, or "heals" models by provider must resolve the REAL provider (`FlatModel.provider`, or the modelID prefix under the gateway), never `providerID` alone — and must be tested against BOTH shapes: a native list and a `projectLlmCatalogToProviderList` gateway list. A native-only guard (the gateway already retries bare Bedrock ids after the 400, #6897) must short-circuit on `GATEWAY_PROVIDER_IDS`.
 - **Enforcement:** `healBedrockModelKey` step 0 returns gateway keys untouched; `bedrock-invokable.test.ts` "under the gateway the heal is inert" builds the fixture through the real `projectLlmCatalogToProviderList` → `flattenModels` and pins OpenRouter, bare-Bedrock and Codex picks as untouched.
+
+## Deployed configuration has one truth, and it is not the file in git
+
+Found 2026-08-27 while auditing secret access. The git profiles
+`apps/api/.env.{dev,staging,prod}` had drifted far from what the deployed
+environments actually run: dev was missing 54 keys, staging 34, prod 90, and
+`.env.prod` still declared `FRONTEND_URL=http://localhost:3000`. Runtime truth
+is the AWS Secrets Manager blob `kortix-<env>-env`, injected by ECS as
+`KORTIX_ENV_JSON`, plus the plain `environment` entries on the API task
+definition. Nothing synchronized the two: the dev and prod blobs are edited by
+operators, and the staging blob is rebuilt as existing-blob-plus-overrides on
+each staging deploy. An operator reading the git file was reading fiction.
+
+**Rules.**
+1. Name the single runtime source for every deployed setting, and make a
+   committed check assert the file equals it. Drift that nothing measures grows
+   without bound.
+2. Pull from the runtime source into the file. Push a file value into the
+   runtime source only as a deliberate change with a rollout.
+3. A file that mirrors a deployed environment must not receive a credential
+   whose value is identical to production, when that file is readable by more
+   people than production is. Keep it in the secret store and record the
+   omission with its reason.
+4. Every tool that reads or writes a dotenvx file must run the CLI with a bare
+   environment. An exported shell variable makes `dotenvx get` return the shell
+   value and `dotenvx set` a silent no-op that reports `○ no change`, so a
+   comparison silently reads — and a write silently skips — the wrong value.
+5. dotenvx writes `KEY="encrypted:…"` with quotes. A plaintext scan that matches
+   `=encrypted:` reports every encrypted value as plaintext. Match
+   `=["']?encrypted:`.
+6. Verify a credential before treating it as sensitive. The three
+   `AWS_SECRET_ACCESS_KEY` values in these files returned
+   `SignatureDoesNotMatch`; they were dead keys, not live production access.
+
+*Automation:* `pnpm test:envs --sm` runs `scripts/secrets-sm-parity.py check`,
+which fails on any Secrets Manager or task-definition key that is missing or
+different in the file. `scripts/secrets-file-only.allowlist` and
+`scripts/secrets-sm-quarantine.allowlist` carry the two classes of deliberate
+exception, each line with the rotation that removes it.
+
+*Incident:* no outage. The audit found the drift; no deployed environment was
+changed.


### PR DESCRIPTION
Learnings entry for the 2026-08-27 secrets audit: git env profiles had drifted from the AWS Secrets Manager blobs that ECS actually injects (dev −54 keys, staging −34, prod −90). Records the two dotenvx traps that cost real time (exported shell variables shadow `get` and no-op `set`; `=encrypted:` misses the quoted form), the quarantine rule that keeps prod-identical credentials out of shared non-prod files, and the `pnpm test:envs --sm` automation from #7000. Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790453152&installation_model_id=434224&pr_number=7001&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7001&signature=c5b6c8448c6f983918db45de3ce250deffe552c144af438e648ee2b44785e085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->