### PR TITLE
fix(worktree): a failed `git worktree remove` aborts the nuke instead of orphaning the worktree

### DIFF
--- a/scripts/worktree/__tests__/git.test.ts
+++ b/scripts/worktree/__tests__/git.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { branchExists, remoteBranchExists, worktreeAddArgs } from '../lib';
+import { branchExists, remoteBranchExists, removeWorktree, worktreeAddArgs } from '../lib';
 
 const git = (cwd: string, ...args: string[]) => {
   const r = Bun.spawnSync(['git', '-C', cwd, ...args], { stdout: 'pipe', stderr: 'pipe' });
@@ -58,3 +58,50 @@ describe('worktreeAddArgs', () => {
     expect(git(wt, 'rev-parse', '--abbrev-ref', '@{upstream}')).toBe('origin/feature');
   });
 });
+
+describe('removeWorktree', () => {
+  /** `fixture()` clone plus a worktree at `<clone>/../wt-<n>` checked out on `feature`. */
+  function withWorktree() {
+    const root = fixture();
+    const path = join(root, '..', 'wt-removal');
+    git(root, 'worktree', 'add', '-q', path, 'origin/feature');
+    return { root, path };
+  }
+
+  test('a clean worktree is removed', () => {
+    const { root, path } = withWorktree();
+    removeWorktree(root, path, false);
+    expect(existsSync(path)).toBe(false);
+    expect(git(root, 'worktree', 'list')).not.toContain(path);
+  });
+
+  test('a dirty worktree throws instead of reporting a removal that did not happen', () => {
+    const { root, path } = withWorktree();
+    writeFileSync(join(path, 'tracked.txt'), 'edit');
+    git(path, 'add', 'tracked.txt');
+
+    expect(() => removeWorktree(root, path, false)).toThrow(/git worktree remove failed/);
+
+    // The whole point: the caller must not go on to drop the registry slot for a
+    // directory that is still on disk and still registered with git.
+    expect(existsSync(path)).toBe(true);
+    expect(git(root, 'worktree', 'list')).toContain(path);
+  });
+
+  test('the thrown message names the remedy', () => {
+    const { root, path } = withWorktree();
+    writeFileSync(join(path, 'tracked.txt'), 'edit');
+    git(path, 'add', 'tracked.txt');
+    expect(() => removeWorktree(root, path, false)).toThrow(/pass --force/);
+  });
+
+  test('--force removes the same dirty worktree', () => {
+    const { root, path } = withWorktree();
+    writeFileSync(join(path, 'tracked.txt'), 'edit');
+    git(path, 'add', 'tracked.txt');
+
+    removeWorktree(root, path, true);
+    expect(existsSync(path)).toBe(false);
+    expect(git(root, 'worktree', 'list')).not.toContain(path);
+  });
+})

