### PR TITLE
fix(triggers): refresh replica mirror before fire miss

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3846,3 +3846,18 @@ own config; no real secret was ever written to disk in plaintext.
 - **Enforcement:** `packages/llm-catalog/package.json` declares `tsc-alias` in
   `devDependencies`. The package build now resolves the executable through its
   own `node_modules/.bin` directory.
+
+## An action endpoint must refresh a replicated mirror before returning 404
+
+- **Incident (2026-08-29, v0.13.9 release QA):** `CLI-TRG` created a trigger,
+  then `triggers ls` and `triggers info` found it through refreshed API
+  replicas. The subsequent `triggers fire` request reached a different replica
+  whose Git mirror was still inside its 60-second cache interval. That replica
+  returned `404 Not found` in two consecutive release-gate attempts.
+- **Rule:** a mutable-resource action endpoint can use its replica cache for the
+  first lookup. It must force one source refresh before it returns a definitive
+  not-found response. A successful read through another replica does not prove
+  fleet-wide cache convergence.
+- **Enforcement:** `findProjectTriggerBySlug()` retries a missing cached trigger
+  through `readManifest(..., { forceRefresh: true })`. The manual fire route
+  uses this helper. Its unit test proves the cached-then-forced read sequence.

--- a/apps/api/src/projects/lib/triggers.test.ts
+++ b/apps/api/src/projects/lib/triggers.test.ts
@@ -9,6 +9,9 @@ import { parseManifestText, validateManifest } from '@kortix/manifest-schema';
 // synthesis path (no manifest committed yet) run with zero DB/network, same
 // pattern as `./compile-agent-config.test.ts`.
 let manifestFile: { path: string; content: string } | null = null;
+let manifestReader:
+  | ((...args: unknown[]) => Promise<{ path: string; content: string } | null>)
+  | null = null;
 
 // `../git` and `./git` are heavily-imported modules (session-lifecycle,
 // github, etc. all pull other exports off them) — spread the REAL module and
@@ -18,7 +21,8 @@ let manifestFile: { path: string; content: string } | null = null;
 const realProjectsGit = await import('../git');
 mock.module('../git', () => ({
   ...realProjectsGit,
-  readManifestFromRepo: async () => manifestFile,
+  readManifestFromRepo: async (...args: unknown[]) =>
+    manifestReader ? manifestReader(...args) : manifestFile,
 }));
 
 const realLibGit = await import('./git');
@@ -32,6 +36,7 @@ mock.module('./git', () => ({
 
 const { loadManifestForEdit } = await import('./triggers');
 const { serializeManifest } = await import('../triggers');
+const { findProjectTriggerBySlug } = await import('../triggers');
 const { DEFAULT_AGENT_SENTINEL, extractAgents, resolveGovernedAgentGrant, loadProjectAgents } =
   await import('../agents');
 const { applyDefaultAgentV2, applyAgentBlockV2 } = await import('./agent-config-v2');
@@ -171,5 +176,55 @@ describe('loadManifestForEdit — blank managed project (no kortix.yaml on disk 
     expect(manifest.schemaVersion).toBe(1);
     expect(manifest.format).toBe('toml');
     expect(manifest.raw.agents).toBeUndefined();
+  });
+});
+
+describe('findProjectTriggerBySlug — replica mirror convergence', () => {
+  test('returns a cached trigger without forcing an unnecessary fetch', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      return {
+        path: 'kortix.yaml',
+        content:
+          'kortix_version: 2\nproject:\n  name: current\ntriggers:\n  - slug: daily\n    name: Daily\n    type: cron\n    cron: "0 0 3 * * *"\n    prompt: Report status\n',
+      };
+    };
+
+    try {
+      const trigger = await findProjectTriggerBySlug(fakeProject(), 'daily');
+      expect(trigger?.slug).toBe('daily');
+      expect(forceRefreshValues).toEqual([undefined]);
+    } finally {
+      manifestReader = null;
+    }
+  });
+
+  test('forces one mirror refresh when the cached manifest does not contain the trigger', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      if (!opts?.forceRefresh) {
+        return {
+          path: 'kortix.yaml',
+          content: 'kortix_version: 2\nproject:\n  name: stale\ntriggers: []\n',
+        };
+      }
+      return {
+        path: 'kortix.yaml',
+        content:
+          'kortix_version: 2\nproject:\n  name: fresh\ntriggers:\n  - slug: daily\n    name: Daily\n    type: cron\n    cron: "0 0 3 * * *"\n    prompt: Report status\n',
+      };
+    };
+
+    try {
+      const trigger = await findProjectTriggerBySlug(fakeProject(), 'daily');
+      expect(trigger?.slug).toBe('daily');
+      expect(forceRefreshValues).toEqual([undefined, true]);
+    } finally {
+      manifestReader = null;
+    }
   });
 });

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -158,7 +158,12 @@ import {
   setTriggerSessionAccess,
   validateTriggerSessionAccessPrincipals,
 } from '../trigger-session-access';
