### PR TITLE
fix(web): restore GitHub repo sources on /new, fix People-with-access gate

### DIFF
--- a/apps/web/src/features/workspace/customize/sections/view/git-view.test.ts
+++ b/apps/web/src/features/workspace/customize/sections/view/git-view.test.ts
@@ -265,3 +265,69 @@ test('the provider sentence follows the same fallback the value does', () => {
   expect(code).toContain('projectRepoFallback(project.repo_url)?.provider');
   expect(code).toContain('<RepositoryValue connection={connection} repoUrl={project.repo_url} />');
 });
+
+/**
+ * "People with access" — the gate, and what shows when the repository is not
+ * one Kortix can invite into.
+ *
+ * The reported symptom was "some users don't see People with access". Two
+ * independent causes, both fixed here and both pinned below: the section was
+ * gated on the wrong permission leaf, and a non-managed repository made it
+ * vanish with no explanation. Neither had anything to do with billing — there
+ * is no entitlement check anywhere on this path, which is what the last test
+ * in this block asserts.
+ */
+test('the invite gate asks for the leaf the route asserts, not project.write', () => {
+  // `POST /:projectId/git/collaborators` asserts
+  // `PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE` (apps/api/src/projects/routes/
+  // r1.ts). Gating the UI on `project.write` meant a custom role with
+  // write-but-not-members.manage saw the form and got a 403 on submit, and the
+  // reverse role saw nothing though the API would have accepted it.
+  expect(code).toContain('PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE');
+  expect(code).toContain('canManageMembers');
+  expect(code).toContain('canManageMembers={canManageMembers}');
+});
+
+test('both leaves are probed in ONE batch, off a module-level action list', () => {
+  // Action-list identity is part of the SDK's `effective:batch` query key, so
+  // an inline literal would mint a new cache entry per render.
+  expect(code).toContain('const GIT_VIEW_ACTIONS = [');
+  expect(code).toContain('useProjectCans(projectId, GIT_VIEW_ACTIONS)');
+  expect(code).not.toContain('useProjectCan(projectId');
+});
+
+test('a non-managed repository explains itself instead of hiding the section', () => {
+  // This is the reported bug. The old markup was
+  // `{managed ? <RepoCollaboratorInvite .../> : null}` — a workspace on a BYO
+  // repo showed the Git repo panel with nothing under it and no way to find
+  // out why.
+  expect(code).not.toContain('{managed ? <RepoCollaboratorInvite');
+  expect(code).toContain('<RepoAccessSection');
+  expect(code).toContain('function ExternallyManagedRepoAccess');
+  // The header renders on both branches, so the section itself never
+  // disappears for someone who may manage members.
+  const section = code.slice(
+    code.indexOf('function RepoAccessSection'),
+    code.indexOf('function ExternallyManagedRepoAccess'),
+  );
+  expect(section).toContain('title="People with access"');
+  expect(section).toContain('managed ? (');
+});
+
+test('the explanation names the provider, so a code-storage repo is not read as a broken GitHub link', () => {
+  // A workspace provisioned while `MANAGED_GIT_PROVIDER=code-storage` was the
+  // default (#5063 → #6796) is MANAGED but on a backend with no
+  // `inviteCollaborator` at all.
+  expect(code).toContain('providerLabel(provider)');
+  expect(code).toContain("provider === 'github'");
+});
+
+test('nothing on this path is gated on billing', () => {
+  // The support question was "is it because he is not a paid user?". It is
+  // not, and this asserts the answer stays true: no entitlement, plan, or
+  // upgrade gate may appear in this view.
+  expect(code).not.toContain('entitlement');
+  expect(code).not.toContain('Entitlement');
+  expect(code).not.toContain('openUpgrade');
+  expect(code).not.toContain('isBillingEnabled');
+});

--- a/apps/web/src/features/workspace/customize/sections/view/git-view.tsx
+++ b/apps/web/src/features/workspace/customize/sections/view/git-view.tsx
@@ -22,7 +22,7 @@ import { useDebounce } from '@/hooks/use-debounce';
 import { getEnv } from '@/lib/env-config';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
 import { useDeploymentCliInstallCommand } from '@/lib/use-deployment-cli-install-command';
-import { useProjectCan } from '@/lib/use-project-can';
+import { useProjectCans } from '@/lib/use-project-can';
 import { cn } from '@/lib/utils';
 import {
   getProjectDetail,
@@ -50,10 +50,23 @@ import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
 import { CopyButton } from '@/components/markdown/copy-button';
 import {
   connectionStatusLabel,
+  providerLabel,
   providerSentence,
   repositoryWebUrl,
   type ConnectionTone,
 } from './git-view-helpers';
+
+/**
+ * The leaves this view gates on, as ONE stable list.
+ *
+ * Action-list identity is part of the SDK's `effective:batch` query key, so a
+ * literal rebuilt on each render would mint a new cache entry every time.
+ * Module scope is what collapses both gates into a single request.
+ */
+const GIT_VIEW_ACTIONS = [
+  PROJECT_ACTIONS.PROJECT_WRITE,
+  PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE,
+] as const;
 
 const DOCS_CLI = '/docs/cli';
 const DOCS_MANIFEST = '/docs/project/manifest';
@@ -580,13 +593,112 @@ function OwnGitClient({ project }: { project: ProjectWithOrigin }) {
   );
 }
 
