### PR TITLE
fix(preview): every Server Action 500s — pin the public host for Next's CSRF guard

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,37 @@ linked, not inlined.
 
 ## Register
 
+### A reverse proxy in front of Next.js owns `x-forwarded-host`, or every Server Action dies (2026-08-27)
+
+**When:** putting any proxy/ingress in front of a Next.js app — a preview edge,
+a sandbox ingress, a tunnel. Next's Server Action CSRF guard compares
+`x-forwarded-host` against `origin` and aborts when they differ:
+`Invalid Server Actions request`, HTTP 500, surfaced in the browser only as
+**minified React error #441**. It kills EVERY Server Action, not just the one
+in front of you — on the preview stack that meant nobody could sign in at all,
+because the whole auth flow is Server Actions.
+
+The mismatch is easy to create and invisible from the client: the sandbox
+ingress set `x-forwarded-host` to the INTERNAL host (`*.aec.local`) while the
+browser's `origin` was the public `*.sbx.platinum.dev`. Nothing in the app is
+wrong, and no application log says so — the error text lives in the **Next
+server's** own stdout, reachable only from the container
+(`docker logs <frontend>`), never from the response, which carries an opaque
+`digest`.
+
+**Rules.** (1) A proxy that terminates the public hostname must pin
+`X-Forwarded-Host` (and `X-Forwarded-Proto`) to the PUBLIC host on the Next
+upstream — the API/Supabase/static handles neither need it nor should get it.
+(2) A minified React error with no stack is a SERVER error: read the server's
+own log before reading any client code. (3) `digest` is a hash, not a message —
+grep the container for it.
+
+*Incident:* every `preview`-labelled PR was impossible to sign into; the whole
+environment read as "the app is broken". Fixed by pinning the host in
+`buildPreviewCaddyfile`.
+*Enforcer:* `tests/unit/preview-stack.test.ts` — "pins the PUBLIC host on the
+Next upstream for Server Actions".
+
 ### An experiment flag that deploy-dev pins to an explicit `false` can never double as a kill switch (2026-08-27)
 
 **When:** reusing an existing feature/experiment flag to gate a new default-on

--- a/tests/bin/preview-stack.ts
+++ b/tests/bin/preview-stack.ts
@@ -39,7 +39,7 @@ await chmod(envPath, 0o600);
 const testEnvPath = join(instanceDir, '.env.test');
 await writeFile(testEnvPath, configured.testEnv, { mode: 0o600 });
 await chmod(testEnvPath, 0o600);
