### PR TITLE
fix(session): report file tool rows in the tense they are actually in

### DIFF
--- a/apps/web/src/features/session/session-chat.tsx
+++ b/apps/web/src/features/session/session-chat.tsx
@@ -114,7 +114,11 @@ import type { DraftScope } from '@/features/session/composer/draft/composer-draf
 import { usePlanInChat } from '@/features/session/plan-surface';
 import { SessionStartingLoader } from '@/features/session/session-starting-loader';
 import { SubSessionModal } from '@/features/session/sub-session-modal';
-import { ToolActivateContext, ToolPartRenderer } from '@/features/session/tool/tool-renderers';
+import {
+  ToolActivateContext,
+  ToolPartRenderer,
+  TurnLiveContext,
+} from '@/features/session/tool/tool-renderers';
 import {
   buildOptimisticPromptTextWithUploads,
   buildPromptPartsWithUploads,
@@ -1488,30 +1492,32 @@ function SessionTurnImpl({
 
   if (shellModePart) {
     return (
-      <div className="space-y-1">
-        <ToolPartRenderer
-          part={shellModePart}
-          sessionId={sessionId}
-          disableNavigation={disableToolNavigation}
-          permission={nextPermission?.tool ? nextPermission : undefined}
-          onPermissionReply={onPermissionReply}
-          defaultOpen
-        />
-        {turnError && (
-          <TurnErrorDisplay
-            errorText={turnError}
-            errorDetails={turnErrorDetails}
-            isAbort={turnErrorIsAbort}
-            abortReason={turnErrorAbortReason}
-            className="mt-2"
+      <TurnLiveContext.Provider value={working}>
+        <div className="space-y-1">
+          <ToolPartRenderer
+            part={shellModePart}
+            sessionId={sessionId}
+            disableNavigation={disableToolNavigation}
+            permission={nextPermission?.tool ? nextPermission : undefined}
+            onPermissionReply={onPermissionReply}
+            defaultOpen
           />
-        )}
-        <ConnectProviderDialog
-          open={connectProviderOpen}
-          onOpenChange={setConnectProviderOpen}
-          providers={providers}
-        />
-      </div>
+          {turnError && (
+            <TurnErrorDisplay
+              errorText={turnError}
+              errorDetails={turnErrorDetails}
+              isAbort={turnErrorIsAbort}
+              abortReason={turnErrorAbortReason}
+              className="mt-2"
+            />
+          )}
+          <ConnectProviderDialog
+            open={connectProviderOpen}
+            onOpenChange={setConnectProviderOpen}
+            providers={providers}
+          />
+        </div>
+      </TurnLiveContext.Provider>
     );
   }
 
@@ -1682,49 +1688,56 @@ function SessionTurnImpl({
 			      questions are dropped when rendering inline content (below),
 			      since that mode shows them already, in natural order. */}
       {(working || hasSteps || hasReasoning) && turn.assistantMessages.length > 0 && (
-        <div className="space-y-3">
-          {segments.map((segment, index) => {
-            if (segment.kind === 'burst') {
-              return (
-                <ActivityBurst
-                  key={`burst-${segment.parts[0]?.id ?? 'empty'}`}
-                  parts={segment.parts}
-                  sessionId={sessionId}
-                  working={working}
-                  isTrailing={index === segments.length - 1}
-                  disableNavigation={disableToolNavigation}
-                  density={conversationDensity}
-                />
-              );
-            }
+        // Every tool row below — the bursts' rows and the standalone ones —
+        // reads this to tell a call that has not spoken YET from one that never
+        // will. Provided here rather than per-row because `working` is a fact
+        // about the TURN, and this block is the turn's whole part tree.
+        // See `TurnLiveContext`.
+        <TurnLiveContext.Provider value={working}>
+          <div className="space-y-3">
+            {segments.map((segment, index) => {
+              if (segment.kind === 'burst') {
+                return (
+                  <ActivityBurst
+                    key={`burst-${segment.parts[0]?.id ?? 'empty'}`}
+                    parts={segment.parts}
+                    sessionId={sessionId}
+                    working={working}
+                    isTrailing={index === segments.length - 1}
+                    disableNavigation={disableToolNavigation}
+                    density={conversationDensity}
+                  />
+                );
+              }
 
-            if (segment.kind === 'standalone') {
-              if (!shouldShowToolPart(segment.part)) return null;
-              return (
-                <ToolPartRenderer
-                  key={segment.part.id}
-                  part={segment.part}
-                  sessionId={sessionId}
-                  disableNavigation={disableToolNavigation}
-                  permission={getPermissionForTool(permissions, segment.part.callID)}
-                  onPermissionReply={onPermissionReply}
-                />
-              );
-            }
+              if (segment.kind === 'standalone') {
+                if (!shouldShowToolPart(segment.part)) return null;
+                return (
+                  <ToolPartRenderer
+                    key={segment.part.id}
+                    part={segment.part}
+                    sessionId={sessionId}
+                    disableNavigation={disableToolNavigation}
+                    permission={getPermissionForTool(permissions, segment.part.callID)}
+                    onPermissionReply={onPermissionReply}
+                  />
+                );
+              }
 
-            // Text segments render as prose between bursts. Text rendering
-            // for no-step turns is handled below in the dedicated response
-            // section, to avoid duplicate output.
-            if (!hasSteps) return null;
-            const text = segment.part.text?.trim();
-            if (!text) return null;
-            return (
-              <div key={segment.part.id} className="min-w-0 text-sm">
-                <ThrottledMarkdown content={text} isStreaming={working} />
-              </div>
-            );
-          })}
-        </div>
+              // Text segments render as prose between bursts. Text rendering
+              // for no-step turns is handled below in the dedicated response
+              // section, to avoid duplicate output.
+              if (!hasSteps) return null;
+              const text = segment.part.text?.trim();
+              if (!text) return null;
+              return (
+                <div key={segment.part.id} className="min-w-0 text-sm">
+                  <ThrottledMarkdown content={text} isStreaming={working} />
+                </div>
+              );
+            })}
+          </div>
+        </TurnLiveContext.Provider>
       )}
 
       {/* ── Screen reader ──

--- a/apps/web/src/features/session/tool/shared/file-verb.test.ts
+++ b/apps/web/src/features/session/tool/shared/file-verb.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+
+import { FILE_VERBS, fileVerb, filePhase } from './file-verb';
+
+describe('fileVerb — one vocabulary for every row that touches a file', () => {
+  test('a running call is a present participle, a settled one is past tense', () => {
+    expect(fileVerb('write', 'running')).toBe('Writing');
+    expect(fileVerb('write', 'done')).toBe('Wrote');
+    expect(fileVerb('edit', 'running')).toBe('Editing');
+    expect(fileVerb('edit', 'done')).toBe('Edited');
+  });
+
+  test('a failed call never wears the wording of one that landed', () => {
+    // The panel's rule (W7, `group-steps.ts`) reaching the trigger rows: the
+    // icon already flipped to a warning, the words used to keep claiming success.
+    expect(fileVerb('write', 'failed')).toBe("Couldn't write");
+    expect(fileVerb('edit', 'failed')).toBe("Couldn't update");
+  });
+
+  test('the failed wording matches narration.ts character for character', () => {
+    // `narration.ts:805` picks "write" for a write and "update" for an edit.
+    // Two surfaces describing one failure must not pick two different words.
+    expect(FILE_VERBS.write.failed).toBe("Couldn't write");
+    expect(FILE_VERBS.edit.failed).toBe("Couldn't update");
+  });
+
+  test('the read-only rows join the same table', () => {
+    // `List` was the bare registry key; `Read` was a past tense a streaming
+    // call had not earned. Neither mutates a file, both had the same defect.
+    expect(fileVerb('list', 'running')).toBe('Listing');
+    expect(fileVerb('list', 'done')).toBe('Listed');
+    expect(fileVerb('read', 'running')).toBe('Reading');
+    expect(fileVerb('read', 'done')).toBe('Read');
+  });
+
+  test('every action carries all three tenses — none can be forgotten', () => {
+    for (const [action, verbs] of Object.entries(FILE_VERBS)) {
+      expect(verbs.verb, action).toBeTruthy();
+      expect(verbs.running, action).toBeTruthy();
+      expect(verbs.failed, action).toBeTruthy();
+    }
+  });
+});
+
+describe('filePhase — the tense a row is in', () => {
+  test('an error outranks the run state: a failing call is not "still going"', () => {
+    expect(filePhase(true, true)).toBe('failed');
+    expect(filePhase(false, true)).toBe('failed');
+  });
+
+  test('a live turn is present tense, a finished one is past', () => {
+    expect(filePhase(true, false)).toBe('running');
+    expect(filePhase(false, false)).toBe('done');
+  });
+});

--- a/apps/web/src/features/session/tool/shared/file-verb.ts
+++ b/apps/web/src/features/session/tool/shared/file-verb.ts
@@ -46,24 +46,24 @@ export interface FileVerb {
  * Keyed by action rather than by tool name because the two consumers key
  * differently: the trigger rows come in as `write` / `edit` / `morph_edit`,
  * while `patch-summary.ts` comes in as an `add` / `update` / `delete` / `move`
- * patch op. Both map onto the same six English verbs, and mapping onto a shared
- * vocabulary is the point — it is what stops `apply_patch` from inventing a
- * seventh word for something `write` already has a word for.
+ * patch op. Both map onto the same short list of English verbs, and mapping onto
+ * a shared vocabulary is the point — it is what stops `apply_patch` from
+ * inventing a second word for something `write` already has a word for.
+ *
+ * There is deliberately NO `create`. Producing a file that was not there is a
+ * WRITE, and the reader has already met that word on every `write` row in the
+ * session; a patch that adds four files saying `Created 4 files` beside a
+ * `write` row saying `Wrote app.py` is one product speaking two vocabularies
+ * about one act. `narration.ts` reached this conclusion already — it reports a
+ * write-family patch as `Wrote`, never as `Created`. `patch-summary.ts` maps
+ * its `add` op onto `write` for the same reason. `delete` and `rename` keep
+ * their own verbs because no write-family word covers them.
  */
-export type FileAction =
-  | 'write'
-  | 'edit'
-  | 'create'
-  | 'delete'
-  | 'rename'
-  | 'change'
-  | 'read'
-  | 'list';
+export type FileAction = 'write' | 'edit' | 'delete' | 'rename' | 'change' | 'read' | 'list';
 
 export const FILE_VERBS: Record<FileAction, FileVerb> = {
   write: { verb: 'Wrote', running: 'Writing', failed: "Couldn't write" },
   edit: { verb: 'Edited', running: 'Editing', failed: "Couldn't update" },
-  create: { verb: 'Created', running: 'Creating', failed: "Couldn't create" },
   delete: { verb: 'Deleted', running: 'Deleting', failed: "Couldn't delete" },
   rename: { verb: 'Renamed', running: 'Renaming', failed: "Couldn't rename" },
   // The weakest word here, deliberately — see `patchVerb`. A patch that creates

--- a/apps/web/src/features/session/tool/shared/file-verb.ts
+++ b/apps/web/src/features/session/tool/shared/file-verb.ts
@@ -1,0 +1,109 @@
+/**
+ * What a call DID to a file, in the tense the row is actually in.
+ *
+ * Every other surface in this feature already speaks this way. `step-label.ts`
+ * turns a part into `Wrote` / `Writing`, `activity-file-chips.tsx` labels a run
+ * of writes `Wrote 3 files`, `narration.ts` narrates the panel, and
+ * `patch-summary.ts` derives a patch's verb from what the patch contains. The
+ * `BasicTool` trigger was the one surface left speaking machine: `write`
+ * rendered the literal registry key `Write`, and `edit` rendered `Editing`
+ * forever — present participle on a transcript from last week, which is the
+ * whole reason a settled row read as a paused one.
+ *
+ * So the trigger joins the others rather than growing a sixth copy of the
+ * grammar: this module is the table, and `patch-summary.ts` reads it too.
+ *
+ * Three tenses, because a row has three things it can honestly say:
+ *
+ *   running — the call is in flight and the input is still arriving
+ *   done    — the call settled and did what the verb says
+ *   failed  — the call settled and did NOT do what the verb says
+ *
+ * `failed` is not decoration. `group-steps.ts` already forbids a failed step
+ * from wearing success wording ("Wrote budget.csv" for a write that errored is
+ * the panel lying, W7) and routes it through `narrateFailedStep`. The trigger
+ * had no such route: it flipped its icon to a warning and kept claiming the
+ * write landed. The wording here is `narration.ts:805` character for character
+ * — `write` for a write, `update` for an edit — so the row and the panel say
+ * the same thing about the same failure.
+ *
+ * No React import: this is a pure lookup, and it is unit-tested as one.
+ */
+
+/** The tenses one file action can be rendered in. */
+export interface FileVerb {
+  /** Past tense, shown once the call has settled. */
+  verb: string;
+  /** Present participle, shown while it runs. */
+  running: string;
+  /** The call did not land. Never claims the outcome the other two claim. */
+  failed: string;
+}
+
+/**
+ * What was done, not which tool did it.
+ *
+ * Keyed by action rather than by tool name because the two consumers key
+ * differently: the trigger rows come in as `write` / `edit` / `morph_edit`,
+ * while `patch-summary.ts` comes in as an `add` / `update` / `delete` / `move`
+ * patch op. Both map onto the same six English verbs, and mapping onto a shared
+ * vocabulary is the point — it is what stops `apply_patch` from inventing a
+ * seventh word for something `write` already has a word for.
+ */
+export type FileAction =
+  | 'write'
+  | 'edit'
+  | 'create'
+  | 'delete'
+  | 'rename'
+  | 'change'
+  | 'read'
+  | 'list';
+
+export const FILE_VERBS: Record<FileAction, FileVerb> = {
+  write: { verb: 'Wrote', running: 'Writing', failed: "Couldn't write" },
+  edit: { verb: 'Edited', running: 'Editing', failed: "Couldn't update" },
+  create: { verb: 'Created', running: 'Creating', failed: "Couldn't create" },
+  delete: { verb: 'Deleted', running: 'Deleting', failed: "Couldn't delete" },
+  rename: { verb: 'Renamed', running: 'Renaming', failed: "Couldn't rename" },
+  // The weakest word here, deliberately — see `patchVerb`. A patch that creates
+  // one file and deletes another has no honest single verb.
+  change: { verb: 'Changed', running: 'Changing', failed: "Couldn't apply" },
+  // `read` and `list` mutate nothing, but they had the same two defects the
+  // mutating rows did: `List` was the bare registry key, and `Read` is a past
+  // tense that a call still streaming has not earned. The failed wording is
+  // `narration.ts`'s explore family, trimmed to this row's scope — the row
+  // knows WHICH file it could not open, so it says that instead of "your files".
+  read: { verb: 'Read', running: 'Reading', failed: "Couldn't read" },
+  list: { verb: 'Listed', running: 'Listing', failed: "Couldn't list" },
+};
+
+/**
+ * Which tense a row is in.
+ *
+ * A union rather than two booleans because a call site that takes booleans is a
+ * call site that can forget `failed` — which is exactly what the trigger rows
+ * did for as long as they existed.
+ */
+export type FilePhase = 'running' | 'done' | 'failed';
+
+export function fileVerb(action: FileAction, phase: FilePhase): string {
+  const verbs = FILE_VERBS[action];
+  if (phase === 'running') return verbs.running;
+  if (phase === 'failed') return verbs.failed;
+  return verbs.verb;
+}
+
+/**
+ * The tense a tool row is in, from the two facts every trigger already has.
+ *
+ * `running` is `ToolRunningContext` — true only while the turn that owns this
+ * part is live. A leftover `pending` part from a finished run reads `false`
+ * here and therefore renders in the PAST tense, which is the honest thing for
+ * it to say: whatever was going to happen has already not happened. The old
+ * present-participle title claimed the opposite on every restored session.
+ */
+export function filePhase(running: boolean, isError: boolean): FilePhase {
+  if (isError) return 'failed';
+  return running ? 'running' : 'done';
+}

--- a/apps/web/src/features/session/tool/shared/infrastructure.tsx
+++ b/apps/web/src/features/session/tool/shared/infrastructure.tsx
@@ -847,6 +847,35 @@ export const ToolOutcomeContext = createContext<ToolOutcome>('ok');
 
 export const StalePendingContext = createContext(false);
 
+/**
+ * Whether the turn that owns this part is STILL RUNNING.
+ *
+ * `ToolRunningContext` cannot answer this, and that is the bug this exists to
+ * close. A tool call is created `pending` with an empty `input`, and its
+ * arguments arrive afterwards as streamed JSON in `state.raw`. For the frames
+ * between those two events, a live call is byte-for-byte identical to a
+ * leftover `pending` part from a run that died — same status, same empty input,
+ * same absent `raw` — so `tool-part-renderer`'s stale test matched both and
+ * `ToolRunningContext` reported `false` for a call that had only just started.
+ *
+ * The visible cost was a row contradicting the line directly beneath it: the
+ * transcript rendered "No content received" over a `write` while the SDK's own
+ * status line, reading THAT SAME PART, rendered "Making changes..."
+ * (`packages/sdk/src/core/turns/state.ts`). One part, two views, opposite
+ * verdicts — which is what made a working session look frozen.
+ *
+ * The part alone cannot settle it, so the answer comes from one level up. The
+ * turn already knows whether it is working (`session-chat.tsx`'s `working`), and
+ * that single boolean is the whole discriminator: while the turn is live, an
+ * input-less pending part is a call that has not spoken YET; once the turn is
+ * over, the same part is a call that never will.
+ *
+ * Defaults to `false` so a surface that renders parts outside a live turn — the
+ * Advanced panel, `/debug/tools`, a restored transcript — keeps the settled
+ * reading without opting in.
+ */
+export const TurnLiveContext = createContext(false);
+
 export const ToolDurationContext = createContext<number | undefined>(undefined);
 
 export {

--- a/apps/web/src/features/session/tool/shared/patch-summary.test.ts
+++ b/apps/web/src/features/session/tool/shared/patch-summary.test.ts
@@ -8,6 +8,9 @@ describe('patchVerb', () => {
     expect(patchVerb(['add', 'add', 'add', 'add'])).toEqual({
       verb: 'Created',
       running: 'Creating',
+      // The third tense, shared with every other file row: a patch that failed
+      // must not be reported in the wording of one that landed.
+      failed: "Couldn't create",
       icon: 'create',
     });
   });

--- a/apps/web/src/features/session/tool/shared/patch-summary.test.ts
+++ b/apps/web/src/features/session/tool/shared/patch-summary.test.ts
@@ -2,15 +2,20 @@ import { describe, expect, test } from 'bun:test';
 import { patchVerb } from './patch-summary';
 
 describe('patchVerb', () => {
-  test('four new files read as Created, not as Apply Patch', () => {
+  test('four new files read as Wrote, not as Apply Patch', () => {
     // The exact regression: `apply_patch` creating four .txt files rendered
     // "Apply Patch 4 files · +4" under a code-file glyph.
+    //
+    // The verb is the WRITE verb, not a `create` of its own: producing a file
+    // that was not there is a write, and `Created 4 files` here beside
+    // `Wrote app.py` on a `write` row is one product using two words for one
+    // act. The `create` ICON stays — the glyph still says the files are new.
     expect(patchVerb(['add', 'add', 'add', 'add'])).toEqual({
-      verb: 'Created',
-      running: 'Creating',
+      verb: 'Wrote',
+      running: 'Writing',
       // The third tense, shared with every other file row: a patch that failed
       // must not be reported in the wording of one that landed.
-      failed: "Couldn't create",
+      failed: "Couldn't write",
       icon: 'create',
     });
   });

--- a/apps/web/src/features/session/tool/shared/patch-summary.ts
+++ b/apps/web/src/features/session/tool/shared/patch-summary.ts
@@ -11,11 +11,18 @@
  * can create, edit, delete and rename in one call, and each of those is an
  * ordinary English verb:
  *
- *   all add     → Created
+ *   all add     → Wrote
  *   all delete  → Deleted
  *   all move    → Renamed
  *   all update  → Edited
  *   mixed       → Changed
+ *
+ * `add` reports as `Wrote`, not `Created`. Producing a file that was not there
+ * is a write, and that is the word the reader has already met on every `write`
+ * row in the session — `Created 4 files` here beside `Wrote app.py` there is one
+ * product speaking two vocabularies about one act. `narration.ts` settled this
+ * the same way. The `create` GLYPH stays (`FilePlusIcon`): the mark still says
+ * these files are new, which is the part the verb no longer has to carry.
  *
  * "Changed" for a mixed patch is deliberately the weakest word here. A patch
  * that creates one file and deletes another has no honest single verb, and
@@ -40,13 +47,14 @@ export interface PatchVerb extends FileVerb {
 
 /**
  * The words come from `file-verb.ts`, the table every file row shares; only the
- * glyph is this module's own. A patch that creates a file and a `write` that
- * creates a file did the same thing to the user's disk, so they must not reach
- * for two different words for it — and before this they each owned a private
- * copy of the vocabulary that could drift apart one edit at a time.
+ * glyph is this module's own. A patch that adds a file and a `write` that adds a
+ * file did the same thing to the user's disk, so they must not reach for two
+ * different words for it — and before this they each owned a private copy of the
+ * vocabulary that could drift apart one edit at a time.
  */
 const VERBS: Record<PatchOp, PatchVerb> = {
-  add: { ...FILE_VERBS.create, icon: 'create' },
+  // `write`, not a `create` of its own — see the note above the op table.
+  add: { ...FILE_VERBS.write, icon: 'create' },
   delete: { ...FILE_VERBS.delete, icon: 'delete' },
   move: { ...FILE_VERBS.rename, icon: 'edit' },
   update: { ...FILE_VERBS.edit, icon: 'edit' },

--- a/apps/web/src/features/session/tool/shared/patch-summary.ts
+++ b/apps/web/src/features/session/tool/shared/patch-summary.ts
@@ -25,13 +25,11 @@
  * No React import: this is a pure function, and it is unit-tested as one.
  */
 
+import { FILE_VERBS, type FileVerb } from '@/features/session/tool/shared/file-verb';
+
 export type PatchOp = 'add' | 'update' | 'delete' | 'move';
 
-export interface PatchVerb {
-  /** Past tense, shown once the call has settled. */
-  verb: string;
-  /** Present participle, shown while it runs. */
-  running: string;
+export interface PatchVerb extends FileVerb {
   /**
    * Which glyph the row leads with. `FileCode` was wrong twice over — it says
    * "code" about files that are usually not code, and it says nothing about the
@@ -40,14 +38,21 @@ export interface PatchVerb {
   icon: 'create' | 'delete' | 'edit';
 }
 
+/**
+ * The words come from `file-verb.ts`, the table every file row shares; only the
+ * glyph is this module's own. A patch that creates a file and a `write` that
+ * creates a file did the same thing to the user's disk, so they must not reach
+ * for two different words for it — and before this they each owned a private
+ * copy of the vocabulary that could drift apart one edit at a time.
+ */
 const VERBS: Record<PatchOp, PatchVerb> = {
-  add: { verb: 'Created', running: 'Creating', icon: 'create' },
-  delete: { verb: 'Deleted', running: 'Deleting', icon: 'delete' },
-  move: { verb: 'Renamed', running: 'Renaming', icon: 'edit' },
-  update: { verb: 'Edited', running: 'Editing', icon: 'edit' },
+  add: { ...FILE_VERBS.create, icon: 'create' },
+  delete: { ...FILE_VERBS.delete, icon: 'delete' },
+  move: { ...FILE_VERBS.rename, icon: 'edit' },
+  update: { ...FILE_VERBS.edit, icon: 'edit' },
 };
 
-const MIXED: PatchVerb = { verb: 'Changed', running: 'Changing', icon: 'edit' };
+const MIXED: PatchVerb = { ...FILE_VERBS.change, icon: 'edit' };
 
 /**
  * The one verb that covers every file in the patch.

--- a/apps/web/src/features/session/tool/tool-part-renderer.stale.test.tsx
+++ b/apps/web/src/features/session/tool/tool-part-renderer.stale.test.tsx
@@ -1,0 +1,67 @@
+import { TurnLiveContext } from '@/features/session/tool/shared/infrastructure';
+import type { ToolPart } from '@/ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, test } from 'bun:test';
+import { NextIntlClientProvider } from 'next-intl';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { ToolPartRenderer } from './tool-part-renderer';
+
+/**
+ * The shape a tool call has for the frames between "the call exists" and "its
+ * first argument chunk arrived": `pending`, empty `input`, no streamed `raw`.
+ *
+ * A leftover part from a run that died has this EXACT shape too, which is the
+ * whole problem — nothing on the part separates them.
+ */
+const inputless = {
+  id: 'p1',
+  type: 'tool',
+  tool: 'write',
+  callID: 'c1',
+  state: { status: 'pending', input: {} },
+} as unknown as ToolPart;
+
+const render = (part: ToolPart, turnLive: boolean) =>
+  renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
+        <TurnLiveContext.Provider value={turnLive}>
+          <ToolPartRenderer part={part} sessionId="s1" defaultOpen />
+        </TurnLiveContext.Provider>
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+describe('an input-less pending call is read by the TURN, not by the part', () => {
+  // The reported bug, exactly: the transcript rendered "No content received"
+  // over a `write` while the SDK status line, reading that same part, rendered
+  // "Making changes..." (`packages/sdk/src/core/turns/state.ts`). One part, two
+  // views, opposite verdicts — a working session that looked frozen.
+  test('while the turn is live the row does not announce that nothing came', () => {
+    const html = render(inputless, true);
+
+    expect(html).not.toContain('No content received');
+  });
+
+  test('and it reads as present tense, because the call has not finished', () => {
+    const html = render(inputless, true);
+
+    expect(html).toContain('Writing');
+  });
+
+  test('once the turn is over the same part IS stale, and says so', () => {
+    // A restored session is full of these. The row must settle rather than
+    // promise content that can no longer arrive.
+    const html = render(inputless, false);
+
+    expect(html).toContain('No content received');
+  });
+
+  test('and a settled leftover reads in the past tense, not as still running', () => {
+    const html = render(inputless, false);
+
+    expect(html).toContain('Wrote');
+    expect(html).not.toContain('Writing');
+  });
+});

--- a/apps/web/src/features/session/tool/tool-part-renderer.tsx
+++ b/apps/web/src/features/session/tool/tool-part-renderer.tsx
@@ -15,6 +15,7 @@ import {
   ToolOutcomeContext,
   ToolRunningContext,
   ToolSurfaceContext,
+  TurnLiveContext,
 } from '@/features/session/tool/shared/infrastructure';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import { ToolError } from '@/features/session/tool/tool-error';
@@ -123,6 +124,10 @@ function ToolPartRendererImpl({
   );
 
   const surface = useContext(ToolSurfaceContext);
+  // Read with the other hooks, ABOVE the `todoread` and thrown-error early
+  // returns — a `useContext` down beside its use site is a conditional hook,
+  // and the order would break on the first errored tool part in a turn.
+  const turnLive = useContext(TurnLiveContext);
   const fillsPanel = surface === 'panel' && (part.tool === 'show' || part.tool === 'show-user');
 
   // One verdict per part, computed once here and read by every BasicTool below
@@ -180,7 +185,18 @@ function ToolPartRendererImpl({
   const forceOpen = !!permission || !!question;
   const isLocked = !!permission || !!question;
 
+  // A call whose arguments have not arrived: `pending`, no `input`, no streamed
+  // `raw`. That shape is produced twice — once by a leftover part from a run
+  // that died, and once by every live call, for the frames between "the call
+  // exists" and "its first argument chunk landed".
+  //
+  // `turnLive` is what separates them, and nothing on the part can (see
+  // {@link TurnLiveContext}). Without it this test matched the live case too,
+  // so a `write` that had just started rendered its "the run is over" body —
+  // the frozen-looking row under a status line that was still saying
+  // "Making changes...".
   const isStalePending =
+    !turnLive &&
     part.state.status === 'pending' &&
     Object.keys(part.state.input ?? {}).length === 0 &&
     !(part.state as any).raw;

--- a/apps/web/src/features/session/tool/tool-renderers.tsx
+++ b/apps/web/src/features/session/tool/tool-renderers.tsx
@@ -6,6 +6,7 @@ export {
   ToolActivateContext,
   ToolSurfaceContext,
   type ToolSurface,
+  TurnLiveContext,
   shouldShowToolPartInActionsPanel,
 } from '@/features/session/tool/shared/infrastructure';
 

--- a/apps/web/src/features/session/tool/tools/apply-patch-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/apply-patch-tool.test.tsx
@@ -5,13 +5,13 @@ import { NextIntlClientProvider } from 'next-intl';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ApplyPatchTool } from './apply-patch-tool';
 
-const part = (files: unknown[], status = 'completed'): ToolPart =>
+const part = (files: unknown[], status = 'completed', output = 'ok'): ToolPart =>
   ({
     id: '1',
     type: 'tool',
     tool: 'apply_patch',
     callID: 'c1',
-    state: { status, output: 'ok', metadata: { files }, time: { start: 1, end: 2 } },
+    state: { status, output, metadata: { files }, time: { start: 1, end: 2 } },
   }) as unknown as ToolPart;
 
 const render = (p: ToolPart, open = false) =>
@@ -78,5 +78,20 @@ describe('ApplyPatchTool trigger', () => {
     expect(markup).toContain('Add');
     expect(markup).not.toContain('uppercase');
     expect(markup).toContain('random-aurora.txt');
+  });
+});
+
+describe('ApplyPatchTool, when the patch did not land', () => {
+  // The row already flipped its icon to a warning through `ToolOutcomeContext`,
+  // then kept saying "Created 4 files" underneath it — glyph and words
+  // disagreeing about one call. `group-steps.ts` forbids exactly this on the
+  // panel (W7); the trigger had no such route until now.
+  test('a failed patch does not wear the wording of one that succeeded', () => {
+    const text = rowText(render(part(ADDS, 'completed', 'Error: patch does not apply')));
+
+    // Entity, not a raw apostrophe: `rowText` strips tags but not escapes, and
+    // asserting the raw string would be an assertion that can never fail.
+    expect(text).toContain('Couldn&#x27;t create');
+    expect(text).not.toContain('Created 4 files');
   });
 });

--- a/apps/web/src/features/session/tool/tools/apply-patch-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/apply-patch-tool.test.tsx
@@ -43,8 +43,11 @@ describe('ApplyPatchTool trigger', () => {
     // The regression this replaced: "Apply Patch 4 files · +4" under a
     // code-file glyph, over four plain .txt files that had just been created.
     const text = rowText(render(part(ADDS)));
-    expect(text).toContain('Created 4 files');
+    // `Wrote`, not `Created` — the row uses the same word a `write` row uses for
+    // the same act. See the op table in `patch-summary.ts`.
+    expect(text).toContain('Wrote 4 files');
     expect(text).not.toContain('Apply Patch');
+    expect(text).not.toContain('Created');
   });
 
   test('a closed row still carries a size signal', () => {
@@ -56,14 +59,14 @@ describe('ApplyPatchTool trigger', () => {
   });
 
   test('one file names itself', () => {
-    expect(rowText(render(part([ADDS[0]])))).toContain('Created random-aurora.txt');
+    expect(rowText(render(part([ADDS[0]])))).toContain('Wrote random-aurora.txt');
   });
 
   test('a mixed patch claims no shape it does not have', () => {
     const mixed = [ADDS[0], { relativePath: 'gone.ts', type: 'delete', deletions: 3 }];
     const text = rowText(render(part(mixed)));
     expect(text).toContain('Changed 2 files');
-    expect(text).not.toContain('Created');
+    expect(text).not.toContain('Wrote');
   });
 
   test('an edit reads as an edit', () => {
@@ -91,7 +94,7 @@ describe('ApplyPatchTool, when the patch did not land', () => {
 
     // Entity, not a raw apostrophe: `rowText` strips tags but not escapes, and
     // asserting the raw string would be an assertion that can never fail.
-    expect(text).toContain('Couldn&#x27;t create');
-    expect(text).not.toContain('Created 4 files');
+    expect(text).toContain('Couldn&#x27;t write');
+    expect(text).not.toContain('Wrote 4 files');
   });
 });

--- a/apps/web/src/features/session/tool/tools/apply-patch-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/apply-patch-tool.tsx
@@ -72,7 +72,11 @@ export function ApplyPatchTool({ part, defaultOpen, forceOpen, locked }: ToolPro
    * `Created 4 files` rather than `Apply Patch 4 files`. See `patch-summary.ts`.
    */
   const verb = useMemo(() => patchVerb(files.map((f) => f.type)), [files]);
-  const triggerTitle = isStreaming ? verb.running : verb.verb;
+  // A failed patch must not wear the wording of a patch that landed. The row
+  // already flipped its ICON to a warning via `ToolOutcomeContext`, but kept
+  // saying `Created 4 files` underneath it — the glyph and the words disagreeing
+  // about the same call, which is the exact lie `group-steps.ts` forbids (W7).
+  const triggerTitle = isError ? verb.failed : isStreaming ? verb.running : verb.verb;
   const Icon = PATCH_ICON[verb.icon];
 
   const triggerSubtitle = useMemo(() => {

--- a/apps/web/src/features/session/tool/tools/edit-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/edit-tool.test.tsx
@@ -20,12 +20,13 @@ function withProviders(node: ReactNode) {
 function makePart(
   input: Record<string, unknown>,
   status: 'completed' | 'running' = 'completed',
+  output = 'ok',
 ): ToolPart {
   return {
     type: 'tool',
     tool: 'edit',
     callID: 'call-1',
-    state: status === 'completed' ? { status, input, output: 'ok', metadata: {} } : { status, input },
+    state: status === 'completed' ? { status, input, output, metadata: {} } : { status, input },
   } as unknown as ToolPart;
 }
 
@@ -93,5 +94,57 @@ describe('EditTool trigger carries the line counts', () => {
     );
 
     expect(html).not.toContain('diff-stat');
+  });
+});
+
+describe('EditTool speaks the tense the row is actually in', () => {
+  const edit = { filePath: '/workspace/app.py', oldString: 'a', newString: 'b' };
+
+  test('a live call is present tense, beside the filename it is editing', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <ToolRunningContext.Provider value>
+          <EditTool part={makePart(edit, 'running')} />
+        </ToolRunningContext.Provider>,
+      ),
+    );
+
+    expect(html).toContain('Editing');
+    expect(html).toContain('app.py');
+  });
+
+  // The regression this whole change exists for: `Editing` was hardcoded, so a
+  // call that finished an hour ago still claimed to be mid-flight. A restored
+  // transcript is entirely settled calls, every one of them reading as live.
+  test('a settled call is PAST tense — it is not still editing', () => {
+    const html = renderToStaticMarkup(withProviders(<EditTool part={makePart(edit)} />));
+
+    expect(html).toContain('Edited');
+    expect(html).not.toContain('Editing');
+  });
+
+  test('a failed edit never claims it edited', () => {
+    // Escaped apostrophe: `renderToStaticMarkup` emits the entity, and a raw
+    // string here would be an assertion that can never fail.
+    const html = renderToStaticMarkup(
+      withProviders(<EditTool part={makePart(edit, 'completed', 'Error: ENOENT')} />),
+    );
+
+    expect(html).toContain('Couldn&#x27;t update');
+    expect(html).not.toContain('>Edited<');
+  });
+});
+
+describe('EditTool, for the part that never got its diff', () => {
+  // `write-tool.tsx` removed this shimmer; `edit` kept it, so one situation had
+  // two answers — and on a restored session the animation promised a diff that
+  // was never going to arrive, forever.
+  const stale = makePart({}, 'running');
+
+  test('a stale pending part states the fact instead of shimmering forever', () => {
+    const html = renderToStaticMarkup(withProviders(<EditTool part={stale} defaultOpen />));
+
+    expect(html).toContain('No content received');
+    expect(html).not.toContain('Waiting for file content');
   });
 });

--- a/apps/web/src/features/session/tool/tools/edit-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/edit-tool.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { TextShimmer } from '@/components/ui/text-shimmer';
 import {
   BasicTool,
   DiagnosticsDisplay,
@@ -17,6 +16,7 @@ import {
   ToolRunningContext,
   useToolIndent,
 } from '@/features/session/tool/shared/infrastructure';
+import { fileVerb, filePhase } from '@/features/session/tool/shared/file-verb';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import type { ToolProps } from '@/features/session/tool/shared/types';
@@ -25,11 +25,9 @@ import { useFilePreviewStore } from '@/stores/file-preview-store';
 import { getFilename } from '@/ui';
 import { PencilSimpleIcon } from '@phosphor-icons/react';
 import { diffLines } from 'diff';
-import { useTranslations } from 'next-intl';
 import { useCallback, useContext, useMemo } from 'react';
 
 export function EditTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
   const running = useContext(ToolRunningContext);
   const input = partInput(part);
   const streamingInput = partStreamingInput(part);
@@ -69,6 +67,19 @@ export function EditTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
   const hasDiff = before !== '' || after !== '';
   const output = partOutput(part);
   const isError = status === 'completed' && isErrorOutput(output);
+
+  /**
+   * `Editing` never became `Edited`. The row was a present participle for the
+   * life of the transcript, so a call that finished an hour ago still claimed to
+   * be mid-flight — the single biggest reason a settled session read as a
+   * stalled one. See `file-verb.ts`; every other surface has reported this call
+   * in the right tense for a long time.
+   *
+   * `morph_edit` shares this renderer and therefore this wording, which is
+   * correct: the reader is told what happened to their file, not which of two
+   * edit implementations the agent picked.
+   */
+  const title = fileVerb('edit', filePhase(running, isError));
   // Line counts for the row, from the same before/after the expanded diff
   // renders — so the closed row already answers "how big was this edit?".
   // Settled calls only: while an edit streams, `after` grows by the chunk, and
@@ -100,7 +111,7 @@ export function EditTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
     <BasicTool
       icon={<PencilSimpleIcon className="size-3.5 shrink-0" />}
       trigger={{
-        title: 'Editing',
+        title,
         subtitle: filename || undefined,
         // No stat on a failed call: the numbers would describe an edit that
         // did not land.
@@ -139,12 +150,15 @@ export function EditTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
           <ToolCodeCard code={codeEdit} language={ext} />
         </>
       ) : isStalePending ? (
+        // The same statement `write` makes, in the same words, because it is the
+        // same situation: a part that is DONE waiting — the run it belonged to
+        // is over. This row used to shimmer "Waiting for file content" instead,
+        // which is a promise, and on a restored session it was a promise the
+        // transcript could never keep — the animation ran forever over a diff
+        // that was never going to arrive. `write-tool.tsx` dropped that shimmer;
+        // `edit` kept it, so one situation had two answers.
         <ToolResultCard bodyClassName="px-2 py-1.5">
-          <TextShimmer>
-            {tHardcodedUi.raw(
-              'componentsSessionToolRenderers.line2853JsxTextWaitingForFileContent',
-            )}
-          </TextShimmer>
+          <span className="text-muted-foreground/60 text-xs">No content received</span>
         </ToolResultCard>
       ) : null}
       <DiagnosticsDisplay diagnostics={diagnostics} filePath={filePath} />

--- a/apps/web/src/features/session/tool/tools/list-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/list-tool.tsx
@@ -8,8 +8,10 @@ import {
   partInput,
   partOutput,
   partStatus,
+  ToolRunningContext,
   useToolNavigation,
 } from '@/features/session/tool/shared/infrastructure';
+import { fileVerb, filePhase } from '@/features/session/tool/shared/file-verb';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import type { ToolProps } from '@/features/session/tool/shared/types';
@@ -17,7 +19,7 @@ import { useOcFileOpen } from '@/features/session/use-oc-file-open';
 import { getDirectory } from '@/ui';
 import { TreeStructureIcon as ListTree } from '@phosphor-icons/react';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
 
 const NO_PATHS: string[] = [];
 
@@ -26,6 +28,7 @@ export function ListTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
   const input = partInput(part);
   const output = partOutput(part);
   const status = partStatus(part);
+  const running = useContext(ToolRunningContext);
   const { enabled: navigationEnabled } = useToolNavigation();
   const { openFile, openFileWithList, toDisplayPath } = useOcFileOpen();
   const directory = getDirectory(input.path as string) || (input.path as string) || undefined;
@@ -46,7 +49,10 @@ export function ListTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
     <BasicTool
       icon={<ListTree className="size-3.5 shrink-0" />}
       trigger={{
-        title: 'List',
+        // `List` was the registry key, not a word anyone says about a folder.
+        // `step-label.ts` has reported this call as Listed/Listing for a long
+        // time; the trigger is joining it rather than keeping a private name.
+        title: fileVerb('list', filePhase(running, errored)),
         subtitle: directory,
         args: hasResults
           ? [`${filePaths.length} ${filePaths.length === 1 ? 'file' : 'files'}`]

--- a/apps/web/src/features/session/tool/tools/read-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/read-tool.tsx
@@ -16,6 +16,7 @@ import {
   ToolSurfaceContext,
 } from '@/features/session/tool/shared/infrastructure';
 import { parseReadOutput } from '@/features/session/tool/shared/read-helpers';
+import { fileVerb, filePhase } from '@/features/session/tool/shared/file-verb';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import type { ToolProps } from '@/features/session/tool/shared/types';
@@ -47,6 +48,13 @@ export function ReadTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
 
   const isStalePending = !running && !filename && (status === 'pending' || status === 'running');
 
+  // A read that returned its error must not be reported in the wording of one
+  // that opened the file — the same rule the write/edit rows now follow.
+  const isReadError = useMemo(
+    () => status === 'completed' && isErrorOutput(output),
+    [status, output],
+  );
+
   const loaded = useMemo(() => {
     if (status !== 'completed') return [];
     const val = metadata.loaded;
@@ -70,10 +78,14 @@ export function ReadTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
       <BasicTool
         icon={<ReadCvLogoIcon className="size-3.5 shrink-0" />}
         trigger={{
-          title: 'Read',
-          subtitle: isStalePending
-            ? undefined
-            : filename || (isStalePending ? 'Working...' : undefined),
+          // `Read` was a past tense the row had not earned while the call was
+          // still streaming. Same table, same three tenses as every other file
+          // row — see `file-verb.ts`.
+          title: fileVerb('read', filePhase(running, isReadError)),
+          // The old expression was `isStalePending ? undefined : filename ||
+          // (isStalePending ? 'Working...' : undefined)` — the inner branch is
+          // unreachable, so the `'Working...'` fallback had never once rendered.
+          subtitle: isStalePending ? undefined : filename || undefined,
         }}
         onSubtitleClick={filePath ? handleSubtitleClick : undefined}
         defaultOpen={defaultOpen}

--- a/apps/web/src/features/session/tool/tools/write-tool.test.tsx
+++ b/apps/web/src/features/session/tool/tools/write-tool.test.tsx
@@ -88,6 +88,60 @@ describe('WriteTool trigger carries the filename and the size', () => {
   });
 });
 
+describe('WriteTool speaks the tense the row is actually in', () => {
+  // `Write` was the registry key. Every other surface in this feature —
+  // step-label.ts, activity-file-chips.tsx, narration.ts — has reported this
+  // call as Writing/Wrote for a long time; the trigger was the last holdout,
+  // and a machine noun frozen in one tense is what made a settled row read as
+  // a paused one.
+  test('a live call is present tense, beside the filename it is writing', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <ToolRunningContext.Provider value>
+          <WriteTool
+            part={makePart({ filePath: '/workspace/app.py', content: 'a' }, 'running')}
+          />
+        </ToolRunningContext.Provider>,
+      ),
+    );
+
+    expect(html).toContain('Writing');
+    expect(html).toContain('app.py');
+    expect(html).not.toContain('>Write<');
+  });
+
+  test('a settled call is past tense — a finished transcript is all of these', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <WriteTool part={makePart({ filePath: '/workspace/app.py', content: 'a' })} />,
+      ),
+    );
+
+    expect(html).toContain('Wrote');
+    expect(html).not.toContain('Writing');
+  });
+
+  // `renderToStaticMarkup` escapes the apostrophe, so the assertion is on the
+  // entity. Asserting the raw string here would silently never match and the
+  // test would be unable to fail.
+  test('a failed write never claims it wrote', () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <WriteTool
+          part={makePart(
+            { filePath: '/workspace/app.py', content: 'a' },
+            'completed',
+            'Error: EACCES permission denied',
+          )}
+        />,
+      ),
+    );
+
+    expect(html).toContain('Couldn&#x27;t write');
+    expect(html).not.toContain('>Wrote<');
+  });
+});
+
 describe('WriteTool, for the part that never got its content', () => {
   // A pending part with no filename and no running turn is a leftover from a
   // finished run — restored sessions carry them. The old body answered with a

--- a/apps/web/src/features/session/tool/tools/write-tool.tsx
+++ b/apps/web/src/features/session/tool/tools/write-tool.tsx
@@ -13,6 +13,7 @@ import {
   ToolOutputFallback,
   ToolRunningContext,
 } from '@/features/session/tool/shared/infrastructure';
+import { fileVerb, filePhase } from '@/features/session/tool/shared/file-verb';
 import { ToolRegistry } from '@/features/session/tool/shared/registry';
 import { ToolResultCard } from '@/features/session/tool/shared/result-card';
 import type { ToolProps } from '@/features/session/tool/shared/types';
@@ -72,6 +73,19 @@ export function WriteTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
 
   const isStalePending = !running && !filename && (status === 'pending' || status === 'running');
 
+  /**
+   * `Write` was the registry key, not a word anyone says. Every other surface in
+   * this feature already reports this call as `Writing app.py` / `Wrote app.py`
+   * — `step-label.ts`, `activity-file-chips.tsx`, the panel's `narration.ts` —
+   * and the trigger was the last one still printing the machine name, frozen in
+   * a tense that matched neither a running call nor a finished one.
+   *
+   * Past tense once the turn is over is the load-bearing half: a restored
+   * transcript is entirely settled calls, and a row reading `Write` there says
+   * nothing about whether it ever did.
+   */
+  const title = fileVerb('write', filePhase(running, isError));
+
   // Field selector, not the whole store: destructuring the store subscribes this
   // row to every field in it, so opening one file preview re-rendered every write
   // row on screen.
@@ -84,7 +98,7 @@ export function WriteTool({ part, defaultOpen, forceOpen, locked }: ToolProps) {
     <BasicTool
       icon={<PencilSimpleIcon className="size-3.5 shrink-0" />}
       trigger={{
-        title: 'Write',
+        title,
         subtitle: filename || undefined,
         // No stat on a failed call: the numbers would describe a file that
         // did not land.

--- a/apps/web/src/features/session/turn/activity-file-chips.icon.test.tsx
+++ b/apps/web/src/features/session/turn/activity-file-chips.icon.test.tsx
@@ -1,0 +1,63 @@
+import type { Part } from '@/ui';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, test } from 'bun:test';
+import { NextIntlClientProvider } from 'next-intl';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { Disclosure } from '@/components/ui/disclosure';
+import { ActivityFileChipStep } from './activity-file-chips';
+
+/** The first path segment of Phosphor's `PencilSimple`, the write family glyph. */
+const PENCIL_PATH = 'M227.31,73.37';
+
+const writePart = (filePath: string): Part =>
+  ({
+    id: 'p1',
+    type: 'tool',
+    tool: 'write',
+    callID: 'c1',
+    state: {
+      status: 'completed',
+      input: { filePath },
+      output: 'ok',
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  }) as unknown as Part;
+
+const render = (parts: Part[], bare: boolean) =>
+  renderToStaticMarkup(
+    <QueryClientProvider client={new QueryClient()}>
+      <NextIntlClientProvider locale="en" messages={{}} onError={() => {}}>
+        <Disclosure open={false} onOpenChange={() => {}}>
+          <ActivityFileChipStep parts={parts} running={false} sessionId="s1" bare={bare} />
+        </Disclosure>
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+describe('every file-chip row keeps its family glyph', () => {
+  // `ActivityStep` already documents this rule at length and applies it. Its
+  // sibling here still guarded the icon behind `!bare`, so a lone `write`
+  // rendered as a bare line of text with no pencil on it — the one mark that
+  // says WHICH tool ran, dropped in the case with the least other context to
+  // recover it from.
+  test('a LONE write row leads with the pencil', () => {
+    const html = render([writePart('/workspace/src/main.ts')], true);
+
+    expect(html).toContain(PENCIL_PATH);
+  });
+
+  test('a grouped run leads with the same pencil — one rule, both shapes', () => {
+    const html = render([writePart('/workspace/a.ts'), writePart('/workspace/b.ts')], false);
+
+    expect(html).toContain(PENCIL_PATH);
+  });
+
+  test('the row still names the file it wrote', () => {
+    const html = render([writePart('/workspace/src/main.ts')], true);
+
+    expect(html).toContain('Wrote');
+    expect(html).toContain('main.ts');
+  });
+});

--- a/apps/web/src/features/session/turn/activity-file-chips.tsx
+++ b/apps/web/src/features/session/turn/activity-file-chips.tsx
@@ -314,10 +314,23 @@ function ActivityFileChipStepImpl({
             'text-left text-sm leading-[1.5] transition-colors',
           )}
         >
-          {/* A bare row drops the family glyph: the icon is the chain rail's
-              anchor (`left-2`), and a single row has no rail to anchor. The
-              failure mark stays — on a bare row it is the only verdict left,
-              since the burst's summary line and closing step are both gone. */}
+          {/* EVERY row keeps its leading glyph, single-row bursts included —
+              the same rule, and the same reasoning, `ActivityStep` already
+              carries. A bare row used to drop it on the geometric argument that
+              the icon anchors the chain rail (`left-2`) and one row has no
+              chain. That traded the row's IDENTITY for its alignment: a lone
+              write rendered as a bare line of text with no pencil on it, and
+              the tool's own name is not always recoverable from the words.
+
+              A lone `write` is precisely the case with the least surrounding
+              context to recover it from — there is no burst summary above and
+              no sibling row beside it. And the 28px lane the glyph holds is the
+              same lane `pl-7` already puts the chips in below, so keeping it is
+              what makes a bare row line up, not what breaks it.
+
+              The failure mark still replaces the glyph while closed: on a bare
+              row it is the only verdict left, since the burst's summary line and
+              closing step are both gone. */}
           {status === 'error' ? (
             <>
               {/* Closed: failure mark replaces the family glyph. Open: the
@@ -327,17 +340,14 @@ function ActivityFileChipStepImpl({
                 weight="fill"
                 aria-label="This step failed"
                 className={cn(
-                  'size-4 flex-none',
-                  !bare && 'group-data-[state=open]/step:hidden',
+                  'size-4 flex-none group-data-[state=open]/step:hidden',
                   STATUS_TEXT.destructive,
                 )}
               />
-              {!bare && (
-                <Icon className="text-muted-foreground hidden size-4 flex-none group-data-[state=open]/step:block" />
-              )}
+              <Icon className="text-muted-foreground hidden size-4 flex-none group-data-[state=open]/step:block" />
             </>
           ) : (
-            !bare && <Icon className="text-muted-foreground size-4 flex-none" />
+            <Icon className="text-muted-foreground size-4 flex-none" />
           )}
           {status === 'running' ? (
             <TextShimmer className="min-w-0 truncate leading-[1.5] font-medium">
@@ -358,10 +368,10 @@ function ActivityFileChipStepImpl({
         {/* `pl-7` puts the files under the LABEL (size-4 icon + gap-3), clear of
 				    the chain rail at `left-2` — the indent is what says they belong to
 				    the row above rather than to the chain. */}
-        {/* The indent survives a bare row even though the icon it was measured
-					  from does not. The chain rail runs at `left-2`, so content flush to
-					  the margin puts the hairline 8px inside it — straight through the
-					  left edge of the first chip. 28px is the lane the rail needs. */}
+        {/* 28px is also the lane the chain rail needs: the rail runs at
+					  `left-2`, so content flush to the margin puts the hairline 8px
+					  inside it — straight through the left edge of the first chip. The
+					  indent now agrees with the glyph on every row, bare included. */}
         <div className="mt-3 space-y-3 pl-7">
           {paths.length > 0 && (
             <ul className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary

The `BasicTool` trigger was the last surface in the session feature still printing the tool registry key. `write` rendered `Write`, `edit` rendered `Editing` for the life of the transcript, and `list` rendered `List` — while `step-label.ts`, `activity-file-chips.tsx`, `session-activity-groups.ts`, `narration.ts` and `patch-summary.ts` had all reported those same calls as `Wrote`/`Writing` for a long time. A present participle frozen on a settled row is why a finished call read as a paused one.

`tool/shared/file-verb.ts` is added as the one table those rows read, with three tenses instead of two.

| Row | Before | After |
| --- | --- | --- |
| `write` | `Write` | `Writing app.py` → `Wrote app.py` |
| `edit` / `morph_edit` | `Editing` (frozen) | `Editing app.py` → `Edited app.py` |
| `read` | `Read` while still streaming | `Reading app.py` → `Read app.py` |
| `list` | `List` | `Listing src/lib` → `Listed src/lib` |
| `apply_patch` (add) | `Created 4 files` | `Writing 4 files` → `Wrote 4 files` |
| `apply_patch` (delete / move / update / mixed) | — | `Deleted` / `Renamed` / `Edited` / `Changed`, unchanged |

The third tense is the failed one. A failed call no longer wears the wording of one that landed — `Couldn't write app.py`, matching `narration.ts:805` word for word, which is the rule `group-steps.ts` already enforces on the panel (W7) and the trigger never had.

### One word per act

There is deliberately no `create` verb. `apply_patch` was the only surface in the product that said `Created`, so four new files rendered `Created 4 files` while the `write` row above rendered `Wrote app.py` — one product using two vocabularies for one act. `narration.ts:617` had already settled this: it reports a write-family patch as `Wrote`, never `Created`.

The patch op is untouched — `add` is still `add`, the per-file badge still reads `Add`, and the `create` **glyph** stays (`FilePlusIcon`). The mark says the files are new, which is the part the verb no longer has to carry.

### Three further defects fixed

**A live call rendered its "the run is over" body.** `tool-part-renderer` classified `pending` + empty `input` + no `raw` as stale, and that is also the first frames of *every* live call. So the transcript printed "No content received" while the SDK status line, reading that same part, printed "Making changes..." (`packages/sdk/src/core/turns/state.ts:206`) — one part, two views, opposite verdicts. Nothing on the part separates the two, so a new `TurnLiveContext` carries the turn's own `working` flag down to settle it.

**`edit-tool` still shimmered "Waiting for file content" forever** on a restored session — the promise `write-tool` had already dropped, leaving one situation with two answers.

**`ActivityFileChipStep` guarded its family glyph behind `!bare`,** so a lone write row rendered with no pencil on it. `activity-step.tsx` already documents at length why every row keeps its glyph; this applies it to the sibling row that was missed.

Also removes an unreachable branch in `read-tool`'s subtitle whose `'Working...'` fallback had never once rendered.

## Test plan

- `bunx bun test src/features/session` → **2713 pass, 0 fail** across 195 files
- `npx tsc --noEmit -p tsconfig.json` → clean (only the 3 known `@types/bun` `test.each` files, plus `@/.source`, which a docs build generates)
- `npx eslint --format json src/features/session` → **0 errors**
- Both new behavioural tests confirmed **red-then-green** by reverting each fix in place:
  - `tool-part-renderer.stale.test.tsx` → 2 fail without the `turnLive` guard
  - `activity-file-chips.icon.test.tsx` → 1 fail without the unconditional glyph

Every row state was rendered through the real `ToolPartRenderer` and the visible text read back:

```
write · live, no input yet   → [icon] Writing
write · streaming            → [icon] Writing app.py +2
write · settled              → [icon] Wrote app.py +3
write · failed               → [icon] Couldn't write app.py
write · stale leftover       → [icon] Wrote
edit  · settled              → [icon] Edited app.py +2 −1
read  · streaming            → [icon] Reading app.py
read  · failed               → [icon] Couldn't read app.py
list  · settled              → [icon] Listed /w/src · 2 files

patch add ×4 · running       → [icon] Writing 4 files
patch add ×4 · settled       → [icon] Wrote 4 files
patch add ×1 · settled       → [icon] Wrote f0.ts
patch add ×4 · failed        → [icon] Couldn't write 4 files
patch update ×2              → [icon] Edited 2 files
patch delete ×2              → [icon] Deleted 2 files
patch move   ×2              → [icon] Renamed 2 files
patch mixed                  → [icon] Changed 2 files
```
