### PR TITLE
fix(projects): a project always has a manifest — seeding is the default, not an opt-in

### DIFF
--- a/apps/api/src/__tests__/e2e-project-limit.test.ts
+++ b/apps/api/src/__tests__/e2e-project-limit.test.ts
@@ -209,6 +209,20 @@ function projectRowFrom(values: any) {
   };
 }
 
+/**
+ * A drizzle-shaped query result: awaitable, and still chainable through
+ * `.returning()`. See the `update` seam below.
+ */
+function thenable(rows: any[]) {
+  const settled = Promise.resolve(rows);
+  return {
+    returning: async () => rows,
+    then: settled.then.bind(settled),
+    catch: settled.catch.bind(settled),
+    finally: settled.finally.bind(settled),
+  };
+}
+
 mock.module('../shared/db', () => ({
   hasDatabase: true,
   db: {
@@ -239,7 +253,12 @@ mock.module('../shared/db', () => ({
         returning: async () => (table === projects ? [projectRowFrom(values)] : []),
       }),
     }),
-    update: () => ({ set: () => ({ where: () => ({ returning: async () => [] }) }) }),
+    // Drizzle's `.where()` is BOTH awaitable and chainable: callers either
+    // `await` it or add `.returning()`. Returning a plain object breaks every
+    // `db.update(t).set(...).where(...).catch(...)` in the provision path —
+    // which is how a bare provision (now seeded by default) turned into a 502
+    // here instead of exercising the quota rule this file is about.
+    update: () => ({ set: () => ({ where: () => thenable([]) }) }),
     delete: () => ({ where: async () => {} }),
   },
 }));
@@ -279,7 +298,9 @@ describe('project limit — POST /v1/projects/provision', () => {
     projectCount = 2;
     const res = await provision();
     expect(res.status).toBe(201);
-    expect(backendCalls).toEqual(['createRepo']);
+    // Under the quota, provisioning runs to completion: create the repo AND seed
+    // the starter (seeding is the default, not an opt-in).
+    expect(backendCalls).toEqual(['createRepo', 'seedFiles']);
   });
 
   test('free account at its limit (count 3 ≥ limit 3) → 403, no repo created', async () => {
@@ -301,7 +322,9 @@ describe('project limit — POST /v1/projects/provision', () => {
     projectCount = 5;
     const res = await provision();
     expect(res.status).toBe(201);
-    expect(backendCalls).toEqual(['createRepo']);
+    // Under the quota, provisioning runs to completion: create the repo AND seed
+    // the starter (seeding is the default, not an opt-in).
+    expect(backendCalls).toEqual(['createRepo', 'seedFiles']);
   });
 
   test('paid plan at its (large) cap (count 200 ≥ limit 200) → 403', async () => {
@@ -320,6 +343,8 @@ describe('project limit — POST /v1/projects/provision', () => {
     projectCount = 9999;
     const res = await provision();
     expect(res.status).toBe(201);
-    expect(backendCalls).toEqual(['createRepo']);
+    // Under the quota, provisioning runs to completion: create the repo AND seed
+    // the starter (seeding is the default, not an opt-in).
+    expect(backendCalls).toEqual(['createRepo', 'seedFiles']);
   });
 });

--- a/apps/api/src/__tests__/e2e-projects-provision.test.ts
+++ b/apps/api/src/__tests__/e2e-projects-provision.test.ts
@@ -454,15 +454,41 @@ describe('POST /v1/projects/provision (managed git)', () => {
       projectRole: 'manager',
     });
 
-    // Provisioned the repo through the backend seam (no seeding without flag).
-    expect(backendCalls).toEqual(['createRepo']);
+    // A caller who says nothing about `seed_starter` gets the starter. Seeding
+    // is the DEFAULT, so a bare provision goes through BOTH backend seams.
+    expect(backendCalls).toEqual(['createRepo', 'seedFiles']);
 
-    // An unseeded managed repo is a legitimate `kortix ship` state, but it must
-    // be RECORDED, not silently indistinguishable from a seeded one.
+    // The row records the INTENT at insert time — the seed push has not been
+    // verified yet at that point, so `pending`, never `caller_opted_out`.
     expect(insertedProject.metadata.git.seed).toMatchObject({
       seeded: false,
-      expected: false,
-      reason: 'caller_opted_out',
+      expected: true,
+      reason: 'pending',
+    });
+    expect(body.seeded).toBe(true);
+  });
+
+  // The one opt-out, and what it does NOT mean. `kortix ship` pushes its own
+  // `kortix init` history with a plain non-force push, so the provision-time
+  // seed must be suppressed or that push is rejected as non-fast-forward. It is
+  // still recorded `expected: true` — a client that never pushes gets repaired
+  // by `shouldSelfHealManagedRepoSeed`, not left permanently without a manifest.
+  test('an explicit seed_starter:false suppresses the push but still expects a manifest', async () => {
+    const app = createApp();
+    const res = await app.request('/v1/projects/provision', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ account_id: ACCOUNT_ID, name: 'Shipped Agent', seed_starter: false }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+
+    expect(backendCalls).toEqual(['createRepo']);
+    expect(insertedProject.metadata.git.seed).toMatchObject({
+      seeded: false,
+      expected: true,
+      reason: 'client_owns_first_commit',
     });
     expect(body.seeded).toBe(false);
   });

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -265,6 +265,46 @@ async function forward(c: any, projectId: string, scope: GitScope, suffix: strin
             );
           });
         }
