### PR TITLE
feat(preview): the preview label keeps an environment online until it is removed

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -293,6 +293,11 @@ jobs:
       KORTIX_GITHUB_APP_SLUG: ${{ secrets.PREVIEW_KORTIX_GITHUB_APP_SLUG }}
       MANAGED_GIT_GITHUB_INSTALL_ID: ${{ secrets.PREVIEW_MANAGED_GIT_GITHUB_INSTALL_ID }}
       MANAGED_GIT_GITHUB_OWNER: ${{ secrets.PREVIEW_MANAGED_GIT_GITHUB_OWNER }}
+      # Optional, and takes PRECEDENCE over the App when set. The App can only
+      # create repos if it is installed on the owner AND has administration:
+      # write; a PAT needs neither. Set this to unblock project creation
+      # without touching the App's permissions.
+      MANAGED_GIT_GITHUB_TOKEN: ${{ secrets.PREVIEW_MANAGED_GIT_GITHUB_TOKEN }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,11 +32,17 @@ permissions:
 jobs:
   authorize:
     name: Authorize exact preview SHA
+    # A labelled preview stays up until the label comes off or the pull request
+    # closes — so a push REDEPLOYS it in place instead of tearing it down. The
+    # approval bar is unchanged: same-repository pull requests only, and the
+    # actor needs write. On `synchronize` the actor is whoever pushed, who
+    # already holds write on this repository, so nothing is loosened.
     if: >-
       (github.event_name == 'pull_request_target' &&
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'preview' &&
-      github.event.pull_request.head.repo.full_name == github.repository) ||
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'synchronize' &&
+      contains(github.event.pull_request.labels.*.name, 'preview')))) ||
       github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     permissions:
@@ -47,6 +53,7 @@ jobs:
       sha: ${{ steps.preview.outputs.sha }}
       ref: ${{ steps.preview.outputs.ref }}
       lockfile_sha256: ${{ steps.preview.outputs.lockfile_sha256 }}
+      head_branch: ${{ steps.preview.outputs.head_branch }}
       provider: ${{ steps.preview.outputs.provider }}
     env:
       GH_TOKEN: ${{ github.token }}
@@ -114,6 +121,7 @@ jobs:
             echo "sha=$sha"
             echo "ref=refs/pull/${num}/head"
             echo "lockfile_sha256=$lockfile_sha256"
+            echo "head_branch=$(gh api "repos/${REPO}/pulls/${num}" --jq .head.ref)"
             echo "provider=$provider"
           } >> "$GITHUB_OUTPUT"
           echo "${APPROVER} approved preview PR ${num} at ${sha} with provider=${provider}."
@@ -276,6 +284,11 @@ jobs:
       APPROVER: ${{ github.actor }}
       NUM: ${{ needs.authorize.outputs.pr_number }}
       COMMIT: ${{ needs.authorize.outputs.sha }}
+      # Naming the environment after the BRANCH is what makes it persistent:
+      # the sandbox is reused instead of replaced, so its URL survives every
+      # push and stays bookmarkable until the label comes off or the pull
+      # request closes. See previewSandboxIdentity in tests/src/core.
+      PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.head_branch }}
       PREVIEW_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
       PREVIEW_SHA: ${{ needs.authorize.outputs.sha }}
       PREVIEW_REF: ${{ needs.authorize.outputs.ref }}
@@ -454,9 +467,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (github.event.action == 'closed' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
-      (github.event.action == 'synchronize' &&
-      contains(github.event.pull_request.labels.*.name, 'preview')))
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview'))
     runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
@@ -467,6 +478,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       PREVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
+      # The persistent sandbox is named after the branch, so teardown must be
+      # told which one or it finds nothing and leaves the box running — a
+      # branch environment has no expiry to fall back on.
+      PREVIEW_BRANCH_ENV: ${{ github.event.pull_request.head.ref }}
       PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL }}
       PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
       DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
@@ -480,12 +495,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - name: Delete the Platinum or Daytona preview sandbox
         run: bun tests/bin/sandbox-preview.ts teardown
-      - name: Remove stale preview approval
-        if: github.event.action == 'synchronize'
-        run: |
-          set -euo pipefail
-          gh api -X DELETE "repos/${GITHUB_REPOSITORY}/issues/${PREVIEW_PR_NUMBER}/labels/preview" --silent
-          echo "Removed preview approval after the pull request head changed."
       - name: Mark GitHub deployment inactive
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -54,6 +54,7 @@ jobs:
       ref: ${{ steps.preview.outputs.ref }}
       lockfile_sha256: ${{ steps.preview.outputs.lockfile_sha256 }}
       head_branch: ${{ steps.preview.outputs.head_branch }}
+      public_origin: ${{ steps.preview.outputs.public_origin }}
       provider: ${{ steps.preview.outputs.provider }}
     env:
       GH_TOKEN: ${{ github.token }}
@@ -64,6 +65,7 @@ jobs:
       INPUT_PR_NUMBER: ${{ inputs.pr_number }}
       INPUT_PROVIDER: ${{ inputs.provider }}
       APPROVER: ${{ github.actor }}
+      PUBLIC_ORIGINS: ${{ vars.PREVIEW_PUBLIC_ORIGINS }}
     steps:
       - name: Require writer approval for the current head SHA
         id: preview
@@ -121,7 +123,21 @@ jobs:
             echo "sha=$sha"
             echo "ref=refs/pull/${num}/head"
             echo "lockfile_sha256=$lockfile_sha256"
-            echo "head_branch=$(gh api "repos/${REPO}/pulls/${num}" --jq .head.ref)"
+            branch="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.ref)"
+            echo "head_branch=$branch"
+            # A branch MAY be fronted by a stable hostname instead of being
+            # reached at the provider's own url. PREVIEW_PUBLIC_ORIGINS maps
+            # `branch=https://host`, one per line; anything unlisted — which is
+            # every branch by default — keeps the provider origin. The stack is
+            # CONFIGURED with whatever this resolves to, so it must be the origin
+            # the browser actually uses or every auth redirect leaves it.
+            public_origin="$(printf '%s\n' "${PUBLIC_ORIGINS:-}" \
+              | awk -F= -v b="$branch" '$1 == b { print $2; exit }')"
+            case "$public_origin" in
+              ''|https://*) ;;
+              *) echo "::error::PREVIEW_PUBLIC_ORIGINS entry for ${branch} must be an https origin."; exit 1 ;;
+            esac
+            echo "public_origin=$public_origin"
             echo "provider=$provider"
           } >> "$GITHUB_OUTPUT"
           echo "${APPROVER} approved preview PR ${num} at ${sha} with provider=${provider}."
@@ -289,6 +305,7 @@ jobs:
       # push and stays bookmarkable until the label comes off or the pull
       # request closes. See previewSandboxIdentity in tests/src/core.
       PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.head_branch }}
+      PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}
       PREVIEW_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
       PREVIEW_SHA: ${{ needs.authorize.outputs.sha }}
       PREVIEW_REF: ${{ needs.authorize.outputs.ref }}

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -226,13 +226,37 @@ class PreviewRuntimeIsolation(unittest.TestCase):
         # NEW: one stable sandbox name per PR; the origin is provider-issued.
         self.assertIn("return `kortix-preview-pr-${prNumber}`;", PREVIEW_CORE)
         self.assertIn("invalid preview PR number", PREVIEW_CORE)
