### PR TITLE
fix(preview): ship the pi-router worker to main so the deploy can re-point it

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,34 @@ linked, not inlined.
 
 ## Register
 
+### `deploy-preview.yml` runs from the DEFAULT BRANCH, so everything it references must be on main (2026-08-28)
+
+**When:** adding anything the preview deploy touches — a file under `tests/`, a
+Cloudflare worker under `infra/cloudflare/workers/`, a script it shells out to —
+while developing on a feature branch. The workflow is `pull_request_target`, and
+its deploy and teardown jobs check out
+`${{ github.event.repository.default_branch }}`, NOT the pull request head. The
+PR's own code is only ever built into the images; the ORCHESTRATION is main's.
+
+Hit twice in one afternoon. First the branch-environment machinery
+(`previewSandboxIdentity`, sandbox reuse, the Caddy reload) lived only on the
+feature branch, so the label flow could not have used it. Then the `pi-router`
+worker did, and the deploy failed with
+`infra/cloudflare/workers/pi-router/wrangler.toml does not exist` — the file was
+right there in the branch being deployed, and irrelevant.
+
+**The rule: if the preview WORKFLOW reads it, it ships to main first** — as its
+own PR, ahead of the feature that needs it. A feature branch may only contribute
+images.
+
+**Diagnostic:** a preview step that cannot find a file which plainly exists on
+your branch is this, every time. `git ls-tree -r --name-only origin/main -- <path>`
+settles it in one command.
+*Near-miss:* PR #7019. The guard failed loudly with the exact path rather than
+proceeding, which is why it cost one run and not an afternoon.
+*Enforcer:* none for the general case. Each referenced path needs its own
+existence check in the step that uses it, the way the worker step now has one.
+
 ### `compose up -d` does not restart a container because a bind-mounted FILE changed (2026-08-28)
 
 **When:** a redeploy rewrites a config file that a container reads through a

--- a/infra/cloudflare/workers/pi-router/worker.mjs
+++ b/infra/cloudflare/workers/pi-router/worker.mjs
@@ -1,0 +1,76 @@
+/**
+ * `pi.kortix.com` — the stable front door for the pi-worker branch environment.
+ *
+ * The environment lives in a Platinum sandbox whose own origin
+ * (`8080-<sandbox>.eu-west.sbx.platinum.dev`) is derived from the sandbox id.
+ * That id survives a redeploy but NOT a rebuild of the sandbox, and it is
+ * unmemorable either way. This Worker gives the environment one name that never
+ * changes, exactly as `dev.kortix.com` does for dev.
+ *
+ * A proxied CNAME cannot do this job: the Platinum edge routes by HOSTNAME, so
+ * it needs `Host` (and TLS SNI) to name the sandbox, while the browser is
+ * asking for `pi.kortix.com`. Host-header override is Enterprise-only. A Worker
+ * rewrites both for free by building the request against the target origin.
+ *
+ * TARGET_ORIGIN is a plain var, re-published by the deploy workflow on every
+ * deploy, so re-pointing the name at a rebuilt sandbox needs no code change.
+ */
+
+/** Hop-by-hop headers must not be forwarded; `host` is set by the target URL. */
+const STRIPPED = ['host', 'connection', 'keep-alive', 'transfer-encoding', 'upgrade-insecure-requests'];
+
+export default {
+  async fetch(request, env) {
+    const target = (env.TARGET_ORIGIN || '').trim();
+    if (!target) {
+      return Response.json(
+        { error: 'pi.kortix.com has no target origin configured' },
+        { status: 503, headers: { 'retry-after': '30' } },
+      );
+    }
+
+    const url = new URL(request.url);
+    const upstream = new URL(`${url.pathname}${url.search}`, target);
+
+    const headers = new Headers(request.headers);
+    for (const name of STRIPPED) headers.delete(name);
+    // The stack is CONFIGURED with https://pi.kortix.com, and Next's Server
+    // Action guard compares `x-forwarded-host` with `origin`. Caddy inside the
+    // sandbox pins this too; state it here so the value is right even if a
+    // request reaches something ahead of Caddy.
+    headers.set('x-forwarded-host', url.host);
+    headers.set('x-forwarded-proto', 'https');
+
+    let response;
+    try {
+      response = await fetch(
+        new Request(upstream, {
+          method: request.method,
+          headers,
+          body: request.body,
+          redirect: 'manual',
+        }),
+      );
+    } catch {
+      return Response.json(
+        { error: 'the pi environment is not reachable', target },
+        { status: 502, headers: { 'retry-after': '15' } },
+      );
+    }
+
+    // Cloudflare attaches the accepted socket to this non-standard property.
+    // Rebuilding the Response would drop it and break WebSocket upgrades, which
+    // Supabase Realtime and Next's dev overlay both use.
+    if (response.status === 101 || response.webSocket) return response;
+
+    // Streaming `response.body` straight through is what keeps SSE — the
+    // session event feed — from being buffered until the turn ends.
+    const output = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+    output.headers.set('x-kortix-environment', 'pi');
+    return output;
+  },
+};

