### PR TITLE
fix(daemon): open the Instance gate where the workspace is complete, not right after spawn

### DIFF
--- a/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/boot-instrumentation.test.ts
@@ -69,8 +69,25 @@ describe('boot instrumentation', () => {
     expect(PROXY).toContain("'workspace_not_ready'")
     // set false only on the early-spawn path, true once deps + skills are in
     expect(MAIN).toContain('if (earlyOpencodeConfigDir) bootState.workspaceReady = false')
-    const deps = MAIN.indexOf("bootMark('config-deps')")
-    expect(MAIN.indexOf('bootState.workspaceReady = true', deps)).toBeGreaterThan(deps)
+    // The gate must open where the workspace is COMPLETE — after the deps and
+    // the injected skills — and never inside the early-spawn block. An earlier
+    // revision opened it right after start(), which made the whole fix inert
+    // (verified on dev: the log showed the gate opening at ~130 ms, before the
+    // checkout landed at ~300 ms). Anchor on the LAST reconfigure, not on a
+    // bare indexOf that a later duplicate can satisfy.
+    const earlySpawn = MAIN.indexOf('const earlyOpencodeStartPromise')
+    const earlySpawnEnd = MAIN.indexOf('const compiledOpencodeConfigDir', earlySpawn)
+    expect(MAIN.slice(earlySpawn, earlySpawnEnd)).not.toContain('markWorkspaceReady')
+
+    const deps = MAIN.indexOf('await ensureOpencodeConfigDeps(opencodeConfigDir)')
+    const skills = MAIN.indexOf('await ensureInjectedManagedSkills(opencodeConfigDir)', deps)
+    const reconfigure = MAIN.indexOf('opencode.reconfigure(cfg, opencodeConfigDir, projectEnv)', skills)
+    const open = MAIN.indexOf('opencode.markWorkspaceReady()', reconfigure)
+    const reload = MAIN.indexOf('opencode.reloadForWorkspace()', open)
+    expect(deps).toBeGreaterThan(-1)
+    expect(skills).toBeGreaterThan(deps)
+    expect(open).toBeGreaterThan(reconfigure)
+    expect(reload).toBeGreaterThan(open)
   })
 
   test('an instance that answered before the workspace was ready forces a restart, not a dispose', () => {

--- a/apps/kortix-sandbox-agent-server/src/main.ts
+++ b/apps/kortix-sandbox-agent-server/src/main.ts
@@ -348,11 +348,7 @@ async function main() {
           opencode.reconfigure(cfg, earlyOpencodeConfigDir, projectEnv)
           await opencode.start()
           opencodeStartedEarly = opencode.getPid() !== null
-          // The checkout, its config-dir deps and the injected skills are all in
-    // place now: OpenCode may build its Instance.
-    bootState.workspaceReady = true
-    opencode.markWorkspaceReady()
-    if (opencodeStartedEarly) {
+          if (opencodeStartedEarly) {
             bootMark('opencode-spawned')
             logger.info('[boot] opencode spawned before checkout (config-dir hint)', {
               opencodeConfigDir: earlyOpencodeConfigDir,
@@ -459,6 +455,13 @@ async function main() {
     // Reconfigure now so any later restart uses the checked-out config. The
     // already-running compiled-config process stays untouched.
     opencode.reconfigure(cfg, opencodeConfigDir, projectEnv)
+    // The checkout, its config-dir dependencies and the injected skills are ALL
+    // on disk now — this is the first moment a directory-scoped request may
+    // reach OpenCode. Opening the gate earlier is the bug this exists to stop
+    // (an Instance built against a partial workspace caches failed tool
+    // imports for the life of the process).
+    bootState.workspaceReady = true
+    opencode.markWorkspaceReady()
     if (opencodeStartedEarly) {
       // The process is up on the right dir; the workspace arrived after it.
       // Dispose in place so instances re-read config + re-detect the git root.


### PR DESCRIPTION
Correction to #7002 — caught by verifying on dev instead of trusting the merge.

`markWorkspaceReady()` landed **inside** the early-spawn block (right after `opencode.start()`), so the directory-scoped probe gate opened at ~130 ms — before the checkout (~300 ms) and before `ensureOpencodeConfigDeps`. The dev daemon log showed the order plainly:

```
20:35:53.583 [opencode] workspace ready; directory-scoped readiness probe opened
20:35:53.583 [boot] opencode spawned before checkout (config-dir hint)
20:35:53.749 [git] repo materialized … ms=176
```

So on a repo whose materialization outlives OpenCode's HTTP start — the case #7002 exists for — the Instance could still be built against a partial workspace.

- Gate now opens after `ensureOpencodeConfigDeps` + `ensureInjectedManagedSkills`, immediately before the reload decision.
- The test that let this through asserted `indexOf('bootState.workspaceReady = true', afterConfigDeps)`, which the repo-materialization-failure branch's duplicate satisfied. It now asserts the real sequence (deps → skills → reconfigure → open → reload) and that the early-spawn block contains no `markWorkspaceReady` at all.

**Verification:** `boot-instrumentation`, `fast-boot-delta`, `dispose-reload` → 23 pass; daemon `tsc` clean (the `kortix-worker` `ws` error is main's). Dev re-verification after deploy: the log must show `config deps installed` → `probe opened`, and a config dir with an npm-importing tool must keep resolving.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790455132&installation_model_id=434224&pr_number=7004&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7004&signature=2d1a7870a2a39517cb95233ed62080df22e50ac0cb1f7c550d89d2ec4f417b66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->