### PR TITLE
Slack channel takeover + secret delivery: targeted release candidate

### DIFF
--- a/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
+++ b/apps/api/src/__tests__/unit-project-secret-strategy-route.test.ts
@@ -1181,7 +1181,23 @@ describe('POST /v1/projects/:projectId/secrets audit', () => {
     expect(JSON.stringify(audits)).not.toContain('plaintext-test-value');
   });
 
-  test('defaults a known LLM credential to the LLM gateway', async () => {
+  // Was: 'defaults a known LLM credential to the LLM gateway'.
+  //
+  // The server no longer infers delivery from a secret's NAME. It used to stamp
+  // `broker`/`llm_gateway` whenever the name matched any provider credential env
+  // in the models.dev catalogue — 204 providers, one of which (`github-copilot`)
+  // claims `GITHUB_TOKEN`. An ordinary GitHub PAT was therefore classified as a
+  // model credential and withheld from the sandbox: the user set a secret, the
+  // agent could not read it, and nothing said why (prod 2026-08-27). The name is
+  // arbitrary, so carving out one name would only relocate the bug.
+  //
+  // Every caller that genuinely means "model credential" says so explicitly —
+  // web provider-connect, the custom-provider form, `kortix providers set`, and
+  // the Codex OAuth flow (which writes its row directly with `strategyLocked`).
+  // The web secrets manager already sent `runtime`/`sandbox` outright, so the old
+  // default also produced a split brain where the same name landed differently
+  // depending on which surface created it.
+  test('does not infer a delivery policy from the secret name', async () => {
     const response = await buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -1189,20 +1205,32 @@ describe('POST /v1/projects/:projectId/secrets audit', () => {
     });
 
     expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ delivery_status: 'available' });
+    // The provider-shaped NAME buys no special treatment: this lands as an
+    // ordinary sandbox secret, which is what the caller asked for by not asking
+    // for anything else.
+    expect(row).toMatchObject({ consumer: 'sandbox' });
+    expect(audits[0]).toMatchObject({ after: { configured: true, rotated: true } });
+  });
+
+  test('an explicit gateway choice is still honored for the same name', async () => {
+    const response = await buildApp().request(`/v1/projects/${PROJECT_ID}/secrets`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'ANTHROPIC_API_KEY',
+        value: 'plaintext-test-value',
+        strategy: 'broker',
+        consumer: 'llm_gateway',
+      }),
+    });
+
+    expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({
       strategy: 'broker',
       consumer: 'llm_gateway',
-      delivery_status: 'available',
     });
     expect(row).toMatchObject({ strategy: 'broker', consumer: 'llm_gateway' });
