### PR TITLE
feat(preview): re-point a stable hostname's worker on every deploy

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -55,6 +55,7 @@ jobs:
       lockfile_sha256: ${{ steps.preview.outputs.lockfile_sha256 }}
       head_branch: ${{ steps.preview.outputs.head_branch }}
       public_origin: ${{ steps.preview.outputs.public_origin }}
+      public_worker: ${{ steps.preview.outputs.public_worker }}
       provider: ${{ steps.preview.outputs.provider }}
     env:
       GH_TOKEN: ${{ github.token }}
@@ -131,13 +132,26 @@ jobs:
             # every branch by default — keeps the provider origin. The stack is
             # CONFIGURED with whatever this resolves to, so it must be the origin
             # the browser actually uses or every auth redirect leaves it.
-            public_origin="$(printf '%s\n' "${PUBLIC_ORIGINS:-}" \
-              | awk -F= -v b="$branch" '$1 == b { print $2; exit }')"
+            entry="$(printf '%s\n' "${PUBLIC_ORIGINS:-}" \
+              | awk -F= -v b="$branch" '$1 == b { print; exit }')"
+            public_origin="$(printf '%s' "$entry" | cut -d= -f2)"
+            # Optional third field: the worker under infra/cloudflare/workers/
+            # that SERVES that hostname. Without it the name is assumed to be
+            # fronted some other way and nothing is re-pointed.
+            public_worker="$(printf '%s' "$entry" | cut -d= -f3)"
             case "$public_origin" in
               ''|https://*) ;;
               *) echo "::error::PREVIEW_PUBLIC_ORIGINS entry for ${branch} must be an https origin."; exit 1 ;;
             esac
+            case "$public_worker" in
+              ''|*[!a-z0-9-]*)
+                [ -z "$public_worker" ] || {
+                  echo "::error::PREVIEW_PUBLIC_ORIGINS worker for ${branch} must match [a-z0-9-]+."
+                  exit 1
+                } ;;
+            esac
             echo "public_origin=$public_origin"
+            echo "public_worker=$public_worker"
             echo "provider=$provider"
           } >> "$GITHUB_OUTPUT"
           echo "${APPROVER} approved preview PR ${num} at ${sha} with provider=${provider}."
@@ -411,6 +425,27 @@ jobs:
         id: preview
         continue-on-error: true
         run: bun tests/bin/sandbox-preview.ts deploy
+      - name: Point the stable hostname at this sandbox
+        # A stable hostname is served by a Worker that proxies to the sandbox's
+        # OWN origin, and that origin is derived from the sandbox id — so it
+        # changes whenever the box is rebuilt. Re-publishing on every deploy is
+        # what stops the name going dead the one time that happens; a reused
+        # sandbox just re-points at the value it already had.
+        #
+        # Runs only for a branch whose PREVIEW_PUBLIC_ORIGINS entry names a
+        # worker, so an ordinary preview never touches Cloudflare.
+        if: needs.authorize.outputs.public_worker != '' && steps.preview.outcome == 'success'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
+          WORKER: ${{ needs.authorize.outputs.public_worker }}
+        run: |
+          set -euo pipefail
+          target="$(jq -r '.sandboxOrigin // empty' tests/test-results/preview/deployment.json)"
+          [ -n "$target" ] || { echo "::error::the deploy reported no sandbox origin to point at"; exit 1; }
+          dir="infra/cloudflare/workers/${WORKER}"
+          [ -f "${dir}/wrangler.toml" ] || { echo "::error::${dir}/wrangler.toml does not exist"; exit 1; }
+          echo "pointing ${{ needs.authorize.outputs.public_origin }} -> ${target}"
+          (cd "$dir" && npx --yes wrangler@4 deploy --var "TARGET_ORIGIN:${target}")
       - name: Publish GitHub deployment result
         if: always() && steps.deployment.outputs.id != ''
         env:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -434,14 +434,23 @@ jobs:
         #
         # Runs only for a branch whose PREVIEW_PUBLIC_ORIGINS entry names a
         # worker, so an ordinary preview never touches Cloudflare.
-        if: needs.authorize.outputs.public_worker != '' && steps.preview.outcome == 'success'
+        # Deliberately NOT gated on the suite passing. A failing flow still
+        # leaves a working environment, and leaving the hostname pointed at the
+        # previous sandbox — or at nothing — would be worse than a red flow.
+        # Only a deploy that produced no sandbox at all has nothing to point at.
+        if: always() && needs.authorize.outputs.public_worker != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
           WORKER: ${{ needs.authorize.outputs.public_worker }}
         run: |
           set -euo pipefail
