### PR TITLE
docs(learnings): compose does not restart a container for new bytes in a mounted file

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,36 @@ linked, not inlined.
 
 ## Register
 
+### `compose up -d` does not restart a container because a bind-mounted FILE changed (2026-08-28)
+
+**When:** a redeploy rewrites a config file that a container reads through a
+bind mount — a Caddyfile, an nginx conf, a prometheus.yml. Compose recreates a
+container for a new image, env var, port or volume DEFINITION; new bytes inside
+an already-mounted file are not part of that comparison. If the process does not
+watch its config either (Caddy does not), the container keeps serving what it
+loaded when it first booted, for as long as the box lives.
+
+A per-PR preview never showed this because it is deleted and recreated on every
+push. It appeared the first time a REUSED environment's config actually changed:
+moving the branch environment to `pi.kortix.com` rewrote the Caddyfile's pinned
+`X-Forwarded-Host`, the file said the new host both on disk and inside the
+container, and the running Caddy still pinned the old one — so every Server
+Action died with React #441 again (see the entry below).
+
+**The rule: after writing a mounted config, reload the process that reads it**
+(`compose exec -T <svc> caddy reload --config …`), or recreate that service
+explicitly. Never infer from "compose up succeeded" that a mounted config took
+effect.
+
+**Diagnostic:** compare the file with the process's LIVE configuration, not with
+the file inside the container — those two agree even when the bug is present.
+For Caddy, `curl localhost:2019/config/` from inside the container; the same
+shape of check applies to any config-reloading daemon.
+*Near-miss:* the pi branch environment, 2026-08-28. Caught within minutes by
+driving the real sign-in page; nothing deployed was affected.
+*Enforcer:* `tests/unit/sandbox-preview.test.ts` asserts the bootstrap issues
+the reload. Nothing detects a NEW mounted config file that lacks one.
+
 ### An environment that shares ONE origin between frontend and API must enumerate every path the API serves outside the common prefix (2026-08-27)
 
 **When:** editing the preview edge (`buildPreviewCaddyfile`), or mounting a


### PR DESCRIPTION
The rule behind a near-miss on the pi branch environment.

`docker compose up -d` recreates a container for a new image, env var, port or
volume DEFINITION. New bytes inside an already-mounted file are not part of that
comparison, and Caddy does not watch its config either — so a REUSED environment
keeps serving the config it booted with.

A per-PR preview never showed this: it is deleted and recreated on every push.
It surfaced the first time a reused environment's config actually changed —
moving the branch environment to a stable hostname rewrote the Caddyfile's
pinned `X-Forwarded-Host`. The file said the new host both on disk and inside
the container; the running Caddy still pinned the old one, so every Server
Action died with React #441 (the failure mode of the entry directly below).

The register entry records the rule (reload the process after writing a mounted
config), and the diagnostic that actually discriminates: compare the file with
the process's LIVE config, not with the file inside the container — those two
agree even when the bug is present.

Fix and its test are on the `pi-worker` branch (`71ea6bc663`); this is the
rule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790481481&installation_model_id=434224&pr_number=7015&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7015&signature=af1af7c09c939cd35d2f2c948eb3bf76d4728ee4e17b154baef6782ba4c0677c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->