-    expect(audits[0]).toMatchObject({
-      after: {
-        configured: true,
-        strategy: 'broker',
-        consumer: 'llm_gateway',
-        rotated: true,
-      },
-    });
   });
 
   test('keeps an explicit runtime choice for a known LLM credential', async () => {

--- a/apps/api/src/channels/slack/channel-binding-ownership.test.ts
+++ b/apps/api/src/channels/slack/channel-binding-ownership.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+// Source tripwires for the 2026-08-28 Slack misrouting incident.
+//
+// `chat_channel_bindings` is UNIQUE on (platform, workspace_id, channel_id) —
+// ONE project owns a channel, workspace-wide. `ensureProjectChannelBinding` runs
+// on EVERY Slack event, before `isOwnBotEvent` and before `classifyEvent`, so it
+// fires even for events the project goes on to ignore. With an
+// `onConflictDoUpdate` that set `projectId`, any project whose Slack app merely
+// observed a channel silently took ownership of it, and the previous owner went
+// permanently dark there — no hourglass, no reply, no session, and no row
+// anywhere recording why.
+//
+// Prod, workspace T07FUFNT3RV: `kortix-incident-reporter` (installed
+// 2026-08-17) held channel C0AASKRLRBR, where `Kortix Company` had run 71
+// sessions through 2026-08-14 and then went silent for 14 days.
+//
+// Re-assignment is a deliberate act with its own paths — the channel picker and
+// `/kortix use` / switch_project, both in interactivity.ts — which is exactly
+// why the per-event path must only ever CLAIM AN UNOWNED channel.
+
+const read = (rel: string): Promise<string> =>
+  Bun.file(new URL(rel, import.meta.url)).text();
+
+describe('ensureProjectChannelBinding claims, never steals', () => {
+  test('the per-event bind cannot overwrite an existing owner', async () => {
+    const source = await read('./dispatch.ts');
+    const start = source.indexOf('export async function ensureProjectChannelBinding');
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf('export async function resolveOauthProject', start);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+
+    expect(body).toContain('onConflictDoNothing');
+    // The exact form that caused the takeover. Never reintroduce it here.
+    expect(body).not.toContain('onConflictDoUpdate');
+    expect(body).not.toContain('set: { projectId');
+  });
+
+  test('the deliberate re-assignment paths still exist and still overwrite', async () => {
+    const interactivity = await read('./interactivity.ts');
+    // The picker pick and the /kortix use switch are how a channel legitimately
+    // moves between projects. If these stop writing projectId, a user can no
+    // longer re-point a channel at all — the opposite failure.
+    expect(interactivity).toContain('set: { projectId');
+  });
+});

--- a/apps/api/src/channels/slack/dispatch.ts
+++ b/apps/api/src/channels/slack/dispatch.ts
@@ -119,16 +119,33 @@ export async function ensureProjectChannelBinding(
   channelId: string,
 ): Promise<void> {
   if (!projectId || !teamId || !channelId) return;
+  // CLAIM-IF-UNOWNED, never steal. This runs on EVERY Slack event, before
+  // `isOwnBotEvent` and before `classifyEvent` — so it fires even for events this
+  // project goes on to ignore. As a conflict-UPDATE it re-assigned `projectId`
+  // on every message, and since `chat_channel_bindings` is UNIQUE on
+  // (platform, workspace_id, channel_id) — one project per channel, workspace-wide
+  // — the previous owner became permanently unreachable in its own channel: no
+  // hourglass, no reply, no session, no row anywhere to explain it.
+  //
+  // Any project whose Slack app merely observes a channel (both manifests
+  // subscribe `message.channels`) was enough to take it. Prod 2026-08-28,
+  // workspace T07FUFNT3RV: `kortix-incident-reporter` (installed 2026-08-17)
+  // held `C0AASKRLRBR`, where `Kortix Company` had run 71 sessions through
+  // 2026-08-14 and then went silent for 14 days.
+  //
+  // Re-assignment is a DELIBERATE act and has its own paths, untouched by this:
+  // the channel picker (`interactivity.ts` pick_project) and `/kortix use` /
+  // switch_project (`interactivity.ts` handleSwitchProject). `/kortix unbind`
+  // (`commands.ts`) deletes the row so the next event can re-claim it.
   await db
     .insert(chatChannelBindings)
     .values({ platform: 'slack', workspaceId: teamId, channelId, projectId, pickerTs: null })
-    .onConflictDoUpdate({
+    .onConflictDoNothing({
       target: [
         chatChannelBindings.platform,
         chatChannelBindings.workspaceId,
         chatChannelBindings.channelId,
       ],
-      set: { projectId, pickerTs: null },
     });
 }
 

--- a/apps/api/src/channels/slack/sandbox-supervisor-oom.test.ts
+++ b/apps/api/src/channels/slack/sandbox-supervisor-oom.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+
+// Source tripwire for the 2026-08-28 zombie-sandbox incident.
+//
+// The guest kernel OOM-killed `kortix-agent` and the supervisor loop EXITED
+// instead of relaunching: exit 137 after 4472s matched neither the swap-code
+// branch nor the early-exit branch, so it fell through to `exit "${status}"`.
+// The comment there assumed that was safe because "this is PID 1 and the
+// provider decides what a stopped sandbox means" — false on Platinum, where
+// PID 1 is `/bin/sh /sbin/pt-init`. The script exiting does not stop the VM, so
+// the box became a corpse: DB status='active', provider state='running', port
+// 8000 closed forever, and nothing reconciled it.
+//
+// Observed on 2 of 21 active prod sandboxes; correlation was exact across the
+// fleet: oom_kill <=> `agent exited 137` <=> port 8000 shut.
+
+const entrypoint = (): Promise<string> =>
+  Bun.file(new URL('../../../../sandbox/entrypoint.sh', import.meta.url)).text();
+
+describe('sandbox supervisor survives an OOM kill', () => {
+  test('a SIGKILL relaunches the daemon instead of exiting the supervisor', async () => {
+    const source = await entrypoint();
+    const guard = source.indexOf('if [ "${status}" -eq 137 ]');
+    const fallthrough = source.indexOf('agent exited ${status} after ${ran}s; exiting');
+    expect(guard).toBeGreaterThan(-1);
+    // The relaunch must be decided BEFORE the unconditional exit, or it is dead code.
+    expect(fallthrough).toBeGreaterThan(guard);
+    expect(source.slice(guard, fallthrough)).toContain('continue');
+  });
+
+  test('the relaunch is bounded, and a healthy run earns a fresh budget', async () => {
+    const source = await entrypoint();
+    expect(source).toContain('MAX_SIGKILL_RELAUNCH');
+    const guard = source.indexOf('if [ "${status}" -eq 137 ]');
+    const block = source.slice(guard, guard + 700);
+    expect(block).toContain('${ran}" -ge "${HEALTHY_AFTER_S}');
+  });
+
+  test('a deliberate stop still exits — only SIGKILL relaunches', async () => {
+    const source = await entrypoint();
+    // 143 (SIGTERM) and 130 (SIGINT) are the provider stopping the box. If the
+    // loop relaunched on those it would fight a shutdown forever.
+    expect(source).not.toContain('"${status}" -ge 128');
+    expect(source).not.toContain('"${status}" -eq 143');
+  });
+});

--- a/apps/api/src/connectors/db-deps.ts
+++ b/apps/api/src/connectors/db-deps.ts
@@ -1203,6 +1203,14 @@ async function listConnectors(projectId: string): Promise<AdminConnectorView[]> 
     const { hasAuth } = authOf(row);
     return hasAuth && row.providerType === 'channel';
   });
+  // Composio rows need the same liveness question channel rows already ask.
+  // `authOf` forces `hasAuth = true` for composio and the shared-credential
+  // lookup below checks a table Composio never writes to, so a composio
+  // connector serialized as `active` no matter whether its OAuth handshake ever
+  // completed. `connectorConnected` already answers correctly for composio (it
+  // reads `connected_account_id` / `is_no_auth` out of the connection metadata,
+  // the same facts the gateway denies calls on) — it was simply never asked.
+  const composioRows = conns.filter((row) => row.providerType === 'composio');
   const boundSecretIdentifiers = [
     ...new Set(
       credentialRows
@@ -1210,7 +1218,13 @@ async function listConnectors(projectId: string): Promise<AdminConnectorView[]> 
         .filter((identifier): identifier is string => Boolean(identifier)),
     ),
   ];
-  const [actions, credentialConnectorIds, connectedChannelSlugs, validBoundSecrets] =
+  const [
+    actions,
+    credentialConnectorIds,
+    connectedChannelSlugs,
+    authorizedComposioSlugs,
+    validBoundSecrets,
+  ] =
     await Promise.all([
       db
         .select()
@@ -1224,6 +1238,11 @@ async function listConnectors(projectId: string): Promise<AdminConnectorView[]> 
       connectorIdsWithSharedCredentials(credentialRows.map((row) => row.connectorId)),
       Promise.all(
         channelRows.map(async (row) => [row.slug, await connectorConnected(row, null)] as const),
+      ).then(
+        (entries) => new Set(entries.filter(([, connected]) => connected).map(([slug]) => slug)),
+      ),
+      Promise.all(
+        composioRows.map(async (row) => [row.slug, await connectorConnected(row, null)] as const),
       ).then(
         (entries) => new Set(entries.filter(([, connected]) => connected).map(([slug]) => slug)),
       ),
@@ -1276,7 +1295,22 @@ async function listConnectors(projectId: string): Promise<AdminConnectorView[]> 
       provider: row.providerType,
       platform: channelPlatform(row.config),
       iconUrl: typeof config?.icon_url === 'string' ? config.icon_url : null,
-      status: row.status,
+      // A composio connector whose authorization never completed reports
+      // `needs_auth` rather than the stored `active`. The gateway already
+      // refuses every call on such a connector, so reporting `active` made the
+      // product contradict itself: a checkmark in the UI and `needs_auth` on
+      // every tool call, with nothing explaining the gap. Prod 2026-08-28: all 6
+      // GitHub connections carried a null `connected_account_id` and no GitHub
+      // tool call had ever executed, while the connector read `active`.
+      //
+      // Read-side only. `disabled` and `error` are deliberate operator/sync
+      // states and outrank this; the DB column is left alone.
+      status:
+        row.providerType === 'composio' &&
+        row.status === 'active' &&
+        !authorizedComposioSlugs.has(row.slug)
+          ? ('needs_auth' as const)
+          : row.status,
       authorizationStrategy: row.authorizationStrategy,
       sensitive: config?.sensitive === true,
       actions: (actionsByConnector.get(row.connectorId) ?? []).map((a) => ({

--- a/apps/api/src/projects/lib/sandbox-env-sync.ts
+++ b/apps/api/src/projects/lib/sandbox-env-sync.ts
@@ -1089,6 +1089,35 @@ async function runBounded<T>(
  * Callers that are already restarting the box pay nothing extra; a caller doing
  * this mid-session is interrupting a turn and must say so.
  */
+/**
+ * A push target that exists but is not `active` is a control-plane DIVERGENCE,
+ * not an ordinary miss, and it must say so.
+ *
+ * Every push below used to filter the lookup on `status = 'active'` and return a
+ * bare `'no active sandbox'`, which no caller logged. A session whose row said
+ * `stopped` while its VM was genuinely running — serving prompts the whole time
+ * — therefore received no secret, model or scope push for HOURS, and the only
+ * visible symptom was an agent that could not see a secret the UI insisted it
+ * had (prod 2026-08-27, session b3848cf5). `backend.ts` deliberately refuses to
+ * heal a row whose deadline has expired, so nothing else reconciles this and
+ * nothing else reports it.
+ *
+ * `sessionSandboxes.status` is NOT NULL, so callers guard on a truthy value
+ * only to stay compatible with test doubles that select a narrower row shape.
+ */
+function nonActiveSandboxSkip(
+  what: string,
+  input: { sessionId: string; projectId?: string },
+  status: string,
+): { applied: false; reason: string } {
+  console.warn(`[env-sync] skipping ${what} — sandbox row is not active`, {
+    sessionId: input.sessionId,
+    projectId: input.projectId,
+    sandboxStatus: status,
+  });
+  return { applied: false, reason: `sandbox row is '${status}', not active` };
+}
+
 export async function pushSessionAgentConfigToSandbox(input: {
   projectId: string;
   sessionId: string;
@@ -1136,14 +1165,25 @@ export async function pushSessionAgentConfigToSandbox(input: {
     // downgrade to no agents at all. Leave the box as it is.
     if (!compiled) return { applied: false, reason: 'no compiled agent config' };
 
+    // Selected WITHOUT the status filter so a non-active row can be NAMED. The
+    // filtered form returned a bare 'no active sandbox' and the caller logged
+    // nothing, so a session whose row said `stopped` while its VM was genuinely
+    // running — serving prompts the whole time — silently received no secret or
+    // config push for HOURS. Prod 2026-08-27, session b3848cf5: every push
+    // since the secret was created was skipped this way, and the only visible
+    // symptom was an agent that could not see a secret the UI said it had.
     const [row] = await db
-      .select({ externalId: sessionSandboxes.externalId, config: sessionSandboxes.config })
+      .select({
+        externalId: sessionSandboxes.externalId,
+        config: sessionSandboxes.config,
+        status: sessionSandboxes.status,
+      })
       .from(sessionSandboxes)
-      .where(
-        and(eq(sessionSandboxes.sessionId, input.sessionId), eq(sessionSandboxes.status, 'active')),
-      )
+      .where(eq(sessionSandboxes.sessionId, input.sessionId))
       .limit(1);
-    if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+    if (!row?.externalId) return { applied: false, reason: 'no sandbox for session' };
+    if (row.status && row.status !== 'active')
+      return nonActiveSandboxSkip('agent-config push', input, row.status);
 
     const config = (row.config || {}) as Record<string, unknown>;
     const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;
@@ -1199,16 +1239,14 @@ export async function pushSessionModelToSandbox(input: {
       .select({
         externalId: sessionSandboxes.externalId,
         config: sessionSandboxes.config,
+        status: sessionSandboxes.status,
       })
       .from(sessionSandboxes)
-      .where(
-        and(
-          eq(sessionSandboxes.sessionId, input.sessionId),
-          eq(sessionSandboxes.status, 'active'),
-        ),
-      )
+      .where(eq(sessionSandboxes.sessionId, input.sessionId))
       .limit(1);
     if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+    if (row.status && row.status !== 'active')
+      return nonActiveSandboxSkip('model push', input, row.status);
 
     const config = (row.config || {}) as Record<string, unknown>;
     const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;
@@ -1285,16 +1323,14 @@ export async function pushSessionScopeToSandbox(input: {
         externalId: sessionSandboxes.externalId,
         provider: sessionSandboxes.provider,
         config: sessionSandboxes.config,
+        status: sessionSandboxes.status,
       })
       .from(sessionSandboxes)
-      .where(
-        and(
-          eq(sessionSandboxes.sessionId, input.sessionId),
-          eq(sessionSandboxes.status, 'active'),
-        ),
-      )
+      .where(eq(sessionSandboxes.sessionId, input.sessionId))
       .limit(1);
     if (!row?.externalId) return { applied: false, reason: 'no active sandbox' };
+    if (row.status && row.status !== 'active')
+      return nonActiveSandboxSkip('scope push', input, row.status);
 
     const config = (row.config || {}) as Record<string, unknown>;
     const serviceKey = typeof config.serviceKey === 'string' ? config.serviceKey : null;

--- a/apps/api/src/projects/lib/scope-push.test.ts
+++ b/apps/api/src/projects/lib/scope-push.test.ts
@@ -41,7 +41,14 @@ let SESSION_ROW: {
   manifestPath: string;
   accountId: string;
 };
-let activeSandbox: { externalId: string; provider: string; config: Record<string, unknown> } | null;
+let activeSandbox: {
+  externalId: string;
+  provider: string;
+  config: Record<string, unknown>;
+  // The push path selects `status` so a non-active row can be NAMED rather than
+  // silently swallowed; the double has to be able to carry it.
+  status?: string;
+} | null;
 let gatewayEnabled = false;
 
 function freshSessionRow(): typeof SESSION_ROW {
@@ -223,5 +230,27 @@ describe('pushSessionScopeToSandbox', () => {
     expect(result.applied).toBe(false);
     expect(result.reason).toContain('daemon unreachable');
     // beforeEach restores the recording fetch for any subsequent test.
+  });
+});
+
+// Prod 2026-08-27, session b3848cf5: `session_sandboxes.status` was 'stopped'
+// while the Platinum VM was genuinely running and serving prompts. Every push
+// filtered the lookup on `status = 'active'` and returned a bare
+// 'no active sandbox' that no caller logged, so the session silently received
+// no secret, model or scope push for HOURS. The only visible symptom was an
+// agent that could not read a secret the UI said it had.
+describe('a live box behind a non-active row is named, not swallowed', () => {
+  test('the skip reason carries the actual status', async () => {
+    activeSandbox = { externalId: 'ext-1', provider: 'platinum', config: { serviceKey: 'k' }, status: 'stopped' };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(false);
+    expect(result.reason).toBe("sandbox row is 'stopped', not active");
+    expect(posted).toEqual([]);
+  });
+
+  test('an active row still pushes', async () => {
+    activeSandbox = { externalId: 'ext-1', provider: 'platinum', config: { serviceKey: 'k' }, status: 'active' };
+    const result = await pushSessionScopeToSandbox(INPUT);
+    expect(result.applied).toBe(true);
   });
 });

--- a/apps/api/src/projects/routes/r3.ts
+++ b/apps/api/src/projects/routes/r3.ts
@@ -652,11 +652,25 @@ projectsApp.openapi(
   ) {
     return c.json({ error: 'Agent sessions cannot change secret delivery policy' }, 403);
   }
-  const defaultToGateway =
-    requestedStrategy === undefined &&
-    requestedConsumer === undefined &&
-    isGatewayManagedEnv(name);
-  const explicitStrategy = (requestedStrategy ?? (defaultToGateway ? 'broker' : undefined)) as
+  // The server does NOT infer delivery from the secret's NAME.
+  //
+  // It used to: a create with no `strategy`/`consumer` whose name matched any
+  // provider credential env in the models.dev catalogue was stamped
+  // `broker`/`llm_gateway`. That catalogue has 204 providers and one of them,
+  // `github-copilot`, claims `GITHUB_TOKEN` — so an ordinary GitHub PAT was
+  // classified as a model credential and withheld from the sandbox. The user
+  // set a secret, the agent could not read it, and nothing said why (prod
+  // 2026-08-27). Any name a provider happens to claim had the same problem;
+  // carving out one name would only move it.
+  //
+  // The callers that actually mean "model credential" all say so explicitly —
+  // web provider-connect, the custom-provider form, `kortix providers set`, and
+  // the Codex OAuth flow, which writes its row directly with `strategyLocked`.
+  // Every other caller means "a secret for my sandbox", which is now what they
+  // get. The web secrets manager already sent `runtime`/`sandbox` outright, so
+  // this also ends a split-brain where the same name landed differently
+  // depending on which surface created it.
+  const explicitStrategy = requestedStrategy as
     | 'runtime'
     | 'broker'
     | 'egress'
@@ -664,12 +678,10 @@ projectsApp.openapi(
     | undefined;
   const explicitConsumer =
     requestedConsumer === undefined
-      ? defaultToGateway
-        ? 'llm_gateway'
-        : requestedStrategy === 'runtime'
-          ? 'sandbox'
-          : requestedStrategy === 'egress'
-            ? 'network'
+      ? requestedStrategy === 'runtime'
+        ? 'sandbox'
+        : requestedStrategy === 'egress'
+          ? 'network'
           : requestedStrategy === 'denied'
             ? null
             : undefined

--- a/apps/api/src/projects/secret-delivery-withholding.test.ts
+++ b/apps/api/src/projects/secret-delivery-withholding.test.ts
@@ -145,9 +145,14 @@ describe('only GRANTED rows may vote on a shared key (Strix HIGH)', () => {
 
 describe('materializeSecretDelivery', () => {
   test('withholds model credentials even when a legacy row says runtime', async () => {
+    // A LEGACY row: written before `consumer` existed, so it carries no stamp.
+    // The fixture used to say `consumer: 'sandbox'`, which today is what the
+    // secrets UI stamps on a HUMAN's own secret — conflating "legacy" with
+    // "explicitly a sandbox secret". That conflation is what withheld a
+    // project's own GITHUB_TOKEN (models.dev maps `github-copilot` to that
+    // name). An unstamped row still strips; see `gatewayStripsRow`.
     const provider = row('openai', 'OPENAI_API_KEY', {
       strategy: 'runtime',
-      consumer: 'sandbox',
     });
     const env = envFor([provider]);
 

--- a/apps/api/src/projects/secret-gateway-name-collision.test.ts
+++ b/apps/api/src/projects/secret-gateway-name-collision.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  gatewayStripsRow,
+  materializeSecretDelivery,
+  type ResolvedProjectSecret,
+} from './secrets';
+
+// Regression: a project's own `GITHUB_TOKEN` never reached its sandbox.
+//
+// models.dev ships a `github-copilot` provider whose credential env is
+// ["GITHUB_TOKEN"], so `providerCredentialEnv()` contains that name and
+// `isGatewayManagedEnv('GITHUB_TOKEN')` is true. `materializeSecretDelivery`
+// then deleted the user's secret from the env by NAME COLLISION alone, while
+// `buildSecretCapabilities` — built from the pre-delivery `selected` list —
+// kept advertising it. The box was told it held a secret it did not hold.
+//
+// Observed in prod 2026-08-27: the agent's capability doc listed GITHUB_TOKEN,
+// `KORTIX_PROJECT_SECRET_NAMES` did not, and no process in the sandbox carried
+// the variable.
+
+const row = (
+  identifier: string,
+  key: string,
+  extra: Partial<ResolvedProjectSecret> = {},
+): ResolvedProjectSecret => ({
+  secretId: `secret-${identifier}`,
+  identifier,
+  key,
+  value: `value-of-${identifier}`,
+  ...extra,
+});
+
+const envFor = (rows: ResolvedProjectSecret[]): Record<string, string> =>
+  Object.fromEntries(rows.map((r) => [r.key, r.value]));
+
+const materialize = (rows: ResolvedProjectSecret[], env: Record<string, string>, gateway: boolean) =>
+  materializeSecretDelivery(rows, env, {
+    sessionId: 'sess-1',
+    grantEnv: 'all',
+    llmGatewayEnabled: gateway,
+    mintHandleFor: async () => 'handle-should-not-be-minted',
+  });
+
+describe('gatewayStripsRow', () => {
+  // The regression. `GITHUB_TOKEN` is a gateway-managed NAME only because
+  // models.dev's `github-copilot` provider declares it; a project's own secret
+  // carrying that name must still reach the box.
+  test("a project's own sandbox secret survives a gateway-managed NAME", () => {
+    expect(
+      gatewayStripsRow({ llmGatewayEnabled: true, nameIsGatewayManaged: true, consumer: 'sandbox' }),
+    ).toBe(false);
+  });
+
+  test('a real gateway credential is still stripped', () => {
+    expect(
+      gatewayStripsRow({
+        llmGatewayEnabled: true,
+        nameIsGatewayManaged: true,
+        consumer: 'llm_gateway',
+      }),
+    ).toBe(true);
+  });
+
+  test('a legacy row with no consumer stamp keeps the old behavior — no widening', () => {
+    expect(
+      gatewayStripsRow({ llmGatewayEnabled: true, nameIsGatewayManaged: true, consumer: null }),
+    ).toBe(true);
+    expect(
+      gatewayStripsRow({
+        llmGatewayEnabled: true,
+        nameIsGatewayManaged: true,
+        consumer: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  test('gateway off strips nothing by name', () => {
+    expect(
+      gatewayStripsRow({
+        llmGatewayEnabled: false,
+        nameIsGatewayManaged: true,
+        consumer: 'llm_gateway',
+      }),
+    ).toBe(false);
+  });
+
+  test('an ordinary name is never stripped', () => {
+    expect(
+      gatewayStripsRow({ llmGatewayEnabled: true, nameIsGatewayManaged: false, consumer: null }),
+    ).toBe(false);
+  });
+});
+
+describe('capabilities never advertise a value the env does not hold', () => {
+  test('materializeSecretDelivery returns only the rows it actually delivered', async () => {
+    const kept = row('ui-auth', 'UI_AUTH_STATE_JSON', { strategy: 'runtime', consumer: 'sandbox' });
+    // `denied` forces the withhold path, which deletes the key from env.
+    const dropped = row('nope', 'NOPE_TOKEN', { strategy: 'denied', consumer: 'sandbox' });
+    const env = envFor([kept, dropped]);
+
+    const delivered = await materialize([kept, dropped], env, true);
+
+    expect(Object.keys(env).sort()).toEqual(['UI_AUTH_STATE_JSON']);
+    // The invariant `secretNamesForSandbox` documents: a name is advertised IFF
+    // a value is emitted. Building capabilities from the input list broke it.
+    expect(delivered.map((r) => r.key)).toEqual(['UI_AUTH_STATE_JSON']);
+  });
+
+  test('a sandbox-consumer GITHUB_TOKEN keeps its plaintext and is reported delivered', async () => {
+    const github = row('github', 'GITHUB_TOKEN', { strategy: 'runtime', consumer: 'sandbox' });
+    const env = envFor([github]);
+
+    const delivered = await materialize([github], env, true);
+
+    expect(env.GITHUB_TOKEN).toBe('value-of-github');
+    expect(delivered.map((r) => r.key)).toEqual(['GITHUB_TOKEN']);
+  });
+});

--- a/apps/api/src/projects/secrets.ts
+++ b/apps/api/src/projects/secrets.ts
@@ -595,6 +595,43 @@ export type SecretHandleMinter = (row: ResolvedProjectSecret) => Promise<string>
  * `rows` contains one deterministic winner per env key. The function mutates
  * the caller-owned map. It never adds a key that the grant resolver excluded.
  */
+/**
+ * Does the LLM-gateway strip apply to this row?
+ *
+ * The strip exists so a PLATFORM-managed model credential never reaches
+ * opencode while the gateway owns that provider. It used to key off the NAME
+ * alone, via `isGatewayManagedEnv`, which answers from the models.dev catalog —
+ * a 204-provider registry that maps `github-copilot` to `GITHUB_TOKEN`. So a
+ * project's own `GITHUB_TOKEN`, stored by the secrets UI as
+ * `consumer: 'sandbox'`, was deleted from every sandbox env by name collision
+ * with a provider nobody in the project had connected. Verified in prod
+ * 2026-08-27: the capability catalog advertised it, no process in the box had
+ * it, and the daemon logged `withheld: 0` because it was dropped server-side.
+ *
+ * The row already carries the answer. The platform stamps `consumer` when it
+ * stores a model credential (`routes/r3.ts` defaultToGateway, the
+ * provider-connect UI) and `sandbox` when a human adds an ordinary secret. Trust
+ * that stamp:
+ *
+ *   - `llm_gateway` (or any non-sandbox consumer) → stripped, as before.
+ *   - `null`/`undefined` → stripped. A row written before the column existed
+ *     carries no intent to trust, so legacy behavior is preserved exactly.
+ *   - `sandbox` → delivered. The user asked for this variable in their own box.
+ *
+ * What this deliberately does NOT weaken: managed credentials and anything the
+ * provider-connect flow stored keep their stamp and stay withheld, and
+ * `CODEX_AUTH_JSON`/`OPENCODE_AUTH_JSON` are unconditionally gateway-managed.
+ *
+ * Pure so the rule is testable without a model catalog.
+ */
+export function gatewayStripsRow(input: {
+  llmGatewayEnabled: boolean;
+  nameIsGatewayManaged: boolean;
+  consumer: SecretConsumer | null | undefined;
+}): boolean {
+  return input.llmGatewayEnabled && input.nameIsGatewayManaged && input.consumer !== 'sandbox';
+}
+
 export async function materializeSecretDelivery(
   rows: ResolvedProjectSecret[],
   env: Record<string, string>,
@@ -616,10 +653,26 @@ export async function materializeSecretDelivery(
      */
     llmGatewayEnabled: boolean;
   },
-): Promise<void> {
+): Promise<ResolvedProjectSecret[]> {
+  const delivered: ResolvedProjectSecret[] = [];
   for (const row of rows) {
     if (!(row.key in env)) continue;
-    if (input.llmGatewayEnabled && isGatewayManagedEnv(row.key)) {
+    // A gateway-managed NAME is not the same thing as a gateway-managed ROW.
+    // `isGatewayManagedEnv` asks the models.dev catalog, which today maps the
+    // `github-copilot` provider to `GITHUB_TOKEN` — so a project's own
+    // `GITHUB_TOKEN` (stored `consumer: 'sandbox'`, the shape the secrets UI
+    // creates) was silently deleted from every sandbox env while the capability
+    // catalog kept advertising it. The platform stamps `consumer` when it
+    // stores a model credential (`routes/r3.ts` defaultToGateway); trust that
+    // stamp, not a third-party name table. `consumer == null` is a legacy row
+    // with no stamp to trust, so it keeps today's strip.
+    if (
+      gatewayStripsRow({
+        llmGatewayEnabled: input.llmGatewayEnabled,
+        nameIsGatewayManaged: isGatewayManagedEnv(row.key),
+        consumer: row.consumer,
+      })
+    ) {
       delete env[row.key];
       continue;
     }
@@ -628,6 +681,7 @@ export async function materializeSecretDelivery(
       // platform defaulted provider keys there (routes/r3.ts `defaultToGateway`,
       // the provider-connect UI). With no gateway in the path it delivers like a
       // `runtime` row — plaintext, so toggling the flag never strands the key.
+      delivered.push(row);
       continue;
     }
     const delivery = resolveSecretDelivery({
@@ -644,7 +698,10 @@ export async function materializeSecretDelivery(
         : row.egressPolicy?.backend === 'kortix_fetch'
           ? 'http_broker'
           : (row.egressPolicy?.backend ?? null));
-    if (delivery.emit === 'plaintext' && consumer === 'sandbox') continue;
+    if (delivery.emit === 'plaintext' && consumer === 'sandbox') {
+      delivered.push(row);
+      continue;
+    }
     if (
       delivery.emit === 'handle' &&
       delivery.strategy === 'broker' &&
@@ -652,6 +709,7 @@ export async function materializeSecretDelivery(
       row.egressPolicy?.backend === 'kortix_fetch'
     ) {
       env[row.key] = await input.mintHandleFor(row);
+      delivered.push(row);
       continue;
     }
     // Egress-enforced: the KEY holds the HANDLE, never the value.
@@ -680,10 +738,12 @@ export async function materializeSecretDelivery(
       row.egressPolicy
     ) {
       env[row.key] = await input.mintHandleFor(row);
+      delivered.push(row);
       continue;
     }
     delete env[row.key];
   }
+  return delivered;
 }
 
 async function mintSessionSecretHandle(
@@ -828,7 +888,7 @@ export async function listProjectSecretsSnapshotForUser(
   // model credentials from the same decision — a caller cannot pass a stale
   // mode and desynchronise the box from the project's flag.
   const llmGatewayEnabled = await projectLlmGatewayEnabledById(projectId);
-  await materializeSecretDelivery(selected, env, {
+  const delivered = await materializeSecretDelivery(selected, env, {
     sessionId: sessionId ?? null,
     grantEnv,
     llmGatewayEnabled,
@@ -839,7 +899,12 @@ export async function listProjectSecretsSnapshotForUser(
   });
 
   const names = Object.keys(env).sort();
-  const capabilities = buildSecretCapabilities(selected, {
+  // From `delivered`, never `selected`: a row whose value materialization
+  // dropped must not be advertised. `secretNamesForSandbox` states the
+  // invariant — a name appears IFF a value is emitted for it — and building
+  // capabilities from the pre-delivery set is exactly how the box came to be
+  // told it held a `GITHUB_TOKEN` that was never in its env.
+  const capabilities = buildSecretCapabilities(delivered, {
     grantEnv,
     sessionId: sessionId ?? null,
   });

--- a/apps/cli/src/commands/providers.ts
+++ b/apps/cli/src/commands/providers.ts
@@ -386,7 +386,18 @@ async function providersSet(
 
   try {
     for (const [name, value] of Object.entries(values)) {
-      await ctx.client.post<ProjectSecret>(`/projects/${ctx.projectId}/secrets`, { name, value });
+      // `kortix providers set` is the BYOK model-credential command — it KNOWS
+      // this value is a provider key, so it says so. It used to omit the pair
+      // and lean on the server inferring "model credential" from the secret's
+      // NAME, which is a guess the server has no business making: models.dev
+      // claims `GITHUB_TOKEN` for `github-copilot`, so an ordinary GitHub PAT
+      // was classified as a Copilot key and withheld from the sandbox.
+      await ctx.client.post<ProjectSecret>(`/projects/${ctx.projectId}/secrets`, {
+        name,
+        value,
+        strategy: 'broker',
+        consumer: 'llm_gateway',
+      });
     }
   } catch (err) {
     return surfaceApiError(err);

--- a/apps/sandbox/entrypoint.sh
+++ b/apps/sandbox/entrypoint.sh
@@ -154,6 +154,12 @@ MAX_EARLY_EXITS=2
 
 early_exits=0
 
+# A SIGKILL death (128+9) is the guest kernel's OOM-killer, never the daemon
+# choosing to stop. It is bounded so a daemon that is genuinely unable to start
+# cannot hot-loop; a run that lasted HEALTHY_AFTER_S earns a fresh budget.
+MAX_SIGKILL_RELAUNCH=5
+sigkill_exits=0
+
 # Move a verified staged binary into place. Any failure leaves the live binary
 # untouched — the caller simply relaunches what is already there.
 promote_staged_agent() {
@@ -272,6 +278,33 @@ while :; do
       continue
     fi
     [ "${early_exits}" -lt "${MAX_EARLY_EXITS}" ] && continue
+  fi
+
+  # A SIGKILL is not the daemon exiting on its own terms — it is the guest
+  # kernel's OOM-killer. Exit 137 after HOURS of healthy service used to fall
+  # through to `exit` below, and the comment above assumed that was safe
+  # because "this is PID 1 and the provider decides what a stopped sandbox
+  # means". That assumption is FALSE on Platinum, where PID 1 is
+  # `/bin/sh /sbin/pt-init`: this script exiting does not stop the VM. It left
+  # a corpse — DB `status='active'`, provider `state='running'`, port 8000
+  # closed forever — and nothing reconciled it, so the control plane kept
+  # routing users to a box that could never answer.
+  #
+  # Observed on 2 of 21 active prod sandboxes (2026-08-28):
+  #   `148 Killed "${agent_bin}" "$@"` then
+  #   `[entrypoint] agent exited 137 after 4472s; exiting`
+  # Correlation was exact across the fleet: oom_kill ⟺ exit 137 ⟺ port 8000 shut.
+  #
+  # Only SIGKILL relaunches. SIGTERM (143) and SIGINT (130) are deliberate stops
+  # and must still exit, or a provider-initiated shutdown would fight this loop.
+  if [ "${status}" -eq 137 ]; then
+    [ "${ran}" -ge "${HEALTHY_AFTER_S}" ] && sigkill_exits=0
+    sigkill_exits=$(( sigkill_exits + 1 ))
+    if [ "${sigkill_exits}" -le "${MAX_SIGKILL_RELAUNCH}" ]; then
+      echo "[entrypoint] agent SIGKILLed after ${ran}s (likely OOM); relaunching ${sigkill_exits}/${MAX_SIGKILL_RELAUNCH}" >&2
+      continue
+    fi
+    echo "[entrypoint] agent SIGKILLed ${sigkill_exits} times without a healthy run; giving up" >&2
   fi
 
   echo "[entrypoint] agent exited ${status} after ${ran}s; exiting" >&2

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -298,10 +298,18 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     const connectWebSocket = async () => {
       if (disposedRef.current) return;
       // A user-initiated attach (panel open, "Reconnect now") may WAKE a parked
-      // sandbox; an automatic backoff retry may not. Consume the flag here so a
-      // single intent wakes the box exactly once — see getPtyWebSocketUrl.
+      // sandbox — see getPtyWebSocketUrl.
+      //
+      // The flag is consumed on a SUCCESSFUL open (ws.onopen), not here. Clearing
+      // it before dialing meant the first attempt asked for a wake, failed while
+      // the box was still waking, and every backoff retry then dialed WITHOUT
+      // `wake=1` — so the API answered `sandbox not ready` (503), refused the
+      // upgrade, and the browser saw a bare `code 1006` with no reason. That is
+      // the "Waking the sandbox…" -> "Reconnecting in 1s/2s/4s (code 1006)" loop
+      // users hit, and with a 15-minute autostop against 23,852 stopped boxes it
+      // is the common case, not an edge case. Waking an already-awake box is a
+      // no-op, so keeping the flag armed across retries costs nothing.
       const wake = wakeOnNextConnectRef.current;
-      wakeOnNextConnectRef.current = false;
 
       // --- WebSocket connect ---
       globalPtyConnectionId++;
@@ -364,6 +372,9 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
           ws.close();
           return;
         }
+        // Consumed only now: the attach succeeded, so the box is awake and the
+        // next dial has nothing left to wake.
+        wakeOnNextConnectRef.current = false;
         if (connectTimeoutRef.current) {
           clearTimeout(connectTimeoutRef.current);
           connectTimeoutRef.current = null;

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.test.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.test.ts
@@ -131,6 +131,36 @@ describe('connected join', () => {
   test('a nameless connector contributes no empty key', () => {
     expect(connectedCatalogKeys([conn({ slug: 'x', name: '   ' })]).has('')).toBe(false);
   });
+
+  // Prod 2026-08-28: all 6 GitHub connections had a null `connected_account_id`
+  // — the OAuth handshake never completed — and zero GitHub tool calls had ever
+  // executed. The catalogue still showed GitHub as connected, because a
+  // connector ROW existing was treated as proof of a working connection. The
+  // user saw a checkmark while every agent call was refused `needs_auth`.
+  test('a connector that never completed auth is NOT connected', () => {
+    const keys = connectedCatalogKeys([
+      conn({ slug: 'github', name: 'GitHub', provider: 'composio', status: 'needs_auth' }),
+    ]);
+    expect(keys.has('github')).toBe(false);
+    expect(keys.has('provider:composio')).toBe(false);
+  });
+
+  test('an errored connector still counts as connected — it has a credential', () => {
+    const keys = connectedCatalogKeys([
+      conn({ slug: 'github', name: 'GitHub', provider: 'composio', status: 'error' }),
+    ]);
+    expect(keys.has('github')).toBe(true);
+  });
+
+  test('one unauthorized connector does not hide a working sibling', () => {
+    const keys = connectedCatalogKeys([
+      conn({ slug: 'github', name: 'GitHub', provider: 'composio', status: 'needs_auth' }),
+      conn({ slug: 'gmail', name: 'Gmail', provider: 'composio', status: 'active' }),
+    ]);
+    expect(keys.has('github')).toBe(false);
+    expect(keys.has('gmail')).toBe(true);
+    expect(keys.has('provider:composio')).toBe(true);
+  });
 });
 
 describe('catalogSections', () => {

--- a/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
+++ b/apps/web/src/features/workspace/capabilities/connectors/catalog/catalog-entry.ts
@@ -124,6 +124,19 @@ export function foldKey(value: string): string {
 export function connectedCatalogKeys(connectors: readonly AdminConnector[]): ReadonlySet<string> {
   const keys = new Set<string>();
   for (const connector of connectors) {
+    // A connector ROW is not a working connection. `needs_auth` means the
+    // OAuth handshake never completed — no `connected_account_id`, so every
+    // tool call is refused by the gateway. Showing it as connected is the
+    // worst possible lie: the user sees a checkmark, the agent gets `needs_auth`
+    // on every call, and nothing in the product explains the contradiction.
+    // Prod 2026-08-28: all 6 GitHub connections had a null connected account
+    // and zero GitHub tool calls had ever executed, while the catalogue showed
+    // GitHub as connected.
+    //
+    // `error` stays connected-looking on purpose: the credential exists and the
+    // card's own error affordance is what surfaces the problem. Only the
+    // never-authorized case is a false checkmark.
+    if (connector.status === 'needs_auth') continue;
     keys.add(`provider:${connector.provider}`);
     keys.add(foldKey(connector.slug));
     if (connector.name?.trim()) keys.add(foldKey(connector.name));

--- a/apps/web/src/features/workspace/customize/sections/connector-connection-form.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-connection-form.test.ts
@@ -165,6 +165,23 @@ describe('connector setup status', () => {
     ).toBe('user_managed');
   });
 
+  // Prod 2026-08-28: 6 of 6 GitHub connections had a null `connected_account_id`
+  // — authorization was never completed — and no GitHub tool call had ever run,
+  // yet the connector grid showed a checkmark. `needs_auth` used to fall
+  // through to the secretSet branch and read as `connected`.
+  test('an authorization that never completed is setup that never finished', () => {
+    expect(connectorSetupStatus({ ...connector, status: 'needs_auth' })).toBe('needs_setup');
+    // Even with a credential present it is NOT connected — the credential is
+    // not the thing that is missing.
+    expect(
+      connectorSetupStatus({ ...connector, status: 'needs_auth', secretSet: true }),
+    ).toBe('needs_setup');
+  });
+
+  test('error still outranks needs_auth', () => {
+    expect(connectorSetupStatus({ ...connector, status: 'error' })).toBe('error');
+  });
+
   test('keeps error and no-auth states independent of credential ownership', () => {
     expect(connectorSetupStatus({ ...connector, status: 'error' })).toBe('error');
     expect(connectorSetupStatus({ ...connector, authSecret: null })).toBe('no_auth');

--- a/apps/web/src/features/workspace/customize/sections/connector-connection-form.ts
+++ b/apps/web/src/features/workspace/customize/sections/connector-connection-form.ts
@@ -87,6 +87,14 @@ export function connectorSetupStatus(
   connector: Pick<AdminConnector, 'authorizationStrategy' | 'authSecret' | 'secretSet' | 'status'>,
 ): ConnectorSetupStatus {
   if (connector.status === 'error') return 'error';
+  // An authorization that never completed is setup that never finished. This
+  // used to fall through to the `authSecret`/`secretSet` branches, so an
+  // unauthorized connector still rendered `connected` — a checkmark on the
+  // connector grid (`connectors-page.tsx`), a green dot, and a place in the
+  // "ready" partition, while the gateway refused every tool call against it
+  // with `needs_auth`. Prod 2026-08-28: 6 of 6 GitHub connections had no
+  // connected account and no GitHub tool call had ever run.
+  if (connector.status === 'needs_auth') return 'needs_setup';
   if (!connector.authSecret) return 'no_auth';
   if (connector.authorizationStrategy === 'user') return 'user_managed';
   return connector.secretSet ? 'connected' : 'needs_setup';


### PR DESCRIPTION
## Why a targeted PR and not a `main` promote

`main` is **185 commits** ahead of `staging`, including `delete the per-project warm image system`, an SDK client revert, and a large preview-infra rework. Shipping all of that to production to deliver two fixes is not a trade worth making, so this is the selective candidate the release process allows.

Two cherry-picks, both clean, both already merged to `main` and verified end-to-end on deployed dev.

## What ships

**#7016** — six prod faults:
1. **Slack channel takeover.** `ensureProjectChannelBinding` ran on every event, before `isOwnBotEvent` and before classification, and upserted `projectId`. Any project whose Slack app merely observed a channel took it, and the previous owner went permanently dark — no hourglass, no reply, no session, nothing logged. Prod: `kortix-incident-reporter` held `C0AASKRLRBR`, where `Kortix Company` ran 71 sessions through 2026-08-14 and then went silent for 14 days. Now claim-if-unowned; the picker and `/kortix use` keep their own re-assign paths.
2. **Gateway strip trusts the `consumer` stamp** instead of a models.dev name collision.
3. **Capabilities can no longer advertise a value the env lacks** — `secretNamesForSandbox` documents the invariant; `materializeSecretDelivery` now returns what it actually delivered.
4. **OOM'd daemon relaunches** instead of leaving a zombie box. (Inert until the sandbox image is rebuilt — see below.)
5. **Terminal wake flag** stays armed until the socket opens, ending the `code 1006` retry loop.
6. **Connectors report `needs_auth`** instead of `active` when the OAuth handshake never completed.

**#7020** — the server stops inferring secret delivery from a secret's **name**. models.dev has 204 providers and `github-copilot` claims `GITHUB_TOKEN`, so an ordinary GitHub PAT was classified as a model credential and withheld from the sandbox. The inference is deleted rather than carved out — the name is arbitrary and any future collision would reproduce it. `kortix providers set` now declares `broker`/`llm_gateway` explicitly, which was the only caller relying on the guess.

## Verified on deployed dev (`3e7bf3a3`), not just in tests

| check | result |
|---|---|
| create `GITHUB_TOKEN`, start session | present in the live sandbox's opencode env, value matches |
| `ANTHROPIC_API_KEY` explicit gateway | correctly **withheld** from the sandbox |
| signed Slack event, owned channel | binding **held** |
| signed Slack event, unowned channel | binding **claimed** (control — proves the write path runs) |
| scope push, row `stopped` | `push_failed: true, reason: "sandbox row is 'stopped', not active"` |
| scope push, row `active` | `applied_live: true` |
| connector without connected account | API reports `needs_auth` while the DB column says `active` |

All dev artifacts removed afterwards: `secrets=0 connectors=0 e2e_bindings=0`.

## Tests on this branch

92 pass, 0 fail across the six affected suites, each run in isolation:

```
secret-gateway-name-collision      7 pass
secret-delivery-withholding       28 pass
channel-binding-ownership          2 pass
sandbox-supervisor-oom             3 pass
scope-push                         9 pass
unit-project-secret-strategy-route 43 pass
```

`bunx tsc --noEmit` clean in `apps/api`.

Note: running `scope-push` and `unit-project-secret-strategy-route` in the **same** bun process cross-contaminates — the latter calls `mock.module('../shared/db')` globally. I verified this is pre-existing by reproducing it on clean `staging` with none of these changes (7 pass / 1 fail there too).

## Known limitation

Fix 4 (OOM relaunch) is **inert until the sandbox image is rebuilt**. `deploy-dev.yml:1012` documents that `kortix/kortix-sandbox` is not built or pushed by any pipeline; I confirmed a running dev box still carries the old `kortix-entrypoint` with the bare `exit "${status}"` fall-through. The code is correct and tested, but it will not reach a sandbox until that build exists. Wiring it up is a separate effort.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790527246&installation_model_id=434224&pr_number=7032&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7032&signature=66872ad7cda333238f6553a48953033a50c2167c0d6897dcedc4a4272595cce0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->