-        self.assertEqual(PREVIEW_PROVIDERS.count("name: previewSandboxName(input.prNumber),"), 2)
+        # Both providers name the sandbox after the PR: Daytona directly, and
+        # Platinum through previewSandboxIdentity, whose PR branch is the same
+        # call. Neither may improvise a name.
+        self.assertIn("name: previewSandboxName(input.prNumber),", PREVIEW_PROVIDERS)
+        self.assertIn("name: previewSandboxName(input.prNumber),", PREVIEW_CORE)
+        self.assertIn("name: identity.name,", PREVIEW_PROVIDERS)
+        # A branch environment is named after the BRANCH and reused in place, so
+        # its origin survives a push. Daytona issues its own URL, so falling back
+        # there would break exactly that — it must refuse rather than rotate.
+        self.assertIn("return `kortix-env-${slug}`;", PREVIEW_CORE)
+        self.assertIn("reuseExisting: true,", PREVIEW_CORE)
+        # A reused sandbox is still serving the previous deploy, so it can never
+        # satisfy the warm check ("restored, nothing running") — waiting on it
+        # timed out at 120s and the cleanup below then deleted the environment.
+        self.assertIn("if (!reusable) {", PREVIEW_PROVIDERS)
+        # ...and cleanup deletes only a sandbox this run CREATED. Deleting a
+        # reused one discards the stable origin the environment exists to hold.
+        self.assertIn("if (sandboxId && !reusedSandboxId) await deletePlatinum(", PREVIEW_PROVIDERS)
+        self.assertIn("if (input.branchEnv) {", PREVIEW_PROVIDERS)
+        self.assertIn("is pinned to Platinum: a Daytona fallback would change its origin", PREVIEW_PROVIDERS)
         # OLD: rollback_deploy / PREVIOUS_TASK_DEFINITION rolled a live service
         # back. A sandbox is disposable, so a redeploy deletes and recreates it.
         self.assertIn("async function replaceExistingPlatinumPreview(", PREVIEW_PROVIDERS)
         self.assertIn("async function replaceExistingDaytonaPreview(", PREVIEW_PROVIDERS)
         self.assertIn("refused to replace unowned Daytona sandbox", PREVIEW_PROVIDERS)
-        self.assertIn("owner: 'kortix-preview',", PREVIEW_PROVIDERS)
+        # The owner a PR preview is stamped with (previewSandboxIdentity) is the
+        # same one every destructive read filters on, so a redeploy, a teardown,
+        # and the nightly sweep can only ever touch a sandbox this system made.
+        self.assertIn("owner: 'kortix-preview',", PREVIEW_CORE)
+        self.assertIn("owner: identity.owner,", PREVIEW_PROVIDERS)
+        self.assertEqual(PREVIEW_PROVIDERS.count("sandbox.metadata?.owner === 'kortix-preview'"), 2)
         self.assertIn("'kortix-preview': 'true',", PREVIEW_PROVIDERS)
         # A provider switch must not leave the other provider's sandbox running.
         self.assertIn(
@@ -253,6 +277,17 @@ class PreviewRuntimeIsolation(unittest.TestCase):
         self.assertIn("preview origin must be an HTTPS origin without a path", PREVIEW_STACK)
         for path, source in PREVIEW_SOURCES.items():
             self.assertNotIn("kortix.com", source, f"{path} must not pin a Kortix hostname")
+        # An operator MAY front an environment with a stable name, but it arrives
+        # as configuration (PREVIEW_PUBLIC_ORIGIN) and is validated like any
+        # other origin — the sources above still name no host of their own.
+        self.assertIn("PREVIEW_PUBLIC_ORIGIN", PREVIEW_CLI)
+        self.assertIn(
+            "const origin = input.publicOrigin ? validatedPreviewUrl(input.publicOrigin) : sandboxOrigin;",
+            PREVIEW_PROVIDERS,
+        )
+        # The provider origin is always reported, because whatever serves the
+        # stable name has to be told which sandbox to send traffic to.
+        self.assertIn("sandboxOrigin,", PREVIEW_PROVIDERS)
 
     def test_only_the_edge_port_is_published_and_the_gateway_stays_internal(self):
         # OLD: LLM_GATEWAY_PROXY_TARGET http://127.0.0.1:8090, an API container
@@ -359,18 +394,43 @@ class PreviewTeardown(unittest.TestCase):
         # NEW: one sandbox holds the whole stack, so teardown deletes it on both
         # providers and refuses to touch a sandbox it does not own.
         teardown_action = cli_action("teardown")
-        self.assertIn("teardownPlatinumPreview({ ...platinum, prNumber })", teardown_action)
+        # Both shapes are deleted: the PR-named sandbox always, and the
+        # branch-named one when this pull request runs a persistent preview.
+        self.assertIn(
+            "teardownPlatinumPreview({ ...platinum, prNumber, ...(branchEnv ? { branchEnv } : {}) })",
+            teardown_action,
+        )
         self.assertIn("teardownDaytonaPreview({ ...daytona, prNumber })", teardown_action)
         self.assertIn("refused to delete unowned Daytona sandbox", PREVIEW_PROVIDERS)
         self.assertIn("sandbox.metadata?.owner === 'kortix-preview' &&", PREVIEW_PROVIDERS)
         self.assertIn("Mark GitHub deployment inactive", teardown)
         self.assertNotIn("branch-scoped Vercel", WORKFLOW)
 
-    def test_a_new_head_sha_invalidates_the_approval(self):
+    def test_a_new_head_sha_redeploys_instead_of_revoking_the_approval(self):
+        # WAS: a push deleted the sandbox AND stripped the `preview` label, so
+        # every push cost a human re-approval and a NEW url. A labelled preview
+        # now stays online until the label comes off or the pull request closes.
+        #
+        # The approval bar is unchanged, only re-expressed: `authorize` still
+        # runs on the push, still accepts SAME-REPOSITORY pull requests only, and
+        # still requires the actor to hold write. On `synchronize` that actor is
+        # whoever pushed — who necessarily already holds write on this
+        # repository — so nothing is loosened. The exact-SHA revalidation before
+        # deploy is untouched.
+        authorize = job("authorize")
+        self.assertIn("github.event.action == 'synchronize'", authorize)
+        self.assertIn(
+            "contains(github.event.pull_request.labels.*.name, 'preview')", authorize
+        )
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository", authorize
+        )
         teardown = job("teardown")
-        self.assertIn("gh api -X DELETE", teardown)
-        self.assertIn("labels/preview", teardown)
-        self.assertIn("if: github.event.action == 'synchronize'", teardown)
+        # A push must no longer tear anything down, and must not strip the label.
+        self.assertNotIn("synchronize", teardown)
+        self.assertNotIn("labels/preview", teardown)
+        self.assertIn("github.event.action == 'closed'", teardown)
+        self.assertIn("github.event.label.name == 'preview'", teardown)
 
     def test_the_nightly_sweep_deletes_only_unapproved_sandboxes(self):
         # OLD: MAX_ACTIVE_PREVIEWS=20 and PREVIEW_MAX_AGE_HOURS=72 bounded a
