### PR TITLE
fix(terminal): keep the PTY WebSocket alive — it was cut every 60s

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,39 @@ linked, not inlined.
 
 ## Register
 
+### A proxied WebSocket that carries idle traffic needs a keepalive YOU send (2026-08-30)
+
+**When:** you proxy a WebSocket through `apps/api` (the PTY terminal, an app
+preview socket, anything on `/v1/p/.../connect`). Every hop between the API and a
+sandbox drops a connection with no bytes on it, and a terminal is idle by nature
+— a shell at its prompt emits nothing and a reader types nothing. Measured on a
+real Platinum box, the API->sandbox leg dies at **exactly 60 s** of silence.
+
+`websocket.idleTimeout: 0` on both Bun servers does NOT cover this: it governs
+neither the provider edge nor the API's own upstream client. And on a PTY you
+cannot keep the leg busy with data — an upstream byte is typed into the user's
+shell, a downstream byte is printed into their terminal. **Send a PING control
+frame on BOTH legs, well under the shortest hop timeout, and clear the interval
+on every close path** (`PREVIEW_WS_KEEPALIVE_MS`, `pingPreviewWsLegs`).
+
+**Diagnosing a WS that dies on a timer:** a browser reports every drop as `1006`
+with no detail, so instrument from a Bun client instead and run three arms on ONE
+sandbox in ONE minute — no keepalive, PING, DATA. A ping terminates at the API,
+so `PING dies / DATA survives` proves the cut is on the UPSTREAM leg; the reverse
+proves it is on the client leg. Guessing at ALB/Cloudflare timeouts from the
+outside is how this stayed unexplained.
+
+*Incident:* PR #7062. Terminals reconnected once a minute on dev, staging AND
+prod ("not connecting anymore, basically EVERY time"), rendered as
+`Reconnecting in Ns (code 1006)`. Root cause reproduced on the LOCAL stack with
+no Cloudflare and no ALB in the path, which is what ruled out the edge.
+*Enforcer:* `apps/api/src/sandbox-proxy/ws-proxy-keepalive.test.ts` pins that both
+legs are pinged, that one leg throwing does not skip the other, and that the
+interval clears the measured 60 s cut twice over. There is still NO end-to-end
+coverage of the PTY WebSocket in `tests/` — `grep -rn "kortix/pty" tests/` was
+empty before this incident, which is why a socket that died every 60 s on every
+environment shipped unnoticed.
+
 ### Keep lazy optional dependencies type-lazy across shared-source imports (2026-08-28)
 
 **When:** a package imports source files from another package without installing

