### PR TITLE
fix(preview): keep the --target-full gate on the label deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -304,6 +304,12 @@ jobs:
       # the sandbox is reused instead of replaced, so its URL survives every
       # push and stays bookmarkable until the label comes off or the pull
       # request closes. See previewSandboxIdentity in tests/src/core.
+      # The suite is the GATE, so it runs when the label goes on and on an
+      # explicit dispatch. A redeploy from a push skips it: the environment is
+      # persistent now, so pushes are iteration, and paying ~10 min of
+      # --target-full on each one would make the label unusable for working in.
+      # Re-run it any time from the Actions tab with 'Run workflow'.
+      PREVIEW_RUN_TESTS: ${{ (github.event.action == 'labeled' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
       PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.head_branch }}
       PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}
       PREVIEW_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -434,6 +434,15 @@ class PreviewTeardown(unittest.TestCase):
         self.assertIn(
             "PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}", job("deploy")
         )
+        # Making every labelled preview persistent turned the --target-full gate
+        # OFF by default, because runTests defaults off once branchEnv is set.
+        # The suite must still run when the label goes on; only a redeploy from a
+        # push skips it, so pushes stay fast without losing the gate.
+        self.assertIn(
+            "PREVIEW_RUN_TESTS: ${{ (github.event.action == 'labeled' || "
+            "github.event_name == 'workflow_dispatch') && '1' || '0' }}",
+            job("deploy"),
+        )
 
         teardown = job("teardown")
         # A push must no longer tear anything down, and must not strip the label.


### PR DESCRIPTION
Follow-up to [#7017](https://github.com/kortix-ai/suna/pull/7017), caught while watching the first label-driven deploy.

Making every labelled preview persistent silently turned the suite **off** for
all of them. `runTests` is `PREVIEW_RUN_TESTS === '1' || !branchEnv`, and the
label flow now always sets `branchEnv` — so the gate a preview exists to be
would have stopped running, quietly, on every pull request.

Run it when the label goes on and on an explicit dispatch; skip it on a redeploy
from a push:

| trigger | suite |
|---|---|
| `labeled` | runs — this is the gate |
| `workflow_dispatch` | runs |
| `synchronize` (push) | skipped — iteration |

That keeps the gate where it belongs while pushes stay fast, which is the point
of making the environment persistent.

`infra/scripts/test-ecs-preview-runtime.py` → Ran 22, OK. Full unit suite → 41
files, 415 tests passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790514700&installation_model_id=434224&pr_number=7018&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7018&signature=00f9f0fadd402d776962f262e725cb9770f218054b82e94ecaeeb6e88b48139f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->