--- a/infra/cloudflare/workers/pi-router/wrangler.toml
+++ b/infra/cloudflare/workers/pi-router/wrangler.toml
@@ -1,0 +1,34 @@
+# Cloudflare Worker that serves `pi.kortix.com` — the stable name for the
+# pi-worker branch environment, the way dev.kortix.com is for dev.
+#
+# Deploy:
+#   wrangler deploy --var TARGET_ORIGIN:https://8080-<sandbox>.eu-west.sbx.platinum.dev
+#
+# `custom_domain = true` makes Cloudflare create and own the DNS record and the
+# certificate for pi.kortix.com, so there is no separate DNS step.
+#
+# Auth: CLOUDFLARE_APPS_EDGE_API_TOKEN (Account Workers Scripts Write; kortix.com
+# zone DNS Write, Workers Routes Write, SSL and Certificates Write, Zone Read) —
+# the same token configure-preview-edge.yml uses.
+#
+# This lives on main because deploy-preview.yml checks out the DEFAULT BRANCH; a
+# worker that exists only on a feature branch cannot be re-pointed by it.
+#
+# TARGET_ORIGIN is re-published by deploy-preview.yml on every deploy of the
+# branch whose PREVIEW_PUBLIC_ORIGINS entry names this worker
+# (`pi-worker=https://pi.kortix.com=pi-router`), so a rebuilt sandbox re-points
+# the name automatically. The empty value below is only the bootstrap default
+# for a manual first deploy; the Worker answers 503 until it is set.
+
+main = "worker.mjs"
+compatibility_date = "2026-08-01"
+workers_dev = false
+account_id = "9785405a992435bb0c7bd19f9b6d26d5"
+
+name = "kortix-pi-router"
+routes = [
+  { pattern = "pi.kortix.com", custom_domain = true },
+]
+
+[vars]
+TARGET_ORIGIN = ""


### PR DESCRIPTION
Follow-up to [#7019](https://github.com/kortix-ai/suna/pull/7019). The re-point step ran on the first deploy after
merging and failed:

```
infra/cloudflare/workers/pi-router/wrangler.toml does not exist
```

The file was right there on the branch being deployed, and irrelevant.
`deploy-preview.yml` is `pull_request_target` and checks out the **default
branch** — the PR's own code is only ever built into the images; the
orchestration is main's. A worker that lives only on a feature branch cannot be
re-pointed by it.

Move it to main alongside `api-router`, `apps-router` and `preview-router`,
where it belongs — it is infrastructure, not pi source. Its header still named
`deploy-pi-worker.yml` as the thing that re-publishes `TARGET_ORIGIN`; that
workflow is gone and `deploy-preview.yml` does it now.

The guard behaved correctly — it failed loudly with the exact path rather than
deploying something unintended, which is why this cost one run rather than an
afternoon.

Also adds the register entry, since this is the **second** time in one afternoon
that something the preview workflow reads was left off main (the first was the
branch-environment machinery under `tests/`). The rule: if the preview workflow
reads it, it ships to main first, as its own PR, ahead of the feature that needs
it. One-command diagnostic included.

`infra/scripts/test-ecs-preview-runtime.py` → Ran 22, OK.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790517124&installation_model_id=434224&pr_number=7021&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7021&signature=3e309ed7fbbadf592a432659fe2a8ce7d24ed8470edd62e634197303f0e8cbc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->