-import { type ParsedManifest, extractTriggers, loadProjectTriggers } from '../triggers';
+import {
+  type ParsedManifest,
+  extractTriggers,
+  findProjectTriggerBySlug,
+  loadProjectTriggers,
+} from '../triggers';
 import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 import {
   abandonSandboxTurn,
@@ -3819,8 +3824,7 @@ projectsApp.openapi(
       PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE,
     );
 
-    const { specs } = await loadProjectTriggers(await withProjectGitAuth(loaded.row));
-    const spec = specs.find((s) => s.slug === slug);
+    const spec = await findProjectTriggerBySlug(await withProjectGitAuth(loaded.row), slug);
     if (!spec) return c.json({ error: 'Not found' }, 404);
 
     const now = new Date();

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -566,10 +566,13 @@ export function extractTriggers(manifest: ParsedManifest): LoadedTriggers {
  * arrays + a single top-level error when the manifest fails to parse —
  * never throws.
  */
-export async function loadProjectTriggers(project: GitBackedProject): Promise<LoadedTriggers> {
+export async function loadProjectTriggers(
+  project: GitBackedProject,
+  opts?: { forceRefresh?: boolean },
+): Promise<LoadedTriggers> {
   let manifest: ParsedManifest | null;
   try {
-    manifest = await readManifest(project);
+    manifest = await readManifest(project, { forceRefresh: opts?.forceRefresh });
   } catch (err) {
     // The manifest failed to parse before we learned which candidate file it
     // actually was (.yaml/.yml/.toml) — fall back to the project's configured
@@ -588,6 +591,23 @@ export async function loadProjectTriggers(project: GitBackedProject): Promise<Lo
   }
   if (!manifest) return { specs: [], errors: [] };
   return extractTriggers(manifest);
+}
+
+/**
+ * Resolve one trigger for an action endpoint. A trigger can be absent from one
+ * API replica's mirror for up to the normal refresh interval after another
+ * replica commits it. Refresh once before returning a definitive miss.
+ */
+export async function findProjectTriggerBySlug(
+  project: GitBackedProject,
+  slug: string,
+): Promise<GitTriggerSpec | null> {
+  const cached = await loadProjectTriggers(project);
+  const cachedSpec = cached.specs.find((spec) => spec.slug === slug);
+  if (cachedSpec) return cachedSpec;
+
+  const refreshed = await loadProjectTriggers(project, { forceRefresh: true });
+  return refreshed.specs.find((spec) => spec.slug === slug) ?? null;
 }
 
 /* ─── Trigger ↔ manifest-entry conversion ───────────────────────────────── */


### PR DESCRIPTION
## Incident

Staging release QA `33275183105` failed `CLI-TRG` twice. Trigger create/list/info succeeded, then manual fire reached a replica with a stale Git mirror and returned `404 Not found`.

## Fix

- Retry a missing trigger through one forced mirror refresh.
- Keep cached hits on the existing single-read path.
- Route manual trigger fire through the convergence helper.
- Record the incident rule.

## Verification

- RED: targeted test failed because `findProjectTriggerBySlug` did not exist.
- GREEN: targeted tests: 6 pass, 0 fail.
- API suite: 8,567 pass, 79 skip, 0 fail.
- API typecheck passed.
- Local `CLI-TRG` could not start because the shared local DB has an existing `branding` column without its migration ledger row. Staging `CLI-TRG` is mandatory before production.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790632730&installation_model_id=434224&pr_number=7053&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7053&signature=b71570497f86b505b558b90292a9d3ce6ea29e75c74fa3a13ea63f3811b58947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->