### PR TITLE
fix(triggers): bound forced mirror refreshes

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3859,5 +3859,7 @@ own config; no real secret was ever written to disk in plaintext.
   not-found response. A successful read through another replica does not prove
   fleet-wide cache convergence.
 - **Enforcement:** `findProjectTriggerBySlug()` retries a missing cached trigger
-  through `readManifest(..., { forceRefresh: true })`. The manual fire route
-  uses this helper. Its unit test proves the cached-then-forced read sequence.
+  through `readManifest(..., { forceRefresh: true })`. A per-project cooldown
+  limits forced fetches to one per Git refresh interval. The manual fire route
+  uses this helper. Unit tests prove cached-hit, forced-refresh, and bounded-miss
+  sequences.

--- a/apps/api/src/projects/lib/triggers.test.ts
+++ b/apps/api/src/projects/lib/triggers.test.ts
@@ -227,4 +227,25 @@ describe('findProjectTriggerBySlug — replica mirror convergence', () => {
       manifestReader = null;
     }
   });
+
+  test('bounds repeated missing slugs to one forced refresh per project interval', async () => {
+    const forceRefreshValues: Array<boolean | undefined> = [];
+    manifestReader = async (...args: unknown[]) => {
+      const opts = args[3] as { forceRefresh?: boolean } | undefined;
+      forceRefreshValues.push(opts?.forceRefresh);
+      return {
+        path: 'kortix.yaml',
+        content: 'kortix_version: 2\nproject:\n  name: stale\ntriggers: []\n',
+      };
+    };
+
+    try {
+      const project = fakeProject({ projectId: 'proj_refresh_cooldown' });
+      expect(await findProjectTriggerBySlug(project, 'missing-one')).toBeNull();
+      expect(await findProjectTriggerBySlug(project, 'missing-two')).toBeNull();
+      expect(forceRefreshValues).toEqual([undefined, true, undefined]);
+    } finally {
+      manifestReader = null;
+    }
+  });
 });

--- a/apps/api/src/projects/routes/r4.ts
+++ b/apps/api/src/projects/routes/r4.ts
@@ -162,7 +162,6 @@ import {
   type ParsedManifest,
   extractTriggers,
   findProjectTriggerBySlug,
-  loadProjectTriggers,
 } from '../triggers';
 import { turnStreamKindField, turnStreamKindNeedsConnectorWrite } from './r4-turn-stream-kind';
 import {

--- a/apps/api/src/projects/triggers.ts
+++ b/apps/api/src/projects/triggers.ts
@@ -593,6 +593,13 @@ export async function loadProjectTriggers(
   return extractTriggers(manifest);
 }
 
+function forcedTriggerRefreshCooldownMs(): number {
+  const value = Number(process.env.KORTIX_GIT_REFRESH_INTERVAL_MS || 60_000);
+  return Number.isFinite(value) && value >= 0 ? value : 60_000;
+}
+
+const lastForcedTriggerRefreshAt = new Map<string, number>();
+
 /**
  * Resolve one trigger for an action endpoint. A trigger can be absent from one
  * API replica's mirror for up to the normal refresh interval after another
@@ -606,6 +613,11 @@ export async function findProjectTriggerBySlug(
   const cachedSpec = cached.specs.find((spec) => spec.slug === slug);
   if (cachedSpec) return cachedSpec;
 
+  const now = Date.now();
+  const lastForcedAt = lastForcedTriggerRefreshAt.get(project.projectId) ?? 0;
+  if (now - lastForcedAt < forcedTriggerRefreshCooldownMs()) return null;
+
+  lastForcedTriggerRefreshAt.set(project.projectId, now);
   const refreshed = await loadProjectTriggers(project, { forceRefresh: true });
   return refreshed.specs.find((spec) => spec.slug === slug) ?? null;
 }


### PR DESCRIPTION
Addresses the two review findings on staging PR #7054.

- Remove the unused `loadProjectTriggers` route import.
- Bound forced Git fetches to one per project per configured refresh interval.
- Add RED/GREEN coverage for repeated missing slugs.

Verification:
- RED: received `[undefined,true,undefined,true]`, expected one forced refresh.
- GREEN: targeted tests: 7 pass, 0 fail.
- API typecheck passed.
- `git diff --check` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790634673&installation_model_id=434224&pr_number=7055&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7055&signature=ab962ce74e07620dfeba2559a63d909b83cf1b9650ae29369392a7b8ce1906df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->