### PR TITLE
fix(preview): route the API's non-/v1 paths through the preview edge

### DIFF
--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -72,7 +72,12 @@ export function buildPreviewCaddyfile(publicHost: string): string {
   return `:8080 {
   encode zstd gzip
 
-  @api path /v1*
+  # Dev gives the API its own host (dev-api.kortix.com), so EVERY path it
+  # serves reaches it. A preview shares one host and splits by prefix, so each
+  # API route mounted outside \`/v1\` has to be listed here or it falls through
+  # to the frontend, which answers 307 -> /auth. Keep in sync with the
+  # non-\`/v1\` mounts in \`apps/api/src/index.ts\`.
+  @api path /v1* /health /health/* /metrics /scim/v2/* /internal/* /.well-known/oauth-authorization-server
   handle @api {
     reverse_proxy kortix-api:8008
   }

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -72,11 +72,11 @@ export function buildPreviewCaddyfile(publicHost: string): string {
   return `:8080 {
   encode zstd gzip
 
-  # Dev gives the API its own host (dev-api.kortix.com), so EVERY path it
-  # serves reaches it. A preview shares one host and splits by prefix, so each
-  # API route mounted outside \`/v1\` has to be listed here or it falls through
-  # to the frontend, which answers 307 -> /auth. Keep in sync with the
-  # non-\`/v1\` mounts in \`apps/api/src/index.ts\`.
+  # A deployed environment gives the API a host of its own, so EVERY path it
+  # serves reaches it. A preview shares ONE origin with the frontend and splits
+  # by prefix, so each API route mounted outside \`/v1\` has to be listed here or
+  # it falls through to the frontend, which answers 307 -> /auth. Keep in sync
+  # with the non-\`/v1\` mounts in \`apps/api/src/index.ts\`.
   @api path /v1* /health /health/* /metrics /scim/v2/* /internal/* /.well-known/oauth-authorization-server
   handle @api {
     reverse_proxy kortix-api:8008

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -15,6 +15,19 @@ describe('ephemeral self-host preview stack', () => {
     expect(caddy).toContain(':8080');
     expect(caddy).toContain('@api path /v1*');
     expect(caddy).toContain('reverse_proxy kortix-api:8008');
+    // Every API route mounted outside `/v1` in `apps/api/src/index.ts`. Without
+    // these the shared preview origin sends them to the frontend, which answers
+    // 307 -> /auth (SYS-1/8/9, SCIM-1..5, GW-1/8/10/12, SEC-J all failed on it).
+    for (const path of [
+      '/health',
+      '/health/*',
+      '/metrics',
+      '/scim/v2/*',
+      '/internal/*',
+      '/.well-known/oauth-authorization-server',
+    ]) {
+      expect(caddy.split('\n').find((line) => line.startsWith('  @api path '))).toContain(path);
+    }
     expect(caddy).toContain('@supabase path /auth/v1* /rest/v1* /storage/v1*');
     expect(caddy).toContain('reverse_proxy supabase-kong:8000');
     expect(caddy).toContain('handle_path /_gateway/*');


### PR DESCRIPTION
## Problem

A preview shares ONE origin between the frontend and the API and splits by path
prefix. The Caddy matcher listed only `/v1*`, so every API route mounted
outside `/v1` in `apps/api/src/index.ts` fell through to `frontend:3000`,
which answered `307 -> /auth`.

13 flows failed on it in the last preview run (`20260827215653-kxkuej`):
SYS-1, SYS-8, SYS-9, SCIM-1..5, GW-1, GW-8, GW-10, GW-12, SEC-J.

Dev does not have this class of bug because `dev-api.kortix.com` is its own
host — every path reaches the API.

## Fix

List the non-`/v1` API mounts in the `@api` matcher: `/health`,
`/health/*`, `/metrics`, `/scim/v2/*`, `/internal/*`, and
`/.well-known/oauth-authorization-server`.

## Verification — live, on a running preview

Applied the regenerated Caddyfile to preview sandbox
`sbx_01M12KFSR8MY0J11ZSP1BE0A29` and ran `caddy reload` (exit 0):

| path | before | after |
|---|---|---|
| `/health` | 307 | 200 (`environment: preview`) |
| `/health/live` | 307 | 200 |
| `/health/ready` | 307 | 200 |
| `/metrics` | 307 | 401 (rejects anonymous, as SYS-9 expects) |
| `/internal/gateway/authorize` | 307 | 401 (as GW-8/10/12 expect) |
| `/.well-known/oauth-authorization-server` | 307 | 200, `revocation_endpoint` present |
| `/scim/v2/accounts/<id>/ServiceProviderConfig` | 307 | 401 |
| `/auth` (frontend) | 200 | 200 — unchanged |

`bun test tests/unit/preview-stack.test.ts` → 6 pass, 0 fail, 45 expect() calls.

## Not fixed here

The preview's other 112 flow failures are one separate cause: the managed-git
GitHub App. `PREVIEW_KORTIX_GITHUB_APP_ID=3812697` is
`kortix-private-repo-access`, installed on org `kortix-ai` with
`{contents: write, metadata: read}` — no `administration` permission, so it
cannot create repos, while `PREVIEW_MANAGED_GIT_GITHUB_OWNER=managed-kortix`.
Every `POST /v1/projects/provision` answers 503
`GitHub /orgs/managed-kortix/repos failed (403)`. Fixing that needs an org
admin to point the `PREVIEW_*` secrets at an app installed on
`managed-kortix` with `administration: write`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461465&installation_model_id=434224&pr_number=7012&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7012&signature=0968a40ed434b1e41c9bbf909e6c3f48e7fc1d227a7c116514ad39ed28b0d736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->