### PR TITLE
fix: a provider connect refreshes the model picker without a hard refresh (+ isolate apps/web tests)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "postinstall": "cp node_modules/@embedpdf/pdfium/dist/pdfium.wasm public/pdfium.wasm 2>/dev/null || true",
-    "test": "bun test"
+    "test": "bun test --isolate --parallel=4"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",

--- a/apps/web/src/test-runner-contract.test.ts
+++ b/apps/web/src/test-runner-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+
+import pkg from '../package.json';
+
+/**
+ * `bun test` shares ONE module registry across every test file in a run.
+ *
+ * Nine files under `src/` call `mock.module('@kortix/sdk', () => ({ … }))` with
+ * a two- or three-key object — `maintenance-store.test.ts` and
+ * `session-audit-shared.test.ts` among them. Without isolation that partial
+ * object REPLACES the real module for every file that runs after it, so the
+ * next file to import a genuine export dies at link time:
+ *
+ *   SyntaxError: Export named 'listProjectsForAccount' not found in module
+ *   '…/packages/sdk/src/index.ts'
+ *
+ * Which export, and whether it happens at all, depends purely on file
+ * discovery order — so it passed on one machine and failed the `packages` lane
+ * on another, naming a different export each run. Reproduce it in two files:
+ *
+ *   bun test src/lib/maintenance-store.test.ts \
+ *            src/lib/onboarding/ensure-first-project.provision.test.ts   # red
+ *   bun test --isolate <the same two>                                    # green
+ *
+ * `--isolate` gives each file a fresh global object, which is the same fix and
+ * the same reasoning `apps/api/scripts/test.sh` documents. `--parallel=4` pays
+ * for it: 680 files run in ~30s isolated versus ~109s isolated-and-serial,
+ * against a ~24s non-isolated baseline that is not actually correct.
+ */
+describe('apps/web test runner', () => {
+  test('runs isolated, so a mock.module() cannot leak across files', () => {
+    expect(pkg.scripts.test).toContain('--isolate');
+  });
+
+  test('keeps the parallelism that makes isolation affordable', () => {
+    expect(pkg.scripts.test).toMatch(/--parallel=\d+/);
+  });
+});

--- a/packages/sdk/src/react/provider-refresh.test.ts
+++ b/packages/sdk/src/react/provider-refresh.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import type { QueryClient } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 
 import { providerConnectedInSecrets, refreshProjectProviderState } from './provider-refresh';
 import { qk } from './query-keys';