-function RepoCollaboratorInvite({
+/**
+ * "People with access" — always rendered for someone who may manage members,
+ * with a body that depends on who actually controls the repository.
+ *
+ * The section used to be gated on `managed && canEdit` and render NOTHING
+ * otherwise, which produced the support question this replaces: a workspace
+ * owner on a BYO repo saw the Git repo panel with no access row under it and
+ * no way to find out why. Hiding a control does not answer "where do I add
+ * someone" — it just moves the question into a support thread.
+ *
+ * Two things the old gate got wrong, both fixed here:
+ *
+ * 1. It read `project.write`. The route asserts `project.members.manage`
+ *    (`apps/api/src/projects/routes/r1.ts`, "Inviting a git collaborator
+ *    grants a human standing access to the repo — membership-tier, not plain
+ *    write"). A custom role holding write-but-not-members.manage saw the form
+ *    and got a 403 on submit; the reverse role saw nothing though the API
+ *    would have accepted it. The gate now asks for the leaf the route asks
+ *    for.
+ * 2. A non-managed repository disappeared instead of explaining itself.
+ */
+function RepoAccessSection({
   projectId,
-  canManage,
+  connection,
+  managed,
+  canManageMembers,
 }: {
   projectId: string;
-  canManage: boolean;
+  connection: ProjectGitConnection | null | undefined;
+  managed: boolean;
+  canManageMembers: boolean;
 }) {
+  // Still gated on the capability — someone who cannot grant repository access
+  // has no use for either the form or an explanation of where to grant it.
+  if (!canManageMembers) return null;
+
+  return (
+    <section className="space-y-3">
+      <SettingsSubsectionHeader
+        title="People with access"
+        description={
+          managed
+            ? 'Invite someone by their GitHub username. GitHub emails them an invite to accept.'
+            : 'Who can read and write this workspace’s repository.'
+        }
+      />
+      {managed ? (
+        <RepoCollaboratorInvite projectId={projectId} />
+      ) : (
+        <ExternallyManagedRepoAccess connection={connection} />
+      )}
+    </section>
+  );
+}
+
+/**
+ * The body for a repository Kortix does not own.
+ *
+ * Collaborator invites go through the managed org's admin credential
+ * (`managedAdminAuth`, `apps/api/src/projects/git-backends/github.ts`), which
+ * only has repo-admin scope on repositories Kortix created — so for a BYO repo
+ * there is nothing Kortix could do here even with the user's permission. The
+ * honest answer is where to go instead, and for GitHub that is a real link
+ * rather than a description of one.
+ *
+ * Providers other than GitHub reach this too: a workspace provisioned while
+ * `MANAGED_GIT_PROVIDER=code-storage` was the default (between #5063 and its
+ * retirement in #6796) is a MANAGED repo whose backend has no
+ * `inviteCollaborator` at all. Naming the provider is what tells those users
+ * they are not looking at a broken GitHub connection.
+ */
+function ExternallyManagedRepoAccess({
+  connection,
+}: {
+  connection: ProjectGitConnection | null | undefined;
+}) {
+  const provider = connection?.provider;
+  // GitHub only. `repositoryWebUrl` also answers for GitLab, but the deep link
+  // below is `/settings/access`, which is GitHub's path — GitLab's is
+  // `/-/project_members`. A link that 404s is worse than no link, so the button
+  // is scoped to the one host whose path is known here.
+  const webUrl =
+    provider === 'github' && connection?.repo_url
+      ? repositoryWebUrl(provider, connection.repo_url)
+      : null;
+
+  return (
+    <div className="bg-popover rounded-md border px-4 py-3">
+      <p className="text-muted-foreground text-xs text-pretty">
+        {provider === 'github'
+          ? 'Kortix did not create this repository, so it cannot add collaborators to it. Manage access from the repository settings on GitHub.'
+          : `This workspace’s repository is hosted on ${providerLabel(provider)}, which does not support collaborator invites from Kortix. Manage access where the repository lives.`}
+      </p>
+      {webUrl ? (
+        <Button asChild variant="outline" size="sm" className="mt-3 gap-1.5">
+          <a href={`${webUrl}/settings/access`} target="_blank" rel="noopener noreferrer">
+            <ExternalLink className="size-3.5 shrink-0" />
+            Manage on GitHub
+          </a>
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function RepoCollaboratorInvite({ projectId }: { projectId: string }) {
   const [username, setUsername] = useState('');
   const [permission, setPermission] = useState<'read' | 'write'>('write');
 
@@ -605,18 +717,11 @@ function RepoCollaboratorInvite({
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
-    if (!canManage) return;
     if (username.trim() && !inviteMutation.isPending) inviteMutation.mutate();
   };
 
-  if (!canManage) return null;
-
   return (
-    <section className="space-y-3">
-      <SettingsSubsectionHeader
-        title="People with access"
-        description="Invite someone by their GitHub username. GitHub emails them an invite to accept."
-      />
+    <>
       {/* `p-3` and `rounded-sm` controls inside a `rounded-md` panel: concentric
           radius, and no third level of inset. The `Field`/`FieldGroup` wrappers
           this form used to carry are gone — they exist to structure a label and
@@ -672,7 +777,7 @@ function RepoCollaboratorInvite({
           </Button>
         </form>
       </div>
-    </section>
+    </>
   );
 }
 
@@ -686,11 +791,19 @@ export function GitView({ projectId }: { projectId: string }) {
   // its `default_branch`/`manifest_path` from this SAME query rather than firing
   // a second project fetch.
   const project = detail.data?.project;
-  // One leaf, asked once. This used to be `role === 'manager' || project.write`,
-  // an OR that existed only because the role label could not express the leaf —
-  // every manager holds `project.write`, so the first half added nothing except
-  // a false positive for a custom role denied that leaf.
-  const canEdit = useProjectCan(projectId, PROJECT_ACTIONS.PROJECT_WRITE).allowed === true;
+  // Two leaves, one roundtrip. This used to be a single `project.write` probe
+  // reused for BOTH the repository settings and the collaborator invite — but
+  // the invite route asserts `project.members.manage`
+  // (`apps/api/src/projects/routes/r1.ts`), a strictly different leaf, so the
+  // one probe was answering a question the server never asked. `GIT_VIEW_ACTIONS`
+  // is module-level and stable because the action-list identity is part of the
+  // SDK query key.
+  const cans = useProjectCans(projectId, GIT_VIEW_ACTIONS);
+  const canEdit = cans[PROJECT_ACTIONS.PROJECT_WRITE]?.allowed === true;
+  const canManageMembers = cans[PROJECT_ACTIONS.PROJECT_MEMBERS_MANAGE]?.allowed === true;
+  // Managed = Kortix created this repository, so the managed-org admin
+  // credential has repo-admin scope on it. False for a BYO repo and for a
+  // repository on any provider other than GitHub.
   const managed = project ? isManagedGithubProject(project) : false;
 
   return (
@@ -733,7 +846,12 @@ export function GitView({ projectId }: { projectId: string }) {
             connection={detail.data?.git_connection}
             canManage={canEdit}
           />
-          {managed ? <RepoCollaboratorInvite projectId={projectId} canManage={canEdit} /> : null}
+          <RepoAccessSection
+            projectId={projectId}
+            connection={detail.data?.git_connection}
+            managed={managed}
+            canManageMembers={canManageMembers}
+          />
           <LocalSetup projectId={projectId} />
           <OwnGitClient project={project as ProjectWithOrigin} />
         </>

--- a/apps/web/src/features/workspace/new/advanced-fields.test.ts
+++ b/apps/web/src/features/workspace/new/advanced-fields.test.ts
@@ -15,6 +15,22 @@ const source = readFileSync(join(import.meta.dir, 'advanced-fields.tsx'), 'utf8'
  */
 const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
 
+/**
+ * Just the repository-source `<Select>`, anchored on its own `htmlFor`.
+ *
+ * The component renders TWO Selects now — the source, and the GitHub account
+ * that the two GitHub sources act through — so a `code.indexOf('<SelectContent')`
+ * … `code.lastIndexOf('</SelectContent>')` slice spans both plus everything
+ * between them, and a `disabled=` on an unrelated control inside that span
+ * reads as "a source option is disabled". Scoping the slice is what keeps the
+ * disabled-option assertion below about the thing it names.
+ */
+const sourceSelect = (() => {
+  const start = code.indexOf('htmlFor="workspace-source"');
+  const contentStart = code.indexOf('<SelectContent', start);
+  return code.slice(contentStart, code.indexOf('</SelectContent>', contentStart));
+})();
+
 describe('AdvancedFields: revealed by the name, not a disclosure', () => {
   /**
    * This used to be a `Collapsible` that opened on click. It is a plain field
@@ -41,19 +57,28 @@ describe('AdvancedFields: revealed by the name, not a disclosure', () => {
   // code rather than repeatedly failing against it.
   test('the page renders it', () => {
     const page = readFileSync(join(import.meta.dir, 'new-workspace-page.tsx'), 'utf8');
-    expect(page).toContain('<AdvancedFields state={state} onChange={setState} />');
+    expect(page).toContain('<AdvancedFields');
+    expect(page).toContain('accountId={effectiveAccountId}');
+    expect(page).toContain('onChange={setState}');
   });
 });
 
 describe('AdvancedFields: repository source', () => {
   test('offers all three repository sources as selectable values', () => {
-    expect(code).toContain("'managed'");
-    expect(code).toContain("'github-create'");
-    expect(code).toContain("'github-import'");
+    // Read off SOURCE_LABELS, which is what the Select maps over — `managed`
+    // is an unquoted object key there, the other two are quoted because of
+    // the hyphen.
+    expect(code).toContain('managed:');
+    expect(code).toContain("'github-create':");
+    expect(code).toContain("'github-import':");
     // Paired presence check: the three sources are wired into a Select, not
     // just referenced as bare strings somewhere unrelated.
     expect(code).toContain('<Select');
     expect(code).toContain('<SelectItem');
+  });
+
+  test('every source description renders — the picked source explains itself', () => {
+    expect(code).toContain('{SOURCE_DESCRIPTIONS[state.source]}');
   });
 
   test('explains each source with the exact wording the old create modal uses, so the two never diverge', () => {
@@ -62,8 +87,12 @@ describe('AdvancedFields: repository source', () => {
     expect(code).toContain('Select an existing repository from your GitHub account.');
   });
 
-  test('changing the source calls onChange with the rest of the state intact', () => {
-    expect(code).toContain('...state, source:');
+  test('changing the source clears what the previous source owned', () => {
+    // NOT a bare `{ ...state, source }`: that leaks `repoFullName` from an
+    // import into a create, and leaks the imported repo's branch into a
+    // managed provision. `withRepositorySource` is the one place that rule
+    // lives, and it is unit-tested in `github-source.test.ts`.
+    expect(code).toContain('withRepositorySource(state, value as RepositorySource)');
   });
 });
 
@@ -74,77 +103,83 @@ describe('AdvancedFields: default branch', () => {
   });
 });
 
-describe('AdvancedFields: honest failure for GitHub sources', () => {
-  test('renders an inline note instead of a GitHub form when the source is not managed', () => {
-    // The note is gated on the non-managed branch specifically - a bare
-    // mention of 'github-create' elsewhere (e.g. the Select options) would not
-    // satisfy this on its own, so this pairs with the GitHubSourceNote check
-    // below.
-    expect(code).toContain("state.source !== 'managed'");
-    expect(code).toContain('<GitHubSourceNote');
+describe('AdvancedFields: the two GitHub sources are wired, not disabled', () => {
+  /**
+   * `/new` shipped with `github-create` and `github-import` rendered
+   * `disabled` in the Select, and `new-workspace-page.tsx` additionally
+   * required `source === 'managed'` before submit — two dead options under an
+   * apology. Nothing was missing on the server: `POST /projects/create-repo`
+   * and `POST /projects/link-repository` were live the whole time. These
+   * tests replace the ones that pinned that dead state; they assert the
+   * opposite, on purpose.
+   */
+  test('no SelectItem is disabled — every source can be picked', () => {
+    expect(sourceSelect).toContain('<SelectItem');
+    expect(sourceSelect).not.toContain('disabled');
   });
 
-  test('is plain text in the field group, not a second bordered card nested in the page card', () => {
-    // Fix round 1: InfoBanner's neutral tone is itself a bordered `bg-popover`
-    // box, and this note already sits inside the page's own bordered card and
-    // inside this disclosure - a nested InfoBanner reads as a card-in-a-card.
-    // Every other InfoBanner call site in the codebase renders it as a
-    // sibling OUTSIDE a bg-popover-bordered container; there is no
-    // counter-example, so this component must never reintroduce one.
+  test('the dead-end apology is gone — no copy claiming GitHub sources cannot be used here', () => {
+    expect(code).not.toContain('Only Kortix-managed repositories can be created here for now');
+    expect(code).not.toContain('to prepare for repository-backed workspaces');
+    expect(code).not.toContain('GitHubSourceNote');
+  });
+
+  test('renders the inputs each GitHub route actually requires', () => {
+    // `installation_id` for both routes, and a repository for import only —
+    // paired with the submit gate in `github-source.ts`'s `githubSourceReady`,
+    // which is what refuses a submit while either is missing.
+    expect(code).toContain('workspace-installation');
+    expect(code).toContain('workspace-repository');
+    expect(code).toContain('listGitHubInstallations');
+    expect(code).toContain('listGitHubRepositories');
+  });
+
+  test('reuses the existing pickers rather than hand-rolling a second repo/branch combobox', () => {
+    // `RepositoryPicker`/`BranchPicker` were orphaned when the create modal
+    // was deleted; they are the system's repo pickers and this screen is
+    // their reason to exist again. Reuse > Compose > Create.
+    expect(code).toContain("from '@/features/projects/modal/github-import-pickers'");
+    expect(code).toContain('<RepositoryPicker');
+    expect(code).toContain('<BranchPicker');
+  });
+
+  test('the repository picker seeds the branch from the picked repo, never leaving the managed default', () => {
+    // `link-repository` VALIDATES `default_branch` when it is sent
+    // (`resolveImportedDefaultBranch`), so submitting the managed default of
+    // `main` against a repo whose trunk is `master` is a guaranteed 400.
+    expect(code).toContain('defaultBranch: repo?.default_branch');
+  });
+
+  test('changing the GitHub account clears the repository chosen under the previous one', () => {
+    expect(code).toContain('installationId: value, repoFullName: null');
+  });
+
+  test('hides the free-text branch field for github-create, which cannot accept one', () => {
+    // `create-repo` reads `repo.default_branch` off the repository GitHub just
+    // created and accepts no branch input, so a field here would be collected
+    // and silently dropped.
+    expect(code).toContain("state.source === 'github-create' ? null");
+  });
+
+  test('still links to the real GitHub connect route when no installation exists, and remembers the way back', () => {
+    expect(code).toContain('/github/setup');
+    expect(code).toContain('rememberGitHubSetupReturn');
+    expect(code).toContain('newWorkspaceReturnPath');
+    // Plain text in the field group, never an InfoBanner: that primitive is a
+    // bordered `bg-popover` box and this note sits inside the page's own
+    // field group, so it would read as a card inside a card.
     expect(code).not.toContain('<InfoBanner');
     expect(code).not.toContain("from '@/components/ui/info-banner'");
-    // Paired presence check: the note still renders as a real element, styled
-    // like the source description directly above it, not silently dropped.
-    expect(code).toContain('function GitHubSourceNote');
     expect(code).toContain('text-muted-foreground text-xs');
   });
 
-  test('never claims /github/setup creates or imports a repository, or promises a return trip', () => {
-    // Fix round 1: /github/setup only verifies and links a GitHub App
-    // installation - it has no repo creation or import path, and this
-    // component's plain <Link> has no equivalent to the old modal's
-    // rememberGitHubSetupReturn/consumeGitHubSetupReturn round trip, so it
-    // must not promise the user will come back here.
-    expect(code).not.toContain('happens on the GitHub connect page');
-    expect(code).not.toContain('come back');
-    expect(code).not.toContain('finish this workspace');
-    // Paired presence check: the accurate replacement copy is the one that
-    // actually renders.
-    expect(code).toContain('Only Kortix-managed repositories can be created here for now');
-    expect(code).toContain('connect a GitHub account');
-  });
-
-  test('links to the real GitHub connect route, not an invented one', () => {
-    expect(code).toContain('/github/setup');
-    // Negative check paired with the positive above: this task does not stand
-    // up a repo picker or installation form of its own.
-    expect(code).not.toContain('create-repo');
-    expect(code).not.toContain('RepositoryPicker');
-  });
-
-  test('never wires a non-managed source into the provision payload', () => {
-    expect(code).not.toContain('buildProvisionPayload');
-    expect(code).not.toContain('/provision');
-  });
-
-  // Final-review FIX 5: picking `github-create` rendered a present-tense
-  // claim ("Kortix creates a private repository in your GitHub account.")
-  // that the form then silently refused — `canSubmit` requires
-  // `source === 'managed'` — with the honest disclaimer appearing only AFTER
-  // the user had already committed to the choice. Task 12 removed exactly
-  // this pattern one field up ("offering any other account would be a choice
-  // that can only fail"); the fix here is the same reasoning applied to the
-  // Select: mark the two unsupported options `disabled` so the constraint is
-  // visible BEFORE selection, not after.
-  test('FIX 5: the two unsupported sources are disabled in the Select — the constraint is visible before picking, not only in the note after', () => {
-    const selectBlock = code.slice(code.indexOf('<SelectContent'), code.indexOf('</SelectContent>'));
-    expect(selectBlock).toContain('<SelectItem');
-    expect(selectBlock).toContain("disabled={source !== 'managed'}");
-  });
-
-  test('the explanatory note stays — disabling the option does not remove the honest failure copy', () => {
-    expect(code).toContain('<GitHubSourceNote');
-    expect(code).toContain('Only Kortix-managed repositories can be created here for now');
+  test('the GitHub queries are account-scoped through the prop, never state.accountId', () => {
+    // `state.accountId` is legitimately null for a single-account user — the
+    // picker hides itself below two accounts — so reading it here would leave
+    // every query disabled for exactly those users. The page passes the
+    // resolved `effectiveAccountId` instead.
+    expect(code).toContain('accountId: string | null');
+    expect(code).not.toContain('state.accountId');
   });
 });
 

--- a/apps/web/src/features/workspace/new/advanced-fields.tsx
+++ b/apps/web/src/features/workspace/new/advanced-fields.tsx
@@ -2,6 +2,7 @@
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import Loading from '@/components/ui/loading';
 import {
   Select,
   SelectContent,
@@ -9,11 +10,27 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { BranchPicker, RepositoryPicker } from '@/features/projects/modal/github-import-pickers';
+import {
+  isGitHubSource,
+  plannedRepoPath,
+  withRepositorySource,
+} from '@/features/workspace/new/github-source';
 import type {
   NewWorkspaceFormState,
   RepositorySource,
 } from '@/features/workspace/new/new-workspace-form';
+import { newWorkspaceReturnPath } from '@/features/workspace/new/source-param';
+import { useDebounce } from '@/hooks/use-debounce';
+import { githubInstallationLabel, isGitHubAppInstallationId, rememberGitHubSetupReturn } from '@/lib/github-installations';
+import {
+  listGitHubInstallations,
+  listGitHubRepositories,
+  listGitHubRepositoryBranches,
+} from '@kortix/sdk';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 /**
  * Repository source is a disclosure, not a visible choice, because `managed`
@@ -39,53 +56,241 @@ const SOURCE_LABELS: Record<RepositorySource, string> = {
 };
 
 /**
- * `github-create` and `github-import` need a GitHub App installation id and a
- * repository — inputs `POST /projects/provision` does not accept. Those two
- * sources go through `POST /projects/create-repo` and the BYO-repo flow the
- * old create modal drives (`project-create-modal.tsx` `handleLinkGitHub` /
- * `githubCreateMutation`), which is out of scope for this task.
+ * Shown when the account has no GitHub App installation to act through.
  *
- * The copy below says only what `/github/setup` actually does: it verifies
- * and links a GitHub App installation (`saveGitHubInstallation`,
- * `linkGitHubInstallation`, `listLinkableGitHubInstallations` —
- * `app/(auth)/github/setup/page.tsx`). It does **not** create or import a
- * repository, so the note must not claim it does. It also makes no "come
- * back and finish" promise: the old modal's round trip
- * (`rememberGitHubSetupReturn` before navigating, `consumeGitHubSetupReturn`
- * on return — `project-create-modal.tsx:126-131,:561`) has no equivalent
- * here, a plain `<Link>` loses the in-progress form state on navigation, and
- * the modal that round trip lives in is itself deleted by a later task in
- * this plan. The full GitHub-source form on `/new` is its own follow-up.
+ * `github-create` and `github-import` both need one — `POST
+ * /projects/create-repo` and `POST /projects/link-repository` resolve their
+ * credentials from it (`apps/api/src/projects/routes/r2.ts`), and answer 409
+ * `Install the Kortix GitHub App…` when there is none. Sending the user to
+ * `/github/setup` BEFORE they press Create is that 409 turned into a link.
  *
- * Rendered as plain text inside the existing field group, not a second
- * bordered surface: `InfoBanner`'s neutral tone is itself a bordered
- * `bg-popover` box, and this note already sits inside the page's own
- * `bg-popover rounded-md border` card (`new-workspace-page.tsx`) and inside
- * this disclosure's `CollapsibleContent` — a nested card reads as an insert,
- * not a sentence in the same field group as the description above it.
+ * `rememberGitHubSetupReturn` is what makes it a round trip rather than a
+ * one-way exit: the setup page reads that path back on completion
+ * (`app/(auth)/github/setup/page.tsx`, `consumeGitHubSetupReturn`), so the
+ * user lands back on `/new` with their chosen source intact
+ * (`newWorkspaceReturnPath`). The typed name does not survive — a real
+ * navigation, not a modal — which is why the source is carried in the URL and
+ * not just assumed.
+ *
+ * Plain text in the existing field group, not an `InfoBanner`: that primitive
+ * is itself a bordered `bg-popover` box and this note sits inside the page's
+ * own field group, so it would read as a card inside a card.
  */
-function GitHubSourceNote({ accountId }: { accountId: string | null }) {
+function ConnectGitHubNote({
+  accountId,
+  source,
+}: {
+  accountId: string | null;
+  source: RepositorySource;
+}) {
   const href = accountId
     ? `/github/setup?account_id=${encodeURIComponent(accountId)}`
     : '/github/setup';
 
   return (
     <p className="text-muted-foreground text-xs">
-      Only Kortix-managed repositories can be created here for now. Choose Kortix managed to
-      continue, or{' '}
-      <Link href={href} className="text-foreground underline underline-offset-2">
-        connect a GitHub account
+      No GitHub account is connected to this workspace's account yet.{' '}
+      <Link
+        href={href}
+        onClick={() => rememberGitHubSetupReturn(newWorkspaceReturnPath(source))}
+        className="text-foreground underline underline-offset-2"
+      >
+        Connect a GitHub account
       </Link>{' '}
-      to prepare for repository-backed workspaces.
+      to use this option.
     </p>
+  );
+}
+
+/**
+ * The inputs the two GitHub sources need on top of the workspace name.
+ *
+ * Mounted only while a GitHub source is selected, so its three queries never
+ * run for the `managed` default — which is the source almost every create
+ * uses. Splitting it out of `AdvancedFields` is what keeps that true: hooks
+ * cannot be called conditionally, so the queries have to live in a component
+ * whose MOUNT is the condition.
+ */
+function GitHubSourceFields({
+  state,
+  accountId,
+  onChange,
+}: {
+  state: NewWorkspaceFormState;
+  accountId: string | null;
+  onChange: (next: NewWorkspaceFormState) => void;
+}) {
+  const [repoSearch, setRepoSearch] = useState('');
+  // The repositories route takes `search` as a server-side filter, so every
+  // keystroke would otherwise be a request. `RepositoryPicker` also filters
+  // what it already holds client-side, so the debounce only delays WIDENING
+  // the result set, never the responsiveness of the list in front of the user.
+  const { debouncedValue: debouncedRepoSearch } = useDebounce(repoSearch, 300);
+
+  // Same cache key `accounts/[id]/page.tsx` and `connected-tab.tsx` already
+  // use, so arriving here after connecting an account on either surface hits a
+  // warm cache instead of refetching.
+  const installationsQuery = useQuery({
+    queryKey: ['github-installations', accountId],
+    queryFn: () => listGitHubInstallations(accountId as string),
+    enabled: Boolean(accountId),
+    staleTime: 60_000,
+  });
+
+  const installations = installationsQuery.data?.installations ?? [];
+  // `create-repo` needs org/repo-admin scope on a real GitHub App
+  // installation. `serializeGitHubInstallations` can also return the synthetic
+  // `pat` entry (the self-host "use a token" setup), which `link-repository`
+  // accepts and `create-repo` does not — so it is offered for import only,
+  // exactly as the old create modal split them.
+  const selectable =
+    state.source === 'github-create'
+      ? installations.filter((installation) =>
+          isGitHubAppInstallationId(installation.installation_id),
+        )
+      : installations;
+
+  const installationId = state.installationId;
+  const onlyInstallationId =
+    selectable.length === 1 ? (selectable[0]?.installation_id ?? null) : null;
+
+  // Seed the single installation rather than making the user "choose" from a
+  // list of one. An effect, not a render-time derivation: `githubSourceReady`
+  // (the submit gate) reads `state.installationId`, so a value that exists
+  // only as a local variable would show a filled-in Select above a disabled
+  // Create button.
+  useEffect(() => {
+    if (installationId || !onlyInstallationId) return;
+    onChange({ ...state, installationId: onlyInstallationId });
+    // `state`/`onChange` are excluded deliberately: this must fire on the
+    // arrival of the single installation, not on every keystroke in the name
+    // field, and the guard above already makes it idempotent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [installationId, onlyInstallationId]);
+
+  const reposQuery = useQuery({
+    queryKey: ['github-repositories', accountId, installationId, debouncedRepoSearch],
+    queryFn: () =>
+      listGitHubRepositories(accountId as string, installationId, {
+        search: debouncedRepoSearch || undefined,
+      }),
+    enabled: Boolean(accountId && installationId) && state.source === 'github-import',
+    staleTime: 30_000,
+  });
+
+  const repos = reposQuery.data?.repositories ?? [];
+  const selectedOwner =
+    selectable.find((installation) => installation.installation_id === installationId)
+      ?.owner_login ?? null;
+  const plannedPath = plannedRepoPath(selectedOwner, state.name);
+
+  if (installationsQuery.isLoading) {
+    return (
+      <p className="text-muted-foreground flex items-center gap-2 text-xs">
+        <Loading className="size-3.5 shrink-0" />
+        Loading GitHub accounts…
+      </p>
+    );
+  }
+
+  if (installationsQuery.isError) {
+    return (
+      <p className="text-destructive text-xs">
+        Could not load GitHub accounts: {(installationsQuery.error as Error).message}
+      </p>
+    );
+  }
+
+  if (selectable.length === 0) {
+    return <ConnectGitHubNote accountId={accountId} source={state.source} />;
+  }
+
+  return (
+    <>
+      <div className="flex flex-col space-y-3">
+        <Label htmlFor="workspace-installation">GitHub account</Label>
+        <Select
+          value={installationId ?? ''}
+          onValueChange={(value) =>
+            // The repository belongs to the installation, so changing the
+            // installation invalidates it — clearing it here is what stops a
+            // repo from one account being submitted against another.
+            onChange({ ...state, installationId: value, repoFullName: null })
+          }
+        >
+          <SelectTrigger id="workspace-installation" className="w-full" size="md">
+            <SelectValue placeholder="Select a GitHub account" />
+          </SelectTrigger>
+          <SelectContent>
+            {selectable.map((installation) => (
+              <SelectItem
+                key={installation.installation_id ?? ''}
+                value={installation.installation_id ?? ''}
+              >
+                {githubInstallationLabel(
+                  installation.installation_id,
+                  installation.owner_login,
+                )}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {state.source === 'github-create' && plannedPath ? (
+          // The workspace name is free text and a GitHub repository name is
+          // not, so `repoSlugFromName` can change it noticeably. Showing the
+          // result before the create is what stops that being a surprise
+          // discovered in the repository list afterwards.
+          <p className="text-muted-foreground text-xs">
+            Creates <span className="font-mono">{plannedPath}</span>
+          </p>
+        ) : null}
+      </div>
+
+      {state.source === 'github-import' ? (
+        <div className="flex flex-col space-y-3">
+          <Label htmlFor="workspace-repository">Repository</Label>
+          <RepositoryPicker
+            value={state.repoFullName ?? ''}
+            repos={repos}
+            loading={reposQuery.isLoading || reposQuery.isFetching}
+            disabled={!installationId}
+            onSearchChange={setRepoSearch}
+            onValueChange={(repoFullName) => {
+              // Seed the branch from the repository's OWN default in the same
+              // update. `link-repository` VALIDATES `default_branch` against
+              // GitHub when it is sent (`resolveImportedDefaultBranch`), so
+              // leaving the managed default of `main` here is a 400 for every
+              // repository whose trunk is called anything else.
+              const repo = repos.find((candidate) => candidate.full_name === repoFullName);
+              onChange({
+                ...state,
+                repoFullName,
+                defaultBranch: repo?.default_branch || state.defaultBranch,
+              });
+            }}
+          />
+          {reposQuery.isError ? (
+            <p className="text-destructive text-xs">
+              Could not load repositories: {(reposQuery.error as Error).message}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </>
   );
 }
 
 export function AdvancedFields({
   state,
+  accountId,
   onChange,
 }: {
   state: NewWorkspaceFormState;
+  /** The account the create targets — resolved by the page, which owns the
+   *  "one account, nothing to pick" fallback. The GitHub queries below are
+   *  account-scoped, so they cannot run on `state.accountId` alone: that is
+   *  legitimately null for a single-account user. */
+  accountId: string | null;
   onChange: (next: NewWorkspaceFormState) => void;
 }) {
   return (
@@ -94,38 +299,95 @@ export function AdvancedFields({
         <Label htmlFor="workspace-source">Repository</Label>
         <Select
           value={state.source}
-          onValueChange={(value) => onChange({ ...state, source: value as RepositorySource })}
+          onValueChange={(value) => onChange(withRepositorySource(state, value as RepositorySource))}
         >
           <SelectTrigger id="workspace-source" className="w-full" size="md">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             {(Object.keys(SOURCE_LABELS) as RepositorySource[]).map((source) => (
-              // `github-create`/`github-import` need inputs `/provision`
-              // does not accept (see `GitHubSourceNote`'s doc comment
-              // above) — `canSubmit` already refuses them. Disabling the
-              // option here makes that constraint visible BEFORE the user
-              // picks it, not only in the note that used to appear after —
-              // same reasoning Task 12 applied one field up.
-              <SelectItem key={source} value={source} disabled={source !== 'managed'}>
+              <SelectItem key={source} value={source}>
                 {SOURCE_LABELS[source]}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
-        {state.source !== 'managed' ? <GitHubSourceNote accountId={state.accountId} /> : null}
+        <p className="text-muted-foreground text-xs">{SOURCE_DESCRIPTIONS[state.source]}</p>
       </div>
 
-      <div className="flex flex-col space-y-3">
-        <Label htmlFor="workspace-branch">Default branch</Label>
-        <Input
-          id="workspace-branch"
-          size="md"
-          value={state.defaultBranch}
-          onChange={(event) => onChange({ ...state, defaultBranch: event.target.value })}
-          placeholder="main"
-        />
-      </div>
+      {isGitHubSource(state.source) ? (
+        <GitHubSourceFields state={state} accountId={accountId} onChange={onChange} />
+      ) : null}
+
+      {/* `create-repo` does not accept a default branch — it reads
+          `repo.default_branch` off the repository GitHub just made
+          (`apps/api/src/projects/routes/r2.ts`) — so the field is hidden for
+          that source rather than collecting a value that would be dropped.
+          Import gets a real branch list off the chosen repository; managed
+          gets the free-text field, because the repo it names does not exist
+          yet and so has no branches to list. */}
+      {state.source === 'github-create' ? null : state.source === 'github-import' ? (
+        <div className="flex flex-col space-y-3">
+          <Label htmlFor="workspace-branch">Default branch</Label>
+          <ImportBranchField state={state} accountId={accountId} onChange={onChange} />
+        </div>
+      ) : (
+        <div className="flex flex-col space-y-3">
+          <Label htmlFor="workspace-branch">Default branch</Label>
+          <Input
+            id="workspace-branch"
+            size="md"
+            value={state.defaultBranch}
+            onChange={(event) => onChange({ ...state, defaultBranch: event.target.value })}
+            placeholder="main"
+          />
+        </div>
+      )}
     </>
+  );
+}
+
+/**
+ * The branch control for `github-import` — a real list off the chosen
+ * repository rather than a free-text box.
+ *
+ * A typed branch that does not exist is a 400 from `link-repository`
+ * (`resolveImportedDefaultBranch`), discovered only on submit. Listing the
+ * repository's actual branches removes that failure rather than reporting it.
+ */
+function ImportBranchField({
+  state,
+  accountId,
+  onChange,
+}: {
+  state: NewWorkspaceFormState;
+  accountId: string | null;
+  onChange: (next: NewWorkspaceFormState) => void;
+}) {
+  const branchesQuery = useQuery({
+    queryKey: [
+      'github-repository-branches',
+      accountId,
+      state.installationId,
+      state.repoFullName,
+    ],
+    queryFn: () =>
+      listGitHubRepositoryBranches(
+        accountId as string,
+        state.installationId as string,
+        state.repoFullName as string,
+      ),
+    enabled: Boolean(accountId && state.installationId && state.repoFullName),
+    staleTime: 30_000,
+  });
+
+  return (
+    <BranchPicker
+      value={state.defaultBranch}
+      branches={branchesQuery.data?.branches ?? []}
+      loading={branchesQuery.isLoading}
+      disabled={!state.repoFullName}
+      onValueChange={(branch) => onChange({ ...state, defaultBranch: branch })}
+    />
   );
 }

--- a/apps/web/src/features/workspace/new/github-source.test.ts
+++ b/apps/web/src/features/workspace/new/github-source.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  buildCreateRepoPayload,
+  buildLinkRepositoryPayload,
+  githubSourceReady,
+  isGitHubSource,
+  plannedRepoPath,
+  repoSlugFromName,
+  withRepositorySource,
+} from './github-source';
+import { INITIAL_FORM_STATE, type NewWorkspaceFormState } from './new-workspace-form';
+
+const base: NewWorkspaceFormState = { ...INITIAL_FORM_STATE, name: 'Support desk' };
+
+describe('repoSlugFromName', () => {
+  test('replaces every character GitHub rejects, not just spaces', () => {
+    // `POST /projects/create-repo` validates against /^[a-zA-Z0-9._-]+$/. The
+    // old create modal only did `.replace(/\s+/g, '-')`, so an apostrophe
+    // reached the route and came back 400.
+    expect(repoSlugFromName("Ana's agents")).toBe('Ana-s-agents');
+    expect(repoSlugFromName('support desk')).toBe('support-desk');
+    expect(repoSlugFromName('a/b:c')).toBe('a-b-c');
+  });
+
+  test('collapses runs and trims edge punctuation', () => {
+    expect(repoSlugFromName('a   b')).toBe('a-b');
+    expect(repoSlugFromName('  -weird-  ')).toBe('weird');
+    expect(repoSlugFromName('.dotfile.')).toBe('dotfile');
+  });
+
+  test('keeps characters GitHub accepts', () => {
+    expect(repoSlugFromName('kortix.api_v2-beta')).toBe('kortix.api_v2-beta');
+  });
+
+  test('falls back rather than emitting an empty name the route would 400', () => {
+    expect(repoSlugFromName('   ')).toBe('workspace');
+    expect(repoSlugFromName('!!!')).toBe('workspace');
+  });
+});
+
+describe('plannedRepoPath', () => {
+  test('shows the derived repo before the create, so the slug is not a surprise', () => {
+    expect(plannedRepoPath('acme', "Ana's agents")).toBe('github.com/acme/Ana-s-agents');
+  });
+
+  test('is null until an owner is known', () => {
+    expect(plannedRepoPath(null, 'anything')).toBeNull();
+  });
+});
+
+describe('isGitHubSource', () => {
+  test('covers exactly the two sources that need an installation', () => {
+    expect(isGitHubSource('managed')).toBe(false);
+    expect(isGitHubSource('github-create')).toBe(true);
+    expect(isGitHubSource('github-import')).toBe(true);
+  });
+});
+
+describe('githubSourceReady', () => {
+  test('managed needs nothing', () => {
+    expect(githubSourceReady({ ...base, source: 'managed' })).toBe(true);
+  });
+
+  test('github-create needs an installation and nothing more', () => {
+    expect(githubSourceReady({ ...base, source: 'github-create' })).toBe(false);
+    expect(githubSourceReady({ ...base, source: 'github-create', installationId: '84' })).toBe(
+      true,
+    );
+  });
+
+  test('github-import needs an installation AND a repository', () => {
+    expect(githubSourceReady({ ...base, source: 'github-import', installationId: '84' })).toBe(
+      false,
+    );
+    expect(
+      githubSourceReady({
+        ...base,
+        source: 'github-import',
+        installationId: '84',
+        repoFullName: 'acme/portal',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('withRepositorySource', () => {
+  test('clears the GitHub fields so an imported repo cannot leak into a create', () => {
+    const imported: NewWorkspaceFormState = {
+      ...base,
+      source: 'github-import',
+      installationId: '84',
+      repoFullName: 'acme/portal',
+    };
+    const next = withRepositorySource(imported, 'github-create');
+    expect(next.installationId).toBeNull();
+    expect(next.repoFullName).toBeNull();
+  });
+
+  test('restores the managed branch default when leaving github-import', () => {
+    // Otherwise a managed provision inherits the imported repository's trunk
+    // name — a default branch the user never chose for a repo that does not
+    // exist yet.
+    const imported: NewWorkspaceFormState = {
+      ...base,
+      source: 'github-import',
+      defaultBranch: 'trunk',
+      installationId: '84',
+      repoFullName: 'acme/portal',
+    };
+    expect(withRepositorySource(imported, 'managed').defaultBranch).toBe('main');
+  });
+
+  test('leaves a branch the user typed for managed alone', () => {
+    const managed: NewWorkspaceFormState = { ...base, defaultBranch: 'develop' };
+    expect(withRepositorySource(managed, 'github-import').defaultBranch).toBe('develop');
+  });
+
+  test('keeps the name, icon and template — only the source-owned fields reset', () => {
+    const withIcon: NewWorkspaceFormState = {
+      ...base,
+      icon: { emoji: '🚀' },
+      templateId: 'kortix-projects:support-agent-kit',
+    };
+    const next = withRepositorySource(withIcon, 'github-create');
+    expect(next.name).toBe('Support desk');
+    expect(next.icon).toEqual({ emoji: '🚀' });
+    expect(next.templateId).toBe('kortix-projects:support-agent-kit');
+  });
+});
+
+describe('buildCreateRepoPayload', () => {
+  test('sends the slug as the repo name and the typed name as the workspace name', () => {
+    const payload = buildCreateRepoPayload(
+      { ...base, name: "Ana's agents", source: 'github-create', installationId: '84' },
+      'acc-1',
+    );
+    expect(payload).toMatchObject({
+      account_id: 'acc-1',
+      name: 'Ana-s-agents',
+      project_name: "Ana's agents",
+      installation_id: '84',
+      private: true,
+      starter_template: 'general-knowledge-worker',
+    });
+  });
+
+  test('never sends default_branch — the route does not accept one', () => {
+    const payload = buildCreateRepoPayload(
+      { ...base, source: 'github-create', installationId: '84', defaultBranch: 'trunk' },
+      'acc-1',
+    );
+    expect(payload).not.toHaveProperty('default_branch');
+  });
+
+  test('forwards the clone template and the icon, each under its own key', () => {
+    const emoji = buildCreateRepoPayload(
+      { ...base, icon: { emoji: '🚀' }, templateId: 'item-1', installationId: '84' },
+      'acc-1',
+    );
+    expect(emoji).toMatchObject({ icon: '🚀', source_item_id: 'item-1' });
+    expect(emoji).not.toHaveProperty('icon_glyph');
+
+    const glyph = buildCreateRepoPayload(
+      { ...base, icon: { glyph: { name: 'Rocket', color: 'blue' } }, installationId: '84' },
+      'acc-1',
+    );
+    expect(glyph).toMatchObject({ icon_glyph: { name: 'Rocket', color: 'blue' } });
+    expect(glyph).not.toHaveProperty('icon');
+  });
+
+  test('omits keys rather than sending nulls the server would have to interpret', () => {
+    const payload = buildCreateRepoPayload({ ...base, source: 'github-create' }, undefined);
+    expect(payload).not.toHaveProperty('account_id');
+    expect(payload).not.toHaveProperty('installation_id');
+    expect(payload).not.toHaveProperty('icon');
+  });
+});
+
+describe('buildLinkRepositoryPayload', () => {
+  test('sends the repository, the installation, and the branch chosen for it', () => {
+    const payload = buildLinkRepositoryPayload(
+      {
+        ...base,
+        source: 'github-import',
+        installationId: '84',
+        repoFullName: 'acme/portal',
+        defaultBranch: 'trunk',
+      },
+      'acc-1',
+    );
+    expect(payload).toMatchObject({
+      account_id: 'acc-1',
+      installation_id: '84',
+      repo_full_name: 'acme/portal',
+      name: 'Support desk',
+      default_branch: 'trunk',
+    });
+  });
+
+  test('omits an empty branch so the repository default wins server-side', () => {
+    // `resolveImportedDefaultBranch` uses `repo.default_branch` when the key is
+    // absent and VALIDATES it when present — sending '' would be a 400.
+    const payload = buildLinkRepositoryPayload(
+      {
+        ...base,
+        source: 'github-import',
+        installationId: '84',
+        repoFullName: 'acme/portal',
+        defaultBranch: '   ',
+      },
+      'acc-1',
+    );
+    expect(payload).not.toHaveProperty('default_branch');
+  });
+
+  test('omits an empty name so the server derives one from the repo', () => {
+    const payload = buildLinkRepositoryPayload(
+      {
+        ...base,
+        name: '   ',
+        source: 'github-import',
+        installationId: '84',
+        repoFullName: 'acme/portal',
+      },
+      'acc-1',
+    );
+    expect(payload).not.toHaveProperty('name');
+  });
+});

--- a/apps/web/src/features/workspace/new/github-source.ts
+++ b/apps/web/src/features/workspace/new/github-source.ts
@@ -1,0 +1,195 @@
+/**
+ * The two GitHub-backed repository sources on `/new`, as pure functions.
+ *
+ * `/new` shipped with `github-create` and `github-import` present in the
+ * Select but `disabled`, and `canSubmit` additionally required
+ * `source === 'managed'` — so both were dead options with an apology under
+ * them. Nothing was missing on the server: `POST /projects/create-repo` and
+ * `POST /projects/link-repository` (`apps/api/src/projects/routes/r2.ts`) are
+ * live, and `createProjectRepo` / `linkRepository` are exported from
+ * `@kortix/sdk`. Only the client wiring was gone, deleted with
+ * `project-create-modal.tsx` in #6276.
+ *
+ * The payload shapes below are the ones those two routes actually read; each
+ * field is commented with the route line that consumes it, because the two
+ * routes disagree in ways that are easy to get wrong (see `repoSlugFromName`
+ * and the `default_branch` note on `buildLinkRepositoryPayload`).
+ */
+
+import type { NewWorkspaceFormState, RepositorySource } from './new-workspace-form';
+import type { CreateProjectRepoInput, LinkRepositoryInput } from '@kortix/sdk';
+
+/** True for the two sources that act through a GitHub App installation. */
+export function isGitHubSource(source: RepositorySource): boolean {
+  return source === 'github-create' || source === 'github-import';
+}
+
+/**
+ * The branch a `managed` workspace defaults to. Kept here beside the switch
+ * that restores it rather than read back off `INITIAL_FORM_STATE`, which would
+ * make this module depend on that object's runtime value purely to recover one
+ * string.
+ */
+const MANAGED_DEFAULT_BRANCH = 'main';
+
+/**
+ * Switch the repository source, clearing what the previous source owned.
+ *
+ * A bare `{ ...state, source }` leaks state across the switch in two ways that
+ * both end in a wrong create:
+ *
+ * 1. `installationId` / `repoFullName` survive into `managed`, where nothing
+ *    reads them — harmless — but ALSO survive from `github-import` into
+ *    `github-create`, where a repository the user picked to IMPORT would sit
+ *    in state while the form creates a new one.
+ * 2. `defaultBranch` survives out of `github-import` carrying the imported
+ *    repository's branch (say `trunk`), and `managed` then provisions a brand
+ *    new repo whose default branch is a name the user never chose for it.
+ *
+ * So the branch is restored to the managed default on any switch away from
+ * `github-import`, and the two GitHub fields are cleared on every switch.
+ */
+export function withRepositorySource(
+  state: NewWorkspaceFormState,
+  source: RepositorySource,
+): NewWorkspaceFormState {
+  return {
+    ...state,
+    source,
+    installationId: null,
+    repoFullName: null,
+    defaultBranch:
+      state.source === 'github-import' ? MANAGED_DEFAULT_BRANCH : state.defaultBranch,
+  };
+}
+
+/**
+ * A workspace name turned into a GitHub repository name.
+ *
+ * `POST /projects/create-repo` validates `name` against
+ * `/^[a-zA-Z0-9._-]+$/` (`r2.ts`) — no spaces — while a workspace name is
+ * free text and routinely has them. The old create modal did this inline as
+ * `values.name.trim().replace(/\s+/g, '-')`, which only covered spaces: a
+ * name like `Ana's agents` still reached the route with an apostrophe and
+ * came back 400. Every character outside GitHub's set collapses to a single
+ * hyphen here instead.
+ *
+ * Leading and trailing `.`/`-`/`_` are trimmed: GitHub accepts them but they
+ * produce repository names nobody would type, and a name of only punctuation
+ * would otherwise reduce to a string of hyphens. A name with no usable
+ * characters at all falls back to `workspace`; the route then auto-dedupes
+ * (`workspace`, `workspace-2`, …) rather than failing.
+ */
+export function repoSlugFromName(name: string): string {
+  const slug = name
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^[._-]+/, '')
+    .replace(/[._-]+$/, '');
+  return slug || 'workspace';
+}
+
+/**
+ * `github.com/<owner>/<repo>` for the repository "Create in GitHub" would
+ * make, or null while the owner is still unknown. Rendered under the source
+ * picker so the derived slug is visible BEFORE the user presses Create —
+ * `repoSlugFromName` can change the name they typed quite a lot, and finding
+ * that out from the created repo is finding out too late.
+ */
+export function plannedRepoPath(ownerLogin: string | null, name: string): string | null {
+  if (!ownerLogin) return null;
+  return `github.com/${ownerLogin}/${repoSlugFromName(name)}`;
+}
+
+/**
+ * Whether the GitHub-specific inputs for `state.source` are filled in.
+ *
+ * Both sources need an installation. Only `github-import` needs a repository:
+ * `github-create` makes one. `managed` needs neither, and returns true so
+ * callers can ask this unconditionally.
+ */
+export function githubSourceReady(state: NewWorkspaceFormState): boolean {
+  if (state.source === 'managed') return true;
+  if (!state.installationId) return false;
+  if (state.source === 'github-import') return Boolean(state.repoFullName);
+  return true;
+}
+
+/**
+ * The icon key, as the create routes read it.
+ *
+ * Spread, never `icon: icon ?? undefined`: the key is absent from the JSON
+ * entirely when nothing is picked, so each route keeps its own "no icon"
+ * default instead of receiving an explicit null to interpret. Which key —
+ * `icon` or `icon_glyph` — comes straight from which side of the union
+ * `state.icon` holds, so no caller can ever send both. Same rule
+ * `buildProvisionPayload` follows for the managed source.
+ */
+export function iconPayload(state: NewWorkspaceFormState): Record<string, unknown> {
+  if (!state.icon) return {};
+  if ('emoji' in state.icon) return { icon: state.icon.emoji };
+  return { icon_glyph: state.icon.glyph };
+}
+
+/**
+ * The request body for `POST /v1/projects/create-repo`.
+ *
+ * `name` is the GITHUB repository name and `project_name` is the Kortix
+ * workspace name — two different fields the route reads separately
+ * (`r2.ts`: `name` is charset-validated then passed to `createRepo`,
+ * `project_name` falls back to `deriveProjectName(repo.full_name)`). Sending
+ * only `name` was survivable in the old modal because its repo-name field WAS
+ * the project name; here the user types a workspace name with spaces, so both
+ * are sent and the workspace keeps the name that was typed.
+ *
+ * No `default_branch`. The route does not accept one — it reads
+ * `repo.default_branch` off the repository GitHub just created (`r2.ts`) —
+ * so `/new` hides the branch field for this source rather than collecting a
+ * value that would be silently dropped.
+ */
+export function buildCreateRepoPayload(
+  state: NewWorkspaceFormState,
+  accountId: string | undefined,
+): CreateProjectRepoInput {
+  return {
+    ...(accountId ? { account_id: accountId } : {}),
+    name: repoSlugFromName(state.name),
+    project_name: state.name.trim(),
+    ...(state.installationId ? { installation_id: state.installationId } : {}),
+    private: true,
+    starter_template: 'general-knowledge-worker',
+    ...(state.templateId ? { source_item_id: state.templateId } : {}),
+    ...iconPayload(state),
+  } as CreateProjectRepoInput;
+}
+
+/**
+ * The request body for `POST /v1/projects/link-repository`.
+ *
+ * `default_branch` is sent, and that is deliberate rather than incidental.
+ * `resolveImportedDefaultBranch` (`apps/api/src/projects/lib/git.ts`) uses
+ * the repository's OWN default when the key is absent, and VALIDATES the
+ * value against GitHub when it is present — 400 `Selected branch "x" does not
+ * exist` otherwise. `/new` seeds `state.defaultBranch` from the picked
+ * repository's `default_branch` the moment a repository is chosen
+ * (`advanced-fields.tsx`), so the value sent is the repository's real default
+ * unless the user deliberately typed another branch — in which case a
+ * validated 400 is the correct answer, not a silent import onto the wrong
+ * branch.
+ */
+export function buildLinkRepositoryPayload(
+  state: NewWorkspaceFormState,
+  accountId: string | undefined,
+): LinkRepositoryInput {
+  const name = state.name.trim();
+  const branch = state.defaultBranch.trim();
+  return {
+    ...(accountId ? { account_id: accountId } : {}),
+    ...(state.installationId ? { installation_id: state.installationId } : {}),
+    ...(state.repoFullName ? { repo_full_name: state.repoFullName } : {}),
+    ...(name ? { name } : {}),
+    ...(branch ? { default_branch: branch } : {}),
+    ...iconPayload(state),
+  };
+}

--- a/apps/web/src/features/workspace/new/new-workspace-form.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.test.ts
@@ -24,6 +24,13 @@ describe('INITIAL_FORM_STATE', () => {
       defaultBranch: 'main',
       templateId: null,
       accountId: null,
+      // The two GitHub sources need an installation, and `github-import`
+      // additionally a repository. Null on a `managed` default, where neither
+      // is read — but present in the shape, so `isSubmittable`'s
+      // `githubSourceReady` gate reads a defined field rather than
+      // `undefined`.
+      installationId: null,
+      repoFullName: null,
     });
   });
 });

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -1,4 +1,5 @@
 import type { ProjectIconValue } from '@/features/projects/modal/project-icon-field';
+import { githubSourceReady } from '@/features/workspace/new/github-source';
 import { validateWorkspaceName } from '@/features/workspace/new/workspace-name';
 import type { KortixAccount } from '@kortix/sdk';
 
@@ -12,6 +13,15 @@ export interface NewWorkspaceFormState {
   templateId: string | null;
   /** Null means "the user has exactly one account, so there is nothing to pick". */
   accountId: string | null;
+  /**
+   * The GitHub App installation the two GitHub sources act through — the
+   * `installation_id` both `POST /projects/create-repo` and
+   * `POST /projects/link-repository` require. Null for `managed`, which needs
+   * no GitHub account at all.
+   */
+  installationId: string | null;
+  /** `owner/repo`, for `github-import` only. Null for the other two sources. */
+  repoFullName: string | null;
 }
 
 /**
@@ -27,6 +37,8 @@ export const INITIAL_FORM_STATE: NewWorkspaceFormState = {
   defaultBranch: 'main',
   templateId: null,
   accountId: null,
+  installationId: null,
+  repoFullName: null,
 };
 
 /**
@@ -105,6 +117,12 @@ export function resolveDefaultCreatableAccountId(
 
 export function isSubmittable(state: NewWorkspaceFormState, accountCount: number): boolean {
   if (!validateWorkspaceName(state.name).ok) return false;
+  // The two GitHub sources need inputs `managed` does not: an installation for
+  // both, and a repository for `github-import`. Gated HERE rather than at the
+  // page, which is where the old `state.source === 'managed'` blanket refusal
+  // lived — that one disabled submit for a correctly-filled GitHub form as
+  // readily as an empty one, because no GitHub form existed to fill.
+  if (!githubSourceReady(state)) return false;
   // Zero is never a legitimate "ready to submit" state. It means either the
   // accounts query has not resolved yet — in which case a multi-account user
   // would submit with no account_id and the server would silently fall back to

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -235,8 +235,13 @@ describe('/new page: layout shape (design is a release gate here)', () => {
    * together — a test that fails five times is not a test anyone reads.
    */
   test('Advanced renders, currently without a name gate', () => {
-    expect(code).toContain('<AdvancedFields state={state} onChange={setState} />');
+    expect(code).toContain('<AdvancedFields');
     expect(code).not.toContain('{showIcon ? <AdvancedFields');
+    // `effectiveAccountId`, not `state.accountId`: the GitHub queries inside
+    // are account-scoped and `state.accountId` is legitimately null for a
+    // single-account user, which would leave them disabled for exactly those
+    // users.
+    expect(code).toContain('accountId={effectiveAccountId}');
   });
 
   test('icon and name sit in one field group; submit is a sibling below it', () => {

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react';
 
 import { readCloneParam } from '@/features/workspace/new/clone-param';
 import { readOnboardingParam } from '@/features/workspace/new/onboarding-param';
+import { readSourceParam } from '@/features/workspace/new/source-param';
 
 import { ProjectOnboardingWizard } from '@/components/projects/project-onboarding-wizard';
 import { Button } from '@/components/ui/button';
@@ -124,9 +125,16 @@ export function NewWorkspacePage() {
     new URLSearchParams(searchParams?.toString() ?? ''),
   );
 
+  // `?source=` is how the picked repository source survives the real
+  // navigation to `/github/setup` and back (`readSourceParam`). Read into the
+  // INITIAL state only — a lazy `useState` initializer, so a later param
+  // change never fights the user's own Select.
+  const initialSource = readSourceParam(new URLSearchParams(searchParams?.toString() ?? ''));
+
   const [state, setState] = useState<NewWorkspaceFormState>(() => ({
     ...INITIAL_FORM_STATE,
     templateId: cloneItemId,
+    ...(initialSource ? { source: initialSource } : {}),
   }));
   const [touched, setTouched] = useState(false);
   const reduceMotion = useReducedMotion();
@@ -198,16 +206,17 @@ export function NewWorkspacePage() {
   // wrong account — is exactly what a stale reading of that count during the
   // loading window would let through.
   //
-  // `state.source === 'managed'` is gated here, not in the shared
-  // `isSubmittable`: `POST /provision` (the only wired submit path —
-  // `useCreateWorkspace`) has no installation-id or repo fields, so a
-  // `github-create` / `github-import` source can never be submittable through
-  // it. `AdvancedFields` explains this inline and links to the real GitHub
-  // connect flow instead of shipping a form that would 400.
+  // The source-specific part of the gate lives in `isSubmittable`
+  // (`githubSourceReady`), not here. It used to be a flat
+  // `state.source === 'managed'` on this line, because `useCreateWorkspace`
+  // only knew how to POST `/projects/provision` — so the two GitHub sources
+  // were unreachable and their Select options were rendered `disabled`. Both
+  // now have their own route (`/projects/create-repo`,
+  // `/projects/link-repository`) and their own inputs, so what blocks submit
+  // is a MISSING input, the same as an empty name — never the choice itself.
   const canSubmit =
     isSubmittable(effectiveState, creatableAccounts.length) &&
     !accountsQuery.isLoading &&
-    state.source === 'managed' &&
     !submitting;
 
   return (
@@ -428,7 +437,17 @@ export function NewWorkspacePage() {
                   </p>
                 ) : null}
 
-                <AdvancedFields state={state} onChange={setState} />
+                {/* `effectiveAccountId`, not `state.accountId`: the GitHub
+                      queries inside are account-scoped, and `state.accountId`
+                      is legitimately null for a single-account user (the
+                      picker hides itself below two accounts). Passing the raw
+                      value would leave those queries permanently disabled for
+                      exactly the users who have nothing to pick. */}
+                <AdvancedFields
+                  state={state}
+                  accountId={effectiveAccountId}
+                  onChange={setState}
+                />
               </div>
 
               <Button type="submit" size="lg" disabled={!canSubmit} className="w-full">

--- a/apps/web/src/features/workspace/new/source-param.test.ts
+++ b/apps/web/src/features/workspace/new/source-param.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+import { newWorkspaceReturnPath, readSourceParam } from './source-param';
+
+describe('readSourceParam', () => {
+  test('reads each known source', () => {
+    expect(readSourceParam(new URLSearchParams('source=managed'))).toBe('managed');
+    expect(readSourceParam(new URLSearchParams('source=github-create'))).toBe('github-create');
+    expect(readSourceParam(new URLSearchParams('source=github-import'))).toBe('github-import');
+  });
+
+  test('rejects anything not a real source, rather than passing it through', () => {
+    // An unvalidated pass-through would put the form in a state
+    // `isSubmittable` has no branch for — reachable by anyone editing the URL.
+    expect(readSourceParam(new URLSearchParams('source=github'))).toBeNull();
+    expect(readSourceParam(new URLSearchParams('source=MANAGED'))).toBeNull();
+    expect(readSourceParam(new URLSearchParams('source='))).toBeNull();
+    expect(readSourceParam(new URLSearchParams(''))).toBeNull();
+  });
+});
+
+describe('newWorkspaceReturnPath', () => {
+  test('carries a GitHub source back from /github/setup', () => {
+    expect(newWorkspaceReturnPath('github-import')).toBe('/new?source=github-import');
+    expect(newWorkspaceReturnPath('github-create')).toBe('/new?source=github-create');
+  });
+
+  test('adds no param for the default source', () => {
+    expect(newWorkspaceReturnPath('managed')).toBe('/new');
+  });
+
+  test('round-trips through readSourceParam', () => {
+    const path = newWorkspaceReturnPath('github-import');
+    const query = path.slice(path.indexOf('?'));
+    expect(readSourceParam(new URLSearchParams(query))).toBe('github-import');
+  });
+});

--- a/apps/web/src/features/workspace/new/source-param.ts
+++ b/apps/web/src/features/workspace/new/source-param.ts
@@ -1,0 +1,29 @@
+/**
+ * `/new?source=github-import` — which repository source the form opens on.
+ *
+ * Exists for one flow: a user picks a GitHub source, has no GitHub account
+ * connected yet, and follows the link to `/github/setup`. That is a real
+ * navigation, so the in-progress form state is gone when they come back. The
+ * setup page returns them to whatever path `rememberGitHubSetupReturn` stored,
+ * so `advanced-fields.tsx` stores `/new?source=<their choice>` and this reads
+ * it back — otherwise they land on a form reset to `managed` and have to
+ * rediscover the option that sent them away.
+ *
+ * Unknown and absent values both resolve to `null`, and the caller keeps its
+ * own default. An unvalidated pass-through would let `?source=anything` put
+ * the form in a state `isSubmittable` has no branch for.
+ */
+import type { RepositorySource } from './new-workspace-form';
+
+const SOURCES: readonly RepositorySource[] = ['managed', 'github-create', 'github-import'];
+
+export function readSourceParam(params: URLSearchParams): RepositorySource | null {
+  const raw = params.get('source')?.trim();
+  if (!raw) return null;
+  return SOURCES.find((source) => source === raw) ?? null;
+}
+
+/** The path `/github/setup` should return to, preserving the picked source. */
+export function newWorkspaceReturnPath(source: RepositorySource): string {
+  return source === 'managed' ? '/new' : `/new?source=${encodeURIComponent(source)}`;
+}

--- a/apps/web/src/features/workspace/new/use-create-workspace.test.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.test.ts
@@ -362,6 +362,8 @@ describe('runCreate: the full create() orchestration', () => {
       attemptKeyFor,
       clearAttemptKey,
       runCreateAttempt: async () => fakeProject('created'),
+      createGitHubRepoProject: async () => fakeProject('created-github'),
+      importGitHubRepoProject: async () => fakeProject('imported-github'),
       primeProjectCache: () => {},
       invalidateProjects: () => {},
       writeLastProjectId: () => {},
@@ -402,6 +404,8 @@ describe('runCreate: the full create() orchestration', () => {
         clearAttemptKey(fingerprint);
       },
       runCreateAttempt: async () => fakeProject('created-order'),
+      createGitHubRepoProject: async () => fakeProject('created-order'),
+      importGitHubRepoProject: async () => fakeProject('created-order'),
       primeProjectCache: () => order.push('primeCache'),
       invalidateProjects: () => order.push('invalidate'),
       writeLastProjectId: () => order.push('writeCookie'),
@@ -484,6 +488,8 @@ describe('runCreate: the full create() orchestration', () => {
           },
           wait: async () => {},
         }),
+      createGitHubRepoProject: async () => fakeProject('created-retry-mint'),
+      importGitHubRepoProject: async () => fakeProject('created-retry-mint'),
       primeProjectCache: () => {},
       invalidateProjects: () => {},
       writeLastProjectId: () => {},
@@ -595,6 +601,168 @@ describe('runCreate: the full create() orchestration', () => {
     );
 
     expect(sentPayloads[0]?.account_id).toBe('acct-owner');
+  });
+
+  /**
+   * The two GitHub sources. Before this work `runCreate` had ONE network call
+   * (`/projects/provision`) and the page refused to submit anything else, so
+   * "Create in GitHub" and "Import from GitHub" were rendered `disabled`.
+   * These tests pin the routing — which call each source makes, and what each
+   * one is handed — because getting it wrong means creating a workspace
+   * against the wrong upstream repository, which is not recoverable by a
+   * retry.
+   */
+  test('github-create routes to create-repo, never to provision', async () => {
+    const state = {
+      ...INITIAL_FORM_STATE,
+      name: "Ana's agents",
+      accountId: 'acct-owner',
+      source: 'github-create' as const,
+      installationId: '84',
+    };
+    let provisionCalls = 0;
+    const created: unknown[] = [];
+
+    const result = await runCreate(state, [OWNER_ACCOUNT], 'user-1', {
+      ...noopClient(),
+      runCreateAttempt: async () => {
+        provisionCalls += 1;
+        return fakeProject('should-not-happen');
+      },
+      createGitHubRepoProject: async (payload) => {
+        created.push(payload);
+        return fakeProject('created-in-github');
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(provisionCalls).toBe(0);
+    expect(created).toHaveLength(1);
+    // The slug for GitHub, the typed name for the workspace.
+    expect(created[0]).toMatchObject({
+      name: 'Ana-s-agents',
+      project_name: "Ana's agents",
+      installation_id: '84',
+      account_id: 'acct-owner',
+    });
+  });
+
+  test('github-import routes to link-repository, never to provision', async () => {
+    const state = {
+      ...INITIAL_FORM_STATE,
+      name: 'Portal',
+      accountId: 'acct-owner',
+      source: 'github-import' as const,
+      installationId: '84',
+      repoFullName: 'acme/portal',
+      defaultBranch: 'trunk',
+    };
+    let provisionCalls = 0;
+    const imported: unknown[] = [];
+
+    const result = await runCreate(state, [OWNER_ACCOUNT], 'user-1', {
+      ...noopClient(),
+      runCreateAttempt: async () => {
+        provisionCalls += 1;
+        return fakeProject('should-not-happen');
+      },
+      importGitHubRepoProject: async (payload) => {
+        imported.push(payload);
+        return fakeProject('imported-from-github');
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(provisionCalls).toBe(0);
+    expect(imported[0]).toMatchObject({
+      repo_full_name: 'acme/portal',
+      installation_id: '84',
+      default_branch: 'trunk',
+      account_id: 'acct-owner',
+    });
+  });
+
+  test('a GitHub source mints no idempotency key — neither route accepts one', async () => {
+    // A minted-but-never-sent key would persist for its full TTL and never be
+    // cleared, so a LATER managed create with the same fingerprint would reuse
+    // a key that no request ever carried.
+    const state = {
+      ...INITIAL_FORM_STATE,
+      name: 'suna-web',
+      accountId: 'acct-owner',
+      source: 'github-create' as const,
+      installationId: '84',
+    };
+    const mintCalls: string[] = [];
+
+    await runCreate(state, [OWNER_ACCOUNT], 'user-1', {
+      ...noopClient(),
+      attemptKeyFor: (fingerprint, now) => {
+        mintCalls.push(fingerprint);
+        return attemptKeyFor(fingerprint, now);
+      },
+    });
+
+    expect(mintCalls).toEqual([]);
+  });
+
+  test('every source runs the SAME success path — cache, invalidate, cookie, onboarding', async () => {
+    // The routing differs; what happens after a project exists must not.
+    for (const state of [
+      { ...INITIAL_FORM_STATE, name: 'a', accountId: 'acct-owner', source: 'managed' as const },
+      {
+        ...INITIAL_FORM_STATE,
+        name: 'b',
+        accountId: 'acct-owner',
+        source: 'github-create' as const,
+        installationId: '84',
+      },
+      {
+        ...INITIAL_FORM_STATE,
+        name: 'c',
+        accountId: 'acct-owner',
+        source: 'github-import' as const,
+        installationId: '84',
+        repoFullName: 'acme/portal',
+      },
+    ]) {
+      const order: string[] = [];
+      const result = await runCreate(state, [OWNER_ACCOUNT], 'user-1', {
+        ...noopClient(),
+        primeProjectCache: () => order.push('primeCache'),
+        invalidateProjects: () => order.push('invalidate'),
+        writeLastProjectId: () => order.push('writeCookie'),
+        enterOnboarding: () => order.push('enterOnboarding'),
+      });
+      expect(result.ok).toBe(true);
+      expect(order).toEqual(['primeCache', 'invalidate', 'writeCookie', 'enterOnboarding']);
+    }
+  });
+
+  test('a failed GitHub create surfaces the error like any other source', async () => {
+    const err = new ApiError('Install the Kortix GitHub App before creating GitHub-backed projects', {
+      status: 409,
+    });
+    const result = await runCreate(
+      {
+        ...INITIAL_FORM_STATE,
+        name: 'suna-web',
+        accountId: 'acct-owner',
+        source: 'github-create' as const,
+        installationId: '84',
+      },
+      [OWNER_ACCOUNT],
+      'user-1',
+      {
+        ...noopClient(),
+        createGitHubRepoProject: async () => {
+          throw err;
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toBe(err);
   });
 
 });

--- a/apps/web/src/features/workspace/new/use-create-workspace.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.ts
@@ -6,6 +6,10 @@ import { useRouter } from 'next/navigation';
 
 import { attemptKeyFor, clearAttemptKey } from '@/features/workspace/new/create-workspace-key';
 import {
+  buildCreateRepoPayload,
+  buildLinkRepositoryPayload,
+} from '@/features/workspace/new/github-source';
+import {
   buildProvisionPayload,
   filterCreatableAccounts,
   resolveDefaultCreatableAccountId,
@@ -19,12 +23,16 @@ import {
 } from '@/lib/onboarding/ensure-first-project';
 import { writeLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import {
+  createProjectRepo,
+  linkRepository,
   listAccounts,
   provisionProject,
   provisionProjectStream,
   PROVISION_IN_FLIGHT_CODE,
+  type CreateProjectRepoInput,
   type KortixAccount,
   type KortixProject,
+  type LinkRepositoryInput,
   type ProvisionPhase,
   type ProvisionProjectInput,
   type ProvisionStreamEvent,
@@ -118,6 +126,32 @@ export function buildCreatePayload(
 }
 
 /**
+ * The `POST /projects/create-repo` body, with the create's target account
+ * resolved through the SAME `resolveTargetAccountId` the provision path uses.
+ *
+ * Resolved here rather than left to the server for the reason that function's
+ * own doc comment gives at length: an omitted `account_id` resolves to the
+ * caller's earliest-joined membership with NO role check, which for a user who
+ * joined someone else's account first is an account they cannot create in.
+ * That reasoning is about the SERVER's default, not about which route is being
+ * called, so it holds identically for all three sources.
+ */
+export function buildGitHubCreatePayload(
+  state: NewWorkspaceFormState,
+  creatableAccounts: KortixAccount[],
+): CreateProjectRepoInput {
+  return buildCreateRepoPayload(state, resolveTargetAccountId(state, creatableAccounts));
+}
+
+/** The `POST /projects/link-repository` body. Same account resolution. */
+export function buildGitHubImportPayload(
+  state: NewWorkspaceFormState,
+  creatableAccounts: KortixAccount[],
+): LinkRepositoryInput {
+  return buildLinkRepositoryPayload(state, resolveTargetAccountId(state, creatableAccounts));
+}
+
+/**
  * A user-facing message for a failed create.
  *
  * `ApiError` field names verified at
@@ -174,7 +208,20 @@ export function messageFor(error: unknown): string {
     return "Managed git isn't set up on this server. An admin needs to connect GitHub in Git settings before workspaces can be created.";
   }
   if (status === 409) {
-    return 'Another attempt to create this workspace is already in progress. Please wait a moment and try again.';
+    // Two different 409s reach here now, and they must not share a message.
+    // `provision_in_flight` carries a typed `code`
+    // (`PROVISION_IN_FLIGHT_CODE`); the GitHub sources' 409s do not — they are
+    // "install the Kortix GitHub App first" (`create-repo` and
+    // `link-repository`, `apps/api/src/projects/routes/r2.ts`) and "no
+    // available repository name near X". Both of those already say exactly
+    // what to do, so the server's own message is reused verbatim rather than
+    // being overwritten with a wait-and-retry line that is simply false for
+    // them.
+    const code = (error as { code?: string } | null | undefined)?.code;
+    if (code === PROVISION_IN_FLIGHT_CODE) {
+      return 'Another attempt to create this workspace is already in progress. Please wait a moment and try again.';
+    }
+    return message || 'Could not create the workspace. Try again.';
   }
   if (status === 502) return 'Could not create the workspace. Try again.';
   return message || 'Could not create the workspace. Try again.';
@@ -416,6 +463,15 @@ export type CreateOrchestrationClient = {
   attemptKeyFor: (fingerprint: string, now: number) => string;
   clearAttemptKey: (fingerprint: string) => void;
   runCreateAttempt: (payload: ProvisionProjectInput) => Promise<KortixProject>;
+  /**
+   * `source: 'github-create'` — `POST /projects/create-repo`. A separate slot
+   * rather than a branch inside `runCreateAttempt` because the three sources
+   * take three different payload TYPES; one slot per route keeps each one
+   * typed instead of collapsing them to `Record<string, unknown>`.
+   */
+  createGitHubRepoProject: (payload: CreateProjectRepoInput) => Promise<KortixProject>;
+  /** `source: 'github-import'` — `POST /projects/link-repository`. */
+  importGitHubRepoProject: (payload: LinkRepositoryInput) => Promise<KortixProject>;
   primeProjectCache: (accountId: string, project: KortixProject) => void;
   invalidateProjects: () => void;
   writeLastProjectId: (userId: string | null | undefined, projectId: string) => void;
@@ -438,6 +494,39 @@ export type CreateOrchestrationClient = {
 };
 
 export type CreateResult = { ok: true; project: KortixProject } | { ok: false; error: unknown };
+
+/**
+ * The one network call this create makes, chosen by `state.source`.
+ *
+ * Every source ends at the same `KortixProject`, which is what lets the
+ * success path in `runCreate` stay single — prime the cache, invalidate, write
+ * the cookie, enter onboarding — instead of growing a copy per source. The
+ * three routes differ only in what they send and which upstream repository
+ * they end up pointing at.
+ *
+ * `idempotencyKey` is non-null only for `managed`; `runCreate` owns that rule
+ * and this function asserts it rather than re-deriving it, so the two can
+ * never disagree about whether a key was minted.
+ */
+async function runSourceAttempt(
+  state: NewWorkspaceFormState,
+  creatableAccounts: KortixAccount[],
+  idempotencyKey: string | null,
+  client: CreateOrchestrationClient,
+): Promise<KortixProject> {
+  if (state.source === 'github-create') {
+    return client.createGitHubRepoProject(buildGitHubCreatePayload(state, creatableAccounts));
+  }
+  if (state.source === 'github-import') {
+    return client.importGitHubRepoProject(buildGitHubImportPayload(state, creatableAccounts));
+  }
+  if (!idempotencyKey) {
+    throw new Error('runCreate: the managed source requires an idempotency key');
+  }
+  return client.runCreateAttempt(
+    buildCreatePayload(state, creatableAccounts, idempotencyKey) as unknown as ProvisionProjectInput,
+  );
+}
 
 /**
  * The full sequence one submit runs:
@@ -478,16 +567,19 @@ export async function runCreate(
   client: CreateOrchestrationClient,
 ): Promise<CreateResult> {
   const fingerprint = fingerprintOf(state);
-  const idempotencyKey = client.attemptKeyFor(fingerprint, client.now());
-  const payload = buildCreatePayload(
-    state,
-    creatableAccounts,
-    idempotencyKey,
-  ) as unknown as ProvisionProjectInput;
+  // The key belongs to `POST /projects/provision` and nothing else — it is the
+  // only one of the three routes that accepts an `idempotency_key`. Minting one
+  // for a GitHub source would persist a key that is never sent and never
+  // cleared, so `usesIdempotencyKey` gates BOTH the mint and the clear rather
+  // than only the field in the payload.
+  const usesIdempotencyKey = state.source === 'managed';
+  const idempotencyKey = usesIdempotencyKey
+    ? client.attemptKeyFor(fingerprint, client.now())
+    : null;
 
   try {
-    const project = await client.runCreateAttempt(payload);
-    client.clearAttemptKey(fingerprint);
+    const project = await runSourceAttempt(state, creatableAccounts, idempotencyKey, client);
+    if (usesIdempotencyKey) client.clearAttemptKey(fingerprint);
     client.primeProjectCache(project.account_id, project);
     client.invalidateProjects();
     client.writeLastProjectId(userId, project.project_id);
@@ -551,6 +643,17 @@ export function useCreateWorkspace(): {
         // render progress. Nothing here consumes it, so nothing here holds
         // state for it.
         runCreateAttempt: (payload) => runProvisionAttempt(payload, () => {}),
+        // No stream and no idempotency retry on either GitHub route: neither
+        // emits provisioning phases and neither accepts an `idempotency_key`,
+        // so there is nothing for `runProvisionAttempt`'s machinery to do. A
+        // failed attempt surfaces through `messageFor` and the user presses
+        // Try again, which is the whole retry story for these two.
+        createGitHubRepoProject: createProjectRepo,
+        // `linkRepository` answers `{ project, git_connection }`; the
+        // orchestration only ever needs the project, and unwrapping HERE (not
+        // inside `runCreate`) keeps every source's success path identical.
+        importGitHubRepoProject: (payload) =>
+          linkRepository(payload).then((response) => response.project),
         // The optimistic write goes ONLY into the account this workspace
         // actually belongs to — the one entry a merge here can never get
         // wrong. `qk.projects.list()` (no account) is a DIFFERENT, sibling

--- a/packages/sdk/src/core/rest/projects-client/projects.test.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.test.ts
@@ -97,6 +97,46 @@ test('createProjectRepo sends icon_glyph on the wire, same as provision and link
   expect(sentBody).toMatchObject({ icon_glyph: { name: 'Rocket', color: 'blue' } });
 });
 
+test('CreateProjectRepoInput carries project_name, the workspace name distinct from the repo name', () => {
+  // `POST /projects/create-repo` reads TWO names (apps/api/src/projects/routes/
+  // r2.ts): `name` is the GitHub repository name, charset-validated against
+  // /^[a-zA-Z0-9._-]+$/, and `project_name` is the Kortix workspace name, which
+  // falls back to `deriveProjectName(repo.full_name)` when absent. Without this
+  // field a caller whose user typed "Ana's agents" must slugify for `name` and
+  // then has no way to keep the typed name — the workspace lands as
+  // "Ana-s-agents". Optional, so every existing caller keeps compiling.
+  const input: CreateProjectRepoInput = {
+    account_id: 'acc-1',
+    name: 'ana-s-agents',
+    project_name: "Ana's agents",
+  };
+  expect(input.project_name).toBe("Ana's agents");
+});
+
+test('createProjectRepo sends project_name on the wire', async () => {
+  // Paired wire assertion, same reasoning as the icon_glyph pair above: the
+  // type-level test proves the field is ACCEPTED, this one proves it is not
+  // dropped before the POST.
+  configureKortix({ backendUrl: 'http://backend.test/v1', getToken: async () => 'tok' });
+
+  let sentBody: unknown;
+  globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    sentBody = JSON.parse(String(init?.body ?? '{}'));
+    return new Response(JSON.stringify({ project_id: 'proj-1' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as unknown as typeof fetch;
+
+  await createProjectRepo({
+    account_id: 'acc-1',
+    name: 'ana-s-agents',
+    project_name: "Ana's agents",
+  });
+
+  expect(sentBody).toMatchObject({ name: 'ana-s-agents', project_name: "Ana's agents" });
+});
+
 test('returns ok:true with the parsed project on a real 200 body', async () => {
   nextResponse = () =>
     new Response(JSON.stringify({ project_id: 'proj-1', name: 'My First Project' }), {

--- a/packages/sdk/src/core/rest/projects-client/projects.ts
+++ b/packages/sdk/src/core/rest/projects-client/projects.ts
@@ -276,7 +276,19 @@ export interface ProjectInput {
 
 export interface CreateProjectRepoInput {
   account_id?: string;
+  /**
+   * The GitHub REPOSITORY name. Charset-validated server-side against
+   * `/^[a-zA-Z0-9._-]+$/` — no spaces. A workspace name typed by a person
+   * usually has to be slugified before it can go here; `project_name` below is
+   * where the typed name belongs.
+   */
   name: string;
+  /**
+   * The Kortix WORKSPACE name, when it differs from the repository name.
+   * Omitted, the server derives one from the created repo's full name
+   * (`deriveProjectName`), so "Ana's agents" would land as "Ana-s-agents".
+   */
+  project_name?: string;
   installation_id?: string;
   private?: boolean;
   description?: string;


### PR DESCRIPTION
## Why

Two reports, one PR.

**1. "Some users don't see People with access."** Not billing — there is no entitlement, plan, or upgrade check anywhere on this path. Two real causes:

- The section was gated on `project.write`, but `POST /:projectId/git/collaborators` asserts `project.members.manage` (`apps/api/src/projects/routes/r1.ts:633`). A custom role with write-but-not-members.manage saw the form and got a 403 on submit; the reverse role saw nothing though the API would have accepted it.
- On a repository Kortix does not own — a BYO repo, or one provisioned while `MANAGED_GIT_PROVIDER=code-storage` was the default (#5063 → #6796) — the whole section rendered `null`. No form, no explanation, no way to find out why.

**2. "Create in GitHub" and "Import from GitHub" were disabled.** `/new` shipped both options `disabled` in the Select, plus `canSubmit` requiring `source === 'managed'`. Nothing was missing on the server: `POST /projects/create-repo` and `POST /projects/link-repository` were live, and `createProjectRepo`/`linkRepository` are exported from the SDK. Only the client wiring was gone, deleted with `project-create-modal.tsx` in #6276.

## What changed

**`/new` repository sources**
- `github-source.ts` (new, pure): payload builders for both routes, `repoSlugFromName` (the route validates `/^[a-zA-Z0-9._-]+$/`, so `Ana's agents` → `Ana-s-agents`), and `withRepositorySource`, which clears the fields the previous source owned so an imported repo cannot leak into a create.
- `advanced-fields.tsx`: GitHub-account picker for both sources, repository picker for import, reusing `RepositoryPicker`/`BranchPicker` — orphaned by the modal deletion, now back in use. Picking a repo seeds the branch from its own `default_branch` (`link-repository` validates the branch it is sent, so leaving `main` was a guaranteed 400 for any repo whose trunk is named otherwise). No branch field for `github-create`: that route does not accept one.
- `use-create-workspace.ts`: routes by source. No idempotency key is minted for the GitHub sources — neither route accepts one. The 409 branch in `messageFor` now distinguishes `provision_in_flight` (typed code) from the GitHub routes' "install the App first" 409, which was previously overwritten with a wait-and-retry line that is false for it.
- `source-param.ts` (new): `/new?source=…` so the picked source survives the round trip to `/github/setup` and back.

**People with access**
- Probes `project.members.manage` — the leaf the route actually asserts — batched with `project.write` in one request off a module-level action list.
- A non-managed repository now renders an explanation naming the provider, with a "Manage on GitHub" link for GitHub repos, instead of disappearing.

**SDK**
- `CreateProjectRepoInput` gains optional `project_name`. The route reads two names — `name` is the GitHub repo (charset-validated), `project_name` is the workspace — and without it a workspace called "Ana's agents" landed as "Ana-s-agents". Additive; every existing caller still compiles.

## Verification

| Gate | Result |
|---|---|
| `apps/web` full suite (`bun test src`) | 8693 pass, 0 fail |
| `apps/web` tsc --noEmit | clean on all touched files |
| `npx eslint` on 7 changed files | 0 errors (1 pre-existing warning on an untouched effect) |
| `@kortix/sdk` typecheck | clean |
| `@kortix/sdk` test | 2756 pass, 0 fail |
| `@kortix/sdk` smoke:install | passed |

New tests: 41 across `github-source.test.ts`, `source-param.test.ts`, the `runCreate` routing block, and the git-view access gate. The routing tests were confirmed RED against the old behavior before being kept — disabling the `github-create` branch fails 3 of them.

## Not yet verified

The three create paths have not been driven against a live API in a browser. Preview label applied for that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790602919&installation_model_id=434224&pr_number=7037&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7037&signature=69579c48f1ee67c67168812a027f6ca1fd67fdfc74739b2daa46139a5eab8c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->