@@ -387,14 +447,38 @@ class PreviewTeardown(unittest.TestCase):
             "reconcileDaytonaPreviews({ ...daytona, activePullRequests: active })", reconcile_action
         )
         self.assertIn("selectStalePreviewSandboxIds", PREVIEW_CORE)
-        self.assertIn("return !activeSha || activeSha !== sandbox.metadata?.git_sha;", PREVIEW_CORE)
-        self.assertIn(".filter((sandbox) => sandbox.metadata?.owner === 'kortix-preview')", PREVIEW_CORE)
+        # Both owners are reaped, by different rules. A moved head makes an
+        # EPHEMERAL preview stale (it was built for one commit); it is the normal
+        # state of a branch environment, which is redeployed in place. Sweeping a
+        # branch environment on sha would delete a live environment every push.
+        self.assertIn("if (!activeSha) return true;", PREVIEW_CORE)
+        self.assertIn(
+            "return owner === 'kortix-preview' && activeSha !== sandbox.metadata?.git_sha;",
+            PREVIEW_CORE,
+        )
+        self.assertIn(
+            "if (owner !== 'kortix-preview' && owner !== 'kortix-branch-env') return false;",
+            PREVIEW_CORE,
+        )
         self.assertIn("const approved = pull.labels?.some((label) => label.name === 'preview');", PREVIEW_CLI)
         self.assertIn("const sameRepository = pull.head?.repo?.full_name === repository;", PREVIEW_CLI)
-        self.assertIn("auto_archive_days: 7,", PREVIEW_PROVIDERS)
-        self.assertIn("auto_delete_days: 7,", PREVIEW_PROVIDERS)
+        # A PR preview is swept after 7 idle days; the Platinum retention now
+        # comes from previewSandboxIdentity, which is where the 7 lives.
+        self.assertIn("auto_archive_days: identity.autoArchiveDays,", PREVIEW_PROVIDERS)
+        self.assertIn("auto_delete_days: identity.autoDeleteDays,", PREVIEW_PROVIDERS)
+        self.assertIn("autoArchiveDays: 7,", PREVIEW_CORE)
+        self.assertIn("autoDeleteDays: 7,", PREVIEW_CORE)
         self.assertIn("autoArchiveInterval: 10_080,", PREVIEW_PROVIDERS)
         self.assertIn("autoDeleteInterval: 10_080,", PREVIEW_PROVIDERS)
+        # A branch environment carries NO provider expiry — it is retired by the
+        # pull request leaving the active set, which is what closing it or
+        # removing the label does, and deleting the branch does both. Teardown
+        # must therefore know the branch, or the box outlives everything.
+        self.assertIn("owner: 'kortix-branch-env',", PREVIEW_CORE)
+        self.assertIn("autoArchiveDays: 0,", PREVIEW_CORE)
+        self.assertIn("autoDeleteDays: 0,", PREVIEW_CORE)
+        self.assertIn("branchEnvSandboxName(input.branchEnv)", PREVIEW_PROVIDERS)
+        self.assertIn("PREVIEW_BRANCH_ENV", job("teardown"))
 
     def test_a_failed_pull_request_query_never_reads_as_no_active_previews(self):
         # OLD: assertNotIn("|| printf closed") — a shell fallback that turned a

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -425,6 +425,16 @@ class PreviewTeardown(unittest.TestCase):
         self.assertIn(
             "github.event.pull_request.head.repo.full_name == github.repository", authorize
         )
+        # A branch MAY be fronted by a stable hostname; every branch keeps the
+        # provider origin unless PREVIEW_PUBLIC_ORIGINS lists it, and the entry
+        # must be https or the deploy refuses rather than configuring the stack
+        # with an origin the browser will never use.
+        self.assertIn("PUBLIC_ORIGINS: ${{ vars.PREVIEW_PUBLIC_ORIGINS }}", authorize)
+        self.assertIn("''|https://*) ;;", authorize)
+        self.assertIn(
+            "PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}", job("deploy")
+        )
+
         teardown = job("teardown")
         # A push must no longer tear anything down, and must not strip the label.
         self.assertNotIn("synchronize", teardown)

