### PR TITLE
fix(sdk): retire the transcript-poll fallback — /events is the single feed

### DIFF
--- a/packages/sdk/src/react/use-session-sync.test.ts
+++ b/packages/sdk/src/react/use-session-sync.test.ts
@@ -228,16 +228,17 @@ describe('livenessBusy: an open server turn keeps the repair running', () => {
   });
 });
 
-describe('transcriptFallbackPollMs (the stale-daemon window)', () => {
-  test('working with NO live runtime channel polls — the only transcript feed left', () => {
-    expect(transcriptFallbackPollMs({ busy: true, runtimeChannelLive: false })).toBe(10_000);
-  });
-
-  test('a live runtime channel silences the fallback — seq gaps repair losses exactly', () => {
+describe('transcriptFallbackPollMs (retired — /events is the only transcript feed)', () => {
+  // The transcript-poll fallback is GONE. It re-read `/kortix/opencode/messages`
+  // whenever the runtime channel was not live — but that is exactly a box that
+  // is down/rebuilding, whose daemon serves NEITHER `/events` NOR `/messages`
+  // (they shipped together), so the poll only 404-spammed for nothing while the
+  // user watched (dev, 2026-08-27). `/events` is the single transcript feed; a
+  // real loss is a dense-seq gap the stream repairs exactly. This function now
+  // never asks for a poll, whatever the state.
+  test('never polls, in any state — the fallback is retired', () => {
+    expect(transcriptFallbackPollMs({ busy: true, runtimeChannelLive: false })).toBeNull();
     expect(transcriptFallbackPollMs({ busy: true, runtimeChannelLive: true })).toBeNull();
-  });
-
-  test('an idle session never polls, channel or not', () => {
     expect(transcriptFallbackPollMs({ busy: false, runtimeChannelLive: false })).toBeNull();
     expect(transcriptFallbackPollMs({ busy: false, runtimeChannelLive: true })).toBeNull();
   });

--- a/packages/sdk/src/react/use-session-sync.ts
+++ b/packages/sdk/src/react/use-session-sync.ts
@@ -25,10 +25,6 @@ import {
   shouldHydrateFromMirror,
 } from '../browser/session-sync/server-transcript-mirror';
 import { transcriptIsFragment } from '../core/session-sync/fragment';
-import {
-  isSessionRuntimeChannelLive,
-  subscribeSessionStreamPresence,
-} from '../core/stream/session-stream-presence';
 import { onTabVisible } from '../browser/session-sync/visibility';
 import { useSandboxConnectionStore } from '../browser/stores/sandbox-connection-store';
 import { useSyncStore } from '../browser/stores/sync-store';
@@ -176,23 +172,31 @@ export function isControlTurnIdle(
 export const TRANSCRIPT_FALLBACK_POLL_MS = 10_000;
 
 /**
- * Should the transcript fall back to a bounded interval read, and how often?
+ * @deprecated Retired — the transcript-poll fallback is gone; always `null`.
  *
- * The steady state polls NOTHING: while the session stream's RUNTIME channel
- * is live, every transcript frame rides a dense seq, so a loss is detected
- * and repaired exactly (`connectSessionStream`). But a working session whose
- * runtime channel is NOT live — a daemon too old to serve
- * `/kortix/opencode/events` (the convergence window after this ships), or an
- * attach that keeps failing — has no live transcript feed at all, and mid-turn
- * output would freeze until turn end. For exactly that window, the old
- * bounded tail read returns, at its old 10s cadence. `null` = do not poll.
+ * It re-read `/kortix/opencode/messages` on a timer whenever the runtime
+ * channel was not live. But "runtime channel not live" is a box that is
+ * down / rebuilding / not-yet-reachable — and such a daemon serves NEITHER
+ * `/kortix/opencode/events` NOR `/kortix/opencode/messages` (they ship
+ * together), so the poll only 404-spammed for nothing while the user watched a
+ * churning network tab (dev, 2026-08-27). It also defeated the whole point of
+ * the owned surface: `/events` + `/snapshot` ARE the feed.
+ *
+ * The steady state polls NOTHING and now so does every other state: while the
+ * runtime channel is live, every transcript frame rides a dense seq so a loss
+ * is detected and repaired EXACTLY by the stream's gap reconcile
+ * (`connectSessionStream` → `reconcileHeldTranscripts` on a `resync`/seq-gap).
+ * A box that is genuinely down has nothing to stream; the composer says so
+ * (the runtime-unreachable / waking notice) instead of hammering a dead route.
+ *
+ * Kept as a no-op export because the name is published API — removing it is a
+ * breaking change. It always returns `null`.
  */
-export function transcriptFallbackPollMs(input: {
+export function transcriptFallbackPollMs(_input: {
   busy: boolean;
   runtimeChannelLive: boolean;
 }): number | null {
-  if (!input.busy || input.runtimeChannelLive) return null;
-  return TRANSCRIPT_FALLBACK_POLL_MS;
+  return null;
 }
 
 export function livenessBusy(input: {
@@ -475,22 +479,12 @@ export function useSessionSync(sessionId: string, options: UseSessionSyncOptions
     controller.setBusy(busy);
   }, [controller, busy]);
 
-  // The stale-daemon fallback poll — see `transcriptFallbackPollMs`. While the
-  // session stream's runtime channel is live this arms NOTHING; a working
-  // session with no live daemon feed re-reads its tail at the old cadence.
-  const streamScope = kortixSessionScope ?? '';
-  const runtimeChannelLive = useSyncExternalStore(
-    (onChange) => (streamScope ? subscribeSessionStreamPresence(streamScope, onChange) : () => {}),
-    () => !!streamScope && isSessionRuntimeChannelLive(streamScope),
-    () => false,
-  );
-  useEffect(() => {
-    if (!networkEnabled || !canQueryOpenCodeSession(sessionId)) return;
-    const pollMs = transcriptFallbackPollMs({ busy, runtimeChannelLive });
-    if (pollMs === null) return;
-    const timer = setInterval(() => void controller.reconcile('poll'), pollMs);
-    return () => clearInterval(timer);
-  }, [busy, controller, networkEnabled, runtimeChannelLive, sessionId]);
+  // No transcript-poll fallback. `/events` is the single feed: a lost frame is
+  // a dense-seq gap the stream repairs exactly (`connectSessionStream` →
+  // `reconcileHeldTranscripts`), and a box that is down has nothing to stream —
+  // the composer shows the waking / lost-contact notice rather than hammering a
+  // dead `/kortix/opencode/messages` route. See `transcriptFallbackPollMs`
+  // (retired). This removed the `/messages` 404-spam a rebuilding box produced.
 
   // Re-read the tail on demand. The transcript body renders this behind its
   // "couldn't load" state so `freshness === 'error'` is recoverable without a


### PR DESCRIPTION
## Incident
A session on a rebuilding / not-yet-reachable box churned the network tab: a loop of `GET /kortix/opencode/messages` + `/log` spam ("giga flaky", "log spam out of nowhere").

## Root
The `/messages` loop is the **transcript-poll fallback** — a 10s timer that re-read the transcript whenever the runtime channel wasn't live. But "channel not live" = a box that's **down/rebuilding**, whose daemon serves **neither** `/kortix/opencode/events` **nor** `/kortix/opencode/messages` (they ship together). So the poll just **404-spammed for nothing**, and defeated the whole point of `/events` + `/snapshot`.

## Fix
Retire it. `/events` is the single transcript feed; a real loss is a dense-seq gap the stream repairs **exactly** (`reconcileHeldTranscripts` on resync/seq-gap). A genuinely-down box has nothing to stream — the composer shows the waking/lost-contact notice instead of hammering a dead route. Removed the `setInterval reconcile('poll')` effect + the `runtimeChannelLive` subscription; kept the gap-driven reconcile. `transcriptFallbackPollMs` stays as a no-op export (published name; removing is breaking) — always `null`.

## Verified (TDD)
- Test updated to assert the poll never arms — RED: `Received 10000`; GREEN: `null`.
- `use-session-sync.test.ts` **20/0**; SDK typecheck clean; full isolated SDK suite **0 failing files**.
- No public-surface change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790460358&installation_model_id=434224&pr_number=7011&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7011&signature=d6e177a2e0c5468261e8a2599d2b6a7fd80e8c0f7dd4c6538ce1ff68dcbb72ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->