+        // MANIFEST TRIPWIRE. A project always has a manifest
+        // (../projects/managed-repo-seed.ts). Provisioning now guarantees one
+        // at birth and `kortix ship` refuses to push without one, but a plain
+        // `git push` straight at this proxy can still land a default branch
+        // with no kortix.yaml — which produces a project with no declared
+        // agents, no skills, and manifest detection falling back to v1
+        // `kortix.toml`. That used to be discovered as an unexplained
+        // session-start failure, long after the push.
+        //
+        // This cannot REJECT the push: the proxy streams the pack straight to
+        // the upstream and only runs here on a 2xx, so the commit has already
+        // landed on GitHub. Blocking it pre-commit means staging the (thin)
+        // pack through the mirror first — tracked separately. Until then, name
+        // it at the moment it happens instead of letting it surface as a
+        // mystery two steps downstream.
+        //
+        // The mirror is already refreshed by this block, so this is one
+        // pathspec-scoped ls-tree.
+        void (async () => {
+          try {
+            const repoPath = await refreshMirror(gitProject);
+            const listed = await runGit(
+              ['ls-tree', gitProject.defaultBranch, '--', 'kortix.yaml', 'kortix.yml', 'kortix.toml'],
+              repoPath,
+            );
+            if (!listed.stdout.trim()) {
+              console.error(
+                `[git-proxy] MANIFEST MISSING after push to ${projectId}: ` +
+                  `${gitProject.defaultBranch} has no kortix.yaml. This project cannot ` +
+                  `declare agents or skills and session start will fail.`,
+              );
+            }
+          } catch (err) {
+            console.warn(
+              `[git-proxy] manifest tripwire skipped for ${projectId}:`,
+              err instanceof Error ? err.message : err,
+            );
+          }
+        })();
+
         const [compiledResult, piResult] = await Promise.allSettled([
           config.KORTIX_COMPILED_BOOT_MODE !== 'off' || piWorkerEnabled
             ? prebuildDefaultBranchArtifacts(

--- a/apps/api/src/projects/managed-repo-seed.test.ts
+++ b/apps/api/src/projects/managed-repo-seed.test.ts
@@ -290,7 +290,7 @@ describe('shouldSelfHealManagedRepoSeed', () => {
     expect(shouldSelfHealManagedRepoSeed({ managed: true, metadata })).toBe(true);
   });
 
-  test('leaves an explicit caller opt-out alone so kortix ship can push its own history', () => {
+  test('leaves a LEGACY caller opt-out alone (pre-invariant rows only)', () => {
     const metadata = {
       git: {
         managed: true,
@@ -298,6 +298,45 @@ describe('shouldSelfHealManagedRepoSeed', () => {
           seeded: false,
           expected: false,
           reason: 'caller_opted_out',
+          at: '2026-07-30T00:00:00.000Z',
+        },
+      },
+    };
+    expect(shouldSelfHealManagedRepoSeed({ managed: true, metadata })).toBe(false);
+  });
+
+  // THE INVARIANT: a project always ends up with a manifest. `seed_starter:
+  // false` says "I am about to push my own scaffold", not "leave this empty" —
+  // so a client that provisions and then never pushes must still be repaired.
+  // This is the case the old `caller_opted_out` state skipped forever, which is
+  // how a bare provision call produced a permanently empty project.
+  test('repairs a client-owned first commit the client never actually pushed', () => {
+    const metadata = {
+      git: {
+        managed: true,
+        seed: {
+          seeded: false,
+          expected: true,
+          reason: 'client_owns_first_commit',
+          at: '2026-07-30T00:00:00.000Z',
+          template: 'minimal',
+        },
+      },
+    };
+    expect(shouldSelfHealManagedRepoSeed({ managed: true, metadata })).toBe(true);
+  });
+
+  // The repair is what makes the above safe for `kortix ship`: it re-checks the
+  // remote and skips a repo the client HAS populated (repairManagedRepo's
+  // `remoteBranchExists` guard). Seeding intent alone never overwrites work.
+  test('a client-owned first commit that DID land is already seeded, so nothing repairs it', () => {
+    const metadata = {
+      git: {
+        managed: true,
+        seed: {
+          seeded: true,
+          expected: true,
+          reason: 'seeded',
           at: '2026-07-30T00:00:00.000Z',
         },
       },

--- a/apps/api/src/projects/managed-repo-seed.ts
+++ b/apps/api/src/projects/managed-repo-seed.ts
@@ -25,12 +25,34 @@
  *     empty repo" is distinguishable from "empty because the seed never
  *     landed", and the second case can be repaired on next access.
  *
- * `expected: false` is a first-class, permanently-respected state: `kortix ship`
- * (apps/cli/src/commands/ship.ts) provisions with no `seed_starter` and then
- * pushes its own local history to the default branch with a plain (non-force)
- * push. Seeding that repo — at provision time or later — would turn that push
- * into a non-fast-forward rejection. So the fix is never "always seed"; it is
- * "always know, and repair only what was supposed to be seeded".
+ * ## The invariant: a project ALWAYS has a manifest
+ *
+ * This module used to end with "the fix is never 'always seed'; it is 'always
+ * know, and repair only what was supposed to be seeded'". That was half right
+ * and it left a hole big enough to drive a product bug through.
+ *
+ * `seed_starter` answers **who supplies the manifest** — the server now, or a
+ * client that is about to push its own `kortix init` scaffold. It does NOT
+ * answer *whether the project gets one*. Both designed paths end with a
+ * `kortix.yaml` (see provision-core.ts: `kortix ship` scaffolds via
+ * `kortix init` — same `@kortix/starter`, same file). Reading the flag as
+ * "should this project have files at all" is what allowed a caller who said
+ * nothing — a bare `POST /v1/projects/provision`, an agent, any integration —
+ * to get a repo with no manifest, no agents and no skills, recorded as
+ * `caller_opted_out` so the repair below would skip it *forever*, in exactly
+ * the case where nobody owns the first commit.
+ *
+ * So: **seeding is the default, and `expected` is now always true.** An
+ * explicit `seed_starter: false` still suppresses the provision-time push —
+ * `kortix ship` pushes its own history with a plain (non-force) push, and
+ * seeding first would turn that into a non-fast-forward rejection — but it
+ * records `client_owns_first_commit`, not "leave this empty". If that client
+ * never pushes, `shouldSelfHealManagedRepoSeed` repairs the repo on next
+ * access. The repair is safe against ship either way because it re-checks
+ * `remoteBranchExists` and skips a repo the client already populated.
+ *
+ * Net: no caller, and no abandoned client, can leave a project without a
+ * manifest.
  */
 
 import type { GitConnectionRef, GitHostBackend, SeedFile } from './git-backends/types';
@@ -52,6 +74,14 @@ export interface ManagedRepoSeedState {
 export type ManagedRepoSeedReason =
   | 'seeded'
   | 'pending'
+  /**
+   * The caller sent `seed_starter: false` because it is about to push its own
+   * `kortix init` scaffold (`kortix ship`). NOT "this project may be empty" —
+   * the state still carries `expected: true`, so a client that never pushes is
+   * repaired instead of left permanently blank. Replaces `caller_opted_out`.
+   */
+  | 'client_owns_first_commit'
+  /** @deprecated Pre-invariant rows only. Read, never written — see the header. */
   | 'caller_opted_out'
   | 'push_failed'
   | 'verify_failed'

--- a/apps/api/src/projects/provision-core.test.ts
+++ b/apps/api/src/projects/provision-core.test.ts
@@ -78,6 +78,33 @@ describe('provision phases', () => {
     expect(between.length).toBeLessThan(80);
   });
 
+  // THE INVARIANT: a project always has a manifest. Seeding is the DEFAULT —
+  // a caller who says nothing (bare `POST /v1/projects/provision`, an agent,
+  // any integration) gets the starter. This used to be opt-in
+  // (`body.seed_starter === true`), which is how such a caller got a repo with
+  // no kortix.yaml, no agents and no skills, recorded `caller_opted_out` so the
+  // self-heal skipped it forever. Pinned here because the regression is silent:
+  // provisioning still returns 201 `{status:'active'}` for an empty repo.
+  test('seeding is the DEFAULT — only an explicit seed_starter:false opts out', async () => {
+    const source = await coreSource();
+
+    // The opt-out is an explicit `false`, never the absence of the flag.
+    expect(source).toContain('body.seed_starter === false');
+    expect(source).toContain('const seedStarter = !clientOwnsFirstCommit');
+
+    // The old opt-in form must be gone: `=== true` as the seed gate is exactly
+    // the defect. (`=== false` above legitimately contains neither.)
+    expect(source).not.toContain('body.seed_starter === true');
+  });
+
+  test('even an opt-out records expected:true, so an unpushed repo is still repaired', async () => {
+    const source = await coreSource();
+    // `caller_opted_out` recorded `expected:false`, which made
+    // shouldSelfHealManagedRepoSeed skip the repo permanently.
+    expect(source).toContain("reason: 'client_owns_first_commit'");
+    expect(source).not.toContain("reason: 'caller_opted_out'");
+  });
+
   test("emit('seeding') is before the seed decision, never after the seed push starts", async () => {
     const source = await coreSource();
     const emitIndex = source.indexOf("emit('seeding')");

--- a/apps/api/src/projects/provision-core.ts
+++ b/apps/api/src/projects/provision-core.ts
@@ -332,20 +332,34 @@ export async function runProvision(ctx: ProvisionContext, emit: ProvisionEmit): 
   const authMethod = provider === 'github' ? 'github_app' : 'managed';
   const now = new Date();
 
-  // Seed the starter into the empty repo when the caller has no local working
-  // tree to push (web "Create project"). `kortix ship` leaves this false and
-  // pushes its own files instead (apps/cli/src/commands/ship.ts) — a plain,
-  // non-force push, so seeding that repo would reject it. Resolved BEFORE the
-  // insert so the row records the INTENT: a crash between the insert and a
-  // verified seed then leaves `{ expected: true, seeded: false }`, which
-  // `shouldSelfHealManagedRepoSeed` repairs on next access instead of leaving a
-  // permanently dead project that reports itself active.
-  const seedStarter = body.seed_starter === true || body.seedStarter === true || !!sourceItemId;
+  // A PROJECT ALWAYS HAS A MANIFEST. Seeding is the DEFAULT, not an opt-in.
+  //
+  // `seed_starter` chooses WHO supplies the scaffold — the server here, or a
+  // client that is about to push its own `kortix init` output — never WHETHER
+  // the project gets one. It used to default to false, so a caller who said
+  // nothing (a bare `POST /v1/projects/provision`, an agent, any integration)
+  // got a repo with no kortix.yaml, no agents and no skills, recorded as
+  // `caller_opted_out` so the self-heal skipped it permanently. See
+  // ./managed-repo-seed.ts for the full rule.
+  //
+  // The one opt-out is an EXPLICIT `seed_starter: false` (`kortix ship`, which
+  // pushes its own history with a plain non-force push that a seeded repo would
+  // reject). Even that records `expected: true` with `client_owns_first_commit`,
+  // so a client that never pushes is repaired on next access by
+  // `shouldSelfHealManagedRepoSeed` instead of being left permanently blank —
+  // and the repair re-checks `remoteBranchExists`, so it is a no-op once the
+  // client HAS pushed.
+  //
+  // Resolved BEFORE the insert so the row records the INTENT: a crash between
+  // the insert and a verified seed leaves `{ expected: true, seeded: false }`,
+  // which the same repair path fixes.
+  const clientOwnsFirstCommit = body.seed_starter === false || body.seedStarter === false;
+  const seedStarter = !clientOwnsFirstCommit || !!sourceItemId;
   const marketplaceItems = normalizeMarketplaceItems(body.marketplace_items ?? body.marketplaceItems);
   const initialSeedState = buildManagedRepoSeedState(
     seedStarter
       ? { seeded: false, expected: true, reason: 'pending', at: now.toISOString(), template: sourceItemId ?? starterTemplate }
-      : { seeded: false, expected: false, reason: 'caller_opted_out', at: now.toISOString() },
+      : { seeded: false, expected: true, reason: 'client_owns_first_commit', at: now.toISOString(), template: starterTemplate },
   );
 
   const insertProjectRow = () => db

--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -313,3 +313,30 @@ describe('ship provisioning declares who owns the first commit', () => {
     expect(body).toContain('seed_starter: false');
   });
 });
+
+// A project always has a manifest. Ship declares `seed_starter: false` — it
+// takes responsibility for the first commit — so it must actually HAVE a
+// kortix.yaml to push. This used to pass as "a `.kortix/`-only project —
+// nothing to verify", which is how a shipped project could end up with no
+// declared agents, no skills, and manifest detection falling back to v1.
+describe('ship refuses a project with no manifest', () => {
+  test('prepareManifest treats a missing kortix.yaml as fatal, and --no-verify does not bypass it', async () => {
+    const source = await Bun.file(
+      new URL('../commands/ship.ts', import.meta.url).pathname,
+    ).text();
+    const fn = source.slice(source.indexOf('function prepareManifest'));
+    const body = fn.slice(0, fn.indexOf('\n}\n'));
+
+    // The old escape hatch must be gone.
+    expect(body).not.toContain('if (!manifest) return { ok: true, env: empty };');
+    // Absence is now fatal.
+    expect(body).toContain('if (!manifest) {');
+    expect(body).toContain('refusing to ship a project with no manifest');
+
+    // --no-verify waives VALIDATION of a manifest, never its existence: the
+    // missing-manifest branch must not be gated on the flag.
+    const missingBranch = body.slice(body.indexOf('if (!manifest) {'));
+    const refusal = missingBranch.slice(0, missingBranch.indexOf('return { ok: false'));
+    expect(refusal).not.toContain('noVerify');
+  });
+});

--- a/apps/cli/src/__tests__/ship.test.ts
+++ b/apps/cli/src/__tests__/ship.test.ts
@@ -293,3 +293,23 @@ describe('stale-CLI warning on a 404 from the connector routes', () => {
     expect(capture.chunks.join('')).toBe('');
   });
 });
+
+// `kortix ship` scaffolds the folder with `kortix init` and then pushes that
+// history with a PLAIN (non-force) push. Server-side seeding is the default now
+// (apps/api/src/projects/managed-repo-seed.ts — "a project always has a
+// manifest"), so a seeded repo would turn ship's push into a non-fast-forward
+// rejection. Ship therefore has to say `seed_starter: false` OUT LOUD; an
+// absent flag no longer means "leave it empty", it means "seed it".
+//
+// Pinned on the source because the failure is silent and remote: the provision
+// call still returns 201 and the break only shows up at `git push`.
+describe('ship provisioning declares who owns the first commit', () => {
+  test('the provision body sends seed_starter:false', async () => {
+    const source = await Bun.file(
+      new URL('../commands/ship.ts', import.meta.url).pathname,
+    ).text();
+    const call = source.slice(source.indexOf("client.post<ProvisionResponse>('/projects/provision'"));
+    const body = call.slice(0, call.indexOf('});'));
+    expect(body).toContain('seed_starter: false');
+  });
+});

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -631,6 +631,14 @@ async function shipFirstTime(
     const prov = await client.post<ProvisionResponse>('/projects/provision', {
       name,
       account_id: accountId,
+      // WE own the first commit: this folder is already a `kortix init` scaffold
+      // and we push its history below with a plain (non-force) push, which a
+      // server-seeded repo would reject as non-fast-forward. Seeding is the
+      // server's DEFAULT now, so this has to be said out loud — an absent flag
+      // means "seed it" (apps/api/src/projects/managed-repo-seed.ts). The
+      // project still ends up with a kortix.yaml either way; this only picks
+      // who writes it.
+      seed_starter: false,
     });
     project = prov;
     // Bind the folder to the project the INSTANT it exists — before resolving a

--- a/apps/cli/src/commands/ship.ts
+++ b/apps/cli/src/commands/ship.ts
@@ -217,8 +217,27 @@ function prepareManifest(flags: ShipFlags): { ok: boolean; env: EnvSpec } {
     return { ok: false, env: empty };
   }
 
-  // No kortix.yaml at all (a `.kortix/`-only project) — nothing to verify.
-  if (!manifest) return { ok: true, env: empty };
+  // NO MANIFEST AT ALL. This used to pass as "a `.kortix/`-only project —
+  // nothing to verify", and it is the client half of the same defect as the
+  // server's opt-in seeding: it let `kortix ship` push a project that has no
+  // kortix.yaml, so the project came out with no declared agents, no skills,
+  // and manifest detection falling back to v1 `kortix.toml`.
+  //
+  // A project always has a manifest (apps/api/src/projects/managed-repo-seed.ts).
+  // Ship declares `seed_starter: false` — it takes responsibility for the first
+  // commit — so it must actually HAVE one to push. `--no-verify` deliberately
+  // does not bypass this: it waives *validation* of a manifest, not its
+  // existence, and waiving existence is what produced the broken projects.
+  if (!manifest) {
+    process.stderr.write(
+      `\n${status.err('No kortix.yaml here — refusing to ship a project with no manifest.')}\n` +
+        `  ${C.dim}A Kortix project is defined by its manifest: agents, skills and\n` +
+        `  connectors all come from it. Pushing without one creates a project\n` +
+        `  that cannot start a session.${C.reset}\n` +
+        `  ${C.dim}Create one with ${C.reset}${C.cyan}kortix init${C.reset}${C.dim} in ${process.cwd()}.${C.reset}\n\n`,
+    );
+    return { ok: false, env: empty };
+  }
 
   if (!flags.noVerify) {
     const { errors, warnings } = lintManifest(manifest.data, manifest.format);


### PR DESCRIPTION
`POST /v1/projects/provision` with no `seed_starter` created a project with **no kortix.yaml, no agents and no skills** — and recorded that state as permanent.

```
curl -X POST $API/projects/provision -d '{"name":"x"}'
→ 201 {"status":"active"}   # 0 files
```

Web create, onboarding and the SDK all pass `seed_starter: true`, so the hole was invisible from the product — it only opened for a bare REST caller: an agent, an integration, anyone reading the API docs. The UI then showed the folder as empty and offered to *"convert kortix.toml to kortix.yaml"*, which is the same empty repo misread as legacy v1 (the banner keys on `manifestVersion === 2`, and there is no manifest to read).

## The actual defect

`seed_starter` answers **who supplies the manifest** — the server now, or a client about to push its own `kortix init` scaffold. It does **not** answer *whether the project gets one*. Both designed paths end with a kortix.yaml; `provision-core.ts:366` already said so. Reading the flag as "should this project have files at all" let a caller who answered neither question fall through both paths — and `caller_opted_out` then told `shouldSelfHealManagedRepoSeed` to skip the repair **forever**, in exactly the case where *nobody* owns the first commit.

## The fix

Seeding is the default; `expected` is now always true. An explicit `seed_starter: false` still suppresses the provision-time push — `kortix ship` pushes its own history with a plain non-force push that a seeded repo would reject — but records `client_owns_first_commit`, not "leave this empty". A client that never pushes is repaired on next access, and the repair re-checks `remoteBranchExists`, so it is a no-op once the client *has* pushed.

**No caller and no abandoned client can leave a project without a manifest.**

`kortix ship` now sends `seed_starter: false` explicitly, because absence no longer means what it used to.

## Verified against the running API

Same bare call that produced the bug:

| | before | after |
|---|---|---|
| files | **0** | **179** |
| kortix.yaml | absent | **present** |
| kortix.toml | — | absent |
| manifest_path | kortix.yaml | kortix.yaml |
| seed state | `{expected:false, reason:'caller_opted_out'}` | `{seeded:true, expected:true, reason:'seeded'}` |

The toml banner needs no separate fix: its input is the manifest version, and there is now a v2 manifest to read.

Tests: **530 pass** `apps/api/src/projects`, **36 pass** seed+provision, **15 pass** CLI ship.

## ⚠️ Migration

A CLI older than this change still provisions with no flag, so its `kortix ship` will now be seeded server-side and its push will reject as non-fast-forward. The CLI half ships in the same release; older binaries need `kortix upgrade` before `kortix ship` **on a new project**. Existing projects are unaffected, and pre-invariant rows keep their `caller_opted_out` behaviour.

I flagged this hazard before implementing and it was an explicit call to proceed — managed repos live on GitHub, so there is no receive-pack hook to absorb the rejection transparently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790621618&installation_model_id=434224&pr_number=7047&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7047&signature=8efa6a781483757e75255d8865766db5574622e9ac62f622c4725e9a3e1b035c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->