### PR TITLE
fix(api): route audit reconciliation writes through the isolated audit pool

### DIFF
--- a/apps/api/src/shared/audit-reconciliation.ts
+++ b/apps/api/src/shared/audit-reconciliation.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { db } from './db';
+import { auditDb } from './audit-db';
 
 export interface AuditReconciliationResult {
   inserted: number;
@@ -18,7 +18,7 @@ export async function reconcileAuditEvents(
   accountId: string,
   limit = 1_000,
 ): Promise<AuditReconciliationResult> {
-  const rows = await db.execute<{ sourceLedger: string }>(sql`
+  const rows = await auditDb().execute<{ sourceLedger: string }>(sql`
     WITH candidates AS (
       SELECT c.account_id, c.project_id, c.session_id::text AS session_id,
              NULL::text AS opencode_session_id, c.acting_user_id AS actor_user_id,


### PR DESCRIPTION
## Why
Production incident 2026-08-30T13:05Z: the hourly Luna heartbeat failed and `kortix gateway test` returned HTTP 503. ClickHouse shows `POST /v1/projects/:p/sessions/:s/audit/events` at 100% 503 (~7.4k requests, 25s timeouts) starting 12:45Z, plus `[audit-reconciliation] page failed` looping every ~5s.

Root cause: `reconcileAuditEvents` (PR #6252, merged 2026-08-08) writes `audit_events` through the **shared** `db` pool instead of `auditDb()`. `audit_prepare_event` takes a per-session `FOR UPDATE` lock held to COMMIT, so a cross-session INSERT on the shared pool pins hot-path connections and starves the gateway auth/app queries into 503 — the exact Essentia 2026-08-21/08-26 convoy that #6702 and #6917 fixed for the queue/ingest paths, but which this newer worker path never received.

## What changed
One behavioral change in `apps/api/src/shared/audit-reconciliation.ts`: `db.execute` → `auditDb().execute`. `auditDb()` is the dedicated audit pool with `lock_timeout` (2.5s) + `statement_timeout` (10s) and a small pool, so a lock convoy degrades audit completeness instead of availability.

## Verification
- `auditDb()` returns the shared `db` in tests (NODE_ENV=test / no DATABASE_URL), so the existing `audit-reconciliation.integration.test.ts` and unit suites are unaffected by this swap.
- No node_modules in the incident sandbox, so local typecheck/lint wasn't run; CI will run the API typecheck/lint + tests.

## Risk / rollback
Low. Single call-site change. Revert restores prior behavior. Follow-up (not in this PR): session-group the reconciliation INSERT like `audit-queue.ts` `statementBatches` so one statement never spans many sessions, and consider capping PAGE_SIZE for very large accounts so the candidate SELECT stays within the audit pool's 10s statement budget.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790701539&installation_model_id=434224&pr_number=7060&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7060&signature=bb62c117998779bcfbdc3bb245e15bead9836f880465e5c104bfa46305d2224a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->