### PR TITLE
Promote trigger mirror convergence fix to staging

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3846,3 +3846,18 @@ own config; no real secret was ever written to disk in plaintext.
 - **Enforcement:** `packages/llm-catalog/package.json` declares `tsc-alias` in
   `devDependencies`. The package build now resolves the executable through its
   own `node_modules/.bin` directory.
+
+## An action endpoint must refresh a replicated mirror before returning 404
+
+- **Incident (2026-08-29, v0.13.9 release QA):** `CLI-TRG` created a trigger,
+  then `triggers ls` and `triggers info` found it through refreshed API
+  replicas. The subsequent `triggers fire` request reached a different replica
+  whose Git mirror was still inside its 60-second cache interval. That replica
+  returned `404 Not found` in two consecutive release-gate attempts.
+- **Rule:** a mutable-resource action endpoint can use its replica cache for the
+  first lookup. It must force one source refresh before it returns a definitive
+  not-found response. A successful read through another replica does not prove
+  fleet-wide cache convergence.
+- **Enforcement:** `findProjectTriggerBySlug()` retries a missing cached trigger
+  through `readManifest(..., { forceRefresh: true })`. The manual fire route
+  uses this helper. Its unit test proves the cached-then-forced read sequence.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3859,5 +3859,7 @@ own config; no real secret was ever written to disk in plaintext.
   not-found response. A successful read through another replica does not prove
   fleet-wide cache convergence.
 - **Enforcement:** `findProjectTriggerBySlug()` retries a missing cached trigger
-  through `readManifest(..., { forceRefresh: true })`. The manual fire route
-  uses this helper. Its unit test proves the cached-then-forced read sequence.
+  through `readManifest(..., { forceRefresh: true })`. A per-project cooldown
+  limits forced fetches to one per Git refresh interval. The manual fire route
+  uses this helper. Unit tests prove cached-hit, forced-refresh, and bounded-miss
+  sequences.

--- a/apps/api/src/projects/lib/triggers.test.ts
+++ b/apps/api/src/projects/lib/triggers.test.ts
@@ -9,6 +9,9 @@ import { parseManifestText, validateManifest } from '@kortix/manifest-schema';
 // synthesis path (no manifest committed yet) run with zero DB/network, same
 // pattern as `./compile-agent-config.test.ts`.
 let manifestFile: { path: string; content: string } | null = null;
+let manifestReader:
+  | ((...args: unknown[]) => Promise<{ path: string; content: string } | null>)
+  | null = null;
 
 // `../git` and `./git` are heavily-imported modules (session-lifecycle,
 // github, etc. all pull other exports off them) — spread the REAL module and
@@ -18,7 +21,8 @@ let manifestFile: { path: string; content: string } | null = null;
 const realProjectsGit = await import('../git');
 mock.module('../git', () => ({
   ...realProjectsGit,
-  readManifestFromRepo: async () => manifestFile,
+  readManifestFromRepo: async (...args: unknown[]) =>
+    manifestReader ? manifestReader(...args) : manifestFile,
 }));
 
 const realLibGit = await import('./git');
@@ -32,6 +36,7 @@ mock.module('./git', () => ({
 
 const { loadManifestForEdit } = await import('./triggers');
 const { serializeManifest } = await import('../triggers');
+const { findProjectTriggerBySlug } = await import('../triggers');
 const { DEFAULT_AGENT_SENTINEL, extractAgents, resolveGovernedAgentGrant, loadProjectAgents } =
   await import('../agents');
 const { applyDefaultAgentV2, applyAgentBlockV2 } = await import('./agent-config-v2');
@@ -171,5 +176,55 @@ describe('loadManifestForEdit — blank managed project (no kortix.yaml on disk 
     expect(manifest.schemaVersion).toBe(1);
     expect(manifest.format).toBe('toml');
     expect(manifest.raw.agents).toBeUndefined();
+  });
+});
+
+describe('findProjectTriggerBySlug — replica mirror convergence', () => {
+  test('returns a cached trigger without forcing an unnecessary fetch', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      return {
+        path: 'kortix.yaml',
+        content:
+          'kortix_version: 2\nproject:\n  name: current\ntriggers:\n  - slug: daily\n    name: Daily\n    type: cron\n    cron: "0 0 3 * * *"\n    prompt: Report status\n',
+      };
+    };
+
+    try {
+      const trigger = await findProjectTriggerBySlug(fakeProject(), 'daily');
+      expect(trigger?.slug).toBe('daily');
+      expect(forceRefreshValues).toEqual([undefined]);
+    } finally {
+      manifestReader = null;
+    }
+  });
+
+  test('forces one mirror refresh when the cached manifest does not contain the trigger', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      if (!opts?.forceRefresh) {
+        return {
+          path: 'kortix.yaml',
+          content: 'kortix_version: 2\nproject:\n  name: stale\ntriggers: []\n',
+        };
+      }
+      return {
+        path: 'kortix.yaml',
+        content:
+          'kortix_version: 2\nproject:\n  name: fresh\ntriggers:\n  - slug: daily\n    name: Daily\n    type: cron\n    cron: "0 0 3 * * *"\n    prompt: Report status\n',
+      };
+    };
+
+    try {
+      const trigger = await findProjectTriggerBySlug(fakeProject(), 'daily');
+      expect(trigger?.slug).toBe('daily');
+      expect(forceRefreshValues).toEqual([undefined, true]);
+    } finally {
+      manifestReader = null;
+    }
   });
 });

--- a/apps/api/src/projects/lib/triggers.test.ts
+++ b/apps/api/src/projects/lib/triggers.test.ts
@@ -227,4 +227,25 @@ describe('findProjectTriggerBySlug — replica mirror convergence', () => {
       manifestReader = null;
     }
   });