--- a/apps/api/src/sandbox-proxy/ws-proxy-keepalive.test.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy-keepalive.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  PREVIEW_WS_KEEPALIVE_MS,
+  pingPreviewWsLegs,
+  stopPreviewWsKeepalive,
+  type PreviewWsData,
+} from './ws-proxy';
+
+// The incident this file pins: an idle terminal WebSocket was dropped on the
+// API→sandbox leg after exactly 60 s with no bytes on it. Measured on a real
+// Platinum box, three controlled arms on the same sandbox in the same minute:
+//   - no keepalive          -> CLOSE +60484ms code=4500 "Connection ended"
+//   - PING from the browser -> CLOSE +60455ms (never reaches the upstream leg)
+//   - DATA from the browser -> alive past 80s (forwarded, so the leg stays busy)
+// The browser can only render that drop as close code 1006, which is the
+// "Reconnecting in Ns (code 1006)" ladder users hit once a minute, forever.
+const MEASURED_UPSTREAM_CUT_MS = 60_000;
+
+function fakeState(upstreamReadyState: number): PreviewWsData & { pings: string[] } {
+  const pings: string[] = [];
+  const upstream = {
+    readyState: upstreamReadyState,
+    ping: () => pings.push('upstream'),
+  } as unknown as WebSocket;
+  return { type: 'preview-ws', url: 'wss://box/pty', headers: {}, upstream, pings };
+}
+
+function fakeWs(state: PreviewWsData & { pings: string[] }, clientPing?: () => void) {
+  return {
+    data: state,
+    send: () => {},
+    close: () => {},
+    ping: clientPing ?? (() => state.pings.push('client')),
+  };
+}
+
+describe('preview WebSocket keepalive', () => {
+  test('pings BOTH legs — the upstream leg is the one that gets cut', () => {
+    const state = fakeState(WebSocket.OPEN);
+    pingPreviewWsLegs(fakeWs(state) as never);
+    expect(state.pings).toEqual(['client', 'upstream']);
+  });
+
+  test('a client leg that rejects the ping still leaves the upstream pinged', () => {
+    const state = fakeState(WebSocket.OPEN);
+    const ws = fakeWs(state, () => {
+      throw new Error('socket closing');
+    });
+    expect(() => pingPreviewWsLegs(ws as never)).not.toThrow();
+    expect(state.pings).toEqual(['upstream']);
+  });
+
+  test('never pings an upstream that is not open', () => {
+    const state = fakeState(WebSocket.CONNECTING);
+    pingPreviewWsLegs(fakeWs(state) as never);
+    expect(state.pings).toEqual(['client']);
+  });
+
+  test('tolerates a connection whose upstream never came up', () => {
+    const state = { type: 'preview-ws', url: 'wss://box/pty', headers: {}, pings: [] } as never;
+    expect(() => pingPreviewWsLegs(fakeWs(state) as never)).not.toThrow();
+  });
+
+  test('stopping the keepalive clears the interval and is idempotent', () => {
+    const state: PreviewWsData = { type: 'preview-ws', url: 'wss://box/pty', headers: {} };
+    state.keepalive = setInterval(() => {}, 60_000);
+    stopPreviewWsKeepalive(state);
+    expect(state.keepalive).toBeUndefined();
+    expect(() => stopPreviewWsKeepalive(state)).not.toThrow();
+  });
+
+  // A ping interval at or above the measured cut keeps nothing alive. Two pings
+  // must fit inside the window so a single dropped one does not cost the socket.
+  test('the interval clears the measured 60s upstream cut twice over', () => {
+    expect(PREVIEW_WS_KEEPALIVE_MS * 2).toBeLessThan(MEASURED_UPSTREAM_CUT_MS);
+  });
+});

--- a/apps/api/src/sandbox-proxy/ws-proxy.ts
+++ b/apps/api/src/sandbox-proxy/ws-proxy.ts
@@ -77,6 +77,27 @@ async function resolveLiveOpencodePort(sandboxId: string): Promise<number> {
   }
 }
 