-          target="$(jq -r '.sandboxOrigin // empty' tests/test-results/preview/deployment.json)"
-          [ -n "$target" ] || { echo "::error::the deploy reported no sandbox origin to point at"; exit 1; }
+          target="$(jq -r '.sandboxOrigin // empty' tests/test-results/preview/deployment.json 2>/dev/null || true)"
+          if [ -z "$target" ]; then
+            # The deploy produced no sandbox, and has already failed loudly for
+            # it. A second error here would only add noise.
+            echo "::notice::no sandbox origin in the deploy result; nothing to re-point"
+            exit 0
+          fi
           dir="infra/cloudflare/workers/${WORKER}"
           [ -f "${dir}/wrangler.toml" ] || { echo "::error::${dir}/wrangler.toml does not exist"; exit 1; }
           echo "pointing ${{ needs.authorize.outputs.public_origin }} -> ${target}"

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -431,6 +431,17 @@ class PreviewTeardown(unittest.TestCase):
         # with an origin the browser will never use.
         self.assertIn("PUBLIC_ORIGINS: ${{ vars.PREVIEW_PUBLIC_ORIGINS }}", authorize)
         self.assertIn("''|https://*) ;;", authorize)
+        # A stable hostname is proxied to the sandbox's OWN origin, which is
+        # derived from the sandbox id — so it dies on a rebuild unless the deploy
+        # re-points it. The optional third field names the worker that serves it;
+        # it is constrained so it cannot escape the workers directory.
+        self.assertIn("public_worker=", authorize)
+        self.assertIn("''|*[!a-z0-9-]*)", authorize)
+        deploy = job("deploy")
+        self.assertIn("Point the stable hostname at this sandbox", deploy)
+        self.assertIn("needs.authorize.outputs.public_worker != ''", deploy)
+        self.assertIn('dir="infra/cloudflare/workers/${WORKER}"', deploy)
+        self.assertIn('wrangler@4 deploy --var "TARGET_ORIGIN:${target}"', deploy)
         self.assertIn(
             "PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}", job("deploy")
         )

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -440,6 +440,10 @@ class PreviewTeardown(unittest.TestCase):
         deploy = job("deploy")
         self.assertIn("Point the stable hostname at this sandbox", deploy)
         self.assertIn("needs.authorize.outputs.public_worker != ''", deploy)
+        # NOT gated on the suite: a failing flow still leaves a working
+        # environment, and a hostname left pointing at the previous sandbox —
+        # or at nothing — is worse than a red flow.
+        self.assertIn("if: always() && needs.authorize.outputs.public_worker != ''", deploy)
         self.assertIn('dir="infra/cloudflare/workers/${WORKER}"', deploy)
         self.assertIn('wrangler@4 deploy --var "TARGET_ORIGIN:${target}"', deploy)
         self.assertIn(


### PR DESCRIPTION
Closes the gap left when `deploy-pi-worker.yml` was retired.

A stable hostname (`pi.kortix.com`) is served by a Cloudflare Worker proxying to
the sandbox's **own** origin, and that origin is derived from the sandbox id — so
it dies the moment the box is rebuilt. The only thing re-pointing it was the
bespoke workflow, which the `preview` label replaced. That left the name one
rebuild away from pointing at nothing, with no automation to notice.

## How

`PREVIEW_PUBLIC_ORIGINS` entries gain an optional third field naming the worker
under `infra/cloudflare/workers/` that serves the hostname:

```
pi-worker=https://pi.kortix.com=pi-router
```

When present, the deploy re-publishes that worker with `TARGET_ORIGIN` set to
the sandbox origin it just deployed. A reused sandbox re-points at the value it
already had — so the step is a **no-op in the normal case and a repair in the
rebuild case**.

## Blast radius

An entry without the third field, and every unlisted branch — which is all of
them — never touches Cloudflare. The step is gated on
`needs.authorize.outputs.public_worker != ''`.

The worker name is constrained to `[a-z0-9-]+` so it cannot escape the workers
directory, and `wrangler.toml` must exist there or the step fails rather than
deploying something unintended.

## Verification

Parsing checked by hand across every shape — three fields, two fields (empty
worker), a later entry in the list, an unlisted branch, an empty map — and the
validation rejecting `pi_router`, `../evil` and `Pi-Router` while accepting
`pi-router` and empty.

`infra/scripts/test-ecs-preview-runtime.py` → Ran 22, OK. Full unit suite → 41
files, 415 tests passing.

The end-to-end proof needs CI (there is no Cloudflare token locally): after merge
I will update the repository variable to the three-field form and push, then
confirm `pi.kortix.com` still resolves to the live sandbox.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516114&installation_model_id=434224&pr_number=7019&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7019&signature=7572a62c0bb7d1e6ad66b4eae14bd6141840fffb881851dfdef16ad2b953c7cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->