### PR TITLE
fix(daemon): never build an OpenCode Instance before the workspace is complete

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
@@ -63,6 +63,16 @@ describe('boot instrumentation', () => {
     expect(reload).toBeGreaterThan(open)
   })
 
+  test('the proxy holds every caller off until the workspace is complete', () => {
+    const PROXY = readFileSync(join(import.meta.dir, '..', 'proxy.ts'), 'utf8')
+    expect(PROXY).toContain("bootState.workspaceReady === false")
+    expect(PROXY).toContain("'workspace_not_ready'")
+    // set false only on the early-spawn path, true once deps + skills are in
+    expect(MAIN).toContain('if (earlyOpencodeConfigDir) bootState.workspaceReady = false')
+    const deps = MAIN.indexOf("bootMark('config-deps')")
+    expect(MAIN.indexOf('bootState.workspaceReady = true', deps)).toBeGreaterThan(deps)
+  })
+
   test('an instance that answered before the workspace was ready forces a restart, not a dispose', () => {
     const fn = OPENCODE.indexOf('async reloadForWorkspace()')
     const body = OPENCODE.slice(fn, OPENCODE.indexOf('async reloadConfig(', fn))

--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
@@ -40,9 +40,41 @@ describe('boot instrumentation', () => {
     expect(ready).toBeGreaterThan(accepted)
   })
 
+  test('the directory-scoped probe stays closed until the workspace is ready', () => {
+    // OpenCode builds a directory Instance — and reads that directory's
+    // node_modules for local tools — on the FIRST directory-scoped request,
+    // and keeps that registry for the life of the process. With the early
+    // spawn our own 100 ms readiness probe is that first request, so it must
+    // not be directory-scoped until the checkout + deps are in place.
+    expect(OPENCODE).toContain('deferDirectoryProbe?: boolean')
+    expect(OPENCODE).toContain('async function probeOpencodeListening(')
+    expect(OPENCODE).toContain('/kortix-liveness-probe')
+    const check = OPENCODE.indexOf('async function checkReady(')
+    expect(OPENCODE.slice(check, check + 220)).toContain('if (!directoryProbeOpen) return false')
+
+    // main.ts: gate requested exactly when the early spawn can happen, and
+    // opened only after config deps + injected skills.
+    expect(MAIN).toContain('deferDirectoryProbe: cfg.autoClone && resolveHintedOpencodeConfigDir(cfg) !== null')
+    const deps = MAIN.indexOf("bootMark('config-deps')")
+    const open = MAIN.indexOf('opencode.markWorkspaceReady()', deps)
+    const reload = MAIN.indexOf('opencode.reloadForWorkspace()', open)
+    expect(deps).toBeGreaterThan(-1)
+    expect(open).toBeGreaterThan(deps)
+    expect(reload).toBeGreaterThan(open)
+  })
+
+  test('an instance that answered before the workspace was ready forces a restart, not a dispose', () => {
+    const fn = OPENCODE.indexOf('async reloadForWorkspace()')
+    const body = OPENCODE.slice(fn, OPENCODE.indexOf('async reloadConfig(', fn))
+    expect(body).toContain('restarting instead of disposing')
+    expect(body).not.toContain('return disposeInstances()')
+    const restart = MAIN.indexOf('opencode.restart()', MAIN.indexOf('const reloaded = await opencode.reloadForWorkspace()'))
+    expect(restart).toBeGreaterThan(-1)
+  })
+
   test('the supervisor reports the first HTTP response separately from the first 200', () => {
     expect(OPENCODE).toContain('onFirstListeningResponse?: () => void')
-    const probe = OPENCODE.indexOf("const probe = await probeOpencodeReadiness(")
+    const probe = OPENCODE.indexOf('const probe = directoryProbeOpen')
     const report = OPENCODE.indexOf('options.onFirstListeningResponse?.()', probe)
     expect(probe).toBeGreaterThan(-1)
     expect(report).toBeGreaterThan(probe)

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -337,6 +337,9 @@ async function main() {
   // dispose the instances in place (~50 ms) so the next request re-detects
   // the git root and re-reads config. No hint → the serial boot below.
   const earlyOpencodeConfigDir = cfg.autoClone ? resolveHintedOpencodeConfigDir(cfg) : null
+  // Only the early-spawn path can expose a half-built workspace; every other
+  // boot leaves this undefined and the proxy gate below is inert.
+  if (earlyOpencodeConfigDir) bootState.workspaceReady = false
   let opencodeStartedEarly = false
   const earlyOpencodeStartPromise: Promise<void> | null =
     earlyOpencodeConfigDir && !(process.env.KORTIX_COMPILED_OPENCODE_CONFIG_DIR ?? '').trim()
@@ -347,6 +350,7 @@ async function main() {
           opencodeStartedEarly = opencode.getPid() !== null
           // The checkout, its config-dir deps and the injected skills are all in
     // place now: OpenCode may build its Instance.
+    bootState.workspaceReady = true
     opencode.markWorkspaceReady()
     if (opencodeStartedEarly) {
             bootMark('opencode-spawned')
@@ -440,6 +444,7 @@ async function main() {
 
   if (bootState.repoMaterializationError) {
     logger.warn('[boot] skipping runtime readiness because repo materialization failed')
+    bootState.workspaceReady = true
     opencode.markWorkspaceReady()
     if (opencodeStartedFromCompiledConfig || opencodeStartedEarly) await opencode.stop()
   } else {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -218,6 +218,10 @@ async function main() {
       bootMark('opencode-session-api-ready')
     },
     nativeBinaryFastPathEnabled: opencodeBinaryPrefetchEnabled,
+    // The early-spawn path (below) starts OpenCode before the checkout exists.
+    // Keep the directory-scoped probe closed until the workspace is complete so
+    // no Instance — and no tool registry — is built against a partial tree.
+    deferDirectoryProbe: cfg.autoClone && resolveHintedOpencodeConfigDir(cfg) !== null,
   onUnplannedRespawn: () => {
       // opencode died on its own and is back. Close whatever turn it was
       // writing, or the client streams a part that will never complete.
@@ -341,7 +345,10 @@ async function main() {
           opencode.reconfigure(cfg, earlyOpencodeConfigDir, projectEnv)
           await opencode.start()
           opencodeStartedEarly = opencode.getPid() !== null
-          if (opencodeStartedEarly) {
+          // The checkout, its config-dir deps and the injected skills are all in
+    // place now: OpenCode may build its Instance.
+    opencode.markWorkspaceReady()
+    if (opencodeStartedEarly) {
             bootMark('opencode-spawned')
             logger.info('[boot] opencode spawned before checkout (config-dir hint)', {
               opencodeConfigDir: earlyOpencodeConfigDir,
@@ -433,6 +440,7 @@ async function main() {
 
   if (bootState.repoMaterializationError) {
     logger.warn('[boot] skipping runtime readiness because repo materialization failed')
+    opencode.markWorkspaceReady()
     if (opencodeStartedFromCompiledConfig || opencodeStartedEarly) await opencode.stop()
   } else {
     // Now that the repo exists, pin the credential helper repo-locally too, so

--- a/apps/kortix-sandbox-agent-server/src/opencode.ts
+++ b/apps/kortix-sandbox-agent-server/src/opencode.ts
@@ -1698,6 +1698,12 @@ export type Opencode = {
    */
   reloadForWorkspace(): Promise<boolean>
   /**
+   * Open the directory-scoped probe gate: the workspace (checkout + config-dir
+   * deps + injected skills) is complete, so OpenCode may now create its
+   * per-directory Instance. See `deferDirectoryProbe`.
+   */
+  markWorkspaceReady(): void
+  /**
    * Boot the new opencode, verify it serves, then swap and retire the old one.
    * Never leaves the session without an opencode.
    */
@@ -1738,6 +1744,18 @@ export interface OpencodeSupervisorOptions {
    * onFirstReadyResponse is then OpenCode's Instance init for the workspace.
    */
   onFirstListeningResponse?: () => void
+  /**
+   * Start with the directory-scoped readiness probe CLOSED. OpenCode creates
+   * an Instance for a directory on the first directory-scoped request, and it
+   * reads that directory's `node_modules` (local tools) ONCE per process: an
+   * Instance created before the checkout landed keeps a tool registry whose
+   * imports failed, for the life of the process (dev, 2026-08-27:
+   * `ResolveMessage: Cannot find module '@mendable/firecrawl-js' from
+   * /workspace/.kortix/opencode/tools/scrape_webpage.ts`). The early-spawn
+   * boot path therefore probes liveness on a non-Instance route until
+   * `markWorkspaceReady()`.
+   */
+  deferDirectoryProbe?: boolean
   binaryPathOverride?: string
   binaryPathResolverOverride?: () => Promise<string | null>
   nativeBinaryFastPathEnabled?: boolean
@@ -1797,6 +1815,7 @@ export function createOpencodeSupervisor(
   let readinessTimer: ReturnType<typeof setTimeout> | null = null
   let firstReadyResponseReported = false
   let firstListeningResponseReported = false
+  let directoryProbeOpen = options.deferDirectoryProbe !== true
   let readyResponseProcess: ChildProcess | null = null
   const readyResponseWaiters = new Set<() => void>()
   let opencodeCwd = cfg.workspace
@@ -2281,6 +2300,7 @@ export function createOpencodeSupervisor(
   }
 
   async function checkReady(port = livePort()): Promise<boolean> {
+    if (!directoryProbeOpen) return false
     return probeOpencodeSessionApi(`http://127.0.0.1:${port}`, currentCfg.projectTarget, 2_000)
   }
 
@@ -2386,7 +2406,10 @@ export function createOpencodeSupervisor(
       if (stopping) return
       const probedPort = livePort()
       const probedChild = child
-      const probe = await probeOpencodeReadiness(`http://127.0.0.1:${probedPort}`, currentCfg.projectTarget, 2_000)
+      // Closed gate → liveness only, on a route that creates no Instance.
+      const probe = directoryProbeOpen
+        ? await probeOpencodeReadiness(`http://127.0.0.1:${probedPort}`, currentCfg.projectTarget, 2_000)
+        : ((await probeOpencodeListening(`http://127.0.0.1:${probedPort}`, 2_000)) ? 'listening' : 'down')
       const ready = probe === 'ready'
       if (probe !== 'down' && !firstListeningResponseReported && probedChild === child) {
         firstListeningResponseReported = true
@@ -2573,6 +2596,11 @@ export function createOpencodeSupervisor(
      * a future opencode that drops the endpoint degrades to today's behaviour
      * rather than silently not applying the config.
      */
+    markWorkspaceReady() {
+      if (directoryProbeOpen) return
+      directoryProbeOpen = true
+      logger.info('[opencode] workspace ready; directory-scoped readiness probe opened')
+    },
     async reloadForWorkspace(): Promise<boolean> {
       if (stopping || !child) return false
       // The composed config was written at spawn, when the workspace's
@@ -2597,7 +2625,12 @@ export function createOpencodeSupervisor(
         logger.info('[opencode] workspace landed before the first instance; no dispose needed')
         return true
       }
-      return disposeInstances()
+      // An Instance already answered for this directory, i.e. it was created
+      // before the workspace was complete. Its tool registry / module
+      // resolution is process-cached, so dispose is NOT enough — take the
+      // restart. With the probe gate this is a fallback, not the normal path.
+      logger.warn('[opencode] an instance answered before the workspace was ready; restarting instead of disposing')
+      return false
     },
     async reloadConfig(opts: { mustRespawn?: boolean } = {}): Promise<ReloadConfigResult> {
       // A dispose re-reads the config in place — same process, no turn lost.
@@ -2769,6 +2802,20 @@ export async function waitForOpencodeReady(
 
 /** Richer boot probe: 'down' = port not answering at all, 'listening' = answers
  *  HTTP but /session not 2xx yet, 'ready' = /session 2xx/3xx. */
+/**
+ * Is the process serving HTTP at all? Any status counts, and the path is
+ * deliberately NOT directory-scoped: OpenCode answers unknown paths from its
+ * SPA catch-all, so this never creates an Instance for a directory.
+ */
+async function probeOpencodeListening(baseUrl: string, timeoutMs = 1_000): Promise<boolean> {
+  try {
+    await fetch(`${baseUrl}/kortix-liveness-probe`, { signal: AbortSignal.timeout(timeoutMs) })
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function probeOpencodeReadiness(
   baseUrl: string,
   directory: string,

--- a/apps/kortix-sandbox-agent-server/src/proxy.ts
+++ b/apps/kortix-sandbox-agent-server/src/proxy.ts
@@ -381,6 +381,19 @@ export function buildOpencodeApp(
         'repo_not_materialized',
       )
     }
+    // The checkout can be on disk while its config-dir dependencies are still
+    // installing. A directory-scoped request in that window makes OpenCode
+    // cache a tool registry whose imports failed, for the life of the process
+    // (dev, 2026-08-27). Hold callers off until the workspace is complete.
+    if (bootState.workspaceReady === false) {
+      return notReady(
+        {
+          error: 'sandbox runtime not ready',
+          reason: 'workspace_not_ready',
+        },
+        'workspace_not_ready',
+      )
+    }
 
     if (bootState.initialOpenCodeSessionError) {
       return notReady(

--- a/apps/kortix-sandbox-agent-server/src/routes/health.ts
+++ b/apps/kortix-sandbox-agent-server/src/routes/health.ts
@@ -62,6 +62,14 @@ export type SandboxBootState = {
   initialOpenCodeSessionError?: string | null
   /** Fatal local persistence failure in the OpenCode audit relay. */
   auditRelayError?: string | null
+  /**
+   * False ONLY while the early-spawn boot path is still assembling the
+   * workspace (checkout + config-dir deps + injected skills). OpenCode builds
+   * a directory Instance — and caches its local-tool registry, imports
+   * included — on the first directory-scoped request, so nothing may reach it
+   * before this flips. Undefined on every other path: unchanged behaviour.
+   */
+  workspaceReady?: boolean
 }
 
 /**


### PR DESCRIPTION
**Live dev breakage** (screenshot from a session on `kortix-ai/company`): every turn answered with

```
ResolveMessage: Cannot find module '@mendable/firecrawl-js' from '/workspace/.kortix/opencode/tools/scrape_webpage.ts'
  at ToolRegistry.state … SessionTools.resolve … SessionPrompt.run
```

**Cause — mine, from #6964.** The daemon now spawns OpenCode at `proxy-up`, before materialization. The supervisor's readiness probe is directory-scoped (`GET /session?directory=/workspace`) and runs every 100 ms from spawn. OpenCode builds a per-directory Instance — including the local-tool registry, which imports from that directory's `node_modules` — on the **first** directory-scoped request. On a repo whose materialization outlives OpenCode's HTTP start (imported repos clone for seconds; bun start is ~4 s) our own probe is that first request, so the registry is built against a workspace that has no checkout and no config-dir deps yet.

That state is cached in the process: verified in a live dev box that `/experimental/tool/ids` returns its first answer unchanged across `POST /global/dispose` (even with `node_modules` moved away). So the post-materialize dispose could never repair it. Scaffold-seeded projects were unaffected because their delta lands in ~200 ms, long before OpenCode serves HTTP.

**Fix**
- `opencode.ts`: new `deferDirectoryProbe` option. While the gate is closed the supervisor polls liveness on a non-Instance route (`/kortix-liveness-probe` → SPA catch-all) and never reports ready, so no Instance is created.
- `main.ts`: the gate is requested exactly when the early spawn can happen (`cfg.autoClone && resolveHintedOpencodeConfigDir(cfg) !== null`) and opened by `markWorkspaceReady()` only after checkout + `ensureOpencodeConfigDeps` + `ensureInjectedManagedSkills`.
- `reloadForWorkspace()` now returns false when an Instance answered before the workspace was ready, so the boot path **restarts** rather than disposes.

**Verification:** new cases in `boot-instrumentation.test.ts` (gate closed by default on the early-spawn path, opened after `config-deps`, restart-not-dispose fallback) + boot/dispose/fast-boot/config-deps suites → 66 pass; daemon `tsc` clean (the `kortix-worker` `ws` error is main's). Dev verification with a project whose OpenCode config dir imports an npm package to follow on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790453515&installation_model_id=434224&pr_number=7002&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7002&signature=14d86132800792c7fc5fa611cd18375123daf7847b1603fd4e81f2f749790281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->