### PR TITLE
fix(api): /events attaches to a reachable box, not only an 'active' row

### DIFF
--- a/apps/api/src/projects/routes/session-stream.test.ts
+++ b/apps/api/src/projects/routes/session-stream.test.ts
@@ -276,6 +276,38 @@ describe('box down — the stream still serves', () => {
     expect(attachCalls).toHaveLength(0);
   });
 
+  test('a provisioning box (environment rebuilding) STILL attaches — the live stream is not gated on a background build', async () => {
+    // Regression (dev, 2026-08-27): a project ENVIRONMENT rebuild left a RUNNING
+    // session's row at `provisioning` while its box was Ready and serving the
+    // turn ("Sandbox build running…", Platinum Ready). Gating the attach on
+    // `status === 'active'` refused the live stream, the client fell back to
+    // POLLING `/kortix/opencode/messages`, and reasoning never collapsed / turns
+    // never ended / `/log` spun — the whole "client is broken" report. A build
+    // happening elsewhere is irrelevant to whether THIS reachable box can stream.
+    sandboxRow = { externalId: 'box-1', status: 'provisioning' };
+    daemonAttach = async () => ({
+      ok: true,
+      epoch: 'ep-prov',
+      body: daemonStream(
+        [
+          'event: kortix.hello\ndata: {"type":"kortix.hello","epoch":"ep-prov","head_seq":1,"first_seq":1,"since":null,"at":1}\n\n',
+          'event: session.status\nid: 1\ndata: {"seq":1,"type":"session.status","at":2,"payload":{"sessionID":"ses_x","status":{"type":"busy"}},"session":"ses_x"}\n\n',
+        ],
+        500,
+      ),
+    });
+    const response = await openStream();
+    const frames = await readFrames(response, 4);
+    // The runtime channel ATTACHES and says UP — never a degrade-to-poll `down`.
+    expect(
+      frames.find((frame) => frame.event === 'kortix.runtime.status')?.data,
+    ).toMatchObject({ state: 'up' });
+    // The daemon WAS attached (a stopped box would be 0), and its frame flows
+    // through verbatim, tagged as a runtime frame the reducer applies.
+    expect(attachCalls.length).toBeGreaterThan(0);
+    expect(frames.find((frame) => frame.event === 'session.status')?.data.channel).toBe('runtime');
+  });
+
   test('an unreachable daemon reports the reason and does not fail the response', async () => {
     daemonAttach = async () => ({ ok: false, reason: 'daemon_503', status: 503 });
     const response = await openStream();

--- a/apps/api/src/projects/routes/session-stream.ts
+++ b/apps/api/src/projects/routes/session-stream.ts
@@ -427,9 +427,25 @@ async function pumpRuntime(args: PumpArgs): Promise<void> {
       continue;
     }
 
-    // NEVER wake. Only `active` is attached to; anything else waits and
-    // re-checks, and the control channel is already telling the client why.
-    if (!sandbox?.externalId || sandbox.status !== 'active') {
+    // Attach to a box that EXISTS and is not reaper-stopped/archived/errored.
+    // `active` AND `provisioning` both mean "a real box is up or coming up":
+    // a project ENVIRONMENT rebuild (or a still-settling cold boot) leaves a
+    // RUNNING session's row at `provisioning` while its box is Ready and
+    // serving the turn (dev, 2026-08-27 — "Sandbox build running…", Platinum
+    // Ready). Gating on `=== 'active'` there refused the live attach, the
+    // client fell back to POLLING the transcript, and reasoning never
+    // collapsed / turns never ended / `/log` spun — the whole "client is
+    // broken" report. `/events` must attach to a REACHABLE box, full stop; a
+    // build happening elsewhere is irrelevant to whether THIS box can stream.
+    //
+    // Still NEVER wakes: attaching is a READ. A `stopped` (reaper-stopped),
+    // `error` or `archived` row is refused, so the "do not resurrect a
+    // reaper-stopped box and bill for it" safety this gate protects is kept.
+    // A `provisioning` box that is not up YET simply fails the attach below and
+    // retries on the backoff ladder — no wake, no bill, just a faster live
+    // stream the instant the daemon answers.
+    const attachable = sandbox?.status === 'active' || sandbox?.status === 'provisioning';
+    if (!sandbox?.externalId || !attachable) {
       announceDown(sandbox ? `sandbox_${sandbox.status}` : 'no_sandbox');
       await sleep(RUNTIME_IDLE_RECHECK_MS, args.abort.signal);
       continue;


### PR DESCRIPTION
## Incident
The session client looked **completely broken** on dev: reasoning rendered as an uncollapsing wall, turns never ended, the send button stayed live mid-turn, duplicate responses, and the browser hammered `GET /kortix/opencode/messages` in a loop.

## Root cause (one thing)
`/events` only attached to the daemon when the sandbox **row** said `active` (`session-stream.ts` `pumpRuntime`). During a project **environment rebuild** the row sits at `provisioning` while the session's box is **Ready and serving the turn** ("Sandbox build running…", Platinum Ready). The gate refused to attach → `kortix.runtime.status {state:'down'}` → the client marked the runtime channel dead and **fell back to polling the transcript**. So the "streaming" was the poll; live completion frames (reasoning `time.end`, turn-end) never arrived → reasoning never collapsed, turns never ended.

## Fix
Attach when the box is **reachable** — `active` **or** `provisioning`. A build elsewhere is irrelevant to whether *this* box can stream. Attaching is a read → cannot resurrect a reaper-stopped box, so refusing `stopped`/`error`/`archived` keeps the safety the gate exists for.

## Verified (TDD, real route + real SSE bytes)
- New test: a `provisioning` box **attaches** (`state:'up'`, frame forwarded verbatim).
- Reverting the gate reproduces the exact bug: `state:'down', reason:'sandbox_provisioning'`.
- **22 pass / 0 fail**; the stopped-box safety test still refuses attach.

## Follow-ups (separate)
- The raw OpenCode client still POSTs `/log` (incomplete cutover) — the `/log` spam.
- Retire the transcript-poll fallback as a streaming mode now that the live channel attaches reliably (per the principle: `/events` should just work, no degraded fallback).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790457326&installation_model_id=434224&pr_number=7007&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7007&signature=2f2b1f4d2006403e04e6cc82733bed2b531c952d04872923ea4c779d53e0d3ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->