### PR TITLE
fix(web): stop shipping every frontend log to the raw sandbox /log route

### DIFF
--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,14 +1,21 @@
 /**
- * Structured logger that ships log entries to the OpenCode server
- * via `client.app.log()` while also writing to the browser console
- * for local development visibility.
+ * Structured logger for the web app. Writes to the browser console only.
+ *
+ * It used to ALSO ship every entry to the sandbox's OpenCode server via
+ * `logRuntimeEvent` → `getClient().app.log()` — a raw `POST /p/<box>/8000/log`
+ * per log line. Two problems, both real (dev, 2026-08-27): it is a RAW OpenCode
+ * route the "web speaks only /kortix/*" cutover was meant to retire, and it
+ * FLOODS — one network POST per frontend log, hundreds of them once anything
+ * logs in a loop (a degraded stream, a retry ladder). Frontend logs belong in
+ * the browser console where the developer already is, not fanned out to the
+ * session sandbox one request at a time. If daemon-side frontend telemetry is
+ * ever wanted, it goes through a BATCHED platform endpoint, never a per-line
+ * raw runtime POST.
  *
  * Usage:
  *   import { logger } from '@/lib/logger';
  *   logger.error('Stream disconnected', { runId, attempt: 3 });
  */
-
-import { logRuntimeEvent } from '@kortix/sdk/react';
 
 const SERVICE_NAME = 'frontend';
 
@@ -30,20 +37,6 @@ function send(level: LogLevel, message: string, extra?: LogExtra): void {
           : console.log;
 
   consoleFn(`[${SERVICE_NAME}] ${message}`, ...(extra ? [extra] : []));
-
-  // Fire-and-forget: ship the log entry to the server.
-  // Wrapped in try/catch so a logging failure never breaks the caller.
-  try {
-    logRuntimeEvent({
-      service: SERVICE_NAME,
-      level,
-      message,
-      extra,
-    });
-  } catch {
-    // Swallow — if the SDK client isn't available yet (e.g. during SSR or
-    // before the first server URL is resolved) we just skip server logging.
-  }
 }
 
 export const logger = {


### PR DESCRIPTION
## The /log flood
The web logger mirrored **every** log line to the sandbox via `logRuntimeEvent → getClient().app.log() → POST /p/<box>/8000/log` — one request per log. In a degraded state (stream fell back to polling, retry ladders) that's **hundreds** of `/log` POSTs. It's also a **raw OpenCode route** the "web speaks only /kortix/*" cutover was meant to retire.

## Fix
Console-only. Frontend logs belong in the browser console, not fanned out to the sandbox one request at a time. If daemon-side frontend telemetry is ever wanted, it goes through a **batched platform endpoint**, never a per-line raw runtime POST. The SDK `logRuntimeEvent` export stays (removing a published export is breaking); it's just no longer called by the web app.

## Verified
- eslint clean; no other web callers; `level`/`extra`/`SERVICE_NAME` still used.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790459308&installation_model_id=434224&pr_number=7008&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7008&signature=d310e56d331ae8126b49d05d7acdce6847a36656097d7328b4374a1d6a56d300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->