+
+  test('bounds repeated missing slugs to one forced refresh per project interval', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      return {
+        path: 'kortix.yaml',
+        content: 'kortix_version: 2\nproject:\n  name: stale\ntriggers: []\n',
+      };
+    };
+
+    try {
+      const project = fakeProject({ projectId: 'proj_refresh_cooldown' });
+      expect(await findProjectTriggerBySlug(project, 'missing-one')).toBeNull();
+      expect(await findProjectTriggerBySlug(project, 'missing-two')).toBeNull();
+      expect(forceRefreshValues).toEqual([undefined, true, undefined]);
+    } finally {
+      manifestReader = null;
+    }
+  });
 });

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -162,7 +162,6 @@ import {
   type ParsedManifest,
   extractTriggers,
   findProjectTriggerBySlug,
-  loadProjectTriggers,
 } from '../triggers';
 import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 import {

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -158,7 +158,12 @@ import {
   setTriggerSessionAccess,
   validateTriggerSessionAccessPrincipals,
 } from '../trigger-session-access';
-import { type ParsedManifest, extractTriggers, loadProjectTriggers } from '../triggers';
+import {
+  type ParsedManifest,
+  extractTriggers,
+  findProjectTriggerBySlug,
+  loadProjectTriggers,
+} from '../triggers';
 import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 import {
   abandonSandboxTurn,
@@ -3819,8 +3824,7 @@ projectsApp.openapi(
       PROJECT_ACTIONS.PROJECT_TRIGGER_FIRE,
     );
 
-    const { specs } = await loadProjectTriggers(await withProjectGitAuth(loaded.row));
-    const spec = specs.find((s) => s.slug === slug);
+    const spec = await findProjectTriggerBySlug(await withProjectGitAuth(loaded.row), slug);
     if (!spec) return c.json({ error: 'Not found' }, 404);
 
     const now = new Date();

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -593,6 +593,13 @@ export async function loadProjectTriggers(
   return extractTriggers(manifest);
 }
 
+function forcedTriggerRefreshCooldownMs(): number {
+  const value = Number(process.env.KORTIX_GIT_REFRESH_INTERVAL_MS || 60_000);
+  return Number.isFinite(value) && value >= 0 ? value : 60_000;
+}
+
+const lastForcedTriggerRefreshAt = new Map<string, number>();
+
 /**
  * Resolve one trigger for an action endpoint. A trigger can be absent from one
  * API replica's mirror for up to the normal refresh interval after another
@@ -606,6 +613,11 @@ export async function findProjectTriggerBySlug(
   const cachedSpec = cached.specs.find((spec) => spec.slug === slug);
   if (cachedSpec) return cachedSpec;
 
+  const now = Date.now();
+  const lastForcedAt = lastForcedTriggerRefreshAt.get(project.projectId) ?? 0;
+  if (now - lastForcedAt < forcedTriggerRefreshCooldownMs()) return null;
+
+  lastForcedTriggerRefreshAt.set(project.projectId, now);
   const refreshed = await loadProjectTriggers(project, { forceRefresh: true });
   return refreshed.specs.find((spec) => spec.slug === slug) ?? null;
 }

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -566,10 +566,13 @@ export function extractTriggers(manifest: ParsedManifest): LoadedTriggers {
  * arrays + a single top-level error when the manifest fails to parse —
  * never throws.
  */
-export async function loadProjectTriggers(project: GitBackedProject): Promise<LoadedTriggers> {
+export async function loadProjectTriggers(
+  project: GitBackedProject,
+  opts?: { forceRefresh?: boolean },
+): Promise<LoadedTriggers> {
   let manifest: ParsedManifest | null;
   try {
-    manifest = await readManifest(project);
+    manifest = await readManifest(project, { forceRefresh: opts?.forceRefresh });
   } catch (err) {
     // The manifest failed to parse before we learned which candidate file it
     // actually was (.yaml/.yml/.toml) — fall back to the project's configured
@@ -588,6 +591,23 @@ export async function loadProjectTriggers(project: GitBackedProject): Promise<Lo
   }
   if (!manifest) return { specs: [], errors: [] };
   return extractTriggers(manifest);
+}
+
+/**
+ * Resolve one trigger for an action endpoint. A trigger can be absent from one
+ * API replica's mirror for up to the normal refresh interval after another
+ * replica commits it. Refresh once before returning a definitive miss.
+ */
+export async function findProjectTriggerBySlug(
+  project: GitBackedProject,
+  slug: string,
+): Promise<GitTriggerSpec | null> {
+  const cached = await loadProjectTriggers(project);
+  const cachedSpec = cached.specs.find((spec) => spec.slug === slug);
+  if (cachedSpec) return cachedSpec;
+
+  const refreshed = await loadProjectTriggers(project, { forceRefresh: true });
+  return refreshed.specs.find((spec) => spec.slug === slug) ?? null;
 }
 
 /* ─── Trigger ↔ manifest-entry conversion ───────────────────────────────── */


### PR DESCRIPTION
Promotes main SHA `8370ff95e1788478ec8da242cd555fa16b987388`.

This release candidate contains:
- the direct `tsc-alias` dependency required to publish `@kortix/llm-catalog`;
- a forced Git-mirror refresh before manual trigger fire returns `404`.

The latter fixes deterministic `CLI-TRG` failures in release QA run `33275183105`.

Exact-SHA staging `CLI-TRG` and `--target-full` must pass before production.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790633827&installation_model_id=434224&pr_number=7054&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7054&signature=0c13de4a47cc8a7b9a40cdfae98cb1ede4dcf18ef50a77da01ceaf2845d69abe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->