+/**
+ * How often the proxy pings BOTH legs of a preview WebSocket.
+ *
+ * A terminal is idle by nature: a shell sitting at its prompt emits nothing,
+ * and a user reading output types nothing. Measured on a real Platinum box, the
+ * API→sandbox leg is dropped after exactly 60 s with no bytes on it — the
+ * browser can only render that as close code `1006`, which is the
+ * "Connection closed (1006)" / "Reconnecting in Ns (code 1006)" ladder users
+ * hit on every environment, once a minute, forever.
+ *
+ * Nothing else on this path can fix it. The daemon does not ping, the browser
+ * does not ping, and no data byte may be injected in either direction: an
+ * upstream byte is typed into the user's shell and a downstream byte is printed
+ * into their terminal. A WebSocket PING is a control frame — it keeps the
+ * connection non-idle at every hop and is invisible to xterm and to the PTY.
+ *
+ * 25 s clears the 60 s provider-edge cut with two pings to spare, and also
+ * clears Cloudflare's ~100 s WebSocket idle timeout on the browser leg.
+ */
+export const PREVIEW_WS_KEEPALIVE_MS = 25_000;
+
 /** Per-connection state stashed on the upgraded socket's `data`. */
 export interface PreviewWsData {
   type: 'preview-ws';
@@ -86,6 +107,8 @@ export interface PreviewWsData {
   upstream?: WebSocket;
   ready?: boolean;
   queue?: Array<string | Buffer | ArrayBuffer | Uint8Array>;
+  /** Interval that pings both legs — see PREVIEW_WS_KEEPALIVE_MS. */
+  keepalive?: ReturnType<typeof setInterval>;
 }
 
 /** Minimal shape of the Bun server WebSocket we touch. */
@@ -93,6 +116,35 @@ interface ServerWs {
   data: PreviewWsData;
   send: (data: string | ArrayBufferView | ArrayBuffer) => void;
   close: (code?: number, reason?: string) => void;
+  /** Bun's ServerWebSocket sends a PING control frame. */
+  ping?: (data?: string | ArrayBufferView | ArrayBuffer) => void;
+}
+
+/**
+ * Ping both legs once. Exported so the keepalive is unit-tested without a
+ * socket pair: it must ping the CLIENT and the UPSTREAM, and a throw on one leg
+ * must not stop the other.
+ */
+export function pingPreviewWsLegs(ws: ServerWs): void {
+  try {
+    ws.ping?.();
+  } catch {
+    // A socket that rejects a ping is closing; its own close handler cleans up.
+  }
+  const upstream = ws.data.upstream as (WebSocket & { ping?: () => void }) | undefined;
+  if (!upstream || upstream.readyState !== WebSocket.OPEN) return;
+  try {
+    upstream.ping?.();
+  } catch {
+    // Same: the upstream close handler tears the pair down.
+  }
+}
+
+/** Stop the keepalive. Idempotent — both close paths call it. */
+export function stopPreviewWsKeepalive(state: PreviewWsData): void {
+  if (!state.keepalive) return;
+  clearInterval(state.keepalive);
+  state.keepalive = undefined;
 }
 
 /** True when the path is a path-based preview route eligible for WS proxying. */
@@ -301,6 +353,10 @@ export const previewWsHandlers = {
       for (const msg of queued) {
         try { upstream.send(msg as any); } catch {}
       }
+      // Armed only once the pair is actually established — a ping before the
+      // upstream opens has nothing to keep alive.
+      stopPreviewWsKeepalive(state);
+      state.keepalive = setInterval(() => pingPreviewWsLegs(ws), PREVIEW_WS_KEEPALIVE_MS);
     };
 
     upstream.onmessage = (ev: MessageEvent) => {
@@ -308,10 +364,12 @@ export const previewWsHandlers = {
     };
 
     upstream.onclose = (ev: CloseEvent) => {
+      stopPreviewWsKeepalive(state);
       try { ws.close(sanitizePreviewWsCloseCode(ev.code), (ev.reason || '').slice(0, 120)); } catch {}
     };
 
     upstream.onerror = () => {
+      stopPreviewWsKeepalive(state);
       try { ws.close(4502, 'upstream error'); } catch {}
     };
   },
@@ -327,6 +385,9 @@ export const previewWsHandlers = {
   },
 
   close(ws: ServerWs) {
+    // The interval holds a reference to the socket pair. Leaving it armed after
+    // a close leaks one timer per terminal the box has ever opened.
+    stopPreviewWsKeepalive(ws.data);
     try { ws.data.upstream?.close(); } catch {}
   },
 };