--- a/tests/bin/sandbox-preview.ts
+++ b/tests/bin/sandbox-preview.ts
@@ -107,7 +107,25 @@ const daytona = {
 if (action === 'deploy') {
   const prNumber = positiveInteger('PREVIEW_PR_NUMBER');
   const sha = required('PREVIEW_SHA');
+  // PREVIEW_BRANCH_ENV turns this deploy into a PERSISTENT per-branch
+  // environment: the sandbox is reused instead of replaced, so the URL is
+  // stable across pushes (see branchEnvSandboxName).
+  const branchEnv = process.env.PREVIEW_BRANCH_ENV?.trim() || undefined;
+  // A PR preview is a gate, so it runs the suite. A branch environment is a
+  // place to work: the suite is ~10 of the ~14 minutes a deploy takes and
+  // proves nothing the stack health check has not, so it is off by default
+  // there. PREVIEW_RUN_TESTS=1 forces it back on for a deliberate full run.
+  const runTests = process.env.PREVIEW_RUN_TESTS?.trim() === '1' || !branchEnv;
+  // PREVIEW_PUBLIC_ORIGIN is the stable name a proxy serves the environment at.
+  // The stack is configured with it; the provider's own hostname stays the
+  // proxy's target and comes back as `sandboxOrigin`. It is supplied by the
+  // caller, never hardcoded here — a preview origin is provider-issued unless
+  // an operator deliberately fronts it.
+  const publicOrigin = process.env.PREVIEW_PUBLIC_ORIGIN?.trim() || undefined;
   const deployment: SandboxPreviewDeploymentInput = {
+    ...(branchEnv ? { branchEnv } : {}),
+    ...(publicOrigin ? { publicOrigin } : {}),
+    runTests,
     repository,
     ref: value('PREVIEW_REF', sha),
     sha,
@@ -142,8 +160,11 @@ if (action === 'deploy') {
   process.exitCode = result.exitCode;
 } else if (action === 'teardown') {
   const prNumber = positiveInteger('PREVIEW_PR_NUMBER');
+  // A persistent environment's sandbox is named after the BRANCH, so teardown
+  // has to be told which branch or it deletes nothing and the box runs forever.
+  const branchEnv = process.env.PREVIEW_BRANCH_ENV?.trim() || undefined;
   const [platinumDeleted, daytonaDeleted] = await Promise.all([
-    teardownPlatinumPreview({ ...platinum, prNumber }),
+    teardownPlatinumPreview({ ...platinum, prNumber, ...(branchEnv ? { branchEnv } : {}) }),
     teardownDaytonaPreview({ ...daytona, prNumber }),
   ]);
   console.log(`[sandbox-preview] teardown platinum=${platinumDeleted} daytona=${daytonaDeleted}`);

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -7,6 +7,7 @@ export const PREVIEW_RUNTIME_SECRET_ALLOWLIST = [
   'KORTIX_GITHUB_APP_SLUG',
   'MANAGED_GIT_GITHUB_INSTALL_ID',
   'MANAGED_GIT_GITHUB_OWNER',
+  'MANAGED_GIT_GITHUB_TOKEN',
   'OPENROUTER_API_KEY',
 ] as const;
 
@@ -177,16 +178,31 @@ export function applyPreviewEnvironment(
   if (!postgresPassword || !anonKey || !serviceRoleKey || !internalServiceKey) {
     throw new Error('self-host environment is missing generated preview credentials');
   }
-  const managedGitValues = [
+  // Managed git has two supported shapes, and the API prefers the PAT when both
+  // are present (see managedGithubToken in projects/git-backends/github.ts):
+  //
+  //   1. a GitHub App — short-lived, repo-scoped, auto-rotating installation
+  //      tokens, but it only works if the App is installed on the owner org AND
+  //      carries `administration: write`, or it cannot create a repo at all;
+  //   2. a single org PAT — no install/permission dance, at the cost of a
+  //      long-lived org-wide token.
+  //
+  // Accept either. Requiring the App shape made a preview whose App lacks the
+  // permission unfixable without a code change, which is what blocked every
+  // preview from creating ANY project.
+  const owner = rawSecrets.MANAGED_GIT_GITHUB_OWNER?.trim();
+  const managedGitApp = [
     rawSecrets.KORTIX_GITHUB_APP_ID,
     rawSecrets.KORTIX_GITHUB_APP_PRIVATE_KEY,
     rawSecrets.KORTIX_GITHUB_APP_SLUG,
     rawSecrets.MANAGED_GIT_GITHUB_INSTALL_ID,
-    rawSecrets.MANAGED_GIT_GITHUB_OWNER,
-  ];
-  const managedGitEnabled = managedGitValues.every((value) => Boolean(value?.trim()));
+  ].every((value) => Boolean(value?.trim()));
+  const managedGitPat = Boolean(rawSecrets.MANAGED_GIT_GITHUB_TOKEN?.trim());
+  const managedGitEnabled = Boolean(owner) && (managedGitApp || managedGitPat);
   if (!managedGitEnabled) {
-    throw new Error('preview target-full requires the complete managed GitHub App configuration');
+    throw new Error(
+      'preview target-full requires MANAGED_GIT_GITHUB_OWNER plus either the complete GitHub App configuration or MANAGED_GIT_GITHUB_TOKEN',
+    );
   }
 
   Object.assign(runtime, {
@@ -235,6 +251,7 @@ export function applyPreviewEnvironment(
     MANAGED_GIT_PROVIDER: 'github',
     MANAGED_GIT_GITHUB_OWNER: rawSecrets.MANAGED_GIT_GITHUB_OWNER ?? '',
     MANAGED_GIT_GITHUB_INSTALL_ID: rawSecrets.MANAGED_GIT_GITHUB_INSTALL_ID ?? '',
+    MANAGED_GIT_GITHUB_TOKEN: rawSecrets.MANAGED_GIT_GITHUB_TOKEN ?? '',
     KORTIX_GITHUB_APP_ID: rawSecrets.KORTIX_GITHUB_APP_ID ?? '',
     KORTIX_GITHUB_APP_PRIVATE_KEY:
       rawSecrets.KORTIX_GITHUB_APP_PRIVATE_KEY?.replace(/\r?\n/g, '\\n') ?? '',

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -34,7 +34,9 @@ import {
   PreviewInfrastructureError,
   type SandboxPreviewResult,
   buildPreviewBootstrapScript,
+  branchEnvSandboxName,
   previewLockfileHash,
+  previewSandboxIdentity,
   previewSandboxName,
   selectStalePreviewSandboxIds,
 } from './sandbox-preview';
@@ -55,6 +57,25 @@ export interface SandboxPreviewDeploymentInput {
   secrets: PreviewRuntimeSecrets;
   platinum: { apiUrl: string; apiKey: string };
   daytona: { apiUrl: string; apiKey: string; target: string };
+  /**
+   * A PERSISTENT per-branch environment instead of an ephemeral per-PR preview.
+   *
+   * When set, the sandbox is named after the BRANCH and reused across deploys
+   * rather than deleted and recreated. That is the whole difference: the
+   * sandbox id — and therefore the public URL — stays put, so the environment
+   * can be bookmarked, registered as a Stripe webhook target, and keep its
+   * Postgres volume (and your signed-in session) across pushes.
+   */
+  branchEnv?: string;
+  /** Run the full suite inside the environment after it comes up. Default true. */
+  runTests?: boolean;
+  /**
+   * The stable origin the environment is reached at, when an operator fronts it
+   * with a proxy. The stack is configured with this rather than with the
+   * provider's own hostname; the provider hostname stays the proxy's target.
+   * Unset for a PR preview, which is reached at its provider origin.
+   */
+  publicOrigin?: string;
 }
 
 interface PlatinumSandboxPage {
@@ -156,8 +177,26 @@ export async function deployPlatinumPreview(
   const api = new PlatinumApi(input.platinum.apiUrl, input.platinum.apiKey);
   let sandboxId = '';
   let launched = false;
+  // Set only when this run adopted an existing branch environment, so the
+  // failure path below can tell "a box I made" from "the standing environment".
+  let reusedSandboxId = '';
   try {
-    await replaceExistingPlatinumPreview(api, input.prNumber);
+    const identity = previewSandboxIdentity(input);
+    // A branch environment reuses its sandbox; only an ephemeral PR preview is
+    // replaced, which is what rotates its URL on every push.
+    const reusable = identity.reuseExisting
+      ? (await allPlatinumPreviewSandboxes(api)).find(
+          (sandbox) => sandbox.name === identity.name && sandbox.metadata?.owner === identity.owner,
+        ) ?? null
+      : null;
+    // A branch environment idles between deploys; Platinum may have stopped it.
+    if (reusable) {
+      reusedSandboxId = reusable.id;
+      await api
+        .json(`/v1/sandboxes/${reusable.id}/start`, { method: 'POST' })
+        .catch(() => undefined);
+    }
+    if (!identity.reuseExisting) await replaceExistingPlatinumPreview(api, input.prNumber);
     const hash = previewLockfileHash(input.lockfileHash);
     const base = await ensureTemplate(
       api,
@@ -169,39 +208,47 @@ export async function deployPlatinumPreview(
     );
     const template = await ensureWarmTemplate(api, base, hash);
     const startedAt = Date.now();
-    const created = await api.json<PlatinumSandbox>(
-      '/v1/sandboxes?wait_for_state=running&wait_timeout_ms=60000',
-      {
-        method: 'POST',
-        headers: { 'idempotency-key': platinumPreviewIdempotencyKey(input) },
-        body: JSON.stringify({
-          name: previewSandboxName(input.prNumber),
-          template: template.id,
-          type: 'persistent',
-          auto_stop_minutes: 0,
-          auto_archive_days: 7,
-          auto_delete_days: 7,
-          cpu: 8,
-          ram_mb: 16_384,
-          disk_gb: 50,
-          expose: [{ port: 8080, public: true }],
-          metadata: {
-            owner: 'kortix-preview',
-            repository: input.repository,
-            pr_number: String(input.prNumber),
-            git_sha: input.sha,
-            run_id: input.runId,
-          },
-        }),
-      },
-    );
+    const created =
+      reusable ??
+      (await api.json<PlatinumSandbox>(
+        '/v1/sandboxes?wait_for_state=running&wait_timeout_ms=60000',
+        {
+          method: 'POST',
+          headers: { 'idempotency-key': platinumPreviewIdempotencyKey(input) },
+          body: JSON.stringify({
+            name: identity.name,
+            template: template.id,
+            type: 'persistent',
+            auto_stop_minutes: 0,
+            auto_archive_days: identity.autoArchiveDays,
+            auto_delete_days: identity.autoDeleteDays,
+            cpu: 8,
+            ram_mb: 16_384,
+            disk_gb: 50,
+            expose: [{ port: 8080, public: true }],
+            metadata: {
+              owner: identity.owner,
+              repository: input.repository,
+              pr_number: String(input.prNumber),
+              git_sha: input.sha,
+              run_id: input.runId,
+            },
+          }),
+        },
+      ));
     sandboxId = created.id;
     const sandbox = await observePlatinumSandboxStart({
       sandbox: created,
       startedAt,
       readSandbox: () => api.json<PlatinumSandbox>(`/v1/sandboxes/${created.id}`),
     });
-    await waitForWarmSandbox(api, sandboxId, platinumWarmReadinessTimeoutMs(sandbox.via));
+    // "Warm" means a template restore has finished and NOTHING is running yet.
+    // A reused branch-environment sandbox is the opposite by construction — it
+    // is still serving the previous deploy — so waiting for warmth there can
+    // only ever time out. Wait for it on a fresh sandbox only.
+    if (!reusable) {
+      await waitForWarmSandbox(api, sandboxId, platinumWarmReadinessTimeoutMs(sandbox.via));
+    }
     let previewUrl = sandbox.exposed?.find((item) => item.port === 8080)?.url;
     if (!previewUrl) {
       const exposed = await api.json<{ url: string }>(`/v1/sandboxes/${sandboxId}/expose`, {
@@ -210,7 +257,12 @@ export async function deployPlatinumPreview(
       });
       previewUrl = exposed.url;
     }
-    const origin = validatedPreviewUrl(previewUrl);
+    const sandboxOrigin = validatedPreviewUrl(previewUrl);
+    // The stack is CONFIGURED with the origin people actually visit: it ends up
+    // in SITE_URL, API_EXTERNAL_URL, CORS_ALLOWED_ORIGINS, the Supabase redirect
+    // allowlist and the frontend's own public URLs. Point those at the sandbox
+    // while the browser is on the stable name and every auth redirect leaves it.
+    const origin = input.publicOrigin ? validatedPreviewUrl(input.publicOrigin) : sandboxOrigin;
     await execPlatinum(api, sandboxId, ['bash', '-lc', 'mkdir -p /workspace/kortix-preview']);
     await api.write(
       `${sandboxId}:/workspace/kortix-preview/runtime-secrets.json`,
@@ -263,6 +315,7 @@ export async function deployPlatinumPreview(
       exitCode,
       sandboxId,
       previewUrl: origin,
+      sandboxOrigin,
     };
     await downloadPlatinumArtifacts(api, sandboxId, input.root).catch((error) => {
       console.warn(`[sandbox-preview] Platinum result download failed: ${String(error)}`);
@@ -271,7 +324,10 @@ export async function deployPlatinumPreview(
     return result;
   } catch (error) {
     if (launched) throw error;
-    if (sandboxId) await deletePlatinum(api, sandboxId).catch(() => {});
+    // Clean up only a sandbox THIS run created. Deleting a reused branch
+    // environment would throw away the stable origin it exists to hold — and a
+    // failed deploy is a reason to look at it, not to destroy it.
+    if (sandboxId && !reusedSandboxId) await deletePlatinum(api, sandboxId).catch(() => {});
     throw new PreviewInfrastructureError('Platinum preview infrastructure failed', error);
   }
 }
@@ -295,6 +351,15 @@ export async function deployDaytonaPreview(
   input: SandboxPreviewDeploymentInput,
 ): Promise<SandboxPreviewResult> {
   if (!input.daytona.apiKey) throw new PreviewInfrastructureError('DAYTONA_API_KEY is required');
+  // Daytona is the fallback for a Platinum infrastructure failure, and it issues
+  // its own preview URL. Falling back would therefore hand a branch environment
+  // a DIFFERENT origin than the one people bookmarked and Stripe posts webhooks
+  // to — the one property it exists to hold still. Fail loudly instead.
+  if (input.branchEnv) {
+    throw new PreviewInfrastructureError(
+      `branch environment ${input.branchEnv} is pinned to Platinum: a Daytona fallback would change its origin`,
+    );
+  }
   const api = new DaytonaApi(input.daytona.apiUrl, input.daytona.apiKey);
   let sandbox: DaytonaSandbox | null = null;
   let launched = false;
@@ -400,6 +465,9 @@ export async function deployDaytonaPreview(
       exitCode,
       sandboxId: sandbox.id,
       previewUrl: origin,
+      // Daytona serves PR previews only (a branch environment is refused
+      // above), and a PR preview IS its provider origin.
+      sandboxOrigin: origin,
     };
     await downloadDaytonaArtifacts(api, sandbox, input.root).catch((error) => {
       console.warn(`[sandbox-preview] Daytona result download failed: ${String(error)}`);
@@ -413,20 +481,32 @@ export async function deployDaytonaPreview(
   }
 }
 
+/**
+ * Delete this pull request's sandbox, in whichever shape it was deployed.
+ *
+ * `branchEnv` is passed when the pull request runs a persistent environment. Its
+ * sandbox is named after the BRANCH, so looking only for the PR-named one would
+ * leave it running forever — a branch environment has no expiry to fall back on.
+ */
 export async function teardownPlatinumPreview(input: {
   apiUrl: string;
   apiKey: string;
   prNumber: number;
+  branchEnv?: string;
 }): Promise<number> {
   if (!input.apiKey) return 0;
   const api = new PlatinumApi(input.apiUrl, input.apiKey);
-  const name = previewSandboxName(input.prNumber);
-  const owned = (await allPlatinumPreviewSandboxes(api)).filter(
-    (sandbox) =>
-      sandbox.name === name &&
-      sandbox.metadata?.owner === 'kortix-preview' &&
-      Number(sandbox.metadata?.pr_number) === input.prNumber,
-  );
+  const ephemeral = previewSandboxName(input.prNumber);
+  const persistent = input.branchEnv ? branchEnvSandboxName(input.branchEnv) : null;
+  const owned = (await allPlatinumPreviewSandboxes(api)).filter((sandbox) => {
+    if (Number(sandbox.metadata?.pr_number) !== input.prNumber) return false;
+    if (sandbox.name === ephemeral && sandbox.metadata?.owner === 'kortix-preview') return true;
+    return (
+      persistent !== null &&
+      sandbox.name === persistent &&
+      sandbox.metadata?.owner === 'kortix-branch-env'
+    );
+  });
   for (const sandbox of owned) await deletePlatinum(api, sandbox.id);
   return owned.length;
 }

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -11,7 +11,13 @@ export interface SandboxPreviewResult {
   provider: 'platinum' | 'daytona';
   exitCode: number;
   sandboxId?: string;
+  /** Where people go. The stable name when there is one, else `sandboxOrigin`. */
   previewUrl?: string;
+  /**
+   * The provider-issued origin, always. A stable name is served by a proxy that
+   * has to be told where to send traffic, and this is what it is told.
+   */
+  sandboxOrigin?: string;
 }
 
 export function previewLockfileHash(value: string): string {
@@ -37,6 +43,15 @@ export function buildPreviewBootstrapScript(input: {
   sha: string;
   prNumber: number;
   origin: string;
+  /**
+   * Run the full suite inside the environment once it is up. Default true.
+   *
+   * A PR preview exists to be a gate, so it runs it. A branch environment
+   * exists to be WORKED IN, and the suite is ~10 of the ~14 minutes a deploy
+   * takes — a tax on every push that proves nothing the health check above
+   * has not already proved. Run it there on demand instead.
+   */
+  runTests?: boolean;
 }): string {
   if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/i.test(input.repository)) {
     throw new Error(`invalid GitHub repository: ${input.repository}`);
@@ -121,20 +136,43 @@ for stack_attempt in 1 2; do
   sleep 10
 done
 
+# The Caddyfile is a BIND MOUNT, so rewriting it changes nothing that
+# \`compose up -d\` compares — it recreates a container for a new image, env or
+# port, never for new bytes in a mounted file — and Caddy does not watch its
+# config either. On a reused sandbox the edge therefore keeps serving the config
+# it loaded on first boot. That silently pins the WRONG X-Forwarded-Host after
+# the public name changes, and Next kills every Server Action when it does not
+# match \`origin\` (React #441 — the whole auth flow). Reload explicitly; it is
+# idempotent and costs nothing on a fresh container.
+${compose} exec -T preview-edge caddy reload --config /etc/caddy/Caddyfile
+
+# Ask the edge container directly rather than through the public name. What is
+# being proven here is that THIS stack came up on THIS commit, and a stable
+# public name is served by a proxy that is only re-pointed at this sandbox after
+# the deploy returns — so going out through it would deadlock the first deploy
+# and, on later ones, would answer from the PREVIOUS sandbox. The public path is
+# proven separately, by the workflow, once the proxy has been pointed.
+HEALTH=http://127.0.0.1:8080/v1/health
 for _ in $(seq 1 60); do
-  health="$(curl -fsS --max-time 5 ${shellQuote(`${origin.origin}/v1/health`)} 2>/dev/null || true)"
+  health="$(curl -fsS --max-time 5 "$HEALTH" 2>/dev/null || true)"
   if printf '%s' "$health" | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null; then
     break
   fi
   sleep 2
 done
-curl -fsS --max-time 10 ${shellQuote(`${origin.origin}/v1/health`)} | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null
+curl -fsS --max-time 10 "$HEALTH" | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null
 
-printf 'tests\n' > "$PHASE"
+${
+    input.runTests === false
+      ? `printf 'tests-skipped\\n' > "$PHASE"
+printf 'suite skipped — this is a branch environment, not a gate. Run it with:\\n' >&2
+printf '  cd %s && set -a && . %s && set +a && pnpm test -- --target-full\\n' "$ROOT" ${shellQuote(`${instanceDir}/.env.test`)} >&2`
+      : `printf 'tests\\n' > "$PHASE"
 set -a
 source ${shellQuote(`${instanceDir}/.env.test`)}
 set +a
-pnpm test -- --target-full
+pnpm test -- --target-full`
+  }
 
 printf 'ready\n' > "$PHASE"
 `;
@@ -147,6 +185,23 @@ export class PreviewInfrastructureError extends Error {
   }
 }
 
+/**
+ * A PERSISTENT per-branch environment, as opposed to the ephemeral per-PR
+ * preview above.
+ *
+ * The difference that matters is lifecycle, not shape: a PR preview is deleted
+ * and recreated on every head change (so its sandbox id — and therefore its
+ * URL — changes every push), while a branch environment is created ONCE and
+ * redeployed in place. Reusing the sandbox is what makes the URL stable enough
+ * to bookmark, to register a Stripe webhook against, and to keep a signed-in
+ * session and its Postgres volume across deploys.
+ */
+export function branchEnvSandboxName(branch: string): string {
+  const slug = branch.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!slug) throw new Error(`invalid branch for a persistent environment: ${branch}`);
+  return `kortix-env-${slug}`;
+}
+
 export function previewSandboxName(prNumber: number): string {
   if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
     throw new Error(`invalid preview PR number: ${prNumber}`);
@@ -154,16 +209,76 @@ export function previewSandboxName(prNumber: number): string {
   return `kortix-preview-pr-${prNumber}`;
 }
 
+export interface PreviewSandboxIdentity {
+  name: string;
+  owner: 'kortix-preview' | 'kortix-branch-env';
+  autoArchiveDays: number;
+  autoDeleteDays: number;
+  reuseExisting: boolean;
+}
+
+/**
+ * Who a deploy's sandbox belongs to and how long it lives. The two modes differ
+ * only here — everything downstream (template, bootstrap, ingress) is identical.
+ *
+ * A PR preview is disposable: named after the PR, owned by `kortix-preview`,
+ * replaced on every head change, and swept after 7 idle days. `kortix-preview`
+ * is also the owner `selectStalePreviewSandboxIds` reconciles on, so a PR
+ * preview whose PR closed is deleted by the nightly sweep.
+ *
+ * A branch environment is a standing deployment: named after the BRANCH, owned
+ * by `kortix-branch-env`, reused in place, and never auto-archived or
+ * auto-deleted. Reuse is what holds the sandbox id — and therefore the public
+ * URL — still, so the environment can be bookmarked, registered as a Stripe
+ * webhook target, and keep its Postgres volume across deploys. The distinct
+ * owner is what keeps the nightly sweep from reaping it: it has no PR to close.
+ */
+export function previewSandboxIdentity(input: {
+  prNumber: number;
+  branchEnv?: string;
+}): PreviewSandboxIdentity {
+  if (input.branchEnv) {
+    return {
+      name: branchEnvSandboxName(input.branchEnv),
+      owner: 'kortix-branch-env',
+      autoArchiveDays: 0,
+      autoDeleteDays: 0,
+      reuseExisting: true,
+    };
+  }
+  return {
+    name: previewSandboxName(input.prNumber),
+    owner: 'kortix-preview',
+    autoArchiveDays: 7,
+    autoDeleteDays: 7,
+    reuseExisting: false,
+  };
+}
+
+/**
+ * Sandboxes the nightly sweep should delete.
+ *
+ * Both owners are reaped, by DIFFERENT rules, because they promise different
+ * things. An ephemeral preview is pinned to one commit, so a moved head makes it
+ * stale. A branch environment is pinned to a BRANCH and redeployed in place, so
+ * a moved head is its normal state — only the pull request leaving the active
+ * set retires it, which is what closing it or removing the `preview` label does,
+ * and deleting the branch does both.
+ *
+ * `activePullRequests` holds only OPEN pull requests carrying the `preview`
+ * label, so "not in the map" already means "no longer approved".
+ */
 export function selectStalePreviewSandboxIds(
   sandboxes: PreviewSandboxRecord[],
   activePullRequests: ReadonlyMap<number, string>,
 ): string[] {
   return sandboxes
-    .filter((sandbox) => sandbox.metadata?.owner === 'kortix-preview')
     .filter((sandbox) => {
-      const prNumber = Number(sandbox.metadata?.pr_number);
-      const activeSha = activePullRequests.get(prNumber);
-      return !activeSha || activeSha !== sandbox.metadata?.git_sha;
+      const owner = sandbox.metadata?.owner;
+      if (owner !== 'kortix-preview' && owner !== 'kortix-branch-env') return false;
+      const activeSha = activePullRequests.get(Number(sandbox.metadata?.pr_number));
+      if (!activeSha) return true;
+      return owner === 'kortix-preview' && activeSha !== sandbox.metadata?.git_sha;
     })
     .map((sandbox) => sandbox.id);
 }

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -39,6 +39,35 @@ describe('ephemeral self-host preview stack', () => {
     expect(caddy).toContain('reverse_proxy frontend:3000');
   });
 
+  it('accepts either a GitHub App or a PAT as managed-git configuration', () => {
+    const base = [
+      'POSTGRES_PASSWORD=p',
+      'SUPABASE_ANON_KEY=a',
+      'SUPABASE_SERVICE_ROLE_KEY=s',
+      'INTERNAL_SERVICE_KEY=i',
+    ].join('\n');
+    const stack = { origin: 'https://x.example.test', sha: SHA, apiImage: 'a', gatewayImage: 'g', frontendImage: 'f' };
+    const app = {
+      KORTIX_GITHUB_APP_ID: '1',
+      KORTIX_GITHUB_APP_PRIVATE_KEY: 'k',
+      KORTIX_GITHUB_APP_SLUG: 's',
+      MANAGED_GIT_GITHUB_INSTALL_ID: '2',
+      MANAGED_GIT_GITHUB_OWNER: 'o',
+    };
+    // The App shape still works unchanged.
+    expect(applyPreviewEnvironment(base, stack, app).testEnv).toContain('KE2E_CAP_MANAGED_GIT=1');
+    // A PAT alone is enough — an App that lacks `administration: write` cannot
+    // create a repo, and before this the preview had no way to work around it.
+    const pat = { MANAGED_GIT_GITHUB_OWNER: 'o', MANAGED_GIT_GITHUB_TOKEN: 't' };
+    const patEnv = applyPreviewEnvironment(base, stack, pat);
+    expect(patEnv.testEnv).toContain('KE2E_CAP_MANAGED_GIT=1');
+    expect(patEnv.runtimeEnv).toContain('MANAGED_GIT_GITHUB_TOKEN=t');
+    // An owner on its own still is not managed git.
+    expect(() => applyPreviewEnvironment(base, stack, { MANAGED_GIT_GITHUB_OWNER: 'o' })).toThrow(
+      /MANAGED_GIT_GITHUB_OWNER plus either/,
+    );
+  });
+
   it('adds preview ingress, Mailpit, direct database access, and preview-only Auth capacity', () => {
     const overlay = buildPreviewComposeOverlay('/workspace/suna/tests/test-results');
     expect(overlay).toContain('preview-edge:');
@@ -60,6 +89,7 @@ describe('ephemeral self-host preview stack', () => {
       'KORTIX_GITHUB_APP_SLUG',
       'MANAGED_GIT_GITHUB_INSTALL_ID',
       'MANAGED_GIT_GITHUB_OWNER',
+      'MANAGED_GIT_GITHUB_TOKEN',
       'OPENROUTER_API_KEY',
     ]);
     expect(() =>
@@ -122,7 +152,7 @@ describe('ephemeral self-host preview stack', () => {
         },
         {},
       ),
-    ).toThrow('complete managed GitHub App configuration');
+    ).toThrow('MANAGED_GIT_GITHUB_OWNER plus either');
   });
 
   // 2026-08-27: every Server Action on the preview 500'd with `Invalid Server

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -3,6 +3,7 @@ import {
   PreviewInfrastructureError,
   buildPreviewBootstrapScript,
   previewLockfileHash,
+  previewSandboxIdentity,
   previewSandboxName,
   runSandboxPreview,
   selectStalePreviewSandboxIds,
@@ -22,6 +23,123 @@ const input = {
 describe('provider-neutral preview lifecycle', () => {
   it('uses one stable sandbox name per pull request', () => {
     expect(previewSandboxName(6337)).toBe('kortix-preview-pr-6337');
+  });
+
+  it('gives a pull request preview a disposable identity and a branch environment a standing one', () => {
+    expect(previewSandboxIdentity({ prNumber: 6337 })).toEqual({
+      name: 'kortix-preview-pr-6337',
+      owner: 'kortix-preview',
+      autoArchiveDays: 7,
+      autoDeleteDays: 7,
+      reuseExisting: false,
+    });
+    expect(previewSandboxIdentity({ prNumber: 6998, branchEnv: 'pi-worker' })).toEqual({
+      name: 'kortix-env-pi-worker',
+      owner: 'kortix-branch-env',
+      autoArchiveDays: 0,
+      autoDeleteDays: 0,
+      reuseExisting: true,
+    });
+  });
+
+  it('names a branch environment after the branch, not the pull request that carries it', () => {
+    // The whole point is a URL that survives a push, so the PR number must not
+    // reach the name — two deploys of one branch have to land on one sandbox.
+    const first = previewSandboxIdentity({ prNumber: 1, branchEnv: 'feat/Pi_Worker' });
+    const second = previewSandboxIdentity({ prNumber: 999, branchEnv: 'feat/Pi_Worker' });
+    expect(first.name).toBe(second.name);
+    expect(first.name).toBe('kortix-env-feat-pi-worker');
+    expect(() => previewSandboxIdentity({ prNumber: 1, branchEnv: '///' })).toThrow(
+      /invalid branch for a persistent environment/,
+    );
+  });
+
+  it('runs the suite in a pull request preview and skips it in a branch environment', () => {
+    const base = {
+      repository: 'kortix-ai/suna',
+      ref: 'pi-worker',
+      sha: 'a'.repeat(40),
+      prNumber: 6998,
+      origin: 'https://x.example.test',
+    };
+    // Match the executed LINE: the skip branch names the command in a hint, so
+    // a substring check would report it as running.
+    const executesSuite = (script: string) =>
+      script.split('\n').some((line) => line.trim() === 'pnpm test -- --target-full');
+
+    expect(executesSuite(buildPreviewBootstrapScript(base))).toBe(true);
+    expect(executesSuite(buildPreviewBootstrapScript({ ...base, runTests: true }))).toBe(true);
+    expect(executesSuite(buildPreviewBootstrapScript({ ...base, runTests: false }))).toBe(false);
+
+    // Skipping the suite must not skip the proof that the stack came up on
+    // this commit — that check is what the deploy is actually gated on.
+    for (const runTests of [true, false]) {
+      expect(buildPreviewBootstrapScript({ ...base, runTests })).toContain('/v1/health');
+    }
+  });
+
+  it('health-checks the stack locally, never through the public name', () => {
+    // The public name is served by a proxy that is only re-pointed at this
+    // sandbox AFTER the deploy returns. Checking through it would deadlock the
+    // first deploy, and on later ones would be answered by the PREVIOUS
+    // sandbox — reporting success for a stack that never came up.
+    const script = buildPreviewBootstrapScript({
+      repository: 'kortix-ai/suna',
+      ref: 'pi-worker',
+      sha: 'a'.repeat(40),
+      prNumber: 6998,
+      origin: 'https://pi.example.test',
+      runTests: false,
+    });
+    expect(script).toContain('HEALTH=http://127.0.0.1:8080/v1/health');
+    // The Caddyfile is a bind mount: `compose up -d` will not recreate the edge
+    // for new bytes in it, and Caddy does not watch it. Without an explicit
+    // reload a reused sandbox keeps the config it booted with — which pins a
+    // stale X-Forwarded-Host and kills every Server Action.
+    expect(script).toContain('exec -T preview-edge caddy reload --config /etc/caddy/Caddyfile');
+    expect(script).not.toContain('https://pi.example.test/v1/health');
+    // The stack is still CONFIGURED with the public origin — that is what ends
+    // up in SITE_URL, the redirect allowlist and the frontend's own URLs.
+    expect(script).toContain("PREVIEW_ORIGIN='https://pi.example.test'");
+  });
+
+  it('retires a branch environment when its pull request stops being an active preview', () => {
+    // A labelled preview stays up until the label comes off or the pull request
+    // closes — and deleting the branch closes it. `activePullRequests` holds
+    // only open, labelled pull requests, so absence IS the retirement signal.
+    const sandboxes = [
+      { id: 'branch-live', metadata: { owner: 'kortix-branch-env', pr_number: '10', git_sha: 'old' } },
+      { id: 'branch-gone', metadata: { owner: 'kortix-branch-env', pr_number: '11', git_sha: 'x' } },
+      { id: 'pr-current', metadata: { owner: 'kortix-preview', pr_number: '12', git_sha: 'head' } },
+      { id: 'pr-moved', metadata: { owner: 'kortix-preview', pr_number: '13', git_sha: 'stale' } },
+    ];
+    const active = new Map<number, string>([
+      [10, 'moved-on'], // the branch env's head moved: NORMAL, it redeploys in place
+      [12, 'head'],
+      [13, 'head'],
+    ]);
+    // Only the unlabelled/closed branch env and the moved ephemeral preview go.
+    expect(selectStalePreviewSandboxIds(sandboxes, active).sort()).toEqual([
+      'branch-gone',
+      'pr-moved',
+    ]);
+  });
+
+  it('does not sweep a branch environment for the one thing that retires a preview', () => {
+    // A MOVED HEAD is the difference between the two owners. It makes an
+    // ephemeral preview stale — it was built for exactly one commit — but it is
+    // the normal state of a branch environment, which is redeployed in place and
+    // must survive it. Sweeping on sha would delete a live environment on every
+    // push, which is the whole thing persistence exists to prevent.
+    const sandboxes = [
+      { id: 'pr-moved', metadata: { owner: 'kortix-preview', pr_number: '4242', git_sha: 'built' } },
+      { id: 'branch-env', metadata: { owner: 'kortix-branch-env', pr_number: '6998', git_sha: 'built' } },
+    ];
+    const active = new Map<number, string>([
+      [4242, 'pushed'],
+      [6998, 'pushed'],
+    ]);
+    expect(selectStalePreviewSandboxIds(sandboxes, active)).toEqual(['pr-moved']);
   });
 
   it('uses a new Platinum idempotency key for each deployment run', () => {

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -161,7 +161,11 @@ describe('web ECS migration', () => {
     expect(buildJobs.match(/platforms: linux\/amd64/g)).toHaveLength(3);
     expect(workflow).toContain("github.event.action == 'labeled'");
     expect(workflow).toContain("github.event.action == 'synchronize'");
-    expect(workflow).toContain('labels/preview');
+    // The label used to be STRIPPED on every push; a labelled preview now stays
+    // online until the label is removed or the pull request closes, so nothing
+    // in this workflow may delete it any more.
+    expect(workflow).not.toContain('labels/preview');
+    expect(workflow).toContain('PREVIEW_BRANCH_ENV');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts deploy');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts teardown');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts reconcile');


### PR DESCRIPTION
Two changes to the preview system, both aimed at the same thing: make the
`preview` label enough on its own.

## 1. A labelled preview stays up

It used to survive exactly one push. `synchronize` deleted the sandbox **and
stripped the label**, so every push cost a human re-approval and issued a new
url. That is why a separate per-branch workflow had to exist beside it.

| event | before | after |
|---|---|---|
| `labeled` | deploy | deploy |
| `synchronize` | delete + strip label | **redeploy in place, same url** |
| `unlabeled` | delete | delete |
| `closed` | delete | delete |

The sandbox is named after the **branch** and reused, so its url survives every
push and stays bookmarkable. Deleting the branch closes the pull request, which
tears it down — so "online until the branch is deleted" is exactly what it does.

The nightly sweep now reaps **both** owners, by different rules: a moved head
makes an *ephemeral* preview stale (built for one commit), but it is the normal
state of a branch environment, so only the pull request leaving the active set
retires that one. Teardown is told the branch, because a branch environment
carries no provider expiry — missing it would leave the box running forever.

### The approval bar is unchanged

Only re-expressed. `authorize` still runs on the push, still accepts
**same-repository** pull requests only, and still requires the actor to hold
write. On `synchronize` that actor is whoever pushed — who necessarily already
holds write on this repository — so nothing is loosened. The exact-SHA
revalidation before deploy is untouched.

This also ports the branch-environment machinery (`previewSandboxIdentity`,
sandbox reuse, the warm-wait and cleanup fixes, the Caddy reload, `runTests`,
`publicOrigin`) from the `pi-worker` branch, because `deploy-preview.yml` runs
`tests/` code from **main**.

## 2. Managed git accepts a PAT, not only a GitHub App

**No project can be created on any preview today.** `POST /v1/projects/provision`
answers 503 `GitHub /orgs/managed-kortix/repos failed (403)` — 112 of the 124
failing flows. The App configured for previews (`kortix-private-repo-access`, on
`kortix-ai`) has `contents:write, metadata:read` and **no `administration`
permission**, so it cannot create a repository anywhere.

The API has always supported an org PAT in `MANAGED_GIT_GITHUB_TOKEN`, which
takes precedence over the App and needs no install or permission dance. The
preview could not reach it — `applyPreviewEnvironment` demanded the complete App
config and the allowlist had no slot — so a preview whose App lacks the
permission was unfixable without a code change. Now it accepts
`MANAGED_GIT_GITHUB_OWNER` plus **either** shape.

Verified on the running environment with a deliberately fake token: the error
moves from `403 Resource not accessible by integration` (App) to `401 Bad
credentials` (PAT path) — different code path, so a real token completes it.

## Verification

- `python3 infra/scripts/test-ecs-preview-runtime.py` → Ran 22, OK
- `vitest unit/{sandbox-preview,preview-stack}.test.ts` → 22 passed

The three invariants that encoded the *old* lifecycle were rewritten rather than
deleted, each keeping the reason the original existed.
