### PR TITLE
fix(release): declare llm catalog build tool

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3832,3 +3832,17 @@ build if a path-only allowlist reappears in `.gitleaks.toml`.
 *Incident:* No leak occurred. Found by audit, closed the same session. All
 findings reproduced in throwaway repos with real gitleaks 8.30.1 and the repo's
 own config; no real secret was ever written to disk in plaintext.
+
+## Every build command must declare its executable in that package
+
+- **Incident (2026-08-29, v0.13.8 production release):** the
+  `@kortix/llm-catalog` publish job ran `tsc-alias` from its `build` script, but
+  the package did not declare `tsc-alias`. Local builds found the executable
+  through `@kortix/sdk`. The isolated production publish runner returned exit
+  `127`. The workflow then skipped the dependent `@kortix/sdk` publish.
+- **Rule:** each publishable package must directly declare every executable in
+  its lifecycle scripts. A sibling package dependency does not satisfy this
+  requirement.
+- **Enforcement:** `packages/llm-catalog/package.json` declares `tsc-alias` in
+  `devDependencies`. The package build now resolves the executable through its
+  own `node_modules/.bin` directory.

--- a/packages/llm-catalog/package.json
+++ b/packages/llm-catalog/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",
+    "tsc-alias": "^1.8.17",
     "typescript": "^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1472,6 +1472,9 @@ importers:
       '@types/bun':
         specifier: ^1.3.9
         version: 1.3.14
+      tsc-alias:
+        specifier: ^1.8.17
+        version: 1.9.0
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
## Incident

The v0.13.8 production workflow failed to publish `@kortix/llm-catalog`. Its build invoked `tsc-alias`, but the package did not declare that executable. The dependent `@kortix/sdk` publish was skipped.

## Fix

- Declare `tsc-alias` in `packages/llm-catalog` dev dependencies.
- Record the incident rule and enforcement.

## Verification

- `pnpm --filter @kortix/llm-catalog build`
- `pnpm --filter @kortix/llm-catalog typecheck`
- `pnpm --filter @kortix/llm-catalog test` — 83 pass, 0 fail
- `pnpm --filter @kortix/sdk run smoke:install` — packed root, React, and server imports passed
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790625416&installation_model_id=434224&pr_number=7050&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7050&signature=56ecd564af6b0daebb946ffe757305960a7800e02940d359cfd2fc6cbef19484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->