--- a/apps/web/src/features/session/pty-terminal.tsx
+++ b/apps/web/src/features/session/pty-terminal.tsx
@@ -53,6 +53,10 @@ const terminalTheme: ITheme = {
 
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
 const PTY_CONNECT_TIMEOUT_MS = 15_000;
+// A close the browser reports as `1006` carries no information at all — it is
+// what a refused upgrade, a dropped socket, and a network blip all look like
+// from JavaScript. Printed at the user it reads as a real error code.
+const UNINFORMATIVE_CLOSE_REASON = /^code (1005|1006)$/;
 // xterm's default is 1000 lines — a single `npm install` or test run scrolls
 // past that, and the buffer is the only place that output exists client-side.
 const PTY_SCROLLBACK_LINES = 10_000;
@@ -149,6 +153,9 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
    *  may therefore wake a parked sandbox. Cleared by each connect so automatic
    *  backoff retries never resurrect a box. */
   const wakeOnNextConnectRef = useRef(true);
+  /** The "Waking the sandbox…" line is written once per wake episode, not once
+   *  per backoff retry. Cleared alongside the wake flag on a successful open. */
+  const wakeNoticeShownRef = useRef(false);
   // Until this timestamp, drop capability-query responses (see isTerminalReport)
   // so the scrollback replayed on connect doesn't echo garbage at the prompt.
   const suppressReportsUntilRef = useRef(0);
@@ -282,7 +289,12 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
 
       reconnectAttemptsRef.current += 1;
       const delay = Math.min(1000 * 2 ** (reconnectAttemptsRef.current - 1), 15000);
-      const suffix = reason ? ` (${reason})` : '';
+      // `code 1006` is the browser's way of saying it has NO information: it is
+      // what every refused upgrade and every dropped socket looks like from
+      // JavaScript, so printing it tells the user nothing and reads like a real
+      // error code they could act on. Anything else — a close reason, a real
+      // code — is genuine signal and still shown.
+      const suffix = reason && !UNINFORMATIVE_CLOSE_REASON.test(reason) ? ` (${reason})` : '';
 
       term.writeln(`\r\n\x1b[33mReconnecting in ${Math.ceil(delay / 1000)}s${suffix}...\x1b[0m`);
       updateStatus('connecting');
@@ -375,6 +387,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
         // Consumed only now: the attach succeeded, so the box is awake and the
         // next dial has nothing left to wake.
         wakeOnNextConnectRef.current = false;
+        wakeNoticeShownRef.current = false;
         if (connectTimeoutRef.current) {
           clearTimeout(connectTimeoutRef.current);
           connectTimeoutRef.current = null;
@@ -411,8 +424,14 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
         // status, so the one thing we DO know is worth saying: this attach asked
         // the API to wake a parked sandbox, and a parked box takes a few seconds
         // to come back. Without this the panel just counts down at the user.
-        if (wake) {
-          term.writeln('\r\n\x1b[33mWaking the sandbox — this can take a few seconds...\x1b[0m');
+        // Once per wake episode, not once per retry. A parked Platinum box takes
+        // ~60s to come back (measured on dev: stop 17:57:02 -> provider running
+        // confirmed 17:58:05), which is a whole backoff ladder of attempts — and
+        // repeating the line every attempt read as a stuck loop rather than as
+        // one thing taking a minute. Reset on a successful open.
+        if (wake && !wakeNoticeShownRef.current) {
+          wakeNoticeShownRef.current = true;
+          term.writeln('\r\n\x1b[33mWaking the sandbox — this can take up to a minute...\x1b[0m');
         }
         // Browser WS error events carry no detail (always an empty Event) and the
         // status (e.g. a 401) is never exposed. The onclose that follows drives
@@ -460,6 +479,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     reconnectNowRef.current = () => {
       if (disposedRef.current) return;
       wakeOnNextConnectRef.current = true;
+      wakeNoticeShownRef.current = false;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = null;
@@ -472,6 +492,7 @@ export const PtyTerminal = forwardRef<PtyTerminalHandle, PtyTerminalProps>(funct
     // A fresh (pty, serverUrl) pair is a new attach — the panel opened, or the
     // runtime moved. Both are user intent, so the first dial may wake a parked box.
     wakeOnNextConnectRef.current = true;
+    wakeNoticeShownRef.current = false;
 
     // Delay fit + initial WS connect to ensure the container has real dimensions
     const initTimer = setTimeout(() => {


### PR DESCRIPTION
## The report

> "the TERMINAL is not connecting anymore, basically EVERY time" — on dev, staging and prod.

The screenshot showed `Waking the sandbox…` followed by `Reconnecting in 1s (code 1006)`, `Reconnecting in 2s (code 1006)`.

## What is actually wrong

The **API → sandbox** leg of the PTY WebSocket is dropped after **exactly 60 s with no bytes on it**. A terminal is idle by nature: a shell at its prompt emits nothing, and a user reading output types nothing. So every terminal dies once a minute, everywhere.

Three controlled arms against one real Platinum box, same minute, same sandbox, on the **local** stack (no Cloudflare, no ALB in the path):

| arm | result |
|---|---|
| no keepalive | `CLOSE +60484ms code=4500 "Connection ended"` |
| PING from the browser | `CLOSE +60455ms` — a browser ping terminates at the API and never reaches the upstream leg |
| DATA from the browser | alive past 80 s — data *is* forwarded, so the leg stays busy |

The middle arm is the discriminator: only the upstream leg can be the one being cut.

Confirmed through the deployed edge as well — driving the real dev UI, the browser held one socket for `+61820ms`, reconnected, and died again at `+61832ms`.

The browser can only render that drop as close code `1006`, which is exactly the ladder in the report.

## Why nothing already fixed it

- The daemon does not ping. The browser does not ping.
- `websocket.idleTimeout: 0` on both Bun servers governs neither the provider edge nor the API's own upstream client. (Verified: an isolated `Bun.serve` of the daemon's exact shape survives 200 s idle.)
- No data byte may be injected in either direction — an upstream byte is typed into the user's shell, a downstream byte is printed into their terminal.

## The fix

`previewWsHandlers` pings **both** legs every 25 s once the pair is established, and clears the interval on every close path so a box that has opened many terminals leaks no timers. A PING is a control frame: invisible to xterm and to the PTY. 25 s also clears Cloudflare's ~100 s WebSocket idle timeout on the browser leg.

Two client-side corrections to the same user-visible failure:

- **`code 1006` is no longer printed.** It is what a refused upgrade, a dropped socket, and a network blip all look like from JavaScript — no information, but it reads as an error code the user could act on. A real code or close reason is still shown.
- **"Waking the sandbox…" is written once per wake episode**, not once per backoff retry. A parked Platinum box takes ~60 s to come back (measured on dev: stop `17:57:02` → provider running confirmed `17:58:05`), so the line repeated down the whole ladder and read as a stuck loop rather than one thing taking a minute.

## Verification

Local stack, real Platinum sandbox:

- **before** — idle hold `CLOSE +60484ms code=4500`; browser panel logged `Connection closed (1006)` + a reconnect ladder every ~60 s.
- **after** — idle hold `SURVIVED 150s` (closed `1000` only when the probe ended); the browser panel over the same window: **1 connect, 0 closes, 0 reconnects**, prompt still live.
- `bun test src/sandbox-proxy/` → **291 pass / 39 fail** with the change, **285 pass / 39 fail** on a stashed-clean tree. Same 39 pre-existing failures, no regressions, 6 new tests.
- `tsc --noEmit` clean in `apps/api`; no new errors in `apps/web`.

Preview + dev verification to follow on this PR.

## Note for whoever picks up the sandbox-proxy next

There was **no test coverage at all** for the PTY WebSocket path before this — `grep -rn "kortix/pty" tests/` returned nothing. That is why a socket that dies once a minute on every environment shipped unnoticed.

https://claude.ai/code/session_015ZCFChe9KT8KYXvvtcJBxS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790719380&installation_model_id=434224&pr_number=7062&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7062&signature=0e5c21d7a87a41dd306ac6f239a0e9eded40c4a1336c7f5e073d3e9df60ce626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->