### PR TITLE
fix(preview): do not point a stable hostname at a stack that is down

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -447,7 +447,9 @@ jobs:
         # Deliberately NOT gated on the suite passing. A failing flow still
         # leaves a working environment, and leaving the hostname pointed at the
         # previous sandbox — or at nothing — would be worse than a red flow.
-        # Only a deploy that produced no sandbox at all has nothing to point at.
+        # It IS gated on the sandbox serving /v1/health: a suite that fails
+        # still leaves somewhere to debug, a stack that never came up does not,
+        # and re-pointing at one is how the public name goes dark. See below.
         if: always() && needs.authorize.outputs.public_worker != ''
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
@@ -460,6 +462,31 @@ jobs:
             # it. A second error here would only add noise.
             echo "::notice::no sandbox origin in the deploy result; nothing to re-point"
             exit 0
+          fi
+          # A sandbox EXISTING is not the same as its stack SERVING, and this
+          # step is deliberately not gated on the suite — so ask the origin
+          # whether it can answer before sending the public name at it.
+          #
+          # On 2026-08-29 `kortix-migrate` exited 1, the stack never bound 8080,
+          # and the name was re-pointed at that box anyway: pi.kortix.com served
+          # Cloudflare's 502 until someone noticed. A failing SUITE still
+          # deserves a live environment to debug in; a failing STACK has nothing
+          # to point at, and the previous sandbox is still serving.
+          #
+          # Left unset on a first-ever deploy, the Worker answers its own 503
+          # naming the missing target — which is the true statement.
+          ok=
+          for _ in $(seq 1 12); do
+            if curl -fsS --max-time 10 "${target%/}/v1/health" 2>/dev/null \
+              | jq -e '.status == "ok"' >/dev/null 2>&1; then
+              ok=1
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::${target} is not serving /v1/health — leaving ${{ needs.authorize.outputs.public_origin }} on its previous target rather than pointing it at a dead stack"
+            exit 1
           fi
           dir="infra/cloudflare/workers/${WORKER}"
           [ -f "${dir}/wrangler.toml" ] || { echo "::error::${dir}/wrangler.toml does not exist"; exit 1; }

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -140,8 +140,8 @@ for stack_attempt in 1 2; do
   # \`compose up -d\` prints container STATE and never container OUTPUT, so a
   # one-shot service that exits non-zero produced exactly one line —
   # \`service "kortix-migrate" didn't complete successfully: exit 1\` — and the
-  # reason for that 1 was nowhere. pi.kortix.com served a 502 for hours behind
-  # a log that could not say why (2026-08-29). \`kortix-migrate\` is the one
+  # reason for that 1 was nowhere. A branch environment's public name served a
+  # 502 for hours behind a log that could not say why (2026-08-29). \`kortix-migrate\` is the one
   # service that can fail this way; the health-gated ones report through
   # \`--wait\`.
   printf '::group::kortix-migrate output (attempt %s)\n' "$stack_attempt"

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -134,7 +134,32 @@ for stack_attempt in 1 2; do
     break
   fi
   test "$stack_attempt" -lt 2
