### PR TITLE
fix(maintenance): fail open on empty edge-config read at the edge write gate

### DIFF
--- a/apps/web/src/lib/maintenance-store.test.ts
+++ b/apps/web/src/lib/maintenance-store.test.ts
@@ -10,6 +10,7 @@ type Config = {
 let databaseConfig: Config;
 let edgeConfig: Config | null;
 let databaseReadFails = false;
+let edgeReadFails = false;
 let events: string[] = [];
 
 mock.module('@kortix/sdk', () => ({
@@ -29,6 +30,7 @@ mock.module('@vercel/edge-config', () => ({
   createClient: () => ({
     get: async (_key: string, options?: { consistentRead?: boolean }) => {
       events.push(options?.consistentRead ? 'edge-read-consistent' : 'edge-read');
+      if (edgeReadFails) throw new Error('Edge Config unavailable');
       return edgeConfig;
     },
   }),
@@ -39,8 +41,12 @@ process.env.EDGE_CONFIG = 'https://edge-config.example.test?token=redacted';
 process.env.EDGE_CONFIG_ID = 'ecfg_test';
 process.env.VERCEL_API_TOKEN = 'vercel-test-token';
 
-const { getMaintenanceConfig, setMaintenanceConfig, __resetMaintenanceCacheForTests } =
-  await import('./maintenance-store');
+const {
+  getMaintenanceConfig,
+  getEdgeMaintenanceConfig,
+  setMaintenanceConfig,
+  __resetMaintenanceCacheForTests,
+} = await import('./maintenance-store');
 
 beforeEach(() => {
   __resetMaintenanceCacheForTests();
@@ -57,6 +63,7 @@ beforeEach(() => {
     updatedAt: 'edge-old',
   };
   databaseReadFails = false;
+  edgeReadFails = false;
   events = [];
   globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
     events.push('edge-write');
@@ -164,5 +171,29 @@ describe('maintenance store', () => {
     await getMaintenanceConfig();
 
     expect(events).toContain('database-read');
+  });
+
+  test('getEdgeMaintenanceConfig returns the persisted Edge Config value', async () => {
+    const config = await getEdgeMaintenanceConfig();
+
+    expect(config).toEqual(edgeConfig);
+  });
+
+  test('getEdgeMaintenanceConfig fails open when Edge Config is empty', async () => {
+    edgeConfig = null;
+
+    const config = await getEdgeMaintenanceConfig();
+
+    // Fail open: an empty Edge Config must not lock the edge down. Only an
+    // explicitly persisted blocking level blocks the edge write gate.
+    expect(config.level).toBe('none');
+  });
+
+  test('getEdgeMaintenanceConfig fails open when the Edge Config read throws', async () => {
+    edgeReadFails = true;
+
+    const config = await getEdgeMaintenanceConfig();
+
+    expect(config.level).toBe('none');
   });
 });

--- a/apps/web/src/lib/maintenance-store.ts
+++ b/apps/web/src/lib/maintenance-store.ts
@@ -44,13 +44,6 @@ const DEFAULT_CONFIG: MaintenanceConfig = {
   updatedAt: new Date(0).toISOString(),
 };
 
-const AUTOMATIC_MAINTENANCE: MaintenanceConfig = {
-  ...DEFAULT_CONFIG,
-  level: 'blocking',
-  title: 'Service maintenance',
-  message: 'Kortix is temporarily unavailable. Service will resume automatically.',
-};
-
 const EDGE_CONFIG_KEY = 'maintenance_config';
 
 let edgeClient: EdgeConfigClient | null = null;
@@ -214,15 +207,16 @@ export async function getEdgeMaintenanceConfig(): Promise<MaintenanceConfig> {
   if (!process.env.EDGE_CONFIG) return { ...memoryStore };
 
   try {
-    return (
-      (await readEdgeConfig()) ?? {
-        ...AUTOMATIC_MAINTENANCE,
-        updatedAt: new Date().toISOString(),
-      }
-    );
+    const edgeConfig = await readEdgeConfig();
+    if (edgeConfig) return edgeConfig;
+    // Fail open: an empty or unreadable Edge Config must not lock the edge down.
+    // Blocking maintenance comes only from an explicit admin action (persisted
+    // in Edge Config or the DB), never from a transient read miss. The same
+    // invariant as readMaintenanceConfig's fail-open path above.
+    return { ...DEFAULT_CONFIG, updatedAt: new Date().toISOString() };
   } catch (error) {
     console.error('[maintenance-store] independent Edge Config read failed:', error);
-    return { ...AUTOMATIC_MAINTENANCE, updatedAt: new Date().toISOString() };
+    return { ...DEFAULT_CONFIG, updatedAt: new Date().toISOString() };
   }
 }
 


### PR DESCRIPTION
## Demo

Non-visual backend-only change — no screen recording applies.

Proof: `apps/web/src/lib/maintenance-store.test.ts` adds 3 tests for `getEdgeMaintenanceConfig` (persisted value, empty Edge Config → `none`, read throws → `none`). All 12 tests pass:

```
$ cd apps/web && bun test --isolate src/lib/maintenance-store.test.ts src/lib/maintenance-client.test.ts
12 pass · 0 fail · 30 expect() calls
```

Live repro of the outage (before fix): `POST /v1/projects/:id/gateway/playground` returned
`503` with body `{"error":{"type":"MAINTENANCE_MODE",...},"maintenance":{"level":"blocking","title":"Service maintenance","message":"Kortix is temporarily unavailable. Service will resume automatically.","updatedAt":"<now>"}}` while the DB-backed maintenance config read `level: none`.

## Why

The Cloudflare api-router worker reads `https://kortix.com/api/maintenance/edge` as its maintenance-state source and returns a blocking `503 MAINTENANCE_MODE` for every non-GET request when the level is `blocking`. That edge route calls `getEdgeMaintenanceConfig()`, which **failed closed**: a null/throwing Vercel Edge Config read returned `AUTOMATIC_MAINTENANCE` (`level: 'blocking'`) instead of `none`. A transient Edge Config miss therefore locked down all mutating API/gateway traffic — the hourly Luna heartbeat's gateway test (`codex/gpt-5.6-luna`) 503'd the same way.

## What changed

- `apps/web/src/lib/maintenance-store.ts`: `getEdgeMaintenanceConfig()` now returns `DEFAULT_CONFIG` (`level: 'none'`) when the independent Edge Config read is empty or throws, matching the existing `readMaintenanceConfig()` fail-open invariant. Removed the now-unused `AUTOMATIC_MAINTENANCE` constant.
- `apps/web/src/lib/maintenance-store.test.ts`: added 3 tests for the edge config path; added an `edgeReadFails` flag to the Edge Config mock.

## Verification

- `bun test --isolate src/lib/maintenance-store.test.ts src/lib/maintenance-client.test.ts` → 12 pass, 0 fail.
- `npx tsc --noEmit -p tsconfig.json` → no errors in the changed file.

## Risk / rollback

Low. The change only affects the `/api/maintenance/edge` fallback path (when Edge Config is empty/unreachable). The explicit blocking path — admin sets `level: 'blocking'` in DB/Edge Config, or `MAINTENANCE_LEVEL_OVERRIDE=blocking` during the US East 2 cutover — is untouched. Rollback = revert this one commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758293&installation_model_id=434224&pr_number=7064&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7064&signature=4a5b7c9f8a9af2d6c6456be5af34b1ec48a119cc329291325b13197f889f1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->