### PR TITLE
fix(api,web): stop offering the managed org as an import source

### DIFF
--- a/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
+++ b/apps/api/src/__tests__/e2e-create-repo-starter.test.ts
@@ -72,6 +72,7 @@ let githubInstallationStateConsumed: boolean;
 let ownerRepoListCalls: any[];
 let installationRepoListCalls: any[];
 let platformAdmin: boolean;
+let selfHostOperator: boolean;
 
 function setTestAuth(userId = USER_ID, userEmail = 'starter@example.test') {
   (globalThis as any)[TEST_AUTH_KEY] = { userId, userEmail };
@@ -113,6 +114,7 @@ function resetState() {
   ownerRepoListCalls = [];
   installationRepoListCalls = [];
   platformAdmin = false;
+  selfHostOperator = false;
   installationRows = [
     {
       installationRowId: '00000000-0000-4000-a000-000000000041',
@@ -155,6 +157,11 @@ const realPlatformRoles = await import('../shared/platform-roles');
 mock.module('../shared/platform-roles', () => ({
   ...realPlatformRoles,
   isPlatformAdmin: async () => platformAdmin,
+  // The managed-git PAT paths ask the NARROWER question — a cloud platform
+  // admin is not a self-host operator, and `managed-kortix` holds every
+  // customer's repo. `selfHostOperator` is a separate switch from
+  // `platformAdmin` on purpose: the test below asserts they differ.
+  isSelfHostOperator: async () => selfHostOperator,
 }));
 
 const realAuthMiddleware = await import('../middleware/auth');
@@ -884,7 +891,7 @@ describe('create-repo starter scaffold contract', () => {
   test('forwards bounded search options to the managed GitHub repository lister', async () => {
     process.env.MANAGED_GIT_GITHUB_OWNER = 'managed-kortix';
     process.env.MANAGED_GIT_GITHUB_TOKEN = 'managed-token';
-    platformAdmin = true;
+    selfHostOperator = true;
 
     const app = createApp();
     const response = await app.request(
@@ -922,7 +929,7 @@ describe('create-repo starter scaffold contract', () => {
     );
     expect(repositories.status).toBe(403);
     expect(await repositories.json()).toEqual({
-      error: 'Managed GitHub repository import requires platform admin access',
+      error: 'Managed GitHub repository import is only available to a self-host operator',
     });
     expect(ownerRepoListCalls).toEqual([]);
 
@@ -937,7 +944,54 @@ describe('create-repo starter scaffold contract', () => {
     });
     expect(linked.status).toBe(403);
     expect(await linked.json()).toEqual({
-      error: 'Managed GitHub repository import requires platform admin access',
+      error: 'Managed GitHub repository import is only available to a self-host operator',
+    });
+  });
+
+  test('THE FIX: a cloud platform admin is NOT a self-host operator — the managed org stays closed', async () => {
+    // Reported 2026-08-29: "why can I import anyone else's project". The PAT
+    // paths were gated on `isPlatformAdmin`, which is ALSO true for Kortix
+    // staff. On cloud, MANAGED_GIT_GITHUB_OWNER is `managed-kortix` — every
+    // customer's project repo — so a staff admin was shown the whole org in
+    // the /new import picker and could have imported any of it.
+    //
+    // `platformAdmin = true` with `selfHostOperator = false` is exactly that
+    // person. Everything below must refuse them.
+    installationRows = [];
+    process.env.MANAGED_GIT_GITHUB_OWNER = 'managed-kortix';
+    process.env.MANAGED_GIT_GITHUB_TOKEN = 'managed-token';
+    platformAdmin = true;
+    selfHostOperator = false;
+
+    const app = createApp();
+
+    // 1. The synthetic installation is not even offered.
+    const installations = await app.request(
+      `/v1/projects/github/installations?account_id=${ACCOUNT_ID}`,
+    );
+    expect(installations.status).toBe(200);
+    expect(await installations.json()).toMatchObject({ installed: false, installations: [] });
+
+    // 2. Listing the org is refused, and no upstream call is made.
+    const repositories = await app.request(
+      `/v1/projects/github/repositories?account_id=${ACCOUNT_ID}&installation_id=pat`,
+    );
+    expect(repositories.status).toBe(403);
+    expect(ownerRepoListCalls).toEqual([]);
+
+    // 3. Importing another customer's repo by name is refused outright.
+    const linked = await app.request('/v1/projects/link-repository', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        account_id: ACCOUNT_ID,
+        installation_id: 'pat',
+        repo_full_name: 'managed-kortix/someone-elses-project',
+      }),
+    });
+    expect(linked.status).toBe(403);
+    expect(await linked.json()).toEqual({
+      error: 'Managed GitHub repository import is only available to a self-host operator',
     });
   });
 

--- a/apps/api/src/projects/routes/github-repositories.ts
+++ b/apps/api/src/projects/routes/github-repositories.ts
@@ -1,7 +1,7 @@
 import { ACCOUNT_ACTIONS, assertAuthorized } from '../../iam';
 import { actorOf } from '../../iam/actor';
 import { auth, errors, json } from '../../openapi';
-import { isPlatformAdmin } from '../../shared/platform-roles';
+import { isSelfHostOperator } from '../../shared/platform-roles';
 import { managedGithubOwner, managedGithubOwnerType, managedGithubToken } from '../git-backends';
 import {
   createInstallationToken,
@@ -66,9 +66,11 @@ projectsApp.openapi(
     // no real GitHub App installation to list repos from — list via the PAT
     // itself instead of an installation token.
     if (installationId === PAT_MANAGED_GIT_INSTALLATION_ID) {
-      if (!(await isPlatformAdmin(scope.userId))) {
+      // `isSelfHostOperator`, not `isPlatformAdmin` — this lists the WHOLE
+      // managed org, which on cloud holds every customer's project repo.
+      if (!(await isSelfHostOperator(scope.userId))) {
         return c.json(
-          { error: 'Managed GitHub repository import requires platform admin access' },
+          { error: 'Managed GitHub repository import is only available to a self-host operator' },
           403,
         );
       }

--- a/apps/api/src/projects/routes/r1.ts
+++ b/apps/api/src/projects/routes/r1.ts
@@ -5,7 +5,7 @@ import { setContextField } from '../../lib/request-context';
 import { supabaseAuth } from '../../middleware/auth';
 import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
-import { isPlatformAdmin } from '../../shared/platform-roles';
+import { isSelfHostOperator } from '../../shared/platform-roles';
 import { kickProjectTemplatePrebuilds } from '../../snapshots/builder';
 import { isAccountManager, type ProjectRole } from '../access';
 import { getBackend, hasBackend, managedGithubOwner, managedGithubToken, parseBasicAuthHeader, type GitScope } from '../git-backends';
@@ -685,8 +685,14 @@ projectsApp.openapi(
   // managed-git PAT ("Use a token" self-host setup) — fall back to it so this
   // account isn't told "GitHub isn't connected" just because it never
   // installed an App (see serializeGitHubInstallations).
+  // `isSelfHostOperator`, NOT `isPlatformAdmin`. The synthetic entry exposes
+  // MANAGED_GIT_GITHUB_OWNER's whole repository list, and on cloud that owner
+  // is `managed-kortix` — every customer's project repo. `isPlatformAdmin` is
+  // also true for Kortix staff, so gating on it put every customer's private
+  // repo in the `/new` import picker (reported 2026-08-29). Only the self-host
+  // operator, for whom that org is their own, may see it.
   const patFallbackOwner =
-    rows.length === 0 && managedGithubToken() && (await isPlatformAdmin(scope.userId))
+    rows.length === 0 && managedGithubToken() && (await isSelfHostOperator(scope.userId))
       ? managedGithubOwner()
       : null;
   return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl, patFallbackOwner));
@@ -721,8 +727,14 @@ projectsApp.openapi(
   // managed-git PAT ("Use a token" self-host setup) — fall back to it so this
   // account isn't told "GitHub isn't connected" just because it never
   // installed an App (see serializeGitHubInstallations).
+  // `isSelfHostOperator`, NOT `isPlatformAdmin`. The synthetic entry exposes
+  // MANAGED_GIT_GITHUB_OWNER's whole repository list, and on cloud that owner
+  // is `managed-kortix` — every customer's project repo. `isPlatformAdmin` is
+  // also true for Kortix staff, so gating on it put every customer's private
+  // repo in the `/new` import picker (reported 2026-08-29). Only the self-host
+  // operator, for whom that org is their own, may see it.
   const patFallbackOwner =
-    rows.length === 0 && managedGithubToken() && (await isPlatformAdmin(scope.userId))
+    rows.length === 0 && managedGithubToken() && (await isSelfHostOperator(scope.userId))
       ? managedGithubOwner()
       : null;
   return c.json(serializeGitHubInstallations(rows, scope.accountId, installUrl, patFallbackOwner));

--- a/apps/api/src/projects/routes/r2.ts
+++ b/apps/api/src/projects/routes/r2.ts
@@ -7,7 +7,7 @@ import { pickPrimaryTemplate, resolveSandboxRuntimeStatus } from '../../snapshot
 import { classifySnapshotError, describeSnapshotError } from '../../snapshots/error-classify';
 import { withTimeout } from '../../shared/with-timeout';
 import { ttlMemo } from '../../shared/ttl-memo';
-import { isPlatformAdmin } from '../../shared/platform-roles';
+import { isSelfHostOperator } from '../../shared/platform-roles';
 import { templateSlugFromBuildSlug } from '../../snapshots/build-slug';
 import { createTemplate, deleteTemplate, getTemplateById, TemplateNotFoundError, updateTemplate } from '../../snapshots/templates';
 import { managedGithubToken } from '../git-backends';
@@ -121,12 +121,16 @@ projectsApp.openapi(
   if (!repoUrl) return c.json({ error: 'repo_url or repo_full_name is required' }, 400);
 
   const installationIdInput = normalizeString(body.installation_id ?? body.installationId);
+  // Narrowed from `isPlatformAdmin` to `isSelfHostOperator`: this path imports
+  // ANY repo in MANAGED_GIT_GITHUB_OWNER, which on cloud is the shared
+  // `managed-kortix` org. Staff admins are platform admins too, so the old gate
+  // let one import another customer's project repository.
   if (
     installationIdInput === PAT_MANAGED_GIT_INSTALLATION_ID &&
-    !(await isPlatformAdmin(scope.userId))
+    !(await isSelfHostOperator(scope.userId))
   ) {
     return c.json(
-      { error: 'Managed GitHub repository import requires platform admin access' },
+      { error: 'Managed GitHub repository import is only available to a self-host operator' },
       403,
     );
   }

--- a/apps/api/src/shared/platform-roles.ts
+++ b/apps/api/src/shared/platform-roles.ts
@@ -1,6 +1,7 @@
 import { platformUserRoles } from '@kortix/db';
 import { eq, sql } from 'drizzle-orm';
 import { db, hasDatabase } from './db';
+import { isSelfHostOperatorEmail, selfHostOperatorAllowlist } from './self-host-operator';
 
 export type PlatformRole = 'user' | 'admin' | 'super_admin';
 
@@ -11,13 +12,6 @@ export type PlatformRole = 'user' | 'admin' | 'super_admin';
  * (e.g. the managed GitHub App) in-app. Unset on cloud, so it is inert there;
  * cloud continues to grant admin through platform_user_roles rows.
  */
-function adminEmailAllowlist(): string[] {
-  return (process.env.KORTIX_PLATFORM_ADMIN_EMAILS || '')
-    .split(',')
-    .map((e) => e.trim().toLowerCase())
-    .filter(Boolean);
-}
-
 export async function getPlatformRole(accountId: string): Promise<PlatformRole> {
   if (!hasDatabase) {
     return 'user';
@@ -26,7 +20,7 @@ export async function getPlatformRole(accountId: string): Promise<PlatformRole> 
   // Env allowlist wins — a self-host operator listed here is always admin even
   // before any platform_user_roles row exists. Personal account id == auth user
   // id, so the email lives in auth.users under the same id.
-  const allowlist = adminEmailAllowlist();
+  const allowlist = selfHostOperatorAllowlist();
   if (allowlist.length > 0) {
     try {
       const rows = (await db.execute(
@@ -57,4 +51,30 @@ export async function getPlatformRole(accountId: string): Promise<PlatformRole> 
 export async function isPlatformAdmin(accountId: string): Promise<boolean> {
   const role = await getPlatformRole(accountId);
   return role === 'admin' || role === 'super_admin';
+}
+
+/**
+ * Is this account the SELF-HOST OPERATOR — the narrow gate the managed-git PAT
+ * paths must use instead of `isPlatformAdmin`?
+ *
+ * See `./self-host-operator` for the full reasoning. In short: `isPlatformAdmin`
+ * also admits cloud staff, for whom `MANAGED_GIT_GITHUB_OWNER` is the shared
+ * `managed-kortix` org holding every customer's repository.
+ *
+ * Short-circuits before any query when the allowlist is empty — the cloud case,
+ * where this is always false and a DB round-trip would be pure waste.
+ */
+export async function isSelfHostOperator(accountId: string): Promise<boolean> {
+  if (!hasDatabase) return false;
+  if (selfHostOperatorAllowlist().length === 0) return false;
+  try {
+    const rows = (await db.execute(
+      sql`SELECT email FROM auth.users WHERE id = ${accountId} LIMIT 1`,
+    )) as unknown as Array<{ email: string | null }>;
+    return isSelfHostOperatorEmail(rows?.[0]?.email);
+  } catch {
+    // Fail CLOSED: an email lookup that errors must not open an
+    // operator-only capability.
+    return false;
+  }
 }

--- a/apps/api/src/shared/self-host-operator.test.ts
+++ b/apps/api/src/shared/self-host-operator.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isSelfHostOperatorEmail, selfHostOperatorAllowlist } from './self-host-operator';
+
+/**
+ * `isPlatformAdmin` answers "may this person configure the server", and TWO
+ * different populations satisfy it:
+ *
+ *  - a **self-host operator**, admitted by `KORTIX_PLATFORM_ADMIN_EMAILS`. The
+ *    managed-git org is THEIR org.
+ *  - a **cloud platform admin**, admitted by a `platform_user_roles` row. On
+ *    cloud, `MANAGED_GIT_GITHUB_OWNER` is `managed-kortix`, which holds every
+ *    customer's project repository.
+ *
+ * The managed-git PAT import path (the synthetic `pat` installation) lists that
+ * org wholesale. Gating it on `isPlatformAdmin` therefore offered every
+ * customer's private repo to any Kortix staff admin, one click from `/new` —
+ * reported 2026-08-29 as "why can I import anyone else's project".
+ *
+ * `isSelfHostOperatorEmail` is the narrower question that path must ask
+ * instead: it is true ONLY via the env allowlist, which `getPlatformRole`'s own
+ * doc comment says is "Unset on cloud, so it is inert there".
+ */
+describe('selfHostOperatorAllowlist', () => {
+  test('is empty when the env var is unset — i.e. on cloud', () => {
+    expect(selfHostOperatorAllowlist(undefined)).toEqual([]);
+    expect(selfHostOperatorAllowlist('')).toEqual([]);
+    expect(selfHostOperatorAllowlist('   ')).toEqual([]);
+  });
+
+  test('parses a comma-separated list, normalizing case and spacing', () => {
+    expect(selfHostOperatorAllowlist(' Ops@Example.com , second@example.com ')).toEqual([
+      'ops@example.com',
+      'second@example.com',
+    ]);
+  });
+
+  test('drops empty entries rather than admitting a blank email', () => {
+    // A trailing comma must not produce an '' entry that an empty/absent email
+    // could then match.
+    expect(selfHostOperatorAllowlist('ops@example.com,,')).toEqual(['ops@example.com']);
+  });
+});
+
+describe('isSelfHostOperatorEmail', () => {
+  test('true only for an email on the allowlist', () => {
+    const list = 'ops@example.com';
+    expect(isSelfHostOperatorEmail('ops@example.com', list)).toBe(true);
+    expect(isSelfHostOperatorEmail('OPS@Example.com', list)).toBe(true);
+    expect(isSelfHostOperatorEmail('someone@example.com', list)).toBe(false);
+  });
+
+  test('THE REGRESSION: false on cloud, where the allowlist is unset', () => {
+    // This is the whole point. A Kortix staff platform admin has a
+    // `platform_user_roles` row and no allowlist entry, so the managed-org
+    // import path must not open for them.
+    expect(isSelfHostOperatorEmail('staff@kortix.ai', undefined)).toBe(false);
+    expect(isSelfHostOperatorEmail('staff@kortix.ai', '')).toBe(false);
+  });
+
+  test('false for a missing email, never a blank match', () => {
+    expect(isSelfHostOperatorEmail(null, 'ops@example.com')).toBe(false);
+    expect(isSelfHostOperatorEmail(undefined, 'ops@example.com')).toBe(false);
+    expect(isSelfHostOperatorEmail('', 'ops@example.com')).toBe(false);
+    expect(isSelfHostOperatorEmail('   ', 'ops@example.com')).toBe(false);
+  });
+});

--- a/apps/api/src/shared/self-host-operator.ts
+++ b/apps/api/src/shared/self-host-operator.ts
@@ -1,0 +1,54 @@
+/**
+ * "Is this a SELF-HOST OPERATOR" — the narrower half of "platform admin".
+ *
+ * Pure, and deliberately in its own module with NO database or config import,
+ * so it can be unit-tested without booting the server's env validation.
+ * `platform-roles.ts` (which does import the db) consumes it.
+ *
+ * ## Why this exists
+ *
+ * `isPlatformAdmin` is true for two populations that must NOT be treated alike
+ * wherever the managed-git ORG is concerned:
+ *
+ *  - the **self-host operator**, admitted by the `KORTIX_PLATFORM_ADMIN_EMAILS`
+ *    allowlist. `MANAGED_GIT_GITHUB_OWNER` is their own org.
+ *  - a **cloud platform admin**, admitted by a `platform_user_roles` row. On
+ *    cloud that owner is `managed-kortix`, which holds EVERY customer's project
+ *    repository.
+ *
+ * The managed-git PAT import path (the synthetic `pat` installation in
+ * `serializeGitHubInstallations`) lists that owner's repositories wholesale.
+ * Gating it on `isPlatformAdmin` therefore offered every customer's private
+ * repository to any Kortix staff admin, one click from `/new` — reported
+ * 2026-08-29 as "why can I import anyone else's project". It must ask THIS
+ * question instead.
+ *
+ * The allowlist is the right gate because, per `getPlatformRole`'s own comment,
+ * it is "Unset on cloud, so it is inert there" — precisely the property an
+ * operator-only capability needs.
+ */
+
+/** The configured operator emails, normalized. Empty on cloud. */
+export function selfHostOperatorAllowlist(
+  raw = process.env.KORTIX_PLATFORM_ADMIN_EMAILS,
+): string[] {
+  return (raw || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * True only for an email on the allowlist.
+ *
+ * A blank or missing email is never a match — otherwise an account with no
+ * email could pair with an empty allowlist entry and slip through.
+ */
+export function isSelfHostOperatorEmail(
+  email: string | null | undefined,
+  raw = process.env.KORTIX_PLATFORM_ADMIN_EMAILS,
+): boolean {
+  const normalized = email?.trim().toLowerCase();
+  if (!normalized) return false;
+  return selfHostOperatorAllowlist(raw).includes(normalized);
+}

--- a/apps/web/src/features/workspace/new/advanced-fields.test.ts
+++ b/apps/web/src/features/workspace/new/advanced-fields.test.ts
@@ -190,3 +190,32 @@ describe('AdvancedFields: exports', () => {
     expect(code).toContain('onChange: (next: NewWorkspaceFormState) => void');
   });
 });
+
+describe('AdvancedFields: the managed org is never an import source', () => {
+  /**
+   * Reported 2026-08-29: picking "Import from GitHub" as a Kortix platform
+   * admin listed `managed-kortix/*` — other customers' private project repos —
+   * and would have imported one on a click.
+   *
+   * The synthetic `pat` installation stands for the server's managed-git TOKEN,
+   * whose owner on cloud is the shared org holding every customer's repo. It
+   * has no place in a "create my workspace" flow for either source. The server
+   * side is fixed too (`isSelfHostOperator`); this is the second layer.
+   */
+  test('filters to real GitHub App installations for BOTH sources, not just github-create', () => {
+    expect(code).toContain(
+      'const selectable = installations.filter((installation) =>\n    isGitHubAppInstallationId(installation.installation_id),\n  );',
+    );
+    // The old shape branched on the source and let the synthetic entry through
+    // for import. It must not come back.
+    expect(code).not.toContain("state.source === 'github-create'\n      ? installations.filter");
+  });
+
+  test('never renders the managed-git PAT installation id', () => {
+    // `githubInstallationLabel` prints "Managed GitHub · github.com/<owner>"
+    // for id 'pat'. With the filter above that branch is unreachable from
+    // this screen, and nothing here may special-case it back into view.
+    expect(code).not.toContain("'pat'");
+    expect(code).not.toContain('Managed GitHub');
+  });
+});

--- a/apps/web/src/features/workspace/new/advanced-fields.tsx
+++ b/apps/web/src/features/workspace/new/advanced-fields.tsx
@@ -138,17 +138,23 @@ function GitHubSourceFields({
   });
 
   const installations = installationsQuery.data?.installations ?? [];
-  // `create-repo` needs org/repo-admin scope on a real GitHub App
-  // installation. `serializeGitHubInstallations` can also return the synthetic
-  // `pat` entry (the self-host "use a token" setup), which `link-repository`
-  // accepts and `create-repo` does not — so it is offered for import only,
-  // exactly as the old create modal split them.
-  const selectable =
-    state.source === 'github-create'
-      ? installations.filter((installation) =>
-          isGitHubAppInstallationId(installation.installation_id),
-        )
-      : installations;
+  // REAL GitHub App installations only — for BOTH sources.
+  //
+  // `serializeGitHubInstallations` can also return a synthetic `pat` entry
+  // standing for the server's managed-git token, and picking it lists
+  // MANAGED_GIT_GITHUB_OWNER's ENTIRE repository set. On cloud that owner is
+  // `managed-kortix`, which holds every customer's project repo — so on
+  // 2026-08-29 this picker showed a Kortix admin a list of other people's
+  // private repositories, one click from importing one.
+  //
+  // The server no longer offers that entry to anyone but a self-host operator
+  // (`isSelfHostOperator`, apps/api/src/shared/self-host-operator.ts). This
+  // filter is the second layer: `/new` is a "create MY workspace" flow, and an
+  // org-wide token is not a thing a person picks there. An operator who wants
+  // it has the CLI and `link-repository` directly.
+  const selectable = installations.filter((installation) =>
+    isGitHubAppInstallationId(installation.installation_id),
+  );
 
   const installationId = state.installationId;
   const onlyInstallationId =


### PR DESCRIPTION
## The report

> "why I can import anyone's else project lol, I shouldn't be able to access anyone's else project don't you think?"

Correct. On dev, `/new` → **Import from GitHub** listed `managed-kortix/my-first-project-…`, `managed-kortix/school-…` — other customers' private project repositories — and would have imported one on a click.

## Cause

`serializeGitHubInstallations` can return a **synthetic `pat` installation** standing for the server's managed-git token. Picking it lists `MANAGED_GIT_GITHUB_OWNER`'s entire repository set. It was gated on `isPlatformAdmin`, and that check is true for two populations that must not be treated alike — `platform-roles.ts` says so itself:

> Self-host operator allowlist… **Unset on cloud, so it is inert there; cloud continues to grant admin through platform_user_roles rows.**

- **self-host operator** (env allowlist) — `MANAGED_GIT_GITHUB_OWNER` is their own org. Listing it is the feature.
- **cloud platform admin** (`platform_user_roles` row) — that owner is `managed-kortix`, the shared org holding every customer's repo. Listing it is cross-tenant exposure.

The capability was built for the first and gated by a check that also admits the second.

## Fix

**Server (the actual leak).** New `isSelfHostOperator` — true *only* via the `KORTIX_PLATFORM_ADMIN_EMAILS` allowlist, and short-circuiting before any query when that list is empty, i.e. always false on cloud. Applied at all four PAT sites:

| Site | Was | Now |
|---|---|---|
| `r1.ts` `GET /github/installation` | `isPlatformAdmin` | `isSelfHostOperator` |
| `r1.ts` `GET /github/installations` | `isPlatformAdmin` | `isSelfHostOperator` |
| `github-repositories.ts` (lists the whole org) | `isPlatformAdmin` | `isSelfHostOperator` |
| `r2.ts` `POST /link-repository` | `isPlatformAdmin` | `isSelfHostOperator` |

The email lookup **fails closed** — an errored query returns false rather than opening an operator-only capability.

**Web (second layer).** `/new` now filters to real GitHub App installations for *both* sources, not just `github-create`. A server-side token standing for an org is not something a person picks in a "create my workspace" flow; an operator who wants it has the CLI and `link-repository` directly.

## Verification

New `self-host-operator.ts` holds the pure logic with **no db/config import**, so it unit-tests without booting env validation.

| Gate | Result |
|---|---|
| `self-host-operator.test.ts` | 6 pass, 0 fail |
| `e2e-create-repo-starter.test.ts` | 12 pass, 0 fail |
| `apps/web` full suite | 8695 pass, 0 fail |
| `apps/api` + `apps/web` tsc | clean on touched files |

Both new tests were confirmed **RED against the old behaviour** before being kept:
- reverting the four gates to `isPlatformAdmin` fails the new `THE FIX: a cloud platform admin is NOT a self-host operator` test plus the existing listing test
- restoring the source-branched installation filter fails the new UI test

The new e2e test drives the exact reported path: `platformAdmin = true, selfHostOperator = false`, then asserts the installation is not offered, the org listing is refused with **no upstream call made**, and importing `managed-kortix/someone-elses-project` by name returns 403.

## Separate issue found, not fixed here

`/github/setup` on dev shows `oauth_not_configured`. `isGithubAppOAuthConfigured()` needs `KORTIX_GITHUB_APP_CLIENT_ID` + `_CLIENT_SECRET`; `apps/api/.env.dev` has `_APP_ID`, `_SLUG`, `_PRIVATE_KEY`, `_STATE_SECRET` but neither client credential. That is a dev secret gap, not code — it needs the two values from the GitHub App's settings page, set via `dotenvx set`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790607779&installation_model_id=434224&pr_number=7040&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7040&signature=5a6706d09fde3c137cdc9b9ccae99028a1e2881b40e478843645a5fb1602d8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->