-  printf 'stack readiness failed on attempt %s; retrying once after container restarts\n' "$stack_attempt"
+
+  # WHY THE STACK FAILED, in the log, before anything retries.
+  #
+  # \`compose up -d\` prints container STATE and never container OUTPUT, so a
+  # one-shot service that exits non-zero produced exactly one line —
+  # \`service "kortix-migrate" didn't complete successfully: exit 1\` — and the
+  # reason for that 1 was nowhere. pi.kortix.com served a 502 for hours behind
+  # a log that could not say why (2026-08-29). \`kortix-migrate\` is the one
+  # service that can fail this way; the health-gated ones report through
+  # \`--wait\`.
+  printf '::group::kortix-migrate output (attempt %s)\n' "$stack_attempt"
+  ${compose} logs --no-color --tail 200 kortix-migrate 2>&1 || true
+  printf '::endgroup::\n'
+  ${compose} ps --all --format '{{.Service}}\t{{.State}}\t{{.Status}}' 2>&1 || true
+
+  # A branch environment REUSES its sandbox, so a container left behind by a
+  # previous failed deploy is still there — and Docker refuses to recreate a
+  # name it already holds:
+  #   Conflict. The container name "/…_kortix-pr-NNNN-kortix-migrate-1" is
+  #   already in use by container "c18af76fa9df…"
+  # That made every failure poison the next deploy. Clear the wreckage before
+  # retrying rather than retrying into it. Deliberately WITHOUT \`-v\`: the
+  # named volumes carry this environment's Postgres, and the whole point of a
+  # branch environment is that its data outlives a redeploy.
+  printf 'stack readiness failed on attempt %s; clearing containers and retrying\n' "$stack_attempt"
+  ${compose} down --remove-orphans --timeout 30 2>&1 || true
   sleep 10
 done
 

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -195,6 +195,33 @@ describe('web ECS migration', () => {
    * belongs to. Two switches turn it off: removing the `preview` label, and
    * deleting the branch. Nothing else may.
    */
+  /**
+   * A sandbox EXISTING is not its stack SERVING.
+   *
+   * 2026-08-29: `kortix-migrate` exited 1, so nothing bound port 8080 — and the
+   * stable hostname was re-pointed at that box anyway, because the step only
+   * checked that a sandbox origin came back. pi.kortix.com served Cloudflare's
+   * 502 until someone noticed. A failing SUITE still deserves a live
+   * environment to debug in; a failing STACK has nothing to point at, and the
+   * previous sandbox is still serving.
+   */
+  it('only points the stable hostname at a sandbox that answers /v1/health', () => {
+    const workflow = read('.github/workflows/deploy-preview.yml');
+    const step = workflow.slice(workflow.indexOf('Point the stable hostname at this sandbox'));
+    const body = step.slice(0, step.indexOf('\n      - name:'));
+
+    // The probe goes at the sandbox's OWN origin, which is what the public name
+    // is about to be pointed at — not at the public name, which still answers
+    // from the previous sandbox and would pass while this one is dead.
+    expect(body).toContain('"${target%/}/v1/health"');
+    expect(body).toContain(`jq -e '.status == "ok"'`);
+    // A dead stack must FAIL the step, leaving TARGET_ORIGIN where it was.
+    expect(body).toMatch(/is not serving \/v1\/health/);
+    expect(body).toMatch(/exit 1/);
+    // And the re-point must still come after the probe, never before it.
+    expect(body.indexOf('/v1/health')).toBeLessThan(body.indexOf('wrangler@4 deploy'));
+  });
+
   it('keeps a preview environment alive until its branch is deleted', () => {
     const workflow = read('.github/workflows/deploy-preview.yml');
     const jobs = (name: string) => {


### PR DESCRIPTION
`pi.kortix.com` served Cloudflare's 502 for hours today. Three defects lined up; each is fixed here.

## What actually happened

The URL, DNS, Worker and target were all **correct** — `TARGET_ORIGIN` pointed at exactly the sandbox in the error page (`sbx_01M12R2XWZNZSJHTTF09Y279D1`). The box behind it wasn't serving:

```
service "kortix-migrate" didn't complete successfully: exit 1
```

Nothing bound port 8080, so Platinum's edge Caddy 502'd, the Worker passed that through, and Cloudflare rendered its branded page.

## 1. A failed deploy poisoned the next one

A branch environment **reuses its sandbox**, so a container left behind by a previous failed run is still there, and Docker refuses to recreate a name it already holds:

```
Conflict. The container name "/…_kortix-pr-6998-kortix-migrate-1" is
already in use by container "c18af76fa9df…"
```

Twice in one run. `compose up -d --wait` had no cleanup in front of it, so every failure made the next failure likelier.

The retry now clears containers before retrying instead of retrying into them — deliberately **without `-v`**: the named volumes carry this environment's Postgres, and outliving a redeploy is the whole point of a branch environment.

## 2. The failure could not be diagnosed

`compose up -d` prints container **state**, never container **output**. A one-shot service that exits non-zero produced exactly one line and the reason for that `1` was nowhere in the log — which is why this took a full investigation rather than a glance.

The retry path now dumps `kortix-migrate`'s output and the full `ps --all` table before retrying. That service is the one that can fail this way; the rest are health-gated and report through `--wait`.

## 3. The stable hostname was re-pointed at the dead box anyway

The step checked only that *a sandbox origin came back*. A sandbox **existing** is not its stack **serving**.

It now probes `${target}/v1/health` and fails rather than re-pointing, so the public name stays on the previous sandbox — which is still serving. Still deliberately **not** gated on the suite: a failing suite leaves somewhere to debug, a failing stack does not.

The probe goes at the sandbox's **own** origin, never the public name — the public name answers from the *previous* sandbox and would pass while this one is dead.

## Verification

The redeploy that this diagnosis triggered brought `pi.kortix.com` back:

```
/            → 307 → /auth → 200
/v1/health   → {"status":"ok","environment":"preview","commit":"cd14bb62…"}
```

`tests/unit`: **331 pass**, against a **330-pass baseline on clean `origin/main` with the same 88 pre-existing failures** — one new test, nothing broken. The new test is **falsifiable**: it goes red against the pre-fix workflow. `tests` typecheck clean.

> The 88 failures are the pre-existing main breakage reported separately; they are not from this change.

## Why this targets `main`

`pull_request_target` runs the workflow file from the **default branch**, and the deploy job checks out `main`. This fix only takes effect once it is on `main` — there is no branch-local way to change how a preview deploys.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790601544&installation_model_id=434224&pr_number=7036&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7036&signature=9eff13299effff7ecace03c9e29a1d8a31d9f3f354e46b726e017a4702da41f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->