### PR TITLE
feat(preview): a preview environment lives until its BRANCH is deleted

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -3,7 +3,15 @@ name: Deploy Preview (PR)
 on:
   pull_request_target:
     branches: [main]
-    types: [labeled, unlabeled, synchronize, closed]
+    # `closed` is deliberately absent. A preview environment lives until its
+    # BRANCH is deleted, not until the pull request is closed — closing one is
+    # routine (superseded, reopened later, split into two) and used to destroy a
+    # working environment plus its Postgres volume. The explicit off switches are
+    # removing the `preview` label and deleting the branch.
+    types: [labeled, unlabeled, synchronize]
+  # Branch deleted: the one event that retires a branch environment. It carries
+  # no pull request, so `teardown-branch` below identifies the sandbox by branch.
+  delete:
   workflow_dispatch:
     inputs:
       pr_number:
@@ -23,7 +31,9 @@ on:
     - cron: "17 6 * * *"
 
 concurrency:
-  group: deploy-preview-${{ github.event.pull_request.number || inputs.pr_number || 'reconcile' }}
+  # `github.event.ref` is the deleted branch, so two branch deletions run in
+  # parallel and neither queues behind the nightly sweep.
+  group: deploy-preview-${{ github.event.pull_request.number || inputs.pr_number || github.event.ref || 'reconcile' }}
   cancel-in-progress: false
 
 permissions:
@@ -32,8 +42,8 @@ permissions:
 jobs:
   authorize:
     name: Authorize exact preview SHA
-    # A labelled preview stays up until the label comes off or the pull request
-    # closes — so a push REDEPLOYS it in place instead of tearing it down. The
+    # A labelled preview stays up until the label comes off or the branch is
+    # deleted — so a push REDEPLOYS it in place instead of tearing it down. The
     # approval bar is unchanged: same-repository pull requests only, and the
     # actor needs write. On `synchronize` the actor is whoever pushed, who
     # already holds write on this repository, so nothing is loosened.
@@ -316,8 +326,8 @@ jobs:
       COMMIT: ${{ needs.authorize.outputs.sha }}
       # Naming the environment after the BRANCH is what makes it persistent:
       # the sandbox is reused instead of replaced, so its URL survives every
-      # push and stays bookmarkable until the label comes off or the pull
-      # request closes. See previewSandboxIdentity in tests/src/core.
+      # push and stays bookmarkable until the label comes off or the branch is
+      # deleted. See previewSandboxIdentity in tests/src/core.
       # The suite is the GATE, so it runs when the label goes on and on an
       # explicit dispatch. A redeploy from a push skips it: the environment is
       # persistent now, so pushes are iteration, and paying ~10 min of
@@ -530,11 +540,14 @@ jobs:
 
   teardown:
     name: Tear down preview and invalidate stale approval
+    # Removing the label is the EXPLICIT off switch, and the only pull request
+    # action that retires an environment. Closing the pull request no longer
+    # does: the branch, not the pull request, is what the environment belongs to
+    # — see `teardown-branch` below.
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      (github.event.action == 'closed' ||
-      (github.event.action == 'unlabeled' && github.event.label.name == 'preview'))
+      github.event.action == 'unlabeled' && github.event.label.name == 'preview'
     runs-on: ${{ vars.CI_RUNNER_M || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     permissions:
@@ -577,6 +590,51 @@ jobs:
           body="$(printf '%s\n' "$marker" '## Preview environment - torn down' '' \
             'The Platinum or Daytona sandbox and its full self-host data plane were deleted.')"
           [ -z "$id" ] || gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${id}" -f body="$body" >/dev/null
+
+  teardown-branch:
+    name: Tear down the deleted branch's environment
+    # The event that actually retires a branch environment. The sandbox is named
+    # after the branch and carries NO provider expiry (autoDeleteDays: 0), so if
+    # nothing deletes it here it runs and bills until a human notices. Deleting
+    # a branch is also what GitHub does on merge when auto-delete is on, so a
+    # merged pull request still cleans up.
+    #
+    # `ref_type` gates out tag deletions, which share this event and name no
+    # branch. Deleting a branch needs push access, the same bar as applying the
+    # `preview` label, and this job reads only default-branch code.
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+    # One Platinum list plus at most one delete — a small runner is enough, and
+    # this fires on EVERY branch deletion in the repository, not just previewed
+    # ones.
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      # No PREVIEW_PR_NUMBER: a delete event carries no pull request, and it
+      # needs none — the branch IS the environment's identity, so the CLI
+      # accepts the branch alone. There is no Daytona credential either: a
+      # branch environment is pinned to Platinum (a Daytona fallback would
+      # change its origin), so nothing of it can exist there.
+      #
+      # The branch name is attacker-chosen text, so it arrives as an environment
+      # variable and is never interpolated into a `run:` script. `bun` compares
+      # it as a string, and branchEnvSandboxName slugs it to [a-z0-9-] first.
+      PREVIEW_BRANCH_ENV: ${{ github.event.ref }}
+      PLATINUM_API_URL: ${{ vars.PLATINUM_API_URL }}
+      PLATINUM_API_KEY: ${{ secrets.PLATINUM_API_KEY }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@v2
+      - name: Delete the branch environment's sandbox
+        run: bun tests/bin/sandbox-preview.ts teardown
+      # No deployment or sticky-comment step: a delete event has no pull request
+      # to patch. The nightly sweep no longer needs one either — it judges a
+      # branch environment by whether its branch still exists.
 
   reconcile:
     name: Reconcile stale preview sandboxes

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -256,7 +256,13 @@ class PreviewRuntimeIsolation(unittest.TestCase):
         # and the nightly sweep can only ever touch a sandbox this system made.
         self.assertIn("owner: 'kortix-preview',", PREVIEW_CORE)
         self.assertIn("owner: identity.owner,", PREVIEW_PROVIDERS)
-        self.assertEqual(PREVIEW_PROVIDERS.count("sandbox.metadata?.owner === 'kortix-preview'"), 2)
+        # Every destructive read filters on the owner this system stamps, so a
+        # redeploy, a teardown and the nightly sweep can only ever touch a
+        # sandbox it created. The replace path checks it in the provider; the
+        # teardown and sweep selectors check it in core.
+        self.assertEqual(PREVIEW_PROVIDERS.count("sandbox.metadata?.owner === 'kortix-preview'"), 1)
+        self.assertIn("if (name === ephemeral && owner === 'kortix-preview') return true;", PREVIEW_CORE)
+        self.assertIn("name === persistent && owner === 'kortix-branch-env'", PREVIEW_CORE)
         self.assertIn("'kortix-preview': 'true',", PREVIEW_PROVIDERS)
         # A provider switch must not leave the other provider's sandbox running.
         self.assertIn(
@@ -511,7 +517,8 @@ class PreviewTeardown(unittest.TestCase):
         self.assertIn("owner: 'kortix-branch-env',", PREVIEW_CORE)
         self.assertIn("autoArchiveDays: 0,", PREVIEW_CORE)
         self.assertIn("autoDeleteDays: 0,", PREVIEW_CORE)
-        self.assertIn("branchEnvSandboxName(input.branchEnv)", PREVIEW_PROVIDERS)
+        self.assertIn("branchEnvSandboxName(input.branchEnv)", PREVIEW_CORE)
+        self.assertIn("selectTeardownSandboxIds(await allPlatinumPreviewSandboxes(api), input)", PREVIEW_PROVIDERS)
         self.assertIn("PREVIEW_BRANCH_ENV", job("teardown"))
 
     def test_a_failed_pull_request_query_never_reads_as_no_active_previews(self):

--- a/infra/scripts/test-ecs-preview-runtime.py
+++ b/infra/scripts/test-ecs-preview-runtime.py
@@ -261,8 +261,9 @@ class PreviewRuntimeIsolation(unittest.TestCase):
         # sandbox it created. The replace path checks it in the provider; the
         # teardown and sweep selectors check it in core.
         self.assertEqual(PREVIEW_PROVIDERS.count("sandbox.metadata?.owner === 'kortix-preview'"), 1)
-        self.assertIn("if (name === ephemeral && owner === 'kortix-preview') return true;", PREVIEW_CORE)
-        self.assertIn("name === persistent && owner === 'kortix-branch-env'", PREVIEW_CORE)
+        self.assertIn("sandbox.name === ephemeral &&", PREVIEW_CORE)
+        self.assertIn("owner === 'kortix-preview' &&", PREVIEW_CORE)
+        self.assertIn("sandbox.name === persistent && owner === 'kortix-branch-env'", PREVIEW_CORE)
         self.assertIn("'kortix-preview': 'true',", PREVIEW_PROVIDERS)
         # A provider switch must not leave the other provider's sandbox running.
         self.assertIn(
@@ -384,29 +385,59 @@ class PreviewRuntimeIsolation(unittest.TestCase):
 
 
 class PreviewTeardown(unittest.TestCase):
-    """Close, unlabel, new head, and the nightly sweep all delete the sandbox."""
+    """Unlabel, branch delete, new head, and the nightly sweep, each by its own rule."""
 
-    def test_close_and_unlabel_run_complete_default_branch_teardown(self):
+    def test_unlabel_and_branch_delete_run_complete_default_branch_teardown(self):
+        # WAS: `closed` tore the environment down. That is the wrong event.
+        # Closing a pull request is routine — superseded, reopened later, split
+        # in two — and none of it means the work is finished, yet it destroyed a
+        # live environment and its Postgres volume. An environment belongs to
+        # its BRANCH, so exactly two things retire it: the `preview` label coming
+        # off (the explicit switch) and the branch being deleted.
         teardown = job("teardown")
-        self.assertIn("github.event.action == 'closed'", WORKFLOW)
+        self.assertNotIn("github.event.action == 'closed'", WORKFLOW)
+        self.assertIn("types: [labeled, unlabeled, synchronize]", WORKFLOW)
         self.assertIn("github.event.action == 'unlabeled' && github.event.label.name == 'preview'", WORKFLOW)
         self.assertIn("github.event.action == 'synchronize'", WORKFLOW)
         # Teardown runs default-branch code, never the pull request head.
         self.assertIn("ref: ${{ github.event.repository.default_branch }}", teardown)
         # OLD: bash infra/scripts/ecs-preview.sh teardown "$NUM".
         self.assertIn("bun tests/bin/sandbox-preview.ts teardown", teardown)
+
+        # The branch-deleted job. `ref_type` gates out tag deletions, which
+        # arrive on the same event and name no branch. It has no pull request to
+        # patch, so it takes no write scope and calls no GitHub API — and it
+        # still reads default-branch code only.
+        self.assertIn("\n  delete:\n", WORKFLOW)
+        branch_teardown = job("teardown-branch")
+        self.assertIn(
+            "github.event_name == 'delete' && github.event.ref_type == 'branch'", branch_teardown
+        )
+        self.assertIn("PREVIEW_BRANCH_ENV: ${{ github.event.ref }}", branch_teardown)
+        self.assertNotIn("\n      PREVIEW_PR_NUMBER:", branch_teardown)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", branch_teardown)
+        self.assertIn("persist-credentials: false", branch_teardown)
+        self.assertNotIn("pull-requests: write", branch_teardown)
+        self.assertNotIn("deployments: write", branch_teardown)
+        self.assertNotIn("gh api", branch_teardown)
+        self.assertIn("bun tests/bin/sandbox-preview.ts teardown", branch_teardown)
+
         # OLD: aws ecs delete-service / elbv2 delete-rule / delete-target-group
         # / ecs deregister-task-definition removed the four ECS resources.
         # NEW: one sandbox holds the whole stack, so teardown deletes it on both
         # providers and refuses to touch a sandbox it does not own.
         teardown_action = cli_action("teardown")
-        # Both shapes are deleted: the PR-named sandbox always, and the
-        # branch-named one when this pull request runs a persistent preview.
+        # Both shapes are deleted, and either key alone is enough: the PR-named
+        # sandbox when a number is known, the branch-named one when a branch is.
+        self.assertIn("...(prNumber === undefined ? {} : { prNumber }),", teardown_action)
+        self.assertIn("...(branchEnv ? { branchEnv } : {}),", teardown_action)
+        # Daytona only ever holds the EPHEMERAL shape — a branch environment is
+        # pinned to Platinum — and its teardown is keyed by pull request number,
+        # so a branch-only teardown has nothing to ask it for.
         self.assertIn(
-            "teardownPlatinumPreview({ ...platinum, prNumber, ...(branchEnv ? { branchEnv } : {}) })",
+            "prNumber === undefined ? Promise.resolve(0) : teardownDaytonaPreview({ ...daytona, prNumber })",
             teardown_action,
         )
-        self.assertIn("teardownDaytonaPreview({ ...daytona, prNumber })", teardown_action)
         self.assertIn("refused to delete unowned Daytona sandbox", PREVIEW_PROVIDERS)
         self.assertIn("sandbox.metadata?.owner === 'kortix-preview' &&", PREVIEW_PROVIDERS)
         self.assertIn("Mark GitHub deployment inactive", teardown)
@@ -469,7 +500,9 @@ class PreviewTeardown(unittest.TestCase):
         # A push must no longer tear anything down, and must not strip the label.
         self.assertNotIn("synchronize", teardown)
         self.assertNotIn("labels/preview", teardown)
-        self.assertIn("github.event.action == 'closed'", teardown)
+        # Nor may closing the pull request: removing the label is the only pull
+        # request action that retires an environment.
+        self.assertNotIn("github.event.action == 'closed'", teardown)
         self.assertIn("github.event.label.name == 'preview'", teardown)
 
     def test_the_nightly_sweep_deletes_only_unapproved_sandboxes(self):
@@ -481,25 +514,29 @@ class PreviewTeardown(unittest.TestCase):
         self.assertIn('cron: "17 6 * * *"', WORKFLOW)
         reconcile_action = cli_action("reconcile")
         self.assertIn(
-            "reconcilePlatinumPreviews({ ...platinum, activePullRequests: active })", reconcile_action
+            "reconcilePlatinumPreviews({ ...platinum, activePullRequests: active, liveBranchSandboxNames })",
+            reconcile_action,
         )
         self.assertIn(
             "reconcileDaytonaPreviews({ ...daytona, activePullRequests: active })", reconcile_action
         )
         self.assertIn("selectStalePreviewSandboxIds", PREVIEW_CORE)
-        # Both owners are reaped, by different rules. A moved head makes an
-        # EPHEMERAL preview stale (it was built for one commit); it is the normal
-        # state of a branch environment, which is redeployed in place. Sweeping a
-        # branch environment on sha would delete a live environment every push.
-        self.assertIn("if (!activeSha) return true;", PREVIEW_CORE)
+        # Both owners are reaped, by different rules, because they are identified
+        # by different things. An EPHEMERAL preview is built for exactly one
+        # commit of one pull request, so a closed pull request or a moved head
+        # makes it stale. A BRANCH environment is redeployed in place — a moved
+        # head is its normal state, and sweeping on sha would delete a live
+        # environment on every push. It is retired by its branch disappearing.
+        self.assertIn("return !activeSha || activeSha !== sandbox.metadata?.git_sha;", PREVIEW_CORE)
+        self.assertIn("if (owner !== 'kortix-preview') return false;", PREVIEW_CORE)
         self.assertIn(
-            "return owner === 'kortix-preview' && activeSha !== sandbox.metadata?.git_sha;",
+            "return !liveBranchSandboxNames.has(sandbox.name);",
             PREVIEW_CORE,
         )
-        self.assertIn(
-            "if (owner !== 'kortix-preview' && owner !== 'kortix-branch-env') return false;",
-            PREVIEW_CORE,
-        )
+        # The name is the ONLY record of which branch a sandbox belongs to.
+        # Deleting one that has none would turn a listing that stopped returning
+        # names into the loss of every branch environment and its volume.
+        self.assertIn("if (sandbox.name === undefined) return false;", PREVIEW_CORE)
         self.assertIn("const approved = pull.labels?.some((label) => label.name === 'preview');", PREVIEW_CLI)
         self.assertIn("const sameRepository = pull.head?.repo?.full_name === repository;", PREVIEW_CLI)
         # A PR preview is swept after 7 idle days; the Platinum retention now
@@ -511,9 +548,9 @@ class PreviewTeardown(unittest.TestCase):
         self.assertIn("autoArchiveInterval: 10_080,", PREVIEW_PROVIDERS)
         self.assertIn("autoDeleteInterval: 10_080,", PREVIEW_PROVIDERS)
         # A branch environment carries NO provider expiry — it is retired by the
-        # pull request leaving the active set, which is what closing it or
-        # removing the label does, and deleting the branch does both. Teardown
-        # must therefore know the branch, or the box outlives everything.
+        # `preview` label coming off or by its BRANCH being deleted, and nothing
+        # else. Teardown must therefore know the branch, or the box outlives
+        # everything and bills until a human notices.
         self.assertIn("owner: 'kortix-branch-env',", PREVIEW_CORE)
         self.assertIn("autoArchiveDays: 0,", PREVIEW_CORE)
         self.assertIn("autoDeleteDays: 0,", PREVIEW_CORE)
@@ -530,6 +567,14 @@ class PreviewTeardown(unittest.TestCase):
             PREVIEW_CLI,
         )
         self.assertIn("if (pulls.length < 100) return active;", PREVIEW_CLI)
+        # The same rule for the branch listing, which now decides the life of
+        # every branch environment. An empty set means "every branch is gone",
+        # so failing open here would delete all of them in one sweep.
+        self.assertIn(
+            "if (!response.ok) throw new Error(`GitHub branch list returned ${response.status}`);",
+            PREVIEW_CLI,
+        )
+        self.assertIn("if (branches.length < 100) return names;", PREVIEW_CLI)
 
 
 class PreviewHealthGate(unittest.TestCase):

--- a/tests/bin/sandbox-preview.ts
+++ b/tests/bin/sandbox-preview.ts
@@ -4,6 +4,7 @@ import { resolve } from 'node:path';
 
 import {
   type SandboxPreviewProvider,
+  branchEnvSandboxName,
   runSandboxPreview,
 } from '../src/core/sandbox-preview';
 import {
@@ -92,6 +93,39 @@ async function activePreviewPullRequests(
   }
 }
 
+/**
+ * The slugged sandbox name of every branch that currently exists on the remote.
+ *
+ * A branch environment is retired by its BRANCH disappearing, not by its pull
+ * request closing, so the sweep compares against this rather than against open
+ * pull requests. Slugging both sides is what makes the lossy
+ * `branchEnvSandboxName` mapping comparable.
+ */
+async function liveBranchNames(repository: string, token: string): Promise<Set<string>> {
+  const names = new Set<string>();
+  for (let page = 1; ; page += 1) {
+    const response = await fetch(
+      `https://api.github.com/repos/${repository}/branches?per_page=100&page=${page}`,
+      {
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+        },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    // Failing OPEN here would make every branch look deleted and the sweep would
+    // delete every branch environment at once.
+    if (!response.ok) throw new Error(`GitHub branch list returned ${response.status}`);
+    const branches = (await response.json()) as Array<{ name?: string }>;
+    for (const branch of branches) {
+      if (branch.name) names.add(branchEnvSandboxName(branch.name));
+    }
+    if (branches.length < 100) return names;
+  }
+}
+
 const action = process.argv[2] ?? 'deploy';
 const repository = value('GITHUB_REPOSITORY', 'kortix-ai/suna');
 const platinum = {
@@ -159,19 +193,31 @@ if (action === 'deploy') {
   await writeOutput('report_url', result.previewUrl ? `${result.previewUrl}/_tests/` : '');
   process.exitCode = result.exitCode;
 } else if (action === 'teardown') {
-  const prNumber = positiveInteger('PREVIEW_PR_NUMBER');
   // A persistent environment's sandbox is named after the BRANCH, so teardown
   // has to be told which branch or it deletes nothing and the box runs forever.
+  // A branch-deleted event carries the branch and no pull request, so the number
+  // is optional whenever the branch is known.
   const branchEnv = process.env.PREVIEW_BRANCH_ENV?.trim() || undefined;
+  const prNumber = branchEnv && !process.env.PREVIEW_PR_NUMBER?.trim()
+    ? undefined
+    : positiveInteger('PREVIEW_PR_NUMBER');
   const [platinumDeleted, daytonaDeleted] = await Promise.all([
-    teardownPlatinumPreview({ ...platinum, prNumber, ...(branchEnv ? { branchEnv } : {}) }),
-    teardownDaytonaPreview({ ...daytona, prNumber }),
+    teardownPlatinumPreview({
+      ...platinum,
+      ...(prNumber === undefined ? {} : { prNumber }),
+      ...(branchEnv ? { branchEnv } : {}),
+    }),
+    prNumber === undefined ? Promise.resolve(0) : teardownDaytonaPreview({ ...daytona, prNumber }),
   ]);
   console.log(`[sandbox-preview] teardown platinum=${platinumDeleted} daytona=${daytonaDeleted}`);
 } else if (action === 'reconcile') {
-  const active = await activePreviewPullRequests(repository, required('GITHUB_TOKEN'));
+  const token = required('GITHUB_TOKEN');
+  const active = await activePreviewPullRequests(repository, token);
+  // A branch environment is retired by its BRANCH disappearing, not by its pull
+  // request closing, so the sweep needs to know which branches still exist.
+  const liveBranchSandboxNames = await liveBranchNames(repository, token);
   const [platinumDeleted, daytonaDeleted] = await Promise.all([
-    reconcilePlatinumPreviews({ ...platinum, activePullRequests: active }),
+    reconcilePlatinumPreviews({ ...platinum, activePullRequests: active, liveBranchSandboxNames }),
     reconcileDaytonaPreviews({ ...daytona, activePullRequests: active }),
   ]);
   console.log(

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -491,7 +491,7 @@ export async function deployDaytonaPreview(
 export async function teardownPlatinumPreview(input: {
   apiUrl: string;
   apiKey: string;
-  prNumber: number;
+  prNumber?: number;
   branchEnv?: string;
 }): Promise<number> {
   if (!input.apiKey) return 0;
@@ -524,11 +524,16 @@ export async function reconcilePlatinumPreviews(input: {
   apiUrl: string;
   apiKey: string;
   activePullRequests: ReadonlyMap<number, string>;
+  liveBranchSandboxNames?: ReadonlySet<string>;
 }): Promise<number> {
   if (!input.apiKey) return 0;
   const api = new PlatinumApi(input.apiUrl, input.apiKey);
   const sandboxes = await allPlatinumPreviewSandboxes(api);
-  const stale = selectStalePreviewSandboxIds(sandboxes, input.activePullRequests);
+  const stale = selectStalePreviewSandboxIds(
+    sandboxes,
+    input.activePullRequests,
+    input.liveBranchSandboxNames,
+  );
   for (const sandboxId of stale) await deletePlatinum(api, sandboxId);
   return stale.length;
 }

--- a/tests/src/core/sandbox-preview-providers.ts
+++ b/tests/src/core/sandbox-preview-providers.ts
@@ -34,11 +34,11 @@ import {
   PreviewInfrastructureError,
   type SandboxPreviewResult,
   buildPreviewBootstrapScript,
-  branchEnvSandboxName,
   previewLockfileHash,
   previewSandboxIdentity,
   previewSandboxName,
   selectStalePreviewSandboxIds,
+  selectTeardownSandboxIds,
 } from './sandbox-preview';
 import type { PreviewRuntimeSecrets } from './preview-stack';
 
@@ -496,18 +496,8 @@ export async function teardownPlatinumPreview(input: {
 }): Promise<number> {
   if (!input.apiKey) return 0;
   const api = new PlatinumApi(input.apiUrl, input.apiKey);
-  const ephemeral = previewSandboxName(input.prNumber);
-  const persistent = input.branchEnv ? branchEnvSandboxName(input.branchEnv) : null;
-  const owned = (await allPlatinumPreviewSandboxes(api)).filter((sandbox) => {
-    if (Number(sandbox.metadata?.pr_number) !== input.prNumber) return false;
-    if (sandbox.name === ephemeral && sandbox.metadata?.owner === 'kortix-preview') return true;
-    return (
-      persistent !== null &&
-      sandbox.name === persistent &&
-      sandbox.metadata?.owner === 'kortix-branch-env'
-    );
-  });
-  for (const sandbox of owned) await deletePlatinum(api, sandbox.id);
+  const owned = selectTeardownSandboxIds(await allPlatinumPreviewSandboxes(api), input);
+  for (const sandboxId of owned) await deletePlatinum(api, sandboxId);
   return owned.length;
 }
 

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -317,7 +317,13 @@ export function selectStalePreviewSandboxIds(
     .filter((sandbox) => {
       const owner = sandbox.metadata?.owner;
       if (owner === 'kortix-branch-env') {
-        return sandbox.name === undefined || !liveBranchSandboxNames.has(sandbox.name);
+        // The name is the ONLY record of which branch this is — nothing puts
+        // the branch in metadata. Without one the sandbox cannot be judged, so
+        // it is kept: an unidentifiable box costs money, while deleting one on
+        // a listing that stopped returning names would destroy every branch
+        // environment and its Postgres volume at once, irreversibly.
+        if (sandbox.name === undefined) return false;
+        return !liveBranchSandboxNames.has(sandbox.name);
       }
       if (owner !== 'kortix-preview') return false;
       const activeSha = activePullRequests.get(Number(sandbox.metadata?.pr_number));
@@ -325,7 +331,6 @@ export function selectStalePreviewSandboxIds(
     })
     .map((sandbox) => sandbox.id);
 }
-
 
 export async function runSandboxPreview(
   input: SandboxPreviewInput,

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -233,7 +233,8 @@ export interface PreviewSandboxIdentity {
  * auto-deleted. Reuse is what holds the sandbox id — and therefore the public
  * URL — still, so the environment can be bookmarked, registered as a Stripe
  * webhook target, and keep its Postgres volume across deploys. The distinct
- * owner is what keeps the nightly sweep from reaping it: it has no PR to close.
+ * owner is what makes the sweep judge it by its BRANCH rather than by its pull
+ * request, so closing the pull request does not retire it.
  */
 export function previewSandboxIdentity(input: {
   prNumber: number;
@@ -258,58 +259,73 @@ export function previewSandboxIdentity(input: {
 }
 
 /**
- * Sandboxes the nightly sweep should delete.
+ * Sandboxes to delete, in whichever shape the pull request deployed.
  *
- * Both owners are reaped, by DIFFERENT rules, because they promise different
- * things. An ephemeral preview is pinned to one commit, so a moved head makes it
- * stale. A branch environment is pinned to a BRANCH and redeployed in place, so
- * a moved head is its normal state — only the pull request leaving the active
- * set retires it, which is what closing it or removing the `preview` label does,
- * and deleting the branch does both.
+ * Either key may be given. `prNumber` matches the ephemeral preview named after
+ * it; `branchEnv` matches the persistent environment named after the branch. A
+ * branch-deleted event knows the branch but no pull request, so the persistent
+ * match does not require one — the branch IS that environment's identity, two
+ * pull requests cannot share it, and ownership is still checked so this can only
+ * ever return a sandbox this system created.
  *
- * `activePullRequests` holds only OPEN pull requests carrying the `preview`
- * label, so "not in the map" already means "no longer approved".
- */
-/**
- * Sandboxes belonging to ONE pull request, in whichever shape it deployed.
- *
- * Ownership is checked as well as the name, so this can only ever return a
- * sandbox this system created for THIS pull request. `branchEnv` must be passed
- * whenever the pull request runs a persistent environment: that sandbox is named
- * after the branch and has NO provider expiry
- * (`autoDeleteDays: 0`), so if teardown does not find it, nothing ever will.
+ * `branchEnv` must be passed whenever a persistent environment exists: it has NO
+ * provider expiry (`autoDeleteDays: 0`), so if teardown does not find it,
+ * nothing ever will.
  */
 export function selectTeardownSandboxIds(
   sandboxes: PreviewSandboxRecord[],
-  input: { prNumber: number; branchEnv?: string },
+  input: { prNumber?: number; branchEnv?: string },
 ): string[] {
-  const ephemeral = previewSandboxName(input.prNumber);
+  const ephemeral = input.prNumber === undefined ? null : previewSandboxName(input.prNumber);
   const persistent = input.branchEnv ? branchEnvSandboxName(input.branchEnv) : null;
+  if (ephemeral === null && persistent === null) {
+    throw new Error('preview teardown needs a pull request number or a branch');
+  }
   return sandboxes
     .filter((sandbox) => {
-      if (Number(sandbox.metadata?.pr_number) !== input.prNumber) return false;
-      const name = sandbox.name;
       const owner = sandbox.metadata?.owner;
-      if (name === ephemeral && owner === 'kortix-preview') return true;
-      return persistent !== null && name === persistent && owner === 'kortix-branch-env';
+      if (
+        ephemeral !== null &&
+        sandbox.name === ephemeral &&
+        owner === 'kortix-preview' &&
+        Number(sandbox.metadata?.pr_number) === input.prNumber
+      ) {
+        return true;
+      }
+      return persistent !== null && sandbox.name === persistent && owner === 'kortix-branch-env';
     })
     .map((sandbox) => sandbox.id);
 }
 
+/**
+ * Sandboxes the nightly sweep should delete.
+ *
+ * The two owners are retired by different facts, because they are identified by
+ * different things. An EPHEMERAL preview belongs to one commit of one pull
+ * request, so a closed pull request or a moved head makes it stale. A BRANCH
+ * environment belongs to the branch: it is redeployed in place, outlives the
+ * pull request being closed, and is retired only when the branch itself is
+ * gone. `liveBranchSandboxNames` therefore carries the slugged name of every
+ * branch that currently exists on the remote.
+ */
 export function selectStalePreviewSandboxIds(
   sandboxes: PreviewSandboxRecord[],
   activePullRequests: ReadonlyMap<number, string>,
+  liveBranchSandboxNames: ReadonlySet<string> = new Set(),
 ): string[] {
   return sandboxes
     .filter((sandbox) => {
       const owner = sandbox.metadata?.owner;
-      if (owner !== 'kortix-preview' && owner !== 'kortix-branch-env') return false;
+      if (owner === 'kortix-branch-env') {
+        return sandbox.name === undefined || !liveBranchSandboxNames.has(sandbox.name);
+      }
+      if (owner !== 'kortix-preview') return false;
       const activeSha = activePullRequests.get(Number(sandbox.metadata?.pr_number));
-      if (!activeSha) return true;
-      return owner === 'kortix-preview' && activeSha !== sandbox.metadata?.git_sha;
+      return !activeSha || activeSha !== sandbox.metadata?.git_sha;
     })
     .map((sandbox) => sandbox.id);
 }
+
 
 export async function runSandboxPreview(
   input: SandboxPreviewInput,

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -30,6 +30,8 @@ export function previewLockfileHash(value: string): string {
 
 export interface PreviewSandboxRecord {
   id: string;
+  /** Present on Platinum records; teardown matches on it as well as ownership. */
+  name?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -268,6 +270,32 @@ export function previewSandboxIdentity(input: {
  * `activePullRequests` holds only OPEN pull requests carrying the `preview`
  * label, so "not in the map" already means "no longer approved".
  */
+/**
+ * Sandboxes belonging to ONE pull request, in whichever shape it deployed.
+ *
+ * Ownership is checked as well as the name, so this can only ever return a
+ * sandbox this system created for THIS pull request. `branchEnv` must be passed
+ * whenever the pull request runs a persistent environment: that sandbox is named
+ * after the branch and has NO provider expiry
+ * (`autoDeleteDays: 0`), so if teardown does not find it, nothing ever will.
+ */
+export function selectTeardownSandboxIds(
+  sandboxes: PreviewSandboxRecord[],
+  input: { prNumber: number; branchEnv?: string },
+): string[] {
+  const ephemeral = previewSandboxName(input.prNumber);
+  const persistent = input.branchEnv ? branchEnvSandboxName(input.branchEnv) : null;
+  return sandboxes
+    .filter((sandbox) => {
+      if (Number(sandbox.metadata?.pr_number) !== input.prNumber) return false;
+      const name = sandbox.name;
+      const owner = sandbox.metadata?.owner;
+      if (name === ephemeral && owner === 'kortix-preview') return true;
+      return persistent !== null && name === persistent && owner === 'kortix-branch-env';
+    })
+    .map((sandbox) => sandbox.id);
+}
+
 export function selectStalePreviewSandboxIds(
   sandboxes: PreviewSandboxRecord[],
   activePullRequests: ReadonlyMap<number, string>,

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -104,26 +104,48 @@ describe('provider-neutral preview lifecycle', () => {
     expect(script).toContain("PREVIEW_ORIGIN='https://pi.example.test'");
   });
 
-  it('retires a branch environment when its pull request stops being an active preview', () => {
-    // A labelled preview stays up until the label comes off or the pull request
-    // closes — and deleting the branch closes it. `activePullRequests` holds
-    // only open, labelled pull requests, so absence IS the retirement signal.
+  it('retires a branch environment when its BRANCH is gone, not when its PR closes', () => {
+    // The rule this test used to state was "absence from activePullRequests IS
+    // the retirement signal", which made CLOSING the pull request destroy the
+    // environment and its Postgres volume. Closing one is routine — superseded,
+    // reopened later, split in two — and none of that means the work is over.
+    // A branch environment is named after the branch and redeployed in place,
+    // so the BRANCH is its identity: it lives exactly as long as the branch.
     const sandboxes = [
-      { id: 'branch-live', metadata: { owner: 'kortix-branch-env', pr_number: '10', git_sha: 'old' } },
-      { id: 'branch-gone', metadata: { owner: 'kortix-branch-env', pr_number: '11', git_sha: 'x' } },
+      // No open labelled pull request at all — and the branch still exists.
+      {
+        id: 'branch-pr-closed',
+        name: 'kortix-env-feat-live',
+        metadata: { owner: 'kortix-branch-env', pr_number: '10', git_sha: 'old' },
+      },
+      {
+        id: 'branch-deleted',
+        name: 'kortix-env-feat-gone',
+        metadata: { owner: 'kortix-branch-env', pr_number: '11', git_sha: 'x' },
+      },
       { id: 'pr-current', metadata: { owner: 'kortix-preview', pr_number: '12', git_sha: 'head' } },
       { id: 'pr-moved', metadata: { owner: 'kortix-preview', pr_number: '13', git_sha: 'stale' } },
     ];
     const active = new Map<number, string>([
-      [10, 'moved-on'], // the branch env's head moved: NORMAL, it redeploys in place
       [12, 'head'],
       [13, 'head'],
     ]);
-    // Only the unlabelled/closed branch env and the moved ephemeral preview go.
-    expect(selectStalePreviewSandboxIds(sandboxes, active).sort()).toEqual([
-      'branch-gone',
+    const liveBranches = new Set(['kortix-env-feat-live']);
+    // Only the branch that is GONE, plus the moved ephemeral preview.
+    expect(selectStalePreviewSandboxIds(sandboxes, active, liveBranches).sort()).toEqual([
+      'branch-deleted',
       'pr-moved',
     ]);
+  });
+
+  it('keeps a branch environment it cannot identify instead of assuming it is gone', () => {
+    // The name is the only record of which branch a sandbox belongs to —
+    // nothing writes the branch into metadata. A listing that stopped returning
+    // names would therefore make every branch environment look deleted, and
+    // sweeping on that would destroy all of them, volumes included, at once.
+    // An unidentifiable sandbox costs money; this mistake is unrecoverable.
+    const sandboxes = [{ id: 'nameless', metadata: { owner: 'kortix-branch-env' } }];
+    expect(selectStalePreviewSandboxIds(sandboxes, new Map(), new Set())).toEqual([]);
   });
 
   it('tears down both sandbox shapes, and only this pull request\'s', () => {
@@ -149,8 +171,25 @@ describe('provider-neutral preview lifecycle', () => {
     // a persistent environment leaks. The teardown job must always pass it.
     expect(selectTeardownSandboxIds(sandboxes, { prNumber: 42 })).toEqual(['pr-box']);
 
-    // Never another pull request's, and never an unowned sandbox.
-    expect(selectTeardownSandboxIds(sandboxes, { prNumber: 99, branchEnv: 'feat/x' })).toEqual([]);
+    // CHANGED DELIBERATELY: this returned [] while a branch environment was
+    // owned by a pull request. It is owned by its BRANCH now, so a mismatched
+    // number no longer hides it — two pull requests cannot share one branch,
+    // and the `delete` event that retires it carries no number to agree with.
+    expect(selectTeardownSandboxIds(sandboxes, { prNumber: 99, branchEnv: 'feat/x' })).toEqual([
+      'branch-box',
+    ]);
+
+    // Branch alone: exactly what the branch-deleted teardown job passes.
+    expect(selectTeardownSandboxIds(sandboxes, { branchEnv: 'feat/x' })).toEqual(['branch-box']);
+    expect(selectTeardownSandboxIds(sandboxes, { branchEnv: 'feat/y' })).toEqual(['other-branch']);
+    // The wrong-owner box shares that name and is still never returned.
+    expect(selectTeardownSandboxIds(sandboxes, { branchEnv: 'feat/x' })).not.toContain('impostor');
+
+    // Neither key is a caller bug, and it must FAIL rather than quietly delete
+    // nothing: a branch environment has no expiry to catch what teardown missed.
+    expect(() => selectTeardownSandboxIds(sandboxes, {})).toThrow(
+      /needs a pull request number or a branch/,
+    );
   });
 
   it('does not sweep a branch environment for the one thing that retires a preview', () => {
@@ -161,13 +200,18 @@ describe('provider-neutral preview lifecycle', () => {
     // push, which is the whole thing persistence exists to prevent.
     const sandboxes = [
       { id: 'pr-moved', metadata: { owner: 'kortix-preview', pr_number: '4242', git_sha: 'built' } },
-      { id: 'branch-env', metadata: { owner: 'kortix-branch-env', pr_number: '6998', git_sha: 'built' } },
+      {
+        id: 'branch-env',
+        name: 'kortix-env-pi-worker',
+        metadata: { owner: 'kortix-branch-env', pr_number: '6998', git_sha: 'built' },
+      },
     ];
     const active = new Map<number, string>([
       [4242, 'pushed'],
       [6998, 'pushed'],
     ]);
-    expect(selectStalePreviewSandboxIds(sandboxes, active)).toEqual(['pr-moved']);
+    const liveBranches = new Set(['kortix-env-pi-worker']);
+    expect(selectStalePreviewSandboxIds(sandboxes, active, liveBranches)).toEqual(['pr-moved']);
   });
 
   it('uses a new Platinum idempotency key for each deployment run', () => {

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -7,6 +7,7 @@ import {
   previewSandboxName,
   runSandboxPreview,
   selectStalePreviewSandboxIds,
+  selectTeardownSandboxIds,
 } from '../src/core/sandbox-preview';
 import {
   daytonaPreviewLabelsFilter,
@@ -123,6 +124,33 @@ describe('provider-neutral preview lifecycle', () => {
       'branch-gone',
       'pr-moved',
     ]);
+  });
+
+  it('tears down both sandbox shapes, and only this pull request\'s', () => {
+    // A branch environment has autoDeleteDays: 0 — no provider expiry. If
+    // teardown does not find it, NOTHING ever will, so it runs until someone
+    // notices the bill.
+    const sandboxes = [
+      { id: 'pr-box', name: 'kortix-preview-pr-42', metadata: { owner: 'kortix-preview', pr_number: '42' } },
+      { id: 'branch-box', name: 'kortix-env-feat-x', metadata: { owner: 'kortix-branch-env', pr_number: '42' } },
+      // Another pull request's boxes, identical in every other way.
+      { id: 'other-pr', name: 'kortix-preview-pr-43', metadata: { owner: 'kortix-preview', pr_number: '43' } },
+      { id: 'other-branch', name: 'kortix-env-feat-y', metadata: { owner: 'kortix-branch-env', pr_number: '43' } },
+      // Right name, wrong owner: something this system did not create.
+      { id: 'impostor', name: 'kortix-env-feat-x', metadata: { owner: 'someone-else', pr_number: '42' } },
+    ];
+
+    expect(selectTeardownSandboxIds(sandboxes, { prNumber: 42, branchEnv: 'feat/x' })).toEqual([
+      'pr-box',
+      'branch-box',
+    ]);
+
+    // WITHOUT branchEnv the branch-named box is invisible — which is exactly how
+    // a persistent environment leaks. The teardown job must always pass it.
+    expect(selectTeardownSandboxIds(sandboxes, { prNumber: 42 })).toEqual(['pr-box']);
+
+    // Never another pull request's, and never an unowned sandbox.
+    expect(selectTeardownSandboxIds(sandboxes, { prNumber: 99, branchEnv: 'feat/x' })).toEqual([]);
   });
 
   it('does not sweep a branch environment for the one thing that retires a preview', () => {

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -169,7 +169,8 @@ describe('web ECS migration', () => {
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts deploy');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts teardown');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts reconcile');
-    expect(workflow.match(/uses: oven-sh\/setup-bun@v2/g)).toHaveLength(3);
+    // deploy, teardown, teardown-branch, reconcile.
+    expect(workflow.match(/uses: oven-sh\/setup-bun@v2/g)).toHaveLength(4);
     expect(workflow).toContain('pnpm test -- --target-full');
     expect(workflow).toContain('PREVIEW_LOCKFILE_SHA256');
     expect(workflow).toContain('Test report:');
@@ -182,6 +183,57 @@ describe('web ECS migration', () => {
     expect(workflow).not.toMatch(/vercel/i);
     expect(workflow).not.toContain('KORTIX_PREVIEW_APPROVED_SHA');
     expect(workflow).toContain('**Preview:**');
+  });
+
+  /**
+   * A preview environment lives until its BRANCH is deleted.
+   *
+   * It used to die when the pull request closed, which is the wrong event:
+   * closing one is routine — superseded, reopened later, split in two — and it
+   * took the environment's Postgres volume with it. The branch is what the
+   * environment is named after and redeployed against, so the branch is what it
+   * belongs to. Two switches turn it off: removing the `preview` label, and
+   * deleting the branch. Nothing else may.
+   */
+  it('keeps a preview environment alive until its branch is deleted', () => {
+    const workflow = read('.github/workflows/deploy-preview.yml');
+    const jobs = (name: string) => {
+      const body = workflow.slice(workflow.indexOf(`\n  ${name}:\n`) + name.length + 5);
+      const next = body.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+      return next === -1 ? body : body.slice(0, next);
+    };
+
+    // `closed` reaches neither the trigger nor any job condition.
+    expect(workflow).toContain('types: [labeled, unlabeled, synchronize]');
+    expect(workflow).not.toContain("github.event.action == 'closed'");
+
+    // Removing the label is still the explicit off switch.
+    expect(jobs('teardown')).toContain(
+      "github.event.action == 'unlabeled' && github.event.label.name == 'preview'",
+    );
+
+    // Deleting the branch is the other one, and the only event that retires a
+    // branch environment — whose sandbox has no provider expiry behind it.
+    expect(workflow).toContain('\n  delete:\n');
+    const branchTeardown = jobs('teardown-branch');
+    // Tag deletions arrive on the same event and name no branch.
+    expect(branchTeardown).toContain(
+      "github.event_name == 'delete' && github.event.ref_type == 'branch'",
+    );
+    expect(branchTeardown).toContain('bun tests/bin/sandbox-preview.ts teardown');
+    // The branch alone identifies the sandbox; a delete event has no number.
+    expect(branchTeardown).toContain('PREVIEW_BRANCH_ENV: ${{ github.event.ref }}');
+    expect(branchTeardown).not.toContain('\n      PREVIEW_PR_NUMBER:');
+    // Default-branch code, never a pull request head — the same rule the
+    // pull_request_target jobs follow.
+    expect(branchTeardown).toContain('ref: ${{ github.event.repository.default_branch }}');
+    expect(branchTeardown).toContain('persist-credentials: false');
+    // No pull request exists to patch, so the job asks for no write scope and
+    // calls no GitHub API.
+    expect(branchTeardown).toContain('permissions:\n      contents: read\n');
+    expect(branchTeardown).not.toContain('pull-requests: write');
+    expect(branchTeardown).not.toContain('deployments: write');
+    expect(branchTeardown).not.toContain('gh api');
   });
 
   it('disables Vercel auto-deploys everywhere except staging', () => {


### PR DESCRIPTION
A `preview` environment used to die when the pull request **closed**. That is the
wrong event.

Closing a pull request is routine — superseded, reopened later, split in two —
and none of it means the work is finished. It nevertheless deleted a live
sandbox, its Postgres volume, and the URL people had bookmarked.

An environment is named after the **branch** and redeployed in place, so the
branch is what it belongs to. After this, exactly two things retire one:

| event | result |
| --- | --- |
| `unlabeled` (`preview` removed) | tear down — the explicit off switch, unchanged |
| pull request `closed` | **nothing**. The environment keeps running |
| branch deleted | tear down |
| nightly reconcile | a branch environment stays while its branch exists |

### What changed

**`.github/workflows/deploy-preview.yml`**
- `closed` removed from the `pull_request_target` types **and** from the
  `teardown` condition, so closing one starts no run at all.
- New `on: delete` trigger and a `teardown-branch` job, gated on
  `github.event.ref_type == 'branch'` so a tag deletion is not mistaken for one.
  It carries no pull request, so it passes `PREVIEW_BRANCH_ENV` alone, takes no
  write scope, calls no GitHub API, and skips every step that patches a pull
  request comment or deployment. GitHub deletes the branch itself on merge when
  auto-delete is on, so a merged pull request still cleans up.
- The branch name is attacker-chosen text. It arrives as an environment
  variable and is never interpolated into a `run:` script.
- `concurrency` keys on `github.event.ref`, so two branch deletions run in
  parallel and neither queues behind the nightly sweep.
- Security invariants untouched: same-repository pull requests only, actor needs
  write, exact-SHA revalidation, default-branch checkout everywhere.

**`tests/src/core/sandbox-preview.ts`**
- `selectTeardownSandboxIds` takes an **optional** `prNumber`. A branch-deleted
  event knows the branch and no pull request, and it needs none — two pull
  requests cannot share a branch. Ownership is still checked, so it can only
  ever return a sandbox this system created. Passing neither key throws rather
  than deleting nothing quietly: a branch environment has `autoDeleteDays: 0`,
  so nothing else would ever find it.
- `selectStalePreviewSandboxIds` judges a `kortix-branch-env` sandbox by whether
  its **branch** still exists, not by its pull request. A sandbox whose `name` is
  missing is **kept**: the name is the only record of which branch it is, and
  deleting on a listing that stopped returning names would destroy every
  environment and volume at once, irreversibly.

**`tests/bin/sandbox-preview.ts`**
- `teardown` accepts branch-only. `reconcile` lists every remote branch and
  slugs each through `branchEnvSandboxName`. That listing **fails closed** — an
  error throws instead of returning an empty set, which would read as "every
  branch is gone" and sweep every environment in one pass.

### Verification

Real Platinum teardown path, against a stubbed sandbox API:

| input | result |
| --- | --- |
| `PREVIEW_BRANCH_ENV` only | `platinum=1` — deletes the branch box, not the same-named box owned by someone else, not another branch's, not the pull request's |
| both keys | `platinum=2` — pull request box + branch box |
| neither | exit `1`, `PREVIEW_PR_NUMBER is required` |

Real repository branch list (1000+ branches, 11+ pages of 100): `pi-worker` and
`ino/preview-parity` both slug into the live set, so the sweep keeps them
(`kortix-env-pi-worker`, `kortix-env-ino-preview-parity`); a name whose branch
does not exist is not in it.

```
python3 infra/scripts/test-ecs-preview-runtime.py   ->  Ran 22 tests, OK
cd tests && npx vitest run unit/                    ->  41 files, 418 tests passed
cd tests && npx tsc --noEmit                        ->  exit 0
```

Both files that encode these rules were rewritten to state the new one, never
deleted — including the teardown expectation that used to assert `[]` for a
mismatched pull request number, which now returns the branch box.

The first commit on this branch (`9ea65f5da5`) extracted `selectTeardownSandboxIds`
and gave it the coverage it never had; the rest builds on it.