-await writeFile(join(stateDir, 'Caddyfile.preview'), buildPreviewCaddyfile(), { mode: 0o644 });
+await writeFile(join(stateDir, 'Caddyfile.preview'), buildPreviewCaddyfile(new URL(origin).host), { mode: 0o644 });
 await writeFile(
   join(stateDir, 'docker-compose.preview.yml'),
   buildPreviewComposeOverlay(

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -68,7 +68,7 @@ export function validatePreviewRuntimeSecrets(
   }
 }
 
-export function buildPreviewCaddyfile(): string {
+export function buildPreviewCaddyfile(publicHost: string): string {
   return `:8080 {
   encode zstd gzip
 
@@ -96,7 +96,17 @@ export function buildPreviewCaddyfile(): string {
   }
 
   handle {
-    reverse_proxy frontend:3000
+    reverse_proxy frontend:3000 {
+      # Next.js Server Actions reject a request whose \`x-forwarded-host\` does
+      # not match its \`origin\` (CSRF guard). The sandbox ingress sets
+      # \`x-forwarded-host\` to the INTERNAL host (\`*.aec.local\`) while the
+      # browser's origin is the PUBLIC one, so every Server Action — the whole
+      # auth flow included — died with \`Invalid Server Actions request\` (500,
+      # surfaced in the browser as minified React error #441). Pin the public
+      # host so the guard compares like with like.
+      header_up X-Forwarded-Host ${publicHost}
+      header_up X-Forwarded-Proto https
+    }
   }
 }
 `;
@@ -196,6 +206,12 @@ export function applyPreviewEnvironment(
     KORTIX_PUBLIC_DISABLE_LANDING_PAGE: 'true',
     KORTIX_RESTRICT_ACCOUNT_CREATION: 'false',
     KORTIX_PUBLIC_RESTRICT_ACCOUNT_CREATION: 'false',
+    // Billing ON, with the Stripe SANDBOX (test-mode) keys below — the same
+    // posture as dev, so the subscribe -> entitlement -> managed-models path is
+    // exercised here rather than bypassed. An account that has not subscribed
+    // is free-tier and therefore NOT entitled to managed models, which is what
+    // makes an agent fall back to the faux provider: subscribe with a Stripe
+    // test card (or connect a BYOK key) to get real model answers.
     KORTIX_BILLING_INTERNAL_ENABLED: 'true',
     KORTIX_PUBLIC_BILLING_ENABLED: 'true',
     KORTIX_WORKERS_ENABLED: 'false',

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -11,7 +11,7 @@ const SHA = 'a'.repeat(40);
 
 describe('ephemeral self-host preview stack', () => {
   it('routes every public surface through one origin', () => {
-    const caddy = buildPreviewCaddyfile();
+    const caddy = buildPreviewCaddyfile('preview.example.test');
     expect(caddy).toContain(':8080');
     expect(caddy).toContain('@api path /v1*');
     expect(caddy).toContain('reverse_proxy kortix-api:8008');
@@ -110,5 +110,18 @@ describe('ephemeral self-host preview stack', () => {
         {},
       ),
     ).toThrow('complete managed GitHub App configuration');
+  });
+
+  // 2026-08-27: every Server Action on the preview 500'd with `Invalid Server
+  // Actions request` — surfaced in the browser as minified React error #441 —
+  // because the sandbox ingress sets `x-forwarded-host` to the INTERNAL host
+  // (`*.aec.local`) while the browser's `origin` is the public one, and Next's
+  // CSRF guard compares the two. The whole auth flow was unusable.
+  it('pins the PUBLIC host on the Next upstream for Server Actions', () => {
+    const caddy = buildPreviewCaddyfile('8080-abc.eu-west.sbx.platinum.dev');
+    expect(caddy).toContain('X-Forwarded-Host 8080-abc.eu-west.sbx.platinum.dev');
+    expect(caddy).toContain('X-Forwarded-Proto https');
+    const frontendBlock = caddy.slice(caddy.indexOf('reverse_proxy frontend:3000'));
+    expect(frontendBlock).toContain('X-Forwarded-Host');
   });
 });


### PR DESCRIPTION
**Any branch labeled `preview` is currently impossible to sign into.** Clicking Continue on the auth page throws minified React error #441 and the flow dies.

It is not the app. The sandbox ingress sets `x-forwarded-host` to the **internal** host (`*.aec.local`) while the browser's `origin` is the **public** one. Next's Server Action CSRF guard compares the two and aborts:

```
`x-forwarded-host` header with value `8080-….aec.local` does not match
`origin` header with value `8080-….sbx.platinum.dev` … Aborting the action.
⨯ Error: Invalid Server Actions request.  digest: '3437182114@E80'
```

That kills **every** Server Action, not just auth — which is why a preview never feels like dev. Read out of the frontend container's log in the live preview sandbox, not inferred.

**Fix:** the preview edge pins the public host (and proto) on the **Next upstream only** — `@api`, `@supabase`, `/_gateway`, `/_tests`, `/_mailpit` are untouched. `buildPreviewCaddyfile(publicHost)` takes the host, threaded from `PREVIEW_ORIGIN`.

**Why this must live on main:** the preview deploy job checks out `default_branch`, so the stack code always runs from main regardless of which branch is being previewed. A fix on a feature branch does nothing.

**Verified on a live preview** by hot-patching the running sandbox: before, `POST /auth` → 500; after, sign-in completes, the session page renders, and the composer works. Unit test pins the header on the frontend upstream (6 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457132&installation_model_id=434224&pr_number=7006&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7006&signature=0d9d40deead42a68a7670b30bccdcbee65539541cb39eed2b1906b8d76c487d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->