### PR TITLE
docs(learnings): a shared-origin environment must enumerate the API's non-/v1 paths

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,34 @@ linked, not inlined.
 
 ## Register
 
+### An environment that shares ONE origin between frontend and API must enumerate every path the API serves outside the common prefix (2026-08-27)
+
+**When:** editing the preview edge (`buildPreviewCaddyfile`), or mounting a
+route in `apps/api/src/index.ts` anywhere other than under `/v1`.
+Deployed environments give the API a host of its own, so every path it serves
+reaches it and prefix questions never arise. A preview shares one origin with
+the frontend and splits by prefix, and the `@api` matcher listed only `/v1*`.
+So `/health`, `/health/live`, `/health/ready`, `/metrics`, `/scim/v2/*`,
+`/internal/*` and `/.well-known/oauth-authorization-server` went to
+`frontend:3000`, which answered `307 -> /auth?redirect=…`. 13 flows failed on
+it (SYS-1/8/9, SCIM-1..5, GW-1/8/10/12, SEC-J), each reading as an auth or
+availability bug rather than a routing one.
+
+**The rule: a new non-`/v1` mount is TWO edits** — the route and the preview
+matcher — and the matcher carries a comment saying so. More generally, an
+environment whose topology differs from dev (one origin instead of two hosts)
+does not inherit dev's routing for free; enumerate what the difference hides.
+
+**Diagnostic:** a `307` to `/auth` on a path that needs no auth is the frontend
+answering, not the API. `curl -o /dev/null -w '%{http_code} %{redirect_url}'`
+tells them apart in one call — the API returns the endpoint's own status
+(`200`/`401`), never a redirect to a login page.
+*Near-miss:* PR #7012, found while verifying preview↔dev parity. Preview only;
+no deployed environment is affected, because none of them share an origin.
+*Enforcer:* `tests/unit/preview-stack.test.ts` asserts each of the six paths is
+present in the `@api` line. Nothing yet fails when a NEW non-`/v1` mount is
+added to the API without updating the matcher — that check is the TODO.
+
 ### A reverse proxy in front of Next.js owns `x-forwarded-host`, or every Server Action dies (2026-08-27)
 
 **When:** putting any proxy/ingress in front of a Next.js app — a preview edge,


### PR DESCRIPTION
The rule behind [#7012](https://github.com/kortix-ai/suna/pull/7012).

A deployed environment gives the API its own host, so no path can be missed. A
preview shares one origin with the frontend and splits by prefix, so every API
route mounted outside `/v1` has to be listed in the edge matcher or it reaches
the frontend and answers `307 -> /auth`. 13 flows failed on it, each reading
as an auth bug rather than a routing one.

The register entry records the rule (a non-`/v1` mount is two edits), the
one-call diagnostic that separates "the frontend answered" from "the API
answered", and the enforcer that exists plus the one that does not yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790463627&installation_model_id=434224&pr_number=7013&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7013&signature=54ad388ae247186ea9ee5458bafc5e5b684b64a253adfdf5ee512f908c770e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->