--- a/scripts/worktree/cli.ts
+++ b/scripts/worktree/cli.ts
@@ -19,7 +19,7 @@
  */
 import {
   STRIDE, BASE, computePorts, loadRegistry, saveRegistry, withLock, sanitizeName,
-  lowestFreeSlot, sh, run, which, portInUse, repoRoot, defaultWorktreePath, branchExists, worktreeAddArgs,
+  lowestFreeSlot, sh, run, which, portInUse, repoRoot, defaultWorktreePath, branchExists, worktreeAddArgs, removeWorktree,
   renderSupabaseProject, runMigrate, supa, supaStatusEnv, slotCredsFromStatus, apiLaunchEnv, webLaunchEnv, gatewayLaunchEnv,
   writeMarker, ensureDeps, checkDeps, supaWorkdir, slotDir, startTunnel, tunnelAnswers, startStripeListen, WT_HOME, REGISTRY_PATH,
   startSupabaseDb, startSupabaseFullStack, hasKortixSchema, ensureRuntimeArtifacts, dbModeOf,
@@ -713,8 +713,11 @@ async function nukeOne(name: string, e: SlotEntry, flags: Record<string, string 
     sub('shared primary Supabase left untouched');
   }
   const root = repoRoot();
-  const force = flags.force ? ['--force'] : [];
-  if (existsSync(e.path)) { sub('removing git worktree…'); sh(['git', '-C', root, 'worktree', 'remove', ...force, e.path]); }
+  // Throws when the checkout is dirty and --force was not passed. That must abort
+  // the nuke: everything below (branch delete, slot dir, registry entry) assumes
+  // the worktree is gone, and dropping the slot for a directory that survived
+  // orphans it beyond the reach of every `pnpm worktree` command.
+  if (existsSync(e.path)) { sub('removing git worktree…'); removeWorktree(root, e.path, Boolean(flags.force)); }
   sh(['git', '-C', root, 'worktree', 'prune']);
   if (e.branch) {
     const del = sh(['git', '-C', root, 'branch', '-d', e.branch]);

--- a/scripts/worktree/lib/git.ts
+++ b/scripts/worktree/lib/git.ts
@@ -27,3 +27,21 @@ export function worktreeAddArgs(root: string, wtPath: string, branch: string, fr
     return { args: ['git', '-C', root, 'worktree', 'add', '--track', '-b', branch, wtPath, `origin/${branch}`], mode: 'remote' };
   return { args: ['git', '-C', root, 'worktree', 'add', '-b', branch, wtPath, from], mode: 'new' };
 }
+
+/**
+ * Remove the worktree at `path`, or throw.
+ *
+ * `git worktree remove` refuses a checkout that has uncommitted changes unless
+ * it is forced. An unchecked call therefore fails silently and leaves both the
+ * directory and its `git worktree list` registration in place — while the
+ * caller goes on to drop the registry slot, orphaning the worktree beyond the
+ * reach of `pnpm worktree`. Callers must let this throw rather than report a
+ * removal that did not happen.
+ */
+export function removeWorktree(root: string, path: string, force: boolean): void {
+  const r = sh(['git', '-C', root, 'worktree', 'remove', ...(force ? ['--force'] : []), path]);
+  if (r.ok) return;
+  const detail = (r.stderr || r.stdout).trim().split('\n')[0] || `exit code ${r.code}`;
+  const remedy = force ? '' : ' — pass --force to discard the working tree';
+  throw new Error(`git worktree remove failed: ${detail}${remedy}`);
+}


### PR DESCRIPTION
## Problem

`nukeOne` (`scripts/worktree/cli.ts:716`) ran `git worktree remove` through `sh()` and never checked the result:

```ts
if (existsSync(e.path)) { sub('removing git worktree…'); sh(['git','-C',root,'worktree','remove',...force, e.path]); }
```

`git worktree remove` refuses a checkout with uncommitted changes unless forced. The failure was swallowed, and nuke went on to delete the branch, the slot directory and the registry entry, then printed `✓ removed "<name>" — slot N freed`.

The directory and its `git worktree list` registration survive; only the registry entry is gone. The worktree is then **orphaned** — `pnpm worktree ls` cannot see it and `nuke` will never select it again.

Measured 2026-08-29: `pnpm worktree nuke --all --older-than 1d` reported `nuked 90/90 · kept 10` while **18 worktrees (~52 GB)** stayed on disk and stayed registered with git.

## Fix

`removeWorktree(root, path, force)` in `lib/git.ts` checks the exit code and throws with the git error plus the `--force` remedy. `nukeOne` calls it *before* anything destructive, so a failure aborts with the slot intact. `cmdNukeAll` (`cli.ts:794-799`) already collects thrown errors into its `failed:` list and `process.exit(1)`, so bulk runs now report the truth.

## Verification

**Unit — `bun test scripts/worktree/__tests__/` → 119 pass, 0 fail.** Four new tests assert the post-conditions, not just the message: after a failed removal the directory is still on disk and still in `git worktree list`.

**Mutation proof** — reverting `removeWorktree` to the original unchecked `return` makes the new tests fail (`6 pass, 2 fail`); restoring the check returns `8 pass, 0 fail`. The tests catch the actual bug.

**End-to-end against the real CLI**, dirty worktree (`apps/api/src/UNSAVED-WORK.ts` staged):

| run | exit | result |
|---|---|---|
| `pnpm worktree nuke nuke-guard-probe --yes` | **1** | `✗ git worktree remove failed: fatal: '…' contains modified or untracked files, use --force to delete it — pass --force to discard the working tree` |
| post-conditions | | dir on disk `YES` · git registration `1` · **registry slot kept `1`** · staged file preserved `YES` |
| `pnpm worktree nuke nuke-guard-probe --force --yes` | **0** | `✓ removed "nuke-guard-probe" — slot 3 freed` |
| post-conditions | | dir `NO` · git registration `0` · registry slot `0` |

Before this change the first run exited 0, printed `✓ removed`, and dropped the slot while the directory stayed.

`bunx tsc --noEmit -p scripts/worktree/tsconfig.json` → exit 0.

## Notes

- No `preview` label: this touches only `scripts/worktree/*`, a local dev CLI. A self-host preview would build API, gateway and frontend for a change none of them contain. Say the word if you want one anyway.
- Detecting existing orphans: `ls -d ~/Projects/kortix/suna-* | wc -l`, `git worktree list | wc -l`, and `pnpm worktree ls | grep -cE '●|○'` disagreeing means orphans. Clean one with `git worktree remove --force <path>` after WIP-committing any dirty tree.

https://claude.ai/code/session_01FyJ1fyomoynPbHLcuZYRot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790630807&installation_model_id=434224&pr_number=7052&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7052&signature=e2e38f8ef993cc2c3237a5e94b0a8f45d4ab00128a8f02f6c2eca98b81bb2441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->