@@ -59,5 +59,83 @@ describe('refreshProjectProviderState — key wiring', () => {
     const secretsKey = qk.project.secrets('proj_1');
     expect(invalidated).toContainEqual({ queryKey: secretsKey });
     expect(refetched).toContainEqual({ queryKey: secretsKey, type: 'all' });
+  });
+});
+
+// THE DEFECT this covers: connecting a provider adds its models server-side,
+// but the session model picker kept serving the pre-connect list until a HARD
+// REFRESH.
+//
+// Why the existing invalidation missed it. Under the LLM gateway the picker's
+// models do not come from `['project-providers', id, 'gateway']`'s own fetcher
+// — that fetcher is a PROJECTION. The bytes come from `/model-picker`, cached
+// one key away under `qk.project.modelPicker(id)` and read through
+// `queryClient.fetchQuery` (see use-opencode-sessions/providers.ts, which
+// routes through the shared entry so a session open makes ONE request instead
+// of two). `fetchQuery` honours staleTime, and `modelPicker` is the `config`
+// tier — 60s. So re-running the projection inside that window re-read the
+// CACHED catalog and issued no request at all. Refetching a projection while
+// its source stays fresh refreshes nothing.
+//
+// A hard refresh "fixed" it only because it dropped the in-memory cache.
+describe('refreshProjectProviderState — the gateway catalog behind the picker', () => {
+  const PROJECT_ID = 'proj_1';
+
+  /**
+   * The real shape from `use-opencode-sessions/providers.ts`: the gateway
+   * provider entry is `staleTime: Infinity`, and its queryFn reads the catalog
+   * through the SHARED `qk.project.modelPicker` entry at the `config` tier.
+   */
+  function gatewayPickerHarness() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const catalogKey = qk.project.modelPicker(PROJECT_ID);
+    const providersKey = ['project-providers', PROJECT_ID, 'gateway'];
+    let catalogFetches = 0;
+
+    const readProviders = () =>
+      queryClient.fetchQuery({
+        queryKey: providersKey,
+        queryFn: () =>
+          queryClient.fetchQuery({
+            queryKey: catalogKey,
+            queryFn: async () => {
+              catalogFetches += 1;
+              return { models: {} };
+            },
+            staleTime: 60_000,
+          }),
+        staleTime: Infinity,
+      });
+
+    return { queryClient, catalogKey, providersKey, readProviders, count: () => catalogFetches };
+  }
+
+  test('marks the /model-picker catalog invalidated, not just the provider projection', () => {
+    const { queryClient, catalogKey } = gatewayPickerHarness();
+    queryClient.setQueryData(catalogKey, { models: {} });
+
+    refreshProjectProviderState(queryClient, PROJECT_ID);
+
+    // `fetchQuery` goes to the network only for a query that is stale OR
+    // invalidated. Inside the 60s config window, invalidated is the only one
+    // of the two a connect can cause.
+    expect(queryClient.getQueryState(catalogKey)?.isInvalidated).toBe(true);
+  });
+
+  test('the next provider read goes back to the network inside the 60s config window', async () => {
+    const harness = gatewayPickerHarness();
+
+    await harness.readProviders();
+    expect(harness.count()).toBe(1);
+
+    // Re-reading with nothing invalidated is a cache hit — this is exactly the
+    // state the picker was stuck in after a connect.
+    await harness.queryClient.refetchQueries({ queryKey: harness.providersKey, type: 'all' });
+    expect(harness.count()).toBe(1);
+
+    refreshProjectProviderState(harness.queryClient, PROJECT_ID);
+    await harness.queryClient.refetchQueries({ queryKey: harness.providersKey, type: 'all' });
+
+    expect(harness.count()).toBe(2);
   });
 });

