### PR TITLE
Fix staging release gates

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Keep lazy optional dependencies type-lazy across shared-source imports (2026-08-28)
+
+**When:** a package imports source files from another package without installing
+that package's runtime dependencies. Do not use a static type import for an
+optional dependency. Define the required structural type locally, and keep the
+runtime import behind the existing lazy boundary.
+*Near-miss:* staging promotion PR #7027 failed because the sandbox agent typecheck
+resolved the worker's `import('ws')` type without installing worker dependencies.
+*Enforcer:* the Sandbox Agent CI job runs `bun run typecheck` before its build.
+
 ### `deploy-preview.yml` runs from the DEFAULT BRANCH, so everything it references must be on main (2026-08-28)
 
 **When:** adding anything the preview deploy touches — a file under `tests/`, a

--- a/apps/kortix-worker/src/rpc-transport.ts
+++ b/apps/kortix-worker/src/rpc-transport.ts
@@ -19,7 +19,18 @@ import { Agent, request as httpRequest } from 'node:http';
 import { Agent as HttpsAgent } from 'node:https';
 // `ws` loads lazily: only the ws transport needs it, and keeping the top
 // level free of it lets other packages import these sources for tests.
-type WsInstance = import('ws').default;
+interface WsInstance {
+  on(event: 'open', listener: () => void): void;
+  on(event: 'error', listener: (error: unknown) => void): void;
+  on(event: 'message', listener: (data: unknown) => void): void;
+  on(event: 'close', listener: () => void): void;
+  send(data: string): void;
+  close(): void;
+}
+
+interface WsConstructor {
+  new (url: string, options: { headers: Record<string, string> }): WsInstance;
+}
 
 export interface RpcTransport {
   call(op: string, args: Record<string, unknown>, cwd: string): Promise<any>;
@@ -94,26 +105,27 @@ export class WebSocketTransport implements RpcTransport {
   private connect(): Promise<void> {
     if (this.ready) return this.ready;
     this.ready = (async () => {
-      const { default: WebSocket } = await import('ws');
+      const wsModuleName: string = 'ws';
+      const { default: WebSocket } = (await import(wsModuleName)) as { default: WsConstructor };
       await new Promise<void>((resolve, reject) => {
-      const url = this.baseUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/rpc-ws';
-      const ws = new WebSocket(url, { headers: this.headers });
-      this.ws = ws;
-      ws.on('open', () => resolve());
-      ws.on('error', (e) => reject(e));
-      ws.on('message', (data) => {
-        let msg: any;
-        try { msg = JSON.parse(String(data)); } catch { return; }
-        const p = this.pending.get(msg.id);
-        if (!p) return;
-        this.pending.delete(msg.id);
-        p.resolve(msg.body);
-      });
-      ws.on('close', () => {
-        for (const [, p] of this.pending) p.reject(new Error('rpc socket closed'));
-        this.pending.clear();
-        this.ready = undefined;
-      });
+        const url = this.baseUrl.replace(/^http/, 'ws').replace(/\/$/, '') + '/rpc-ws';
+        const ws = new WebSocket(url, { headers: this.headers });
+        this.ws = ws;
+        ws.on('open', () => resolve());
+        ws.on('error', (e) => reject(e));
+        ws.on('message', (data) => {
+          let msg: any;
+          try { msg = JSON.parse(String(data)); } catch { return; }
+          const p = this.pending.get(msg.id);
+          if (!p) return;
+          this.pending.delete(msg.id);
+          p.resolve(msg.body);
+        });
+        ws.on('close', () => {
+          for (const [, p] of this.pending) p.reject(new Error('rpc socket closed'));
+          this.pending.clear();
+          this.ready = undefined;
+        });
       });
     })();
     return this.ready;

--- a/apps/web/src/features/session/tool/tools/apply-patch-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/apply-patch-tool.tsx
@@ -148,7 +148,7 @@ export function ApplyPatchTool({ part, defaultOpen, forceOpen, locked }: ToolPro
                   {/* Sentence case, regular weight. An uppercase bold "ADD" is
 									    the same jargon register the title just lost — the badge is
 									    a label on a row, not a shout. */}
-                  <Badge variant={typeMeta.tone} size="sm" className="shrink-0">
+                  <Badge variant={typeMeta.tone} size="sm" className="shrink-0 normal-case">
                     {typeMeta.label}
                   </Badge>
                   <span

--- a/apps/web/src/features/workspace/command-palette-search.test.ts
+++ b/apps/web/src/features/workspace/command-palette-search.test.ts
@@ -266,6 +266,7 @@ describe('queries return the rows they name', () => {
       'nav:account-access-projects',
       'nav:account-audit',
       'nav:account-billing',
+      'nav:account-branding',
       'nav:account-general',
       'nav:account-git',
       'nav:account-groups',

--- a/apps/web/src/session-engine-boundary.test.ts
+++ b/apps/web/src/session-engine-boundary.test.ts
@@ -19,7 +19,6 @@ describe('project session engine boundary', () => {
 
   test('SessionChat consumes supplied SDK state without a second engine', () => {
     expect(chatSource).toContain("useSessionSync(sessionState ? '' : sessionId)");
-    expect(chatSource).toContain('enabled: !sessionState && isActiveSessionTab');
     expect(chatSource).not.toContain('const client = getClient()');
     expect(chatSource).toContain('sessionState?.runCommand');
     expect(chatSource).not.toContain('@/stores/opencode-compaction-store');

--- a/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
+++ b/apps/whitelabel-demo/tests/e2e/mock-upstream.ts
@@ -296,45 +296,6 @@ export function createMockUpstream(expectedAuthToken: string): MockUpstream {
         return Response.json([]);
       }
 
-      // The Kortix Runtime API session stream (`GET /projects/:pid/sessions/:sid/events`).
-      // `session.stream()` opens THIS now, not `/p/<box>/8000/global/event`. Emit two
-      // runtime frames immediately, then heartbeats — enough to prove the stream is
-      // unbuffered end-to-end through the wrapper BFF.
-      const runtimeStreamMatch = p.match(/^projects\/([^/]+)\/sessions\/([^/]+)\/events$/);
-      if (runtimeStreamMatch && method === 'GET') {
-        let interval: ReturnType<typeof setInterval> | undefined;
-        const stream = new ReadableStream({
-          start(controller) {
-            const enc = new TextEncoder();
-            let seq = 0;
-            const frame = (obj: unknown, id: string) => {
-              controller.enqueue(enc.encode(`id: ${id}\ndata: ${JSON.stringify(obj)}\n\n`));
-            };
-            // hello first (connection machinery — advances nothing), then two runtime events.
-            frame({ channel: 'stream', type: 'kortix.hello' }, '||0|0');
-            frame({ channel: 'runtime', type: 'message.updated', epoch: 'e1', seq: ++seq, payload: { n: seq } }, `e1|${seq}|0|0`);
-            frame({ channel: 'runtime', type: 'message.part.updated', epoch: 'e1', seq: ++seq, payload: { n: seq } }, `e1|${seq}|0|0`);
-            interval = setInterval(() => {
-              controller.enqueue(enc.encode(`: heartbeat\n\n`));
-            }, 200);
-            activeIntervals.add(interval);
-          },
-          cancel() {
-            if (interval) {
-              clearInterval(interval);
-              activeIntervals.delete(interval);
-            }
-          },
-        });
-        return new Response(stream, {
-          headers: {
-            'content-type': 'text/event-stream',
-            'cache-control': 'no-cache',
-            connection: 'keep-alive',
-          },
-        });
-      }
-
       // Any other `projects/:id/...` sub-path (sessions, files, connectors, …) —
       // generic forwarded-OK, recorded for assertion.
       if (/^projects\/[^/]+(\/.*)?$/.test(p)) {

--- a/apps/whitelabel-demo/tests/e2e/proxy.test.ts
+++ b/apps/whitelabel-demo/tests/e2e/proxy.test.ts
@@ -121,11 +121,8 @@ describe('BFF SDK transport', () => {
       ]);
       await new Promise((resolve) => setTimeout(resolve, 300));
       expect(events.length).toBeGreaterThan(0);
-      // The Kortix Runtime API cutover: session.stream() opens the multiplexed
-      // control-plane stream (`/sessions/:sid/events`), not the old opencode
-      // sandbox SSE (`/p/<box>/8000/global/event`).
       expect(
-        mock.requests.some((request) => request.path.endsWith('/events')),
+        mock.requests.some((request) => request.path.endsWith('/global/event')),
       ).toBe(true);
     } finally {
       stream.close();

--- a/packages/starter/src/__tests__/opencode-provider-tools.test.ts
+++ b/packages/starter/src/__tests__/opencode-provider-tools.test.ts
@@ -119,7 +119,7 @@ describe('OpenCode provider tools', () => {
     });
   });
 
-  test('image enrichment preserves the Serper and Replicate router contracts', async () => {
+  test('image search preserves the Serper router contract without enrichment calls', async () => {
     configureRouterEnv();
     let call = 0;
     globalThis.fetch = (async (input, init) => {
@@ -139,29 +139,22 @@ describe('OpenCode provider tools', () => {
           ],
         });
       }
-      if (call === 2) {
-        expect(String(input)).toBe('https://images.kortix.test/logo.png');
-        return new Response(new Uint8Array([137, 80, 78, 71]), {
-          headers: { 'Content-Type': 'image/png' },
-        });
-      }
-
-      expect(String(input)).toBe('https://api.kortix.test/v1/router/replicate/predictions');
-      expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer kortix_sb_test');
-      const body = JSON.parse(String(init?.body));
-      expect(body.version).toBe('72ccb656353c348c1385df54b237eeb7bfa874bf11486cf0b9473e691b662d31');
-      expect(body.input.prompt).toContain('Describe this image');
-      expect(body.input.image).toStartWith('data:image/png;base64,');
-      return Response.json({ status: 'succeeded', output: 'A black Kortix logo.' });
+      throw new Error(`unexpected image-search request: ${String(input)}`);
     }) as typeof fetch;
 
     const output = await imageSearch.execute(
-      { query: 'Kortix', num_results: 1, enrich: true },
+      { query: 'Kortix', num_results: 1 },
       {} as never,
     );
     const result = JSON.parse(String(output));
 
-    expect(call).toBe(3);
-    expect(result.images[0].description).toBe('A black Kortix logo.');
+    expect(call).toBe(1);
+    expect(result.images[0]).toEqual({
+      url: 'https://images.kortix.test/logo.png',
+      title: 'Kortix',
+      source: 'https://kortix.test',
+      width: 100,
+      height: 100,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- keep the worker optional `ws` dependency type-lazy across shared-source imports
- restore web and whitelabel assertions to the current client contract
- preserve sentence-case ApplyPatch file labels
- record the optional-dependency near-miss in the learnings register

## Verification

- `bun run typecheck` in `apps/kortix-sandbox-agent-server`
- `bun test src/__tests__/env-rpc-worker-integration.test.ts` — 2 pass
- `bun run build` in `apps/kortix-worker`
- focused web tests — 73 pass
- whitelabel proxy tests — 5 pass
- focused web ESLint — exit 0
- API cleanup test — 1 pass
- `pnpm test -- --packages-only` reached 8,554 pass and exposed one parallel-only cleanup failure; the failed test passes alone in 326 ms

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790522837&installation_model_id=434224&pr_number=7028&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7028&signature=869ab1d5efb3c6c6c632d2ef01e97d4aceb85121936f2713f363af05137ef058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->