--- a/packages/sdk/src/react/provider-refresh.ts
+++ b/packages/sdk/src/react/provider-refresh.ts
@@ -47,6 +47,20 @@ export function providerConnectedInSecrets(
 function invalidateProviderQueries(queryClient: QueryClient, projectId: string): void {
   const projectProviderKey = ['project-providers', projectId];
   clearProjectProviderCache(projectId);
+  // FIRST, and never optional: the gateway provider list is a PROJECTION of
+  // `/model-picker`, which lives under its own key at the `config` tier (60s)
+  // and is read through `fetchQuery` (use-opencode-sessions/providers.ts).
+  // `fetchQuery` skips the network for an entry that is neither stale nor
+  // invalidated, so refetching the projection alone re-served the pre-connect
+  // catalog and the session picker kept the old model list until a hard
+  // refresh. Marking the SOURCE invalidated is what makes the refetch below
+  // an actual request. `refetchType: 'all'` so a picker with no mounted
+  // observer is refreshed too — the projection's own `fetchQuery` then dedupes
+  // onto this in-flight read rather than adding a second one.
+  void queryClient.invalidateQueries({
+    queryKey: qk.project.modelPicker(projectId),
+    refetchType: 'all',
+  });
   void queryClient.invalidateQueries({ queryKey: projectProviderKey });
   void queryClient.invalidateQueries({ queryKey: qk.project.secrets(projectId) });
   void queryClient.refetchQueries({ queryKey: qk.project.secrets(projectId), type: 'all' });


### PR DESCRIPTION
Two fixes. The first is the objective; the second is the CI defect that had to
be cleared to prove it.

---

## 1. Connecting a provider did not refresh the model picker

Connect a provider from the picker's `+` button and its models do not appear.
They appear only after a hard page refresh.

### Root cause

Under the LLM gateway the picker's models do **not** come from
`['project-providers', id, 'gateway']`'s own fetcher — that entry is a
**projection**. The bytes come from `/model-picker`, cached one key away under
`qk.project.modelPicker(id)` and read through `queryClient.fetchQuery`
(`use-opencode-sessions/providers.ts` routes through the shared entry so a
session open makes one request instead of two).

`fetchQuery` goes to the network only for an entry that is stale **or**
invalidated. `modelPicker` is the `config` freshness tier — **60s**. So
`refreshProjectProviderState` invalidated the projection and never the source,
and every refetch inside that window re-served the pre-connect catalog. A hard
refresh "fixed" it only by dropping the in-memory cache.

This also explains why it looked intermittent: connect more than 60s after the
page loaded and the entry is already stale, so it works.

### The fix

`invalidateProviderQueries` now invalidates `qk.project.modelPicker(id)` with
`refetchType: 'all'`, **before** it refetches the projection — the same key
`useModelEnablement` already restamps on a model toggle.

Every credential path funnels through that one function, so this covers all of
them: API-key connect, ChatGPT subscription connect, custom provider save, the
Customize secrets view, and provider **removal** (a removed provider's models
now disappear without a hard refresh too).

### Verified in a real browser, A/B

One API (`:8008`), one project, the same fake OpenAI key, both runs ~23s after
page load (inside the 60s window):

| build | picker rows before | after connect, **no reload** | `GET /model-picker` after connect |
|---|---|---|---|
| `main` @ 2108aa3c8a | 8 | **8** — the bug | **0** |
| this branch | 8 | **16** | **6** |

Server truth in both runs: 55 models, `OPENAI_API_KEY` connected. On `main` the
picker only reached 16 after a hard refresh.

### Tests

Written RED first, both observed failing against the old code:

1. the `/model-picker` entry is marked invalidated, not just the projection
2. a provider read after the refresh goes back to the network inside the 60s
   config window (catalog fetches 1 → 2)

The harness reproduces the real shape: a `staleTime: Infinity` projection whose
queryFn reads the catalog through a shared `fetchQuery` at the `config` tier.

---

## 2. `apps/web` tests were not isolated, and a partial mock leaked

The `packages` lane failed twice with **90** errors of this shape:

    SyntaxError: Export named 'listProjectsForAccount' not found in module
    '…/packages/sdk/src/index.ts'

across four unrelated exports. **The exports are all present.** `bun test`
shares one module registry across every file in a run, and nine files under
`apps/web/src` replace the WHOLE of `@kortix/sdk` with a two- or three-key
object. Without isolation that object stands in for the real module for every
file that runs afterwards.

Which export is named — and whether it happens at all — depends purely on file
discovery order, which is why it passed on macOS and failed the Linux runner.
Deterministic repro:

    cd apps/web
    bun test src/lib/maintenance-store.test.ts \
             src/lib/onboarding/ensure-first-project.provision.test.ts   # red
    bun test --isolate <the same two>                                    # green

`--isolate` is the same fix, for the same reason, that
`apps/api/scripts/test.sh` already documents. `--parallel=4` pays for it: 680
files in **30.3s** isolated versus 108.6s isolated-and-serial, against a 24.4s
non-isolated baseline that was not actually correct.
`src/test-runner-contract.test.ts` pins both flags.

---

## Gates

- `pnpm --filter @kortix/sdk typecheck` — clean
- `pnpm --filter @kortix/sdk test` — **2758 pass / 0 fail** (baseline 2756)
- `pnpm --filter @kortix/sdk run smoke:install` — pack → install → import OK
- `apps/web` `bun test` — **8720 pass / 0 fail** across 680 files
- `apps/web` `tsc --noEmit` — clean apart from the ~15 known `@types/bun`
  `test.each` errors in 3 files; `eslint` clean on the new file
- CI at `8acd1bc3d1`: core, browser-1, browser-2 and **packages** lanes all pass
- Preview at `8acd1bc3d1`: `pnpm test -- --target-full` **passed** (454 flows)

No public SDK surface change; the snapshot tests are unchanged.

## Not verified here

**A manual browser check of this specific feature on the preview origin.** The
preview's own `target-full` gate passed at this SHA, but a hand-driven run
needs a project, and `POST /v1/projects/provision` on that origin answers
**503** right now:

    GitHub /orgs/***/repos failed (403): Resource not accessible by integration

The same 403 failed 124/454 flows on the earlier preview run for commit
`f55f0d8bff` and then cleared by itself, so the preview GitHub App's
managed-repo permission looks intermittent (token lifetime). Nothing in this PR
touches provisioning. The feature's browser evidence is the local A/B above.