### PR TITLE
fix(web,api): close the cross-account identity boundary

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -3863,3 +3863,31 @@ own config; no real secret was ever written to disk in plaintext.
   limits forced fetches to one per Git refresh interval. The manual fire route
   uses this helper. Unit tests prove cached-hit, forced-refresh, and bounded-miss
   sequences.
+
+## An explicit pathspec does not isolate concurrent agents — it commits file STATE, not your hunks
+
+- **Incident (2026-08-31, `identity-boundary`):** three implementer agents ran
+  in parallel in ONE worktree on verified-disjoint file sets, each instructed to
+  commit only its own pathspec. One task's whole job was retiring a bare
+  `['accounts']` query key across ~39 call sites, and
+  `app/(app)/projects/start/page.tsx` was both on that list and owned by another
+  task. The second agent's `git commit -- <its files>` captured the first
+  agent's in-flight `useAccountsList` refactor of that shared file. HEAD stayed
+  self-consistent only because the other agent later committed the module its
+  import needed — but for three commits the branch **did not build**, and a
+  commit whose subject says "scope the suppress-auto-project check" contains an
+  unrelated key migration. Its `git log`-based reference count also came out
+  wrong (43 vs 42), because it measured a worktree another agent was mutating.
+- **Rule:** `git commit -- <path>` records that path's CURRENT CONTENT, not the
+  hunks you authored, so it is not isolation. Before running implementers in
+  parallel on one worktree, compute disjointness against **every task still
+  capable of writing — including ones not yet dispatched** — and never run a
+  task with a wide call-site surface (a key/API/rename migration) concurrently
+  with anything. Otherwise give each agent its own worktree, or serialize. What
+  saved this one was luck: both agents completed. Had the migration reported
+  BLOCKED — which its brief explicitly invited — half a cutover would have been
+  stranded inside another task's commit.
+- **Enforcement:** none. A pre-commit check that refuses when a staged path
+  carries unstaged changes from another process, or a `pnpm worktree` guard that
+  refuses a second concurrent writer, is the TODO. Until then this rule is the
+  only guard, alongside the existing `git stash` and shared-worktree entries.

--- a/apps/api/src/__tests__/e2e-accounts-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-accounts-contract.test.ts
@@ -976,4 +976,88 @@ describe('accounts API contract', () => {
     expect(memberRows.filter((m) => m.userId === OWNER_ID)).toHaveLength(2);
     expect(accountRows.some((a) => a.accountId === OWNER_ID)).toBe(false);
   });
+
+  // GET /v1/accounts/me (tokens.ts) had the identical claim-before-check
+  // defect as GET /v1/accounts: it claimed pending invites first, then only
+  // fell back to `resolveAccountId` (which bootstraps) when the resulting
+  // membership count was still zero — so an invite-first caller of THIS
+  // route also never got a personal account. Same R3 fix, same ordering,
+  // applied here too.
+  //
+  // NOTE: this suite's `resolveAccountId` mock (above) models a "repair an
+  // existing orphaned account" shortcut, not real `bootstrapPersonalAccount`
+  // semantics (`account_id === user.id`) — it reuses whatever account
+  // happens to be first in `accountRows` rather than minting one keyed on
+  // the caller's own id. That identity-equality guarantee is a property of
+  // the REAL `bootstrapPersonalAccount`/`resolveAccountId` (covered by
+  // `unit-resolve-account.test.ts` and, for the real function, by the
+  // GET /v1/accounts tests above). What THIS test proves is the ordering:
+  // the route must end with a membership beyond the invited-into org, not
+  // just the org — so it identifies the bootstrapped entry by "not the org
+  // id" rather than asserting a specific id the mock cannot faithfully
+  // produce.
+  test('bootstraps before claiming on /accounts/me too, so an invite-first identity probe shows both memberships', async () => {
+    const ME_INVITE_USER_ID = '00000000-0000-4000-a000-000000000007';
+    const ME_INVITE_EMAIL = 'me-invite-first@example.test';
+    const ME_ORG_ID = '00000000-0000-4000-a000-000000000303';
+    accountRows.push({
+      accountId: ME_ORG_ID,
+      name: 'Me Org',
+      personalAccount: false,
+      createdAt: baseDate,
+      updatedAt: baseDate,
+    });
+    inviteRows.push({
+      inviteId: '00000000-0000-4000-a000-000000000403',
+      accountId: ME_ORG_ID,
+      email: ME_INVITE_EMAIL,
+      invitedBy: OWNER_ID,
+      initialRole: 'member',
+      acceptedAt: null,
+      createdAt: baseDate,
+      expiresAt: futureDate,
+    });
+    currentUserId = ME_INVITE_USER_ID;
+    currentUserEmail = ME_INVITE_EMAIL;
+
+    const res = await createApp().request('/v1/accounts/me');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Two memberships, not just the org.
+    expect(body.accounts).toHaveLength(2);
+    const orgEntry = body.accounts.find((a: any) => a.account_id === ME_ORG_ID);
+    expect(orgEntry).toMatchObject({ account_id: ME_ORG_ID, role: 'member' });
+    const bootstrapped = body.accounts.find((a: any) => a.account_id !== ME_ORG_ID);
+    expect(bootstrapped).toBeDefined();
+    expect(bootstrapped.role).toBe('owner');
+
+    expect(memberRows).toContainEqual(expect.objectContaining({
+      userId: ME_INVITE_USER_ID,
+      accountId: ME_ORG_ID,
+      accountRole: 'member',
+    }));
+    expect(memberRows.filter((m) => m.userId === ME_INVITE_USER_ID)).toHaveLength(2);
+    expect(inviteRows.find((i) => i.email === ME_INVITE_EMAIL)?.acceptedAt).toBeInstanceOf(Date);
+
+    // Idempotency: a repeat call must not add a third membership — the
+    // invite is already accepted, and the mocked `resolveAccountId` only
+    // fires when the pre-claim membership count is zero (it is not, on the
+    // second call).
+    const res2 = await createApp().request('/v1/accounts/me');
+    expect(res2.status).toBe(200);
+    expect((await res2.json()).accounts).toHaveLength(2);
+    expect(memberRows.filter((m) => m.userId === ME_INVITE_USER_ID)).toHaveLength(2);
+  });
+
+  test('/accounts/me does not bootstrap for a user who already has memberships', async () => {
+    // OWNER already has two memberships from resetState.
+    const accountCountBefore = accountRows.length;
+    const res = await createApp().request('/v1/accounts/me');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.accounts).toHaveLength(2);
+    expect(accountRows).toHaveLength(accountCountBefore);
+    expect(memberRows.filter((m) => m.userId === OWNER_ID)).toHaveLength(2);
+  });
 });

--- a/apps/api/src/__tests__/e2e-accounts-contract.test.ts
+++ b/apps/api/src/__tests__/e2e-accounts-contract.test.ts
@@ -826,4 +826,154 @@ describe('accounts API contract', () => {
     const expired = await app.request('/v1/account-invites/00000000-0000-4000-a000-000000000202/accept', { method: 'POST' });
     expect(expired.status).toBe(410);
   });
+
+  // R3: bootstrap the personal account BEFORE claiming pending invites, so an
+  // invite-first signup ends with BOTH — not just the inviter's org. Before
+  // this ordering, `autoClaimPendingInvites` ran first, so the membership
+  // count checked afterward was never zero the moment any invite existed,
+  // and the bootstrap silently never fired.
+  test('bootstraps the personal account before claiming a pending invite, so an invite-first signup gets both', async () => {
+    const INVITE_FIRST_USER_ID = '00000000-0000-4000-a000-000000000005';
+    const INVITE_FIRST_EMAIL = 'invite-first@example.test';
+    inviteRows.push({
+      inviteId: INVITE_ID,
+      accountId: ACCOUNT_ID,
+      email: INVITE_FIRST_EMAIL,
+      invitedBy: OWNER_ID,
+      initialRole: 'member',
+      acceptedAt: null,
+      createdAt: baseDate,
+      expiresAt: futureDate,
+    });
+    currentUserId = INVITE_FIRST_USER_ID;
+    currentUserEmail = INVITE_FIRST_EMAIL;
+
+    const res = await createApp().request('/v1/accounts');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Two memberships: their own personal account (account_id === their own
+    // user id) AND the org they were invited into — not just the org, which
+    // was the pre-fix defect this test guards against.
+    expect(body).toHaveLength(2);
+    const own = body.find((a: any) => a.account_id === INVITE_FIRST_USER_ID);
+    expect(own).toMatchObject({
+      account_id: INVITE_FIRST_USER_ID,
+      account_role: 'owner',
+      is_primary_owner: true,
+    });
+    const org = body.find((a: any) => a.account_id === ACCOUNT_ID);
+    expect(org).toMatchObject({
+      account_id: ACCOUNT_ID,
+      account_role: 'member',
+      is_primary_owner: false,
+    });
+
+    // The invite is still claimed — stamped accepted and turned into a real
+    // membership, exactly like before this change.
+    expect(inviteRows[0]?.acceptedAt).toBeInstanceOf(Date);
+    expect(memberRows).toContainEqual(expect.objectContaining({
+      userId: INVITE_FIRST_USER_ID,
+      accountId: INVITE_FIRST_USER_ID,
+      accountRole: 'owner',
+    }));
+    expect(memberRows).toContainEqual(expect.objectContaining({
+      userId: INVITE_FIRST_USER_ID,
+      accountId: ACCOUNT_ID,
+      accountRole: 'member',
+    }));
+
+    // Idempotency: a second call must not mint a second personal account or
+    // duplicate the org membership — the invite is already accepted, and
+    // `bootstrapPersonalAccount` is a conflict no-op on the existing row.
+    const res2 = await createApp().request('/v1/accounts');
+    expect(res2.status).toBe(200);
+    expect(await res2.json()).toHaveLength(2);
+    expect(accountRows.filter((a) => a.accountId === INVITE_FIRST_USER_ID)).toHaveLength(1);
+    expect(memberRows.filter((m) => m.userId === INVITE_FIRST_USER_ID)).toHaveLength(2);
+  });
+
+  // Task 2's `isForeignAccountList` fail-closed rule on the web `/new` form
+  // blocks submit when an account list has >= 2 entries and NONE has
+  // account_id === the caller's own user id. An invite-first user who is
+  // admin on two orgs has exactly that shape without this fix — their
+  // account list is [org A, org B], neither equal to their user id — so
+  // Task 2 would wrongly classify their real, legitimate list as foreign and
+  // lock them out of creating any workspace. This proves the fix removes
+  // that precondition: their own account is always present.
+  test('an invite-first user who is admin on two orgs ends with three memberships, one always their own', async () => {
+    const TWO_ORG_USER_ID = '00000000-0000-4000-a000-000000000006';
+    const TWO_ORG_EMAIL = 'two-org-invitee@example.test';
+    const ORG_ALPHA_ID = '00000000-0000-4000-a000-000000000301';
+    const ORG_BETA_ID = '00000000-0000-4000-a000-000000000302';
+    accountRows.push(
+      { accountId: ORG_ALPHA_ID, name: 'Org Alpha', personalAccount: false, createdAt: baseDate, updatedAt: baseDate },
+      { accountId: ORG_BETA_ID, name: 'Org Beta', personalAccount: false, createdAt: baseDate, updatedAt: baseDate },
+    );
+    inviteRows.push(
+      {
+        inviteId: '00000000-0000-4000-a000-000000000401',
+        accountId: ORG_ALPHA_ID,
+        email: TWO_ORG_EMAIL,
+        invitedBy: OWNER_ID,
+        initialRole: 'admin',
+        acceptedAt: null,
+        createdAt: baseDate,
+        expiresAt: futureDate,
+      },
+      {
+        inviteId: '00000000-0000-4000-a000-000000000402',
+        accountId: ORG_BETA_ID,
+        email: TWO_ORG_EMAIL,
+        invitedBy: OWNER_ID,
+        initialRole: 'admin',
+        acceptedAt: null,
+        createdAt: baseDate,
+        expiresAt: futureDate,
+      },
+    );
+    currentUserId = TWO_ORG_USER_ID;
+    currentUserEmail = TWO_ORG_EMAIL;
+
+    const res = await createApp().request('/v1/accounts');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toHaveLength(3);
+    expect(body.map((a: any) => a.account_id).sort()).toEqual(
+      [ORG_ALPHA_ID, ORG_BETA_ID, TWO_ORG_USER_ID].sort(),
+    );
+
+    // The exact invariant Task 2's fail-closed rule relies on: their own
+    // account is present, so a real >= 2-org list is never classified
+    // foreign.
+    expect(body.some((a: any) => a.account_id === TWO_ORG_USER_ID)).toBe(true);
+
+    const own = body.find((a: any) => a.account_id === TWO_ORG_USER_ID);
+    expect(own).toMatchObject({ account_role: 'owner', is_primary_owner: true });
+    for (const orgId of [ORG_ALPHA_ID, ORG_BETA_ID]) {
+      const org = body.find((a: any) => a.account_id === orgId);
+      expect(org).toMatchObject({ account_role: 'admin', is_primary_owner: false });
+    }
+
+    expect(
+      inviteRows.filter((i) => i.email === TWO_ORG_EMAIL && i.acceptedAt !== null),
+    ).toHaveLength(2);
+  });
+
+  // The bootstrap must stay conditional on "no membership yet" — not become
+  // unconditional. A user who already has memberships (however they got
+  // them) must not have a personal account minted retroactively on every
+  // list call.
+  test('a user who already has memberships gets no personal account bootstrapped retroactively', async () => {
+    // OWNER already has two memberships from resetState (team ACCOUNT_ID +
+    // fixture PERSONAL_ACCOUNT_ID, neither equal to OWNER_ID itself).
+    const accountCountBefore = accountRows.length;
+    const res = await createApp().request('/v1/accounts');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toHaveLength(2);
+    expect(accountRows).toHaveLength(accountCountBefore);
+    expect(memberRows.filter((m) => m.userId === OWNER_ID)).toHaveLength(2);
+    expect(accountRows.some((a) => a.accountId === OWNER_ID)).toBe(false);
+  });
 });

--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -79,82 +79,99 @@ export function registerAccountRoutes(): void {
         ]);
       }
 
-      await autoClaimPendingInvites(userId, userEmail);
-
       // `account_members` says WHICH accounts; `role_assignments` says at what
       // role. Reading the role off the join labelled the switcher with a value
       // the engine no longer decides on.
-      const [membershipRows, rolesByAccount] = await Promise.all([
-        db
-          .select({
-            accountId: accountMembers.accountId,
-            name: accounts.name,
-            createdAt: accounts.createdAt,
-            updatedAt: accounts.updatedAt,
-            branding: accounts.branding,
-          })
-          .from(accountMembers)
-          .innerJoin(accounts, eq(accountMembers.accountId, accounts.accountId))
-          .where(eq(accountMembers.userId, userId)),
-        accountRolesForUser(userId),
-      ]);
-      const memberships = membershipRows.map((m) => ({
-        ...m,
-        accountRole: rolesByAccount.get(m.accountId) ?? 'member',
-      }));
+      const loadMemberships = async () => {
+        const [membershipRows, rolesByAccount] = await Promise.all([
+          db
+            .select({
+              accountId: accountMembers.accountId,
+              name: accounts.name,
+              createdAt: accounts.createdAt,
+              updatedAt: accounts.updatedAt,
+              branding: accounts.branding,
+            })
+            .from(accountMembers)
+            .innerJoin(accounts, eq(accountMembers.accountId, accounts.accountId))
+            .where(eq(accountMembers.userId, userId)),
+          accountRolesForUser(userId),
+        ]);
+        return membershipRows.map((m) => ({
+          ...m,
+          accountRole: rolesByAccount.get(m.accountId) ?? 'member',
+        }));
+      };
 
-      if (memberships.length > 0) {
-        const displayNames = await resolveAccountDisplayNames(memberships, {
-          userId,
-          email: userEmail,
-        });
-        // Deterministic order (owned first, oldest first): the web landing
-        // door falls back to the FIRST account of this list, so an unordered
-        // result made the default landing account nondeterministic.
-        // Branding is resolved per account — `effectiveBranding` only touches
-        // billing for accounts that actually carry a record, so this stays a
-        // no-op for the overwhelming majority of lists.
-        return c.json(
-          await Promise.all(
-            sortAccountsForListing(memberships).map(async (m) => ({
-              account_id: m.accountId,
-              name: displayNames.get(m.accountId) ?? accountDisplayName(m.name, userEmail),
-              slug: m.accountId.slice(0, 8),
-              created_at: m.createdAt?.toISOString() ?? new Date().toISOString(),
-              updated_at: m.updatedAt?.toISOString() ?? new Date().toISOString(),
-              account_role: m.accountRole || 'owner',
-              is_primary_owner: m.accountRole === 'owner',
-              branding: await effectiveBranding(m.accountId, m.branding),
-            })),
-          ),
-        );
+      // Bootstrap BEFORE claiming pending invites, not after (R3). The old
+      // order claimed invites first and only bootstrapped when the resulting
+      // membership count was still zero — so the moment ANY invite was
+      // pending, the claim alone made that count nonzero and the bootstrap
+      // never ran. An invite-first signup then had no personal account at
+      // all: its entire `GET /v1/accounts` was the inviter's org, and the
+      // web landing door (which takes the first account in this list) put a
+      // brand-new user straight into a stranger's workspace.
+      //
+      // `resolveAccountId` (shared/resolve-account.ts) never had this bug —
+      // it bootstraps unconditionally the moment a caller has NO membership,
+      // and never claims invites itself. Deciding on the PRE-claim
+      // membership set here (not the post-claim one) makes this route agree
+      // with that one: bootstrap fires exactly when the caller had no
+      // account at all, independent of whether an invite is waiting.
+      let memberships = await loadMemberships();
+      if (memberships.length === 0) {
+        try {
+          await bootstrapPersonalAccount(userId, userEmail);
+        } catch (err) {
+          console.warn('[accounts] Failed to bootstrap personal account:', err);
+          return c.json({ error: 'Failed to initialize account' }, 500);
+        }
       }
 
-      try {
-        const { accountId } = await bootstrapPersonalAccount(userId, userEmail);
-        const [row] = await db
-          .select()
-          .from(accounts)
-          .where(eq(accounts.accountId, accountId))
-          .limit(1);
-        if (!row) {
-          throw new Error(`Personal account ${accountId} missing after bootstrap`);
-        }
-        return c.json([
-          {
-            account_id: row.accountId,
-            name: accountDisplayName(row.name, userEmail),
-            slug: row.accountId.slice(0, 8),
-            created_at: row.createdAt.toISOString(),
-            updated_at: row.updatedAt.toISOString(),
-            account_role: 'owner',
-            is_primary_owner: true,
-          },
-        ]);
-      } catch (err) {
-        console.warn('[accounts] Failed to bootstrap personal account:', err);
+      // Claim AFTER the bootstrap decision above. `autoClaimPendingInvites`
+      // already swallows its own errors (best-effort, must never block
+      // listing) and is idempotent — a claimed invite is stamped
+      // `accepted_at` and re-running is a no-op — so a claim failure here
+      // leaves the user with exactly the personal account bootstrapped above
+      // and the invite still pending, to be retried on the next call. No
+      // shared transaction wraps the two steps: bootstrap failure is fatal
+      // (500, above) because without it the account list is meaningless,
+      // while invite-claiming is explicitly optional and self-healing, and
+      // wrapping both in one transaction would contradict the per-invite
+      // isolation `autoClaimPendingInvites` already does internally (one bad
+      // invite must not roll back the others, or the account just bootstrapped).
+      await autoClaimPendingInvites(userId, userEmail);
+
+      memberships = await loadMemberships();
+      if (memberships.length === 0) {
+        console.warn(`[accounts] No memberships for ${userId} after bootstrap+claim`);
         return c.json({ error: 'Failed to initialize account' }, 500);
       }
+
+      const displayNames = await resolveAccountDisplayNames(memberships, {
+        userId,
+        email: userEmail,
+      });
+      // Deterministic order (owned first, oldest first): the web landing
+      // door falls back to the FIRST account of this list, so an unordered
+      // result made the default landing account nondeterministic.
+      // Branding is resolved per account — `effectiveBranding` only touches
+      // billing for accounts that actually carry a record, so this stays a
+      // no-op for the overwhelming majority of lists.
+      return c.json(
+        await Promise.all(
+          sortAccountsForListing(memberships).map(async (m) => ({
+            account_id: m.accountId,
+            name: displayNames.get(m.accountId) ?? accountDisplayName(m.name, userEmail),
+            slug: m.accountId.slice(0, 8),
+            created_at: m.createdAt?.toISOString() ?? new Date().toISOString(),
+            updated_at: m.updatedAt?.toISOString() ?? new Date().toISOString(),
+            account_role: m.accountRole || 'owner',
+            is_primary_owner: m.accountRole === 'owner',
+            branding: await effectiveBranding(m.accountId, m.branding),
+          })),
+        ),
+      );
     },
   );
 

--- a/apps/api/src/accounts/core/accounts.ts
+++ b/apps/api/src/accounts/core/accounts.ts
@@ -118,6 +118,16 @@ export function registerAccountRoutes(): void {
       // membership set here (not the post-claim one) makes this route agree
       // with that one: bootstrap fires exactly when the caller had no
       // account at all, independent of whether an invite is waiting.
+      //
+      // GET /v1/accounts/me (accounts/core/tokens.ts) applies the identical
+      // pre-claim-decision ordering for the same reason — kept as a
+      // parallel implementation rather than a shared helper because its
+      // bootstrap primitive (`resolveAccountId`, best-effort, never fails
+      // the request), gating (`authType === 'supabase'`), and response
+      // shape all differ from this route's; forcing one function to cover
+      // both would trade a 10-line ordering discipline for a multi-parameter
+      // abstraction that hides the one real asymmetry that matters — this
+      // route's bootstrap failure is fatal (500 below), /me's is not.
       let memberships = await loadMemberships();
       if (memberships.length === 0) {
         try {

--- a/apps/api/src/accounts/core/tokens.ts
+++ b/apps/api/src/accounts/core/tokens.ts
@@ -93,12 +93,22 @@ accountsRouter.openapi(
     }
   };
 
-  if (authType === 'supabase' && userEmail) {
-    await autoClaimPendingInvites(userId, userEmail);
-  }
+  // Bootstrap BEFORE claiming pending invites (R3 — see
+  // accounts/core/accounts.ts:registerAccountRoutes, GET /). Decide on the
+  // PRE-claim membership count, not the post-claim one: the old order
+  // claimed first, so an invite-first caller of THIS route also never got a
+  // personal account — whichever of /accounts or /accounts/me a client hit
+  // first silently decided the user's fate, which is exactly the coupling
+  // R3 was chosen to remove. `resolveAccountId` re-checks membership itself
+  // and bootstraps only when it is still zero, so reading it here before
+  // the claim is what makes the bootstrap actually fire.
   let memberships = await loadMemberships();
   if (memberships.length === 0 && authType === 'supabase') {
     await resolveAccountId(userId);
+    memberships = await loadMemberships();
+  }
+  if (authType === 'supabase' && userEmail) {
+    await autoClaimPendingInvites(userId, userEmail);
     memberships = await loadMemberships();
   }
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -168,9 +168,24 @@ const eslintConfig = [
           //
           // The pattern matches the whole family rather than an allowlist,
           // so a NEW literal (`['project-widgets', id]`) is caught too.
+          //
+          // `accounts` joined the family for a DIFFERENT reason from the
+          // project literals, and a stronger one. `['accounts']` carried no
+          // signed-in user, so one document that saw two users held ONE cache
+          // entry for both — and `/new` resolves its create target out of
+          // that list, so a leftover single-account list belonging to the
+          // previous user made `POST /projects/provision` go out with a
+          // foreign `account_id` under the new user's JWT (403). The list
+          // CONTENTS cannot tell that apart from a legitimate invited admin;
+          // only `qk.accounts.list(userId)` can. This rule is what keeps that
+          // fix from being undone by the next person who types the obvious
+          // four-line `useQuery`.
+          //
+          // Singular `account` is deliberately NOT matched: `['account', id]`
+          // is a different, still-live family already scoped by account id.
           selector:
             "Property[key.name='queryKey'] > ArrayExpression > " +
-            "Literal:first-child[value=/^projects?(-[a-z-]+)?$/]",
+            "Literal:first-child[value=/^(projects?|accounts)(-[a-z-]+)?$/]",
           message:
             'Query keys come from `qk` in @kortix/sdk/react. Never hand-type an entity key.',
         },
@@ -186,7 +201,7 @@ const eslintConfig = [
           // selectors below.
           selector:
             "Property[key.name='queryKey'] > TSAsExpression > ArrayExpression > " +
-            "Literal:first-child[value=/^projects?(-[a-z-]+)?$/]",
+            "Literal:first-child[value=/^(projects?|accounts)(-[a-z-]+)?$/]",
           message:
             'Query keys come from `qk` in @kortix/sdk/react. Never hand-type an entity key.',
         },
@@ -227,7 +242,7 @@ const eslintConfig = [
           // Covers every TanStack QueryClient method whose first positional
           // argument is (or can be) a query key.
           selector:
-            "CallExpression[callee.property.name=/^(set|get)Quer(y|ies)Data$|^(remove|cancel|refetch|invalidate)Queries$/] > ArrayExpression:first-child > Literal:first-child[value=/^projects?(-[a-z-]+)?$|^kx$/]",
+            "CallExpression[callee.property.name=/^(set|get)Quer(y|ies)Data$|^(remove|cancel|refetch|invalidate)Queries$/] > ArrayExpression:first-child > Literal:first-child[value=/^(projects?|accounts)(-[a-z-]+)?$|^kx$/]",
           message:
             'Query keys come from `qk` in @kortix/sdk/react. Never hand-type an entity key.',
         },
@@ -238,7 +253,7 @@ const eslintConfig = [
           // and its first-argument ArrayExpression instead of between a
           // Property and its value.
           selector:
-            "CallExpression[callee.property.name=/^(set|get)Quer(y|ies)Data$|^(remove|cancel|refetch|invalidate)Queries$/] > TSAsExpression:first-child > ArrayExpression > Literal:first-child[value=/^projects?(-[a-z-]+)?$|^kx$/]",
+            "CallExpression[callee.property.name=/^(set|get)Quer(y|ies)Data$|^(remove|cancel|refetch|invalidate)Queries$/] > TSAsExpression:first-child > ArrayExpression > Literal:first-child[value=/^(projects?|accounts)(-[a-z-]+)?$|^kx$/]",
           message:
             'Query keys come from `qk` in @kortix/sdk/react. Never hand-type an entity key.',
         },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -483,14 +483,37 @@ const nextConfig = (): NextConfig => ({
           // server.ts / middleware.ts) is now Secure-only on HTTPS, but
           // without this header a plaintext http:// hit on a domain that
           // NORMALLY redirects to HTTPS is still a window an on-path
-          // attacker can use before that redirect happens. Browsers ignore
-          // this header entirely when it arrives over plain HTTP (RFC 6797),
-          // so it is a no-op locally and on any HTTP-only self-host —
-          // effective only where it matters, on real HTTPS deployments.
-          {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=63072000; includeSubDomains',
-          },
+          // attacker can use before that redirect happens.
+          //
+          // CONTROLLER RULING (R18, final): gated to production, and
+          // WITHOUT `includeSubDomains`. `headers()` here has no per-request
+          // environment check — the entry, once added, ships identically
+          // from local `next dev`, `dev.kortix.com`, `staging.kortix.com`
+          // and prod. Browsers ignore this header over plain HTTP (RFC
+          // 6797), so it is genuinely inert on bare `localhost` — but dev
+          // and staging are REAL HTTPS deployments of this same app, so an
+          // ungated header is enforced there too, and `includeSubDomains`
+          // would pin `*.dev.kortix.com` / `*.staging.kortix.com`, and from
+          // the prod apex the entire `*.kortix.com` zone — known and future
+          // subdomains — for two years, in every visitor's browser, with no
+          // server-side undo. The auth-cookie plaintext window this closes
+          // is fully closed by the header on the ONE host serving that
+          // cookie; subdomain-wide enforcement is a separate, DNS-wide
+          // infra decision that belongs to whoever owns that zone, not a
+          // side effect of this fix. `process.env.NODE_ENV === 'production'`
+          // here is a BUILD-time check (`next build` sets it), same
+          // mechanism `next.config.ts`'s `rewrites()` already uses for the
+          // Supabase proxy rewrite above, and matches how `secure` is gated
+          // server-side in
+          // `lib/supabase/server.ts` / `middleware.ts`.
+          ...(process.env.NODE_ENV === 'production'
+            ? [
+                {
+                  key: 'Strict-Transport-Security',
+                  value: 'max-age=63072000',
+                },
+              ]
+            : []),
         ],
       },
       {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -485,27 +485,35 @@ const nextConfig = (): NextConfig => ({
           // NORMALLY redirects to HTTPS is still a window an on-path
           // attacker can use before that redirect happens.
           //
-          // CONTROLLER RULING (R18, final): gated to production, and
-          // WITHOUT `includeSubDomains`. `headers()` here has no per-request
-          // environment check — the entry, once added, ships identically
-          // from local `next dev`, `dev.kortix.com`, `staging.kortix.com`
-          // and prod. Browsers ignore this header over plain HTTP (RFC
-          // 6797), so it is genuinely inert on bare `localhost` — but dev
-          // and staging are REAL HTTPS deployments of this same app, so an
-          // ungated header is enforced there too, and `includeSubDomains`
-          // would pin `*.dev.kortix.com` / `*.staging.kortix.com`, and from
-          // the prod apex the entire `*.kortix.com` zone — known and future
-          // subdomains — for two years, in every visitor's browser, with no
-          // server-side undo. The auth-cookie plaintext window this closes
-          // is fully closed by the header on the ONE host serving that
-          // cookie; subdomain-wide enforcement is a separate, DNS-wide
-          // infra decision that belongs to whoever owns that zone, not a
-          // side effect of this fix. `process.env.NODE_ENV === 'production'`
-          // here is a BUILD-time check (`next build` sets it), same
-          // mechanism `next.config.ts`'s `rewrites()` already uses for the
-          // Supabase proxy rewrite above, and matches how `secure` is gated
-          // server-side in
-          // `lib/supabase/server.ts` / `middleware.ts`.
+          // HONEST STATE OF THIS GATE (R21, correcting R18's own comment):
+          // `next build` sets `process.env.NODE_ENV = 'production'`
+          // UNCONDITIONALLY, regardless of which host the build is deployed
+          // to. The ternary below is therefore a BUILD-time check, not an
+          // environment check — it ships the header from EVERY environment
+          // built with `next build`: `dev.kortix.com`, `staging.kortix.com`,
+          // every HTTPS self-host preview, and prod, all identically. The
+          // only thing this gate actually excludes is bare `next dev`
+          // (`NODE_ENV === 'development'`), which nothing on the public
+          // internet is served by. Read this as "not `next dev`", never as
+          // "production only" — a comment that implied the latter is
+          // exactly what stood here before and is what this note replaces.
+          //
+          // CONTROLLER RULING (R18/R21, final): keep the header and its
+          // 2-year `max-age` anyway, despite shipping everywhere. It is
+          // HOST-ONLY — `includeSubDomains` was dropped in the same fix —
+          // and every host it reaches is HTTPS-only regardless, so at worst
+          // it is redundant with a redirect that already exists. What it
+          // must not do is UNDERSTATE its own commitment: `max-age=63072000`
+          // has NO SERVER-SIDE UNDO. A browser that received this header
+          // from dev.kortix.com refuses plain HTTP to that exact host for
+          // two years, even if the header is removed from a later build.
+          // That commitment is made from dev and staging TODAY, not only
+          // from prod. `includeSubDomains` would additionally have pinned
+          // `*.dev.kortix.com` / `*.staging.kortix.com`, and from the prod
+          // apex the whole `*.kortix.com` zone — known and future
+          // subdomains, for two years, in every visitor's browser. That
+          // DNS-wide decision belongs to whoever owns the zone, not to this
+          // auth-cookie fix, which is why it stays out.
           ...(process.env.NODE_ENV === 'production'
             ? [
                 {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -479,6 +479,18 @@ const nextConfig = (): NextConfig => ({
             key: 'X-Frame-Options',
             value: 'SAMEORIGIN',
           },
+          // The Supabase session cookie (see lib/supabase/client.ts /
+          // server.ts / middleware.ts) is now Secure-only on HTTPS, but
+          // without this header a plaintext http:// hit on a domain that
+          // NORMALLY redirects to HTTPS is still a window an on-path
+          // attacker can use before that redirect happens. Browsers ignore
+          // this header entirely when it arrives over plain HTTP (RFC 6797),
+          // so it is a no-op locally and on any HTTP-only self-host —
+          // effective only where it matters, on real HTTPS deployments.
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains',
+          },
         ],
       },
       {

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -19,7 +19,7 @@ import {
   ScrollIcon as ScrollText,
   PlugsIcon as Unplug,
 } from '@phosphor-icons/react';
-import { invalidatePermissionProbes } from '@kortix/sdk/react';
+import { invalidatePermissionProbes, qk } from '@kortix/sdk/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { m, useReducedMotion } from 'motion/react';
 import Link from 'next/link';
@@ -1127,7 +1127,10 @@ function GeneralCard({
     onSuccess: (updated) => {
       successToast('Account updated');
       queryClient.setQueryData(['account', account.account_id], updated);
-      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      // The account LIST renders this name in every switcher. `scope()` is
+      // the prefix that reaches the signed-in user's list slot from inside a
+      // mutation callback, which has no user id in hand.
+      queryClient.invalidateQueries({ queryKey: qk.accounts.scope() });
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to update account'),
   });
@@ -1367,7 +1370,7 @@ function MembersCard({
     onSettled: () => clearPending(currentUserId),
     onSuccess: () => {
       successToast(`Left ${account.name}`);
-      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      queryClient.invalidateQueries({ queryKey: qk.accounts.scope() });
       router.push('/accounts');
     },
     onError: (err: Error) => errorToast(err.message || 'Failed to leave team'),

--- a/apps/web/src/app/(app)/accounts/[id]/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/page.tsx
@@ -67,6 +67,7 @@ import { SettingsRowGroup } from '@/components/ui/settings-row';
 import { Skeleton } from '@/components/ui/skeleton';
 import { errorToast, infoToast, successToast, warningToast } from '@/components/ui/toast';
 import { UserAvatar } from '@/components/ui/user-avatar';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { BillingTab } from '@/features/accounts/settings/billing-tab';
 import { BrandingTab } from '@/features/accounts/settings/branding-tab';
 import { useBrandingScope } from '@/features/branding/branding-provider';
@@ -305,9 +306,7 @@ export default function AccountSettingsPage() {
   const queryClient = useQueryClient();
   const { user, isLoading: authLoading } = useAuth();
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   // Granular capabilities sourced from the IAM engine. MUST be called
   // before any conditional return — moving these below the auth-loading

--- a/apps/web/src/app/(app)/accounts/[id]/scim-setup/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/scim-setup/page.tsx
@@ -3,22 +3,18 @@
 // Guided Directory Sync (SCIM) setup — the provisioning counterpart to the
 // SSO wizard. Linked from the SCIM card; provider picked via ?provider=<id>.
 
-import { useParams, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-
+import { useParams } from 'next/navigation';
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { ScimSetupWizard } from '@/features/sso-setup/setup-wizard';
 import { useAuth } from '@/features/providers/auth-provider';
 
 export default function ScimSetupPage() {
-  const router = useRouter();
   const params = useParams<{ id: string }>();
   const accountId = params?.id;
   const { user, isLoading: authLoading } = useAuth();
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   if (authLoading || !user || !accountId) {
     return <ConnectingScreen />;

--- a/apps/web/src/app/(app)/accounts/[id]/sso-setup/page.tsx
+++ b/apps/web/src/app/(app)/accounts/[id]/sso-setup/page.tsx
@@ -3,22 +3,18 @@
 // Guided SSO setup (Vercel-style wizard). Linked from the SAML SSO card's
 // Configure button; provider picked via ?provider=<id>.
 
-import { useParams, useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-
+import { useParams } from 'next/navigation';
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { SsoSetupWizard } from '@/features/sso-setup/setup-wizard';
 import { useAuth } from '@/features/providers/auth-provider';
 
 export default function SsoSetupPage() {
-  const router = useRouter();
   const params = useParams<{ id: string }>();
   const accountId = params?.id;
   const { user, isLoading: authLoading } = useAuth();
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   if (authLoading || !user || !accountId) {
     return <ConnectingScreen />;

--- a/apps/web/src/app/(app)/accounts/layout.tsx
+++ b/apps/web/src/app/(app)/accounts/layout.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { AppHeader } from '@/features/layout/app-header';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useRouter } from 'next/navigation';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 type LayoutProps = { children: React.ReactNode };
 
@@ -12,9 +13,7 @@ const Layout = ({ children }: LayoutProps) => {
   const { user, isLoading } = useAuth();
   const router = useRouter();
 
-  useEffect(() => {
-    if (!isLoading && !user) router.replace('/auth');
-  }, [isLoading, user, router]);
+  useSignedOutRedirect();
 
   if (isLoading || !user) {
     return <ConnectingScreen forceConnecting overrideStage="auth" hideWorkspacePicker />;

--- a/apps/web/src/app/(app)/accounts/layout.tsx
+++ b/apps/web/src/app/(app)/accounts/layout.tsx
@@ -4,14 +4,12 @@ import { ConnectingScreen } from '@/components/dashboard/connecting-screen';
 import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { AppHeader } from '@/features/layout/app-header';
 import { useAuth } from '@/features/providers/auth-provider';
-import { useRouter } from 'next/navigation';
 import React from 'react';
 
 type LayoutProps = { children: React.ReactNode };
 
 const Layout = ({ children }: LayoutProps) => {
   const { user, isLoading } = useAuth();
-  const router = useRouter();
 
   useSignedOutRedirect();
 

--- a/apps/web/src/app/(app)/accounts/page.tsx
+++ b/apps/web/src/app/(app)/accounts/page.tsx
@@ -10,17 +10,18 @@ import { CreateAccountModal } from '@/features/accounts/create-account-modal';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { useAuth } from '@/features/providers/auth-provider';
+import { useAccountsList, useAccountsQueryKey } from '@/hooks/account/use-accounts-list';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import { isAccountCreationRestricted } from '@/lib/config';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts, type KortixAccount } from '@kortix/sdk';
+import { type KortixAccount } from '@kortix/sdk';
 import { qk } from '@kortix/sdk/react';
 import {
   CaretRightIcon as ChevronRight,
   PlusIcon as Plus,
   UsersIcon as Users,
 } from '@phosphor-icons/react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -42,12 +43,9 @@ export default function AccountsPage() {
 
   useSignedOutRedirect();
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    enabled: !!user,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
+  // The exact key `accountsQuery` reads, for the create-account seed below.
+  const accountsQueryKey = useAccountsQueryKey();
 
   const sortedAccounts = useMemo(() => {
     const accounts = accountsQuery.data ?? [];
@@ -135,13 +133,19 @@ export default function AccountsPage() {
         open={createOpen}
         onOpenChange={setCreateOpen}
         onCreated={(account) => {
-          queryClient.setQueryData<KortixAccount[]>(['accounts'], (accounts) => {
+          // The reader's OWN key, not a hand-built one: writer and reader
+          // on different keys is silent — the create appears to succeed and
+          // the list never changes.
+          queryClient.setQueryData<KortixAccount[]>(accountsQueryKey, (accounts) => {
             const current = accounts ?? [];
             return current.some((item) => item.account_id === account.account_id)
               ? current.map((item) => (item.account_id === account.account_id ? account : item))
               : [account, ...current];
           });
-          void queryClient.invalidateQueries({ queryKey: ['accounts'] });
+          // `scope()`, not `list(userId)`: this is the "the account list
+          // changed" prefix, and it provably reaches the only slot that can
+          // be live without a callback having to re-derive whose slot it is.
+          void queryClient.invalidateQueries({ queryKey: qk.accounts.scope() });
           setSelectedAccountId(account.account_id);
           // qk.projects.scope(): reaches every account's list (and the
           // accountless slot), the same reach the old bare projects-literal

--- a/apps/web/src/app/(app)/accounts/page.tsx
+++ b/apps/web/src/app/(app)/accounts/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EntityAvatar } from '@/components/ui/entity-avatar';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { CreateAccountModal } from '@/features/accounts/create-account-modal';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
@@ -22,7 +23,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
 
 export default function AccountsPage() {
@@ -39,9 +40,7 @@ export default function AccountsPage() {
   // this only avoids showing an affordance a non-admin can't use.
   const canCreateAccount = !isAccountCreationRestricted() || Boolean(adminRole?.isAdmin);
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   const accountsQuery = useQuery({
     queryKey: ['accounts'],

--- a/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
+++ b/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
@@ -34,6 +34,26 @@ describe('/projects/start does not bounce to /projects', () => {
 });
 
 /**
+ * `StartSignOutButton`'s executable text, comments stripped.
+ *
+ * The doc comment above the component legitimately names the old mechanism, so
+ * matching against raw source here would let an assertion pass on prose that
+ * never runs. Both anchors are checked, so a rename fails this instead of
+ * quietly producing an empty slice.
+ */
+function signOutButton(): string {
+  const start = source.indexOf('function StartSignOutButton()');
+  const end = source.indexOf('function ProjectStartError(');
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  return source
+    .slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/**
  * The terminal and error states render with zero app chrome, so without an
  * explicit control a user parked there could not sign out and try another
  * account — the page was a dead end. Both stuck branches must mount the
@@ -46,8 +66,23 @@ describe('/projects/start stuck states offer a sign-out escape hatch', () => {
     expect(mounts).toBe(2);
   });
 
-  test('the escape hatch signs out through the provider (which resets client state)', () => {
-    expect(source).toContain('await signOut();');
-    expect(source).toContain("router.replace('/auth')");
+  test('the escape hatch signs out through the one shared sign-out', () => {
+    // `performSignOut` owns the whole sequence — read the `{ error }`, retry
+    // locally, clear the bounce cookie, reset every client cache, then leave.
+    // The button contributes only the press.
+    expect(signOutButton()).toContain('void performSignOut();');
+  });
+
+  test('the escape hatch leaves on a DOCUMENT load, never a soft navigation', () => {
+    // It used to be `await signOut()` followed by a soft replace to /auth. A
+    // soft navigation keeps the App Router route cache, the segment cache and
+    // bfcache across an identity change, and `resetClientState()` reaches none
+    // of the three. `performSignOut` ends on `window.location.assign` — see
+    // `lib/auth/sign-out-navigation.test.ts` for the enumerated proof.
+    const button = signOutButton();
+    expect(button).not.toContain('router.replace');
+    expect(button).not.toContain('router.push');
+    // The warm-up went with it: a document load never reads the segment cache.
+    expect(button).not.toContain('router.prefetch');
   });
 });

--- a/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
+++ b/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
@@ -63,20 +63,31 @@ function signOutButton(): string {
 /**
  * JAY: symptom 5. `isAutoProjectSuppressed()` used to be called with no
  * argument — a process-wide flag with no owner. It now takes an account id
- * and this route must never call it with a bare, unbound check: the
- * suppression must be evaluated against the accounts this signed-in session
- * actually owns, never against a persisted (and possibly stale) single
- * selection.
+ * and this route must never call it with a bare, unbound check.
+ *
+ * Review round 1 found the FIRST fix here (`accounts.some((account) =>
+ * isAutoProjectSuppressed(account.account_id))`) too broad: it suppressed
+ * auto-create on ANY account the caller owns if ANY of them had a live flag,
+ * while `resolveLandingDestination` only ever gates creation for ONE primary
+ * candidate account. The scoping now lives THERE
+ * (`resolve-landing-destination.ts` — see its own tests for the behavioral
+ * proof), and this route just passes `isAutoProjectSuppressed` straight
+ * through as a per-account predicate.
  */
 describe('/projects/start binds the suppression check to real accounts', () => {
   test('never calls isAutoProjectSuppressed() with zero arguments', () => {
     expect(source).not.toContain('isAutoProjectSuppressed()');
   });
 
-  test('the suppressed flag is derived from the fetched account list', () => {
-    expect(source).toContain(
-      'accounts.some((account) => isAutoProjectSuppressed(account.account_id))',
-    );
+  test('passes isAutoProjectSuppressed straight through, not pre-reduced to a single boolean here', () => {
+    expect(source).toContain('isAccountSuppressed: isAutoProjectSuppressed,');
+    // The bug this guards against: computing `.some(...)` over every account
+    // the caller owns HERE would let a flag on one account suppress creation
+    // on an unrelated one owned by the same user. Scoping to the actual
+    // primary candidate is resolveLandingDestination's job now, not this
+    // route's — so this route must never itself reduce the check to a
+    // single account-agnostic boolean.
+    expect(source).not.toContain('accounts.some((account) => isAutoProjectSuppressed');
   });
 });
 

--- a/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
+++ b/apps/web/src/app/(app)/projects/start/landing-loop-contract.test.ts
@@ -60,6 +60,26 @@ function signOutButton(): string {
  * escape hatch; the transient skeleton must not (it is a loading frame, not
  * a destination).
  */
+/**
+ * JAY: symptom 5. `isAutoProjectSuppressed()` used to be called with no
+ * argument — a process-wide flag with no owner. It now takes an account id
+ * and this route must never call it with a bare, unbound check: the
+ * suppression must be evaluated against the accounts this signed-in session
+ * actually owns, never against a persisted (and possibly stale) single
+ * selection.
+ */
+describe('/projects/start binds the suppression check to real accounts', () => {
+  test('never calls isAutoProjectSuppressed() with zero arguments', () => {
+    expect(source).not.toContain('isAutoProjectSuppressed()');
+  });
+
+  test('the suppressed flag is derived from the fetched account list', () => {
+    expect(source).toContain(
+      'accounts.some((account) => isAutoProjectSuppressed(account.account_id))',
+    );
+  });
+});
+
 describe('/projects/start stuck states offer a sign-out escape hatch', () => {
   test('terminal AND error branches mount StartSignOutButton', () => {
     const mounts = source.split('<StartSignOutButton />').length - 1;

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -99,7 +99,12 @@ export default function ProjectStartPage() {
     resolving.current = true;
     attempts.current += 1;
 
-    const suppressed = isAutoProjectSuppressed();
+    // Bound per-account (ensure-first-project.ts): a flag left over from a
+    // DIFFERENT account (a sign-out path that skipped the client-state sweep)
+    // must never suppress provisioning here. Checked against every account
+    // this SIGNED-IN session actually owns — never against a persisted
+    // selection, which can itself be stale left over from a previous account.
+    const suppressed = accounts.some((account) => isAutoProjectSuppressed(account.account_id));
 
     try {
       // Every membership is a candidate, not just the remembered/first one: a

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -5,6 +5,7 @@ import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/features/providers/auth-provider';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
+import { isSigningOut } from '@/lib/auth/sign-out-sequence';
 import { SignOutIcon } from '@phosphor-icons/react';
 import {
   clearAutoProjectSuppression,
@@ -68,7 +69,13 @@ export default function ProjectStartPage() {
     null,
   );
 
+  // `isSigningOut()` first: `StartSignOutButton` below is rendered by this same
+  // page, and `performSignOut` fires `SIGNED_OUT` before its document load
+  // starts. Without this the guard wins that race and the user reaches `/auth`
+  // by SOFT navigation, carrying the App Router route cache across the identity
+  // change — the defect the hard navigation exists to remove.
   useEffect(() => {
+    if (isSigningOut()) return;
     if (!authLoading && !user) router.replace('/auth');
   }, [authLoading, user, router]);
 

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -15,9 +15,8 @@ import {
 } from '@/lib/onboarding/ensure-first-project';
 import { readLastProjectId, writeLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import { resolveLandingDestination } from '@/lib/onboarding/resolve-landing-destination';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts } from '@kortix/sdk';
-import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -83,13 +82,10 @@ export default function ProjectStartPage() {
     if (terminal === 'suppressed') clearAutoProjectSuppression();
   }, [terminal]);
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    enabled: !!user,
-    staleTime: 60_000,
-    retry: 3,
-  });
+  // `retry: 3` is this reader's own budget, kept verbatim: the landing
+  // destination is resolved FROM this list, so one transient failure here
+  // strands the user on a spinner with nowhere to go.
+  const accountsQuery = useAccountsList({ retry: 3 });
 
   const resolve = useCallback(async () => {
     if (resolving.current) return;
@@ -99,23 +95,30 @@ export default function ProjectStartPage() {
     resolving.current = true;
     attempts.current += 1;
 
-    // Bound per-account (ensure-first-project.ts): a flag left over from a
-    // DIFFERENT account (a sign-out path that skipped the client-state sweep)
-    // must never suppress provisioning here. Checked against every account
-    // this SIGNED-IN session actually owns — never against a persisted
-    // selection, which can itself be stale left over from a previous account.
-    const suppressed = accounts.some((account) => isAutoProjectSuppressed(account.account_id));
-
     try {
       // Every membership is a candidate, not just the remembered/first one: a
       // stale persisted selection (a team where the user is a plain member
       // with zero grants) used to end here as a false "No workspace yet"
       // while the personal account, in the same list, held their projects.
+      //
+      // `isAccountSuppressed` is passed straight through, NOT pre-reduced to
+      // a single boolean here: suppression is bound per-account
+      // (ensure-first-project.ts), and this resolver only ever evaluates
+      // auto-create for ONE primary candidate account
+      // (resolve-landing-destination.ts). Computing `.some(...)` over every
+      // account the user owns — the earlier version of this fix — let a flag
+      // set on account A suppress creation on an unrelated account B owned
+      // by the same user, which is the same cross-account leak this task
+      // exists to close, just at a narrower scope. `isAutoProjectSuppressed`
+      // itself is still identity-safe on its own: never against a persisted
+      // `selectedAccountId`, which can be stale left over from a previous
+      // account — the resolver applies it only to the account IT resolves
+      // as primary from the freshly-fetched, server-verified `accounts` list.
       const resolution = await resolveLandingDestination({
         accounts,
         selectedAccountId,
         preferredProjectId: readLastProjectId(user?.id),
-        suppressed,
+        isAccountSuppressed: isAutoProjectSuppressed,
         mayCreate: navigationMayCreateProject(),
       });
 
@@ -135,7 +138,7 @@ export default function ProjectStartPage() {
       // project, or the rare cross-site-navigation edge. `/projects` is a
       // redirect back to THIS route (Task 21), so bouncing there would loop
       // forever — render the terminal state inline instead.
-      setTerminal(classifyLandingTerminal({ canCreate: resolution.canCreate, suppressed }));
+      setTerminal(classifyLandingTerminal({ canCreate: resolution.canCreate, suppressed: resolution.suppressed }));
     } catch (err) {
       // A concurrent, healthy provision — this account's OTHER tab or entry
       // point is mid-create with the same persisted idempotency key — is not

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/features/providers/auth-provider';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { SignOutIcon } from '@phosphor-icons/react';
 import {
   clearAutoProjectSuppression,
@@ -204,22 +205,16 @@ export default function ProjectStartPage() {
 /**
  * Both stuck states on this route (terminal and error) used to be dead ends:
  * no app chrome renders here, so a user parked on "No workspace yet" had no
- * way to sign out and try another account. `signOut` (auth-provider) already
- * clears every piece of persisted client state — including the stale account
- * selection that used to cause the false terminal.
+ * way to sign out and try another account. `performSignOut` clears every piece
+ * of persisted client state — including the stale account selection that used
+ * to cause the false terminal — and then leaves on a document load.
  *
  * Deliberately OUTSIDE `ProjectStartEmpty`: the no-permission case pins "no
  * <a>/<button> in the empty surface" (landing-terminal.test.tsx), and that
  * contract is about create controls that would 403 — not about this exit.
  */
 function StartSignOutButton() {
-  const router = useRouter();
-  const { signOut } = useAuth();
   const [pending, setPending] = useState(false);
-
-  useEffect(() => {
-    router.prefetch('/auth');
-  }, [router]);
 
   return (
     <div className="absolute top-4 right-4 sm:top-6 sm:right-6">
@@ -228,13 +223,14 @@ function StartSignOutButton() {
         size="sm"
         className="gap-1.5 rounded-full"
         disabled={pending}
-        onClick={async () => {
+        onClick={() => {
           setPending(true);
-          await signOut();
-          // nav-contract: prefetch-only — the navigation must follow `signOut`,
-          // so an anchor would race the sign-out it is meant to complete. The
-          // effect above warms `/auth`.
-          router.replace('/auth');
+          // `performSignOut` owns the navigation and ends it on a DOCUMENT
+          // load, so there is nothing to prefetch and nothing to push: a soft
+          // transition would carry this account's route cache into the next
+          // one's session. `pending` is never cleared because the document is
+          // replaced, not re-rendered.
+          void performSignOut();
         }}
       >
         {pending ? (

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -72,12 +72,14 @@ export default function ProjectStartPage() {
 
   // The guard has done its one job the moment this surface renders: the user
   // has now been TOLD their last workspace is gone and offered a way back
-  // (below). Leaving the flag set past this point would silently block
-  // auto-provision for the next account this tab visits that happens to be
-  // empty too — it's a single process-wide sessionStorage key, not scoped to
-  // the account that triggered it. Session-scoped by design (see
-  // ensure-first-project.ts): a later sign-in or a fresh tab still
-  // auto-provisions normally, clear or not.
+  // (below). `isAutoProjectSuppressed` binds the flag to `{accountId, at}`
+  // (`ensure-first-project.ts`), so a stale flag can no longer suppress
+  // auto-provision for a DIFFERENT account — but nothing un-suppresses THIS
+  // account's own retries without this clear: leaving it set would keep
+  // showing this SAME account the "suppressed" terminal on every later visit
+  // to this tab, past the one deliberate delete it was recorded for. Session-
+  // scoped by design (see ensure-first-project.ts): a later sign-in or a
+  // fresh tab still auto-provisions normally, clear or not.
   useEffect(() => {
     if (terminal === 'suppressed') clearAutoProjectSuppression();
   }, [terminal]);

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -3,9 +3,9 @@
 import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { useAuth } from '@/features/providers/auth-provider';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
-import { isSigningOut } from '@/lib/auth/sign-out-sequence';
 import { SignOutIcon } from '@phosphor-icons/react';
 import {
   clearAutoProjectSuppression,
@@ -69,15 +69,7 @@ export default function ProjectStartPage() {
     null,
   );
 
-  // `isSigningOut()` first: `StartSignOutButton` below is rendered by this same
-  // page, and `performSignOut` fires `SIGNED_OUT` before its document load
-  // starts. Without this the guard wins that race and the user reaches `/auth`
-  // by SOFT navigation, carrying the App Router route cache across the identity
-  // change — the defect the hard navigation exists to remove.
-  useEffect(() => {
-    if (isSigningOut()) return;
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   // The guard has done its one job the moment this surface renders: the user
   // has now been TOLD their last workspace is gone and offered a way back

--- a/apps/web/src/app/(auth)/auth/actions.ts
+++ b/apps/web/src/app/(auth)/auth/actions.ts
@@ -2,6 +2,7 @@
 
 import { accountHasAppAccess } from '@/lib/auth/account-access';
 import { buildMobileSessionHandoffUrl } from '@/lib/auth/mobile-handoff';
+import { clearAuthBounceCookie } from '@/lib/auth/sign-out-actions';
 import {
   isInviteReturnUrl,
   resolveNewAccountReturnUrl,
@@ -19,16 +20,10 @@ import { createClient } from '@/lib/supabase/server';
 import {
   checkAccessEmail,
   fetchAccountStateWithToken,
-  recordPlatformLogout,
   submitAccessRequest,
 } from '@kortix/sdk';
-import {
-  AUTH_BOUNCE_COOKIE,
-  LAST_PROJECT_COOKIE,
-  parseAuthBounceOwner,
-} from '@/lib/onboarding/landing-destination';
+import { AUTH_BOUNCE_COOKIE, parseAuthBounceOwner } from '@/lib/onboarding/landing-destination';
 import { cookies, headers } from 'next/headers';
-import { redirect } from 'next/navigation';
 
 /**
  * Who the middleware bounced to `/auth` on this browser, or `''` when the
@@ -37,17 +32,6 @@ import { redirect } from 'next/navigation';
  */
 async function readBouncedOwnerId(): Promise<string> {
   return parseAuthBounceOwner((await cookies()).get(AUTH_BOUNCE_COOKIE)?.value);
-}
-
-/**
- * The bounce is spent the moment authentication resolves a destination. Leaving
- * it behind would let one sign-in's attribution demote the NEXT one, and it has
- * to be cleared on every successful path — password, OTP and signup all return
- * a destination to the client without ever touching `/auth/callback`, so the
- * clear beside that route's `ACTIVE_INSTANCE_COOKIE` reaches none of them.
- */
-async function clearAuthBounce(): Promise<void> {
-  (await cookies()).delete(AUTH_BOUNCE_COOKIE);
 }
 
 function normalizeTrustedOrigin(value?: string | null): string | null {
@@ -382,7 +366,7 @@ export async function signInWithPassword(prevState: any, formData: FormData) {
   })
     ? resolveNewAccountReturnUrl(returnUrl)
     : returnUrl;
-  await clearAuthBounce();
+  await clearAuthBounceCookie();
   const redirectUrl = new URL(finalReturnUrl, 'http://localhost');
   redirectUrl.searchParams.set('auth_event', authEvent);
   redirectUrl.searchParams.set('auth_method', 'email');
@@ -520,7 +504,7 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   })
     ? newAccountReturnUrl
     : requestedReturnUrl;
-  await clearAuthBounce();
+  await clearAuthBounceCookie();
 
   return {
     success: true,
@@ -536,44 +520,17 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   };
 }
 
-export async function signOut() {
-  const supabase = await createClient();
-
-  // Tell our backend first so it can audit the logout + mark the
-  // session revoked in account_session_activity. The Supabase token
-  // is still valid here; the call falls through cleanly if BACKEND_URL
-  // isn't configured. We DON'T fail the signOut on backend errors —
-  // the user should always be able to sign out client-side.
-  try {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    if (session?.access_token) {
-      const backendUrl = getServerPublicEnv().BACKEND_URL || 'http://localhost:8008/v1';
-      await recordPlatformLogout({
-        backendUrl,
-        accessToken: session.access_token,
-        signal: AbortSignal.timeout(3_000),
-      });
-    }
-  } catch {
-    /* swallow — backend logout is best-effort for audit; client
-       signOut() below is the authoritative session end */
-  }
-
-  const { error } = await supabase.auth.signOut();
-
-  if (error) {
-    return { message: error.message || 'Could not sign out' };
-  }
-
-  // Forget the remembered project. Ownership binding already stops the next
-  // account from following it, but leaving one user's project id sitting in a
-  // shared browser after they sign out is needless.
-  (await cookies()).delete(LAST_PROJECT_COOKIE);
-
-  return redirect('/');
-}
+// `signOut()` used to live here. It moved to `lib/auth/sign-out-actions.ts` as
+// `finalizeServerSignOut()`, which every logout control now reaches through
+// `performSignOut()`. Two behaviours changed on the way, both deliberate:
+//
+//  - the server-side revoke + audit ran on ONE of six controls; it runs on all
+//    six now;
+//  - it no longer deletes `kortix_last_project`. That cookie is owner-bound, so
+//    the next account cannot follow it, and the middleware reads its owner half
+//    to attribute a bounce once identity resolution has returned `user: null` —
+//    which is what happens after a logout. Deleting it un-attributed every
+//    post-logout bounce.
 
 export async function verifyOtp(prevState: any, formData: FormData) {
   const email = formData.get('email') as string;
@@ -623,7 +580,7 @@ export async function verifyOtp(prevState: any, formData: FormData) {
   })
     ? resolveNewAccountReturnUrl(returnUrl)
     : returnUrl;
-  await clearAuthBounce();
+  await clearAuthBounceCookie();
 
   // Invited users (returnUrl → /invites/:id) must land on the accept/decline
   // dialog verbatim — skip the billing-aware landing (account page or a freshly

--- a/apps/web/src/app/(auth)/auth/actions.ts
+++ b/apps/web/src/app/(auth)/auth/actions.ts
@@ -6,6 +6,7 @@ import {
   isInviteReturnUrl,
   resolveNewAccountReturnUrl,
   sanitizeAuthReturnUrl,
+  shouldDemoteReturnUrl,
 } from '@/lib/auth/return-url';
 import {
   type EmailFlowMode,
@@ -21,9 +22,33 @@ import {
   recordPlatformLogout,
   submitAccessRequest,
 } from '@kortix/sdk';
-import { LAST_PROJECT_COOKIE } from '@/lib/onboarding/landing-destination';
+import {
+  AUTH_BOUNCE_COOKIE,
+  LAST_PROJECT_COOKIE,
+  parseAuthBounceOwner,
+} from '@/lib/onboarding/landing-destination';
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
+
+/**
+ * Who the middleware bounced to `/auth` on this browser, or `''` when the
+ * bounce was unattributed (or there was no bounce at all — a visitor who typed
+ * the address, or a link opened on a different device).
+ */
+async function readBouncedOwnerId(): Promise<string> {
+  return parseAuthBounceOwner((await cookies()).get(AUTH_BOUNCE_COOKIE)?.value);
+}
+
+/**
+ * The bounce is spent the moment authentication resolves a destination. Leaving
+ * it behind would let one sign-in's attribution demote the NEXT one, and it has
+ * to be cleared on every successful path — password, OTP and signup all return
+ * a destination to the client without ever touching `/auth/callback`, so the
+ * clear beside that route's `ACTIVE_INSTANCE_COOKIE` reaches none of them.
+ */
+async function clearAuthBounce(): Promise<void> {
+  (await cookies()).delete(AUTH_BOUNCE_COOKIE);
+}
 
 function normalizeTrustedOrigin(value?: string | null): string | null {
   if (!value) return null;
@@ -162,14 +187,27 @@ export async function sendEmailCode(prevState: any, formData: FormData) {
     return { code: 'sso_required', message: SSO_REQUIRED_MESSAGE };
   }
 
-  // `flowMode === 'signup'` means the API just confirmed this address has no
-  // account, so resolve the return URL against the signup rule HERE — before it
-  // is baked into the email link. That link can be opened minutes or days
-  // later, long after the "created in the last 60s?" heuristic the callback
-  // uses stops being true, and a stale link is precisely how a fresh account
-  // ends up staring at a stranger's "Request access" page.
-  const returnUrl =
-    flowMode === 'signup' ? resolveNewAccountReturnUrl(requestedReturnUrl) : requestedReturnUrl;
+  // Resolve the return URL HERE — before it is baked into the email link. That
+  // link can be opened minutes or days later, on a device that never held the
+  // bounced session, so this is the LAST point at which either rule can still
+  // reach it:
+  //  - `flowMode === 'signup'` means the API just confirmed this address has no
+  //    account. The link outlives the callback's "created in the last 60s?"
+  //    heuristic, and a stale link is precisely how a fresh account ends up
+  //    staring at a stranger's "Request access" page.
+  //  - an ATTRIBUTED bounce cannot be matched against a signer here, because no
+  //    identity exists yet — the address has not been proven. Fail closed: a
+  //    path bounced from a named session does not get minted into an email.
+  //    Nothing is lost in the common case; the same-browser code-entry path
+  //    (`verifyOtp`) still carries the full return URL from the form, and it
+  //    CAN compare identities.
+  const returnUrl = shouldDemoteReturnUrl({
+    bouncedOwnerId: await readBouncedOwnerId(),
+    signedInUserId: null,
+    isNewUser: flowMode === 'signup',
+  })
+    ? resolveNewAccountReturnUrl(requestedReturnUrl)
+    : requestedReturnUrl;
 
   const supabase = await createClient();
   const emailRedirectTo = emailRedirectUrl({
@@ -334,8 +372,17 @@ export async function signInWithPassword(prevState: any, formData: FormData) {
   // Return success — let the client redirect after auth state hydrates. An
   // account this young signed up moments ago (the sign-up form ends in a
   // password sign-in), so it gets the signup destination rule, not a return URL
-  // pointing at a resource that predates it.
-  const finalReturnUrl = isNewUser ? resolveNewAccountReturnUrl(returnUrl) : returnUrl;
+  // pointing at a resource that predates it. The same rule applies when the
+  // return URL was bounced here from somebody ELSE's session — an existing
+  // account is exactly the case `isNewUser` alone never covered.
+  const finalReturnUrl = shouldDemoteReturnUrl({
+    bouncedOwnerId: await readBouncedOwnerId(),
+    signedInUserId: data.user?.id ?? null,
+    isNewUser,
+  })
+    ? resolveNewAccountReturnUrl(returnUrl)
+    : returnUrl;
+  await clearAuthBounce();
   const redirectUrl = new URL(finalReturnUrl, 'http://localhost');
   redirectUrl.searchParams.set('auth_event', authEvent);
   redirectUrl.searchParams.set('auth_method', 'email');
@@ -461,8 +508,19 @@ export async function signUpWithPassword(prevState: any, formData: FormData) {
   // could return a redirect, which blocked the sign-up form itself.
   //
   // `alreadyExists` means the address had an account and the password was
-  // right — that is a sign-IN, so the visitor's own return URL still stands.
-  const redirectTo = alreadyExists ? requestedReturnUrl : newAccountReturnUrl;
+  // right — that is a sign-IN, so the visitor's own return URL still stands…
+  // unless the path was bounced here from a DIFFERENT account's session. This
+  // form is a real sign-in door for anyone who already has an account, which is
+  // the second-paid-account case, so it needs the same identity gate the
+  // sign-in action has.
+  const redirectTo = shouldDemoteReturnUrl({
+    bouncedOwnerId: await readBouncedOwnerId(),
+    signedInUserId: signInData.user?.id ?? null,
+    isNewUser: !alreadyExists,
+  })
+    ? newAccountReturnUrl
+    : requestedReturnUrl;
+  await clearAuthBounce();
 
   return {
     success: true,
@@ -555,8 +613,17 @@ export async function verifyOtp(prevState: any, formData: FormData) {
   // `sendEmailCode` already applied this rule when the API could tell us the
   // address was new. Re-applying it here covers the case where it could not
   // (a fail-open 'unknown' flow mode), so a fresh account never rides a
-  // pre-signup return URL into a project it cannot open.
-  let finalDestination = isNewUser ? resolveNewAccountReturnUrl(returnUrl) : returnUrl;
+  // pre-signup return URL into a project it cannot open. This is also the one
+  // place the bounce owner CAN be matched against a real identity: the code was
+  // entered in the same browser that was bounced, and the account is now known.
+  let finalDestination = shouldDemoteReturnUrl({
+    bouncedOwnerId: await readBouncedOwnerId(),
+    signedInUserId: data.user?.id ?? null,
+    isNewUser,
+  })
+    ? resolveNewAccountReturnUrl(returnUrl)
+    : returnUrl;
+  await clearAuthBounce();
 
   // Invited users (returnUrl → /invites/:id) must land on the accept/decline
   // dialog verbatim — skip the billing-aware landing (account page or a freshly

--- a/apps/web/src/app/(auth)/auth/bounce-attribution.test.ts
+++ b/apps/web/src/app/(auth)/auth/bounce-attribution.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+/**
+ * The three sign-in actions must honor WHO the middleware bounced.
+ *
+ * `callback/bounce-attribution.test.ts` covers the OAuth/magic-link handler.
+ * Password and OTP sign-in never touch that route, so the same rule has to be
+ * proven on the server actions — including the LINK-MINT gate, which is the
+ * only place that can stop a poisoned path before it leaves the browser
+ * entirely inside an emailed sign-in link.
+ */
+
+const A_PROJECT = '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c';
+const USER_A = '11111111-1111-1111-1111-111111111111';
+const USER_B = '22222222-2222-2222-2222-222222222222';
+const LANDING = '/projects/start';
+
+const jar = new Map<string, string>();
+let signedInUserId = USER_B;
+let userCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+let otpEmailRedirectTo: string | null = null;
+let signUpError: { message: string; status?: number } | null = null;
+
+mock.module('next/headers', () => ({
+  cookies: async () => ({
+    get: (name: string) => (jar.has(name) ? { value: jar.get(name) } : undefined),
+    delete: (name: string) => {
+      jar.delete(name);
+    },
+  }),
+  headers: async () => new Headers(),
+}));
+
+function signedInUser() {
+  return { id: signedInUserId, created_at: userCreatedAt, user_metadata: {} };
+}
+
+mock.module('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      signInWithOtp: async (options: { options?: { emailRedirectTo?: string } }) => {
+        otpEmailRedirectTo = options.options?.emailRedirectTo ?? null;
+        return { error: null };
+      },
+      signUp: async () => ({ data: {}, error: signUpError }),
+      signInWithPassword: async () => ({
+        data: { user: signedInUser(), session: { access_token: 'tok', refresh_token: 'ref' } },
+        error: null,
+      }),
+      verifyOtp: async () => ({
+        data: { user: signedInUser(), session: { access_token: 'tok', refresh_token: 'ref' } },
+        error: null,
+      }),
+    },
+  }),
+}));
+
+// A dead BACKEND_URL, so `checkEmailFlowMode` fails open to 'unknown' — the
+// case where the API cannot say whether the address is new. That is the exact
+// state in which only bounce attribution can still tell these apart.
+mock.module('@/lib/public-env-server', () => ({
+  getServerPublicEnv: () => ({
+    APP_URL: 'https://dev.kortix.com',
+    BACKEND_URL: 'http://127.0.0.1:1/v1',
+    BILLING_ENABLED: false,
+  }),
+}));
+
+const { sendEmailCode, signInWithPassword, signUpWithPassword, verifyOtp } =
+  await import('./actions');
+const { AUTH_BOUNCE_COOKIE, serializeAuthBounce } =
+  await import('@/lib/onboarding/landing-destination');
+
+function bounce(ownerId: string | null) {
+  jar.set(AUTH_BOUNCE_COOKIE, serializeAuthBounce(ownerId, A_PROJECT));
+}
+
+function form(fields: Record<string, string>): FormData {
+  const data = new FormData();
+  for (const [key, value] of Object.entries(fields)) data.set(key, value);
+  return data;
+}
+
+beforeEach(() => {
+  jar.clear();
+  signedInUserId = USER_B;
+  userCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  otpEmailRedirectTo = null;
+  signUpError = null;
+});
+
+describe('signInWithPassword', () => {
+  async function destination(): Promise<string> {
+    const result = (await signInWithPassword(
+      null,
+      form({ email: 'b@example.com', password: 'password123', returnUrl: A_PROJECT }),
+    )) as { redirectTo?: string };
+    return result.redirectTo as string;
+  }
+
+  test('bounced as A, signed in as B → demoted to the landing door', async () => {
+    bounce(USER_A);
+
+    expect(await destination()).toStartWith(LANDING);
+  });
+
+  test('bounced as A, signed in as A → keeps the path', async () => {
+    signedInUserId = USER_A;
+    bounce(USER_A);
+
+    expect(await destination()).toStartWith(A_PROJECT);
+  });
+
+  test('an UNATTRIBUTED bounce keeps the path', async () => {
+    bounce(null);
+
+    expect(await destination()).toStartWith(A_PROJECT);
+  });
+
+  test('no bounce cookie keeps the path', async () => {
+    expect(await destination()).toStartWith(A_PROJECT);
+  });
+
+  test('the bounce is cleared — password sign-in never reaches /auth/callback', async () => {
+    bounce(USER_A);
+    await destination();
+
+    expect(jar.has(AUTH_BOUNCE_COOKIE)).toBe(false);
+  });
+});
+
+describe('verifyOtp', () => {
+  async function destination(): Promise<string> {
+    const result = (await verifyOtp(
+      null,
+      form({ email: 'b@example.com', token: '123456', returnUrl: A_PROJECT }),
+    )) as { redirectTo?: string };
+    return result.redirectTo as string;
+  }
+
+  test('bounced as A, signed in as B → demoted to the landing door', async () => {
+    bounce(USER_A);
+
+    expect(await destination()).toBe(LANDING);
+  });
+
+  test('bounced as A, signed in as A → keeps the path', async () => {
+    // The code was typed in the same browser that was bounced, so the full deep
+    // link survives even though the emailed link for the same request would not.
+    signedInUserId = USER_A;
+    bounce(USER_A);
+
+    expect(await destination()).toBe(A_PROJECT);
+  });
+
+  test('an UNATTRIBUTED bounce keeps the path', async () => {
+    bounce(null);
+
+    expect(await destination()).toBe(A_PROJECT);
+  });
+
+  test('the bounce is cleared — OTP sign-in never reaches /auth/callback', async () => {
+    bounce(USER_A);
+    await destination();
+
+    expect(jar.has(AUTH_BOUNCE_COOKIE)).toBe(false);
+  });
+});
+
+describe('signUpWithPassword is also a sign-IN door for an existing account', () => {
+  // `alreadyExists` + a correct password is a sign-in wearing the sign-up
+  // form's clothes, and it kept the raw return URL. That is the same
+  // second-paid-account case the sign-in action had, spelled differently, so it
+  // needs the same gate.
+  async function destination(): Promise<string> {
+    signUpError = { message: 'User already registered', status: 422 };
+    const result = (await signUpWithPassword(
+      null,
+      form({
+        email: 'b@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        returnUrl: A_PROJECT,
+      }),
+    )) as { redirectTo?: string };
+    return result.redirectTo as string;
+  }
+
+  test('bounced as A, signed in as B → demoted to the landing door', async () => {
+    bounce(USER_A);
+
+    expect(await destination()).toBe(LANDING);
+  });
+
+  test('bounced as A, signed in as A → keeps the path', async () => {
+    signedInUserId = USER_A;
+    bounce(USER_A);
+
+    expect(await destination()).toBe(A_PROJECT);
+  });
+
+  test('an UNATTRIBUTED bounce keeps the path', async () => {
+    bounce(null);
+
+    expect(await destination()).toBe(A_PROJECT);
+  });
+
+  test('a real signup is demoted whatever the bounce says', async () => {
+    signUpError = null;
+    const result = (await signUpWithPassword(
+      null,
+      form({
+        email: 'new@example.com',
+        password: 'password123',
+        confirmPassword: 'password123',
+        returnUrl: A_PROJECT,
+      }),
+    )) as { redirectTo?: string };
+
+    expect(result.redirectTo).toBe(LANDING);
+  });
+});
+
+describe('sendEmailCode mints the link, so the gate has to run there', () => {
+  async function mintedReturnUrl(): Promise<string | null> {
+    await sendEmailCode(
+      null,
+      form({
+        email: 'b@example.com',
+        returnUrl: A_PROJECT,
+        origin: 'https://dev.kortix.com',
+      }),
+    );
+    if (!otpEmailRedirectTo) return null;
+    return new URL(otpEmailRedirectTo).searchParams.get('returnUrl');
+  }
+
+  test('an ATTRIBUTED bounce never reaches the email', async () => {
+    // The link outlives this browser: it can be opened on a phone that never
+    // held A's session, where no bounce cookie exists to catch it. There is no
+    // identity to compare against yet, so the path does not travel.
+    bounce(USER_A);
+
+    expect(await mintedReturnUrl()).toBe(LANDING);
+  });
+
+  test('an UNATTRIBUTED bounce still mints the real path', async () => {
+    bounce(null);
+
+    expect(await mintedReturnUrl()).toBe(A_PROJECT);
+  });
+
+  test('no bounce cookie still mints the real path — a shared project link', async () => {
+    expect(await mintedReturnUrl()).toBe(A_PROJECT);
+  });
+
+  test('the bounce is NOT cleared here — nobody has authenticated yet', async () => {
+    // Clearing on the way out would un-gate the code the user is about to type.
+    bounce(USER_A);
+    await mintedReturnUrl();
+
+    expect(jar.has(AUTH_BOUNCE_COOKIE)).toBe(true);
+  });
+});

--- a/apps/web/src/app/(auth)/auth/callback/bounce-attribution.test.ts
+++ b/apps/web/src/app/(auth)/auth/callback/bounce-attribution.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+/**
+ * An existing account must not inherit somebody else's bounce.
+ *
+ * Live report: A's session ends on `/projects/<A>`; anything returns the
+ * browser there logged out (Back, a bookmark, a second tab), so middleware
+ * writes `/auth?redirect=/projects/<A>`. B signs in on that screen and lands on
+ * A's "Request access" page — B is an EXISTING user, which is precisely the
+ * population the signup-only guard excludes, and the project shell's 403
+ * self-heal is ownership-scoped so it parks B there instead of bouncing home.
+ *
+ * `bounce-attribution.test.ts` (lib/auth) proves the decision. This proves the
+ * callback actually makes it, on the real route handler — the same reason
+ * `signup-destination.test.ts` exists beside it.
+ */
+
+const A_PROJECT = '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c';
+const USER_A = '11111111-1111-1111-1111-111111111111';
+const USER_B = '22222222-2222-2222-2222-222222222222';
+
+let signedInUserId = USER_B;
+let userCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+mock.module('@/lib/supabase/server', () => ({
+  createClient: async () => ({
+    auth: {
+      exchangeCodeForSession: async () => ({
+        data: {
+          user: {
+            id: signedInUserId,
+            created_at: userCreatedAt,
+            app_metadata: { provider: 'google' },
+            user_metadata: {},
+          },
+        },
+        error: null,
+      }),
+      getSession: async () => ({ data: { session: { access_token: 'tok' } } }),
+      updateUser: async () => ({ data: {}, error: null }),
+    },
+  }),
+}));
+
+mock.module('@/lib/public-env-server', () => ({
+  getServerPublicEnv: () => ({
+    APP_URL: 'https://dev.kortix.com',
+    BACKEND_URL: '',
+    BILLING_ENABLED: false,
+  }),
+}));
+
+const { GET } = await import('./route');
+const { AUTH_BOUNCE_COOKIE, PROJECT_LANDING_PATH, serializeAuthBounce } =
+  await import('@/lib/onboarding/landing-destination');
+
+/** A magic-link/OAuth callback carrying whatever bounce cookie the browser holds. */
+function callbackRequest(returnUrl: string, bounceCookie?: string) {
+  const url = new URL('https://dev.kortix.com/auth/callback');
+  url.searchParams.set('code', 'auth-code');
+  url.searchParams.set('returnUrl', returnUrl);
+  return {
+    url: url.toString(),
+    nextUrl: url,
+    cookies: {
+      get: (name: string) =>
+        name === AUTH_BOUNCE_COOKIE && bounceCookie !== undefined
+          ? { value: bounceCookie }
+          : undefined,
+    },
+  } as never;
+}
+
+async function destinationFor(returnUrl: string, bounceCookie?: string): Promise<string> {
+  const response = await GET(callbackRequest(returnUrl, bounceCookie));
+  const location = new URL(response.headers.get('location') as string);
+  return `${location.pathname}${location.search}`;
+}
+
+describe('auth callback honors who was bounced', () => {
+  beforeEach(() => {
+    signedInUserId = USER_B;
+    // An hour old: an EXISTING account, so no signup rule is in play. The bug
+    // lives entirely in this case.
+    userCreatedAt = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  });
+
+  test('bounced as A, signed in as B → demoted to the landing door', async () => {
+    const destination = await destinationFor(A_PROJECT, serializeAuthBounce(USER_A, A_PROJECT));
+
+    expect(destination.startsWith(PROJECT_LANDING_PATH)).toBe(true);
+    expect(destination).not.toContain('319395c1-9c3f-41b4-ac6c-9539a12dbb7c');
+    // Still a login for analytics — this is a destination rule, not an identity
+    // downgrade.
+    expect(destination).toContain('auth_event=login');
+  });
+
+  test('bounced as A, signed in as A → keeps the path', async () => {
+    signedInUserId = USER_A;
+
+    const destination = await destinationFor(A_PROJECT, serializeAuthBounce(USER_A, A_PROJECT));
+
+    expect(destination).toStartWith(A_PROJECT);
+  });
+
+  test('an UNATTRIBUTED bounce keeps the path', async () => {
+    // Middleware could not name an owner (the self-heal had already dropped the
+    // session, and nothing remembered a project). Treating unknown as foreign
+    // would demote every one of these — including the user's own return.
+    const destination = await destinationFor(A_PROJECT, serializeAuthBounce(null, A_PROJECT));
+
+    expect(destination).toStartWith(A_PROJECT);
+  });
+
+  test('no bounce cookie at all keeps the path — a pasted or bookmarked link', async () => {
+    expect(await destinationFor(A_PROJECT)).toStartWith(A_PROJECT);
+  });
+
+  test('a bounce cookie whose owner is not a user id attributes nobody', async () => {
+    expect(await destinationFor(A_PROJECT, 'not-a-user:%2Fx')).toStartWith(A_PROJECT);
+  });
+
+  test('the bounce is cleared on the way out, so it cannot demote the next sign-in', async () => {
+    const response = await GET(callbackRequest(A_PROJECT, serializeAuthBounce(USER_A, A_PROJECT)));
+    const cleared = response.headers
+      .getSetCookie()
+      .find((value: string) => value.startsWith(`${AUTH_BOUNCE_COOKIE}=`));
+
+    expect(cleared).toBeDefined();
+    expect(cleared).toContain('Max-Age=0');
+  });
+
+  test('a signup is still demoted regardless of attribution', async () => {
+    userCreatedAt = new Date().toISOString();
+
+    expect(await destinationFor(A_PROJECT)).toStartWith(PROJECT_LANDING_PATH);
+  });
+});

--- a/apps/web/src/app/(auth)/auth/callback/route.ts
+++ b/apps/web/src/app/(auth)/auth/callback/route.ts
@@ -5,12 +5,15 @@ import {
   resolveAuthRedirectBaseUrl,
   resolveNewAccountReturnUrl,
   sanitizeAuthReturnUrl,
+  shouldDemoteReturnUrl,
 } from '@/lib/auth/return-url';
 import {
+  AUTH_BOUNCE_COOKIE,
   LAST_PROJECT_COOKIE,
   POST_AUTH_INTENT_COOKIE,
   POST_AUTH_INTENT_MAX_AGE,
   PROJECT_LANDING_PATH,
+  parseAuthBounceOwner,
   parseLastProjectForUser,
   projectPathFromId,
 } from '@/lib/onboarding/landing-destination';
@@ -181,7 +184,21 @@ export async function GET(request: NextRequest) {
         // created, so this is where a provider signup gets the rule the
         // email flows already applied when they minted their link: a return
         // URL the new account cannot own does not survive the signup.
-        if (isNewUser) finalDestination = resolveNewAccountReturnUrl(next);
+        //
+        // The same rule covers an EXISTING account that signed in on a screen
+        // the middleware bounced here for somebody else — an IdP hop keeps the
+        // browser, so the bounce cookie is still readable and the account is
+        // now known. No cookie, or one with no owner, means the bounce was
+        // unattributed and the return URL stands.
+        if (
+          shouldDemoteReturnUrl({
+            bouncedOwnerId: parseAuthBounceOwner(request.cookies.get(AUTH_BOUNCE_COOKIE)?.value),
+            signedInUserId: data.user.id,
+            isNewUser,
+          })
+        ) {
+          finalDestination = resolveNewAccountReturnUrl(next);
+        }
 
         const pendingReferralCode = request.cookies.get('pending-referral-code')?.value;
         if (pendingReferralCode) {
@@ -287,6 +304,10 @@ export async function GET(request: NextRequest) {
         path: '/',
         sameSite: 'lax',
       });
+
+      // The bounce is spent: its attribution has been used to resolve this
+      // destination and must not survive to demote the next sign-in.
+      response.cookies.set(AUTH_BOUNCE_COOKIE, '', { maxAge: 0, path: '/' });
 
       // Clear stale legacy instance cookie so repo-first sessions do not inherit it after login.
       response.cookies.set(ACTIVE_INSTANCE_COOKIE, '', { maxAge: 0, path: '/' });

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -119,7 +119,6 @@ function AuthCardForm({
   returnUrl: string;
   mobileCallbackState: string | null;
 }) {
-  const router = useRouter();
   const prefersReducedMotion = useReducedMotion();
   const enabledMethods = useMemo(() => parseAuthMethods(getEnv().AUTH_METHODS), []);
   const magicLinkEnabled = enabledMethods.includes('magic');
@@ -237,13 +236,28 @@ function AuthCardForm({
       }
     }
 
-    // Client-side navigation keeps the referrer /auth itself loaded with —
+    // The referrer /auth carries is whatever /auth itself was loaded with —
     // often a search engine — so the landing door cannot read intent from it.
     // The marker is what proves "this user just signed in" to the door.
     markPostAuthIntent();
+
+    // A HARD navigation, deliberately, NOT `router.push`.
+    //
+    // `dest` is the destination the server action resolved, which is the only
+    // one that has been through the identity gate: it drops a return URL the
+    // middleware bounced here for a DIFFERENT account (see
+    // `shouldDemoteReturnUrl`). `setSession` above fires `onAuthStateChange`,
+    // which re-renders `AuthContent` with `trustedUser === true` and runs its
+    // redirect effect — `router.replace(returnUrl)` on the RAW query param,
+    // ungated. A soft push loses that race: the later `replace` supersedes it
+    // and lands this user on the previous one's project. A document navigation
+    // is already in flight by the time that effect runs and a history swap
+    // cannot supersede it.
+    //
+    // It also discards the Next client cache, which an identity change must
+    // never carry across.
     const dest = result?.redirectTo || returnUrl;
-    router.push(dest);
-    router.refresh();
+    window.location.assign(dest);
   };
 
   const buildBaseFormData = (target: string) => {

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -924,7 +924,7 @@ const STALE_SESSION_FALLBACK_MS = 2500;
 function AuthContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { user, session, isLoading, signOut } = useAuth();
+  const { supabase, user, session, isLoading } = useAuth();
   const returnUrl = sanitizeAuthReturnUrl(
     searchParams.get('returnUrl') || searchParams.get('redirect'),
   );
@@ -955,8 +955,16 @@ function AuthContent() {
     if (user && sessionExpired) {
       // Dead session, proven locally — clear it now and fall through to the
       // real form on this same render pass rather than the placeholder.
+      //
+      // NOT `performSignOut()`, which every logout CONTROL goes through. This
+      // is session repair, not a logout: the user is already on `/auth`, and
+      // the document navigation a logout performs would reload this page
+      // without its `redirect`/`returnUrl` query — discarding the destination
+      // the middleware bounce carried here. `scope: 'local'` is the whole job,
+      // because the session is already dead server-side and there is nothing
+      // left to revoke.
       setForceForm(true);
-      void signOut();
+      void supabase.auth.signOut({ scope: 'local' });
       return;
     }
 
@@ -990,7 +998,7 @@ function AuthContent() {
     router,
     session,
     sessionExpired,
-    signOut,
+    supabase,
     trustedUser,
     user,
   ]);

--- a/apps/web/src/app/(auth)/auth/phone-verification/page.tsx
+++ b/apps/web/src/app/(auth)/auth/phone-verification/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { signOut } from '@/app/(auth)/auth/actions';
 import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { errorToast } from '@/components/ui/toast';
@@ -15,12 +14,12 @@ import {
   useUnenrollFactor,
   useVerifyChallenge,
 } from '@/hooks/auth';
-import { clearUserLocalStorage } from '@/lib/utils/clear-local-storage';
 import { SignOutIcon as LogOut } from '@phosphor-icons/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { useAppHome } from '@/lib/onboarding/use-app-home';
 
 export default function PhoneVerificationPage() {
@@ -189,13 +188,18 @@ export default function PhoneVerificationPage() {
   };
 
   const signOutMutation = useMutation({
-    mutationFn: async () => {
-      // Clear local storage before sign out
-      clearUserLocalStorage();
-      await signOut().catch(() => void 0);
-      // eslint-disable-next-line @next/next/no-location-assign-relative-destination -- Sign-out: the document load is the point, it drops every in-memory cache and provider.
-      window.location.href = '/';
-    },
+    // `performSignOut`, not the `signOut` SERVER ACTION this used to call.
+    // The action swallowed its own failure (`.catch(() => void 0)`), cleared
+    // only `localStorage` — leaving the React Query cache, the persisted
+    // account selection and the IDB session cache behind — and landed on `/`
+    // instead of `/auth`.
+    //
+    // Losing the action also, deliberately, stops this control deleting
+    // `kortix_last_project`. That cookie is owner-bound, and the middleware
+    // reads its owner half to attribute a bounce once identity resolution has
+    // already returned `user: null` — which is exactly what happens after a
+    // logout. Deleting it here un-attributed every post-logout bounce.
+    mutationFn: performSignOut,
   });
 
   const handleSignOut = () => {

--- a/apps/web/src/app/(auth)/auth/post-signin-navigation.test.ts
+++ b/apps/web/src/app/(auth)/auth/post-signin-navigation.test.ts
@@ -1,0 +1,109 @@
+// The destination a sign-in navigates to must be the one the SERVER resolved.
+//
+// `signInWithPassword`, `verifyOtp` and `signUpWithPassword` each run the
+// return URL through the identity gate (`shouldDemoteReturnUrl`) and hand back
+// a `redirectTo`. `AuthContent` separately holds `returnUrl` — the RAW query
+// param — and redirects to it the moment a session exists
+// (`router.replace(returnUrl)`), which `setSession()` makes true milliseconds
+// after the action returns. A soft `router.push(dest)` loses that race: the
+// later `replace` supersedes it and lands the user on the path the middleware
+// bounced here for a DIFFERENT account, neutralizing the gate on all three
+// actions. A document navigation is already in flight by then, so it wins.
+//
+// Source assertions, in this directory's convention (`sso-entry.test.ts`):
+// every anchor is asserted to exist before it is used, so a rename or a move
+// fails this test instead of silently slicing it into something that cannot
+// fail.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const rawSource = readFileSync(join(import.meta.dir, 'page.tsx'), 'utf8');
+
+/**
+ * Comments stripped. This test's own prose quotes `router.push` and
+ * `router.replace(returnUrl)`, and so does the code it guards — matching
+ * against commented-out prose would make every assertion below pass on text
+ * that never runs.
+ */
+const source = rawSource
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  // `//` only when it is not a URL scheme, so `https://…` inside a string
+  // survives intact and a navigation on that line is still visible.
+  .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+const ESTABLISH_START = 'const establishSessionAndRedirect';
+const ESTABLISH_END = 'const buildBaseFormData';
+
+function establishBody(): string {
+  const start = source.indexOf(ESTABLISH_START);
+  const end = source.indexOf(ESTABLISH_END);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+/** Every navigation in a slice, as `[mechanism, argument]` pairs. */
+function navigations(slice: string): string[][] {
+  const pattern =
+    /window\.location\.(assign|replace)\(([^)]*)\)|window\.location\.(href)\s*=\s*([^;]+);|router\.(push|replace|refresh)\(([^)]*)\)/g;
+  return [...slice.matchAll(pattern)].map((match) => [
+    match[1] ?? match[3] ?? match[5],
+    (match[2] ?? match[4] ?? match[6] ?? '').trim(),
+  ]);
+}
+
+describe('post-sign-in navigation', () => {
+  test('is a HARD navigation, so the raw-returnUrl effect cannot supersede it', () => {
+    const body = establishBody();
+
+    expect(body).toContain('window.location.assign(dest)');
+    expect(body).not.toContain('router.push');
+    expect(body).not.toContain('router.refresh');
+  });
+
+  test('every navigation on the sign-in path carries a gated value', () => {
+    // Enumerated, not spot-checked: adding `router.push(returnUrl)` — the exact
+    // regression this pins — fails here rather than slipping in beside a
+    // passing `toContain`.
+    expect(navigations(establishBody())).toEqual([
+      ['assign', 'mobileHandoffUrl'],
+      ['assign', 'dest'],
+    ]);
+  });
+
+  test('the destination is the server-resolved one, with the raw param only as a fallback', () => {
+    expect(establishBody()).toContain('const dest = result?.redirectTo || returnUrl;');
+  });
+
+  test('the post-auth intent marker is still set before leaving the page', () => {
+    // A hard navigation abandons the document. The marker is what proves "this
+    // user just signed in" to the landing door; setting it after the navigation
+    // starts would demote every signup to the projects list.
+    const body = establishBody();
+    const marker = body.indexOf('markPostAuthIntent()');
+    const leave = body.indexOf('window.location.assign(dest)');
+
+    expect(marker).toBeGreaterThan(-1);
+    expect(leave).toBeGreaterThan(marker);
+  });
+
+  test('the sign-in form holds no soft router at all', () => {
+    const start = source.indexOf('function AuthCardForm(');
+    const end = source.indexOf('function AuthContent(');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    expect(source.slice(start, end)).not.toContain('useRouter()');
+  });
+
+  test('exactly one navigation in the file still takes the raw returnUrl', () => {
+    // `AuthContent`'s already-signed-in redirect. It is a known residual: the
+    // bounce cookie is httpOnly, so this client component cannot read it to
+    // apply the same gate. Pinned at ONE so a second ungated navigation cannot
+    // appear unnoticed.
+    const raw = source.match(/router\.(?:push|replace)\(returnUrl\)/g) ?? [];
+
+    expect(raw.length).toBe(1);
+  });
+});

--- a/apps/web/src/app/(system)/api/maintenance/bypass/route.ts
+++ b/apps/web/src/app/(system)/api/maintenance/bypass/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Forbidden: admin access required' }, { status: 403 });
   }
 
-  const token = await createBypassToken();
+  const token = await createBypassToken(user.id);
   const res = NextResponse.json({ ok: true });
   res.cookies.set(MAINTENANCE_BYPASS_COOKIE, token, {
     httpOnly: true,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -373,7 +373,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
                       billing, IAM) can open it via useRequestDemo(). */}
                       {/* Organization branding (Enterprise): the active
                       account's own logo / icon / favicon / product name.
-                      Reads the shared ['accounts'] query, so it sits inside
+                      Reads the shared account-list query, so it sits inside
                       ReactQueryProvider and above everything that renders a
                       KortixLogo. */}
                       <BrandingProvider>

--- a/apps/web/src/app/logout/page.test.ts
+++ b/apps/web/src/app/logout/page.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
+import { sanitizeAuthReturnUrl } from '@/lib/auth/return-url';
+
+const WEB_SRC = resolve(import.meta.dir, '../..');
+
+/** Source with comments removed, so an assertion can never match prose. */
+function code(relPath: string): string {
+  return readFileSync(resolve(WEB_SRC, relPath), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+describe('/logout signs the user out', () => {
+  test('runs the ONE shared sign-out, not a second implementation of it', () => {
+    const page = code('app/logout/page.tsx');
+    expect(page).toContain('performSignOut()');
+    expect(page).toContain("from '@/lib/auth/perform-sign-out'");
+  });
+
+  test('does not hand-roll any part of the exit path', () => {
+    const page = code('app/logout/page.tsx');
+    // Each of these would be a second copy of something performSignOut owns:
+    // the session end, the client-state reset, and the hard navigation that
+    // discards Next's caches. A soft router push would keep them.
+    expect(page).not.toContain('supabase.auth.signOut');
+    expect(page).not.toContain('resetClientState');
+    expect(page).not.toContain('router.push');
+    expect(page).not.toContain('router.replace');
+  });
+});
+
+describe('/logout cannot become a sign-in loop', () => {
+  test('is public, so a signed-out visitor is never bounced to sign IN first', () => {
+    const middleware = code('middleware.ts');
+    const start = middleware.indexOf('const PUBLIC_ROUTES');
+    const end = middleware.indexOf('];', start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    expect(middleware.slice(start, end)).toContain("'/logout'");
+  });
+
+  test('a sign-in can never RETURN to it — behavioural, through the real resolver', () => {
+    // Without this, `?redirect=/logout` from a stale link would sign the user
+    // in and immediately sign them back out.
+    expect(sanitizeAuthReturnUrl('/logout')).toBe(PROJECT_LANDING_PATH);
+    expect(sanitizeAuthReturnUrl('/logout?from=somewhere')).toBe(PROJECT_LANDING_PATH);
+    expect(sanitizeAuthReturnUrl('/logout/anything')).toBe(PROJECT_LANDING_PATH);
+  });
+
+  test('the guard is specific — a path merely STARTING with those letters still works', () => {
+    // `/logout-survey` is a different route; the prefix match is on segment
+    // boundaries, so it must survive.
+    expect(sanitizeAuthReturnUrl('/logout-survey')).toBe('/logout-survey');
+  });
+});

--- a/apps/web/src/app/logout/page.tsx
+++ b/apps/web/src/app/logout/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import Loading from '@/components/ui/loading';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
+
+/**
+ * `/logout` — type the URL, and you are signed out.
+ *
+ * A URL people can type, bookmark, or send to someone who is stuck. It runs the
+ * SAME `performSignOut()` every in-app control runs, so it inherits the whole
+ * exit path rather than reimplementing it: the server-side session revoke, the
+ * `{ error }` read with a local retry, the auth-cookie expiry that covers a
+ * sign-out the network refused, `resetClientState()`, and the hard navigation
+ * that discards Next's route, segment and bfcache. A second logout written here
+ * would be a second thing to keep in step, and the first one to drift.
+ *
+ * Two properties this route needs that are NOT in this file, because they are
+ * decided where the request is routed rather than where it is rendered:
+ *
+ * 1. It is PUBLIC (`middleware.ts` `PUBLIC_ROUTES`). Not because logging out is
+ *    unauthenticated work, but because middleware turns any protected request
+ *    into `/auth?redirect=<path>` — so a signed-out visitor typing `/logout`
+ *    would be bounced to sign IN, and then, having signed in, be sent straight
+ *    here and signed out again. Public means an already-signed-out visitor just
+ *    lands on `/auth`, which is where they were going anyway.
+ * 2. It can never be a post-sign-in destination (`LEGACY_AUTH_RETURN_PREFIXES`
+ *    in `lib/auth/return-url.ts`). That closes the same loop from the other end:
+ *    a `?redirect=/logout` arriving from anywhere — a stale link, a crafted one —
+ *    is replaced with the landing door instead of undoing the sign-in that just
+ *    happened.
+ *
+ * No confirmation dialog. A typed URL IS the intent; the in-app controls confirm
+ * because they sit next to things you might click by accident, and a URL does
+ * not. Re-entrancy is handled inside `performSignOut` (a second call navigates
+ * rather than starting a second sequence), so React's double-invoked effect in
+ * development needs no guard here.
+ */
+export default function LogoutPage() {
+  useEffect(() => {
+    void performSignOut();
+  }, []);
+
+  return (
+    <main className="flex min-h-svh flex-col items-center justify-center gap-3">
+      <Loading className="size-5 shrink-0" />
+      <p className="text-muted-foreground text-sm" aria-live="polite">
+        Signing you out…
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/config/security-headers.test.ts
+++ b/apps/web/src/config/security-headers.test.ts
@@ -37,7 +37,13 @@ function slice(source: string, startAnchor: string, endAnchor: string): string {
 }
 
 describe('Strict-Transport-Security header', () => {
-  test('is set, with a >= 1 year max-age and includeSubDomains', () => {
+  // R18, CONTROLLER RULING (final): a >= 1 year max-age, WITHOUT
+  // `includeSubDomains`, and gated to production. `includeSubDomains` pins
+  // every `*.kortix.com` subdomain — and, from the prod apex, the whole
+  // zone — for the max-age duration, in every visitor's browser, with no
+  // server-side undo. That is a DNS-wide infra decision, not a side effect
+  // of an auth-cookie fix, so it does not belong in this diff.
+  test('is set, with a >= 1 year max-age, and WITHOUT includeSubDomains', () => {
     // Match the literal header assignment, not just the string anywhere in
     // the file (e.g. inside this test's own describe name if it were ever
     // copy-pasted back into next.config.ts).
@@ -52,7 +58,27 @@ describe('Strict-Transport-Security header', () => {
     const maxAge = Number(maxAgeMatch?.[1] ?? 0);
     expect(maxAge).toBeGreaterThanOrEqual(31_536_000); // 1 year, in seconds
 
-    expect(value).toContain('includeSubDomains');
+    expect(value).not.toContain('includeSubDomains');
+  });
+
+  // `headers()` has no per-request environment branch — an entry added here
+  // ships IDENTICALLY from local `next dev`, `dev.kortix.com`,
+  // `staging.kortix.com`, and prod. `NODE_ENV === 'production'` is the
+  // BUILD-time gate (`next build` sets it) that keeps HSTS off local dev and
+  // off any HTTP-only self-host, without touching CSP / X-Frame-Options,
+  // which stay unconditional for every environment.
+  test('is gated to production, unlike CSP / X-Frame-Options which stay unconditional', () => {
+    const block = slice(nextConfig, "source: '/:path*',", "source: '/fonts/:path*',");
+    const gateIdx = block.indexOf("process.env.NODE_ENV === 'production'");
+    expect(gateIdx).toBeGreaterThan(-1);
+    const hstsIdx = block.indexOf('Strict-Transport-Security');
+    expect(hstsIdx).toBeGreaterThan(gateIdx);
+
+    // CSP / X-Frame-Options are NOT behind that same gate — they come before
+    // it in the array, outside the conditional spread.
+    const cspIdx = block.indexOf('Content-Security-Policy');
+    expect(cspIdx).toBeGreaterThan(-1);
+    expect(cspIdx).toBeLessThan(gateIdx);
   });
 
   test('applies on the same catch-all block as the other security headers, not a narrower route', () => {

--- a/apps/web/src/config/security-headers.test.ts
+++ b/apps/web/src/config/security-headers.test.ts
@@ -61,18 +61,34 @@ describe('Strict-Transport-Security header', () => {
     expect(value).not.toContain('includeSubDomains');
   });
 
-  // `headers()` has no per-request environment branch — an entry added here
-  // ships IDENTICALLY from local `next dev`, `dev.kortix.com`,
-  // `staging.kortix.com`, and prod. `NODE_ENV === 'production'` is the
-  // BUILD-time gate (`next build` sets it) that keeps HSTS off local dev and
-  // off any HTTP-only self-host, without touching CSP / X-Frame-Options,
-  // which stay unconditional for every environment.
+  // `NODE_ENV === 'production'` is a BUILD-time gate (`next build` sets it
+  // unconditionally), not a per-environment one — it ships the header from
+  // EVERY environment built with `next build`, including `dev.kortix.com`
+  // and `staging.kortix.com`, not only prod. What it genuinely excludes is
+  // bare `next dev` and any HTTP-only self-host build. See the honest
+  // comment beside the real gate in `next.config.ts` (I4/R21) for the full
+  // reasoning; CSP / X-Frame-Options stay unconditional for every
+  // environment, gated or not.
   test('is gated to production, unlike CSP / X-Frame-Options which stay unconditional', () => {
     const block = slice(nextConfig, "source: '/:path*',", "source: '/fonts/:path*',");
     const gateIdx = block.indexOf("process.env.NODE_ENV === 'production'");
     expect(gateIdx).toBeGreaterThan(-1);
-    const hstsIdx = block.indexOf('Strict-Transport-Security');
-    expect(hstsIdx).toBeGreaterThan(gateIdx);
+
+    // CONTAINMENT, not ordering: the HSTS entry must sit INSIDE the
+    // ternary's true branch (between its `?` and the matching `: []` false
+    // branch) — not merely somewhere later in the file. A bare
+    // `hstsIdx > gateIdx` position check is satisfied by lifting the entry
+    // OUT of the ternary into the unconditional part of the array, which
+    // would ship HSTS from every environment unconditionally while still
+    // passing that check.
+    const questionIdx = block.indexOf('?', gateIdx);
+    expect(questionIdx).toBeGreaterThan(gateIdx);
+    const falseBranchMatch = block.slice(questionIdx).match(/:\s*\[\s*\]/);
+    expect(falseBranchMatch).not.toBeNull();
+    const falseBranchIdx = questionIdx + (falseBranchMatch?.index ?? 0);
+    expect(falseBranchIdx).toBeGreaterThan(questionIdx);
+    const trueBranch = block.slice(questionIdx, falseBranchIdx);
+    expect(trueBranch).toContain('Strict-Transport-Security');
 
     // CSP / X-Frame-Options are NOT behind that same gate — they come before
     // it in the array, outside the conditional spread.

--- a/apps/web/src/config/security-headers.test.ts
+++ b/apps/web/src/config/security-headers.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * JAY: Task 8. No `Strict-Transport-Security` header existed anywhere in
+ * `apps/web` — the Supabase session cookie being `Secure`-only (see
+ * `lib/supabase/client.ts` / `server.ts` / `middleware.ts`) still leaves a
+ * plaintext http:// window open before any redirect-to-HTTPS happens, on any
+ * client that has not already been told this origin is HTTPS-only. `bun
+ * test` cannot execute `next.config.ts` directly — `nextConfig()` is called
+ * eagerly at module load with real side effects (git shell-outs, filesystem
+ * copies) and is wrapped in Sentry/Better Stack/MDX/next-intl plugin
+ * machinery not meant to run outside `next build`/`next dev` — so this
+ * follows `next-output.test.ts`'s established pattern: a source assertion
+ * against the raw config text, comments stripped first (this repo's
+ * documented trap: a source match can land inside prose that never runs).
+ */
+
+const nextConfig = stripComments(
+  readFileSync(new URL('../../next.config.ts', import.meta.url), 'utf8'),
+);
+
+/** Comments stripped; `//` spared when it is a URL scheme (matches
+ *  `sign-out-navigation.test.ts`'s `stripComments`). */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+/** The executable text between two anchors, both asserted present so a
+ *  rename fails this test instead of silently matching an empty slice. */
+function slice(source: string, startAnchor: string, endAnchor: string): string {
+  const start = source.indexOf(startAnchor);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(endAnchor, start + startAnchor.length);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('Strict-Transport-Security header', () => {
+  test('is set, with a >= 1 year max-age and includeSubDomains', () => {
+    // Match the literal header assignment, not just the string anywhere in
+    // the file (e.g. inside this test's own describe name if it were ever
+    // copy-pasted back into next.config.ts).
+    const match = nextConfig.match(
+      /key:\s*'Strict-Transport-Security',\s*value:\s*'([^']+)'/,
+    );
+    expect(match).not.toBeNull();
+    const value = match?.[1] ?? '';
+
+    const maxAgeMatch = value.match(/max-age=(\d+)/);
+    expect(maxAgeMatch).not.toBeNull();
+    const maxAge = Number(maxAgeMatch?.[1] ?? 0);
+    expect(maxAge).toBeGreaterThanOrEqual(31_536_000); // 1 year, in seconds
+
+    expect(value).toContain('includeSubDomains');
+  });
+
+  test('applies on the same catch-all block as the other security headers, not a narrower route', () => {
+    // The '/:path*' headers() entry that already carries CSP / X-Frame-Options
+    // is the one every response goes through — HSTS has to live in that same
+    // block, not a route-scoped one a future edit could silently narrow.
+    const block = slice(nextConfig, "source: '/:path*',", "source: '/fonts/:path*',");
+    expect(block).toContain('Content-Security-Policy');
+    expect(block).toContain('Strict-Transport-Security');
+  });
+});

--- a/apps/web/src/features/accounts/settings/branding-tab.tsx
+++ b/apps/web/src/features/accounts/settings/branding-tab.tsx
@@ -8,7 +8,7 @@
  * variant. Every upload goes to
  * the API (`POST /accounts/:id/branding/assets/:kind`), which sniffs the bytes
  * and owns the URL — this pane never chooses where an image lives. After every
- * write the `['accounts']` query is invalidated, which is what
+ * write the account-list query is invalidated (`qk.accounts.scope()`), which is what
  * `BrandingProvider` renders from, so the header above this very pane
  * re-brands live.
  *
@@ -28,6 +28,7 @@ import {
   type AccountBrandingAssetKind,
   type AccountBrandingState,
 } from '@kortix/sdk';
+import { qk } from '@kortix/sdk/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { TrashIcon, UploadSimpleIcon } from '@phosphor-icons/react';
 import { type FormEvent, useRef, useState } from 'react';
@@ -94,10 +95,10 @@ export function BrandingTab({ accountId, canManage }: { accountId: string; canMa
   });
 
   // Every write returns the full state — seed the cache from it and let the
-  // rendering provider (`['accounts']`) refetch so the header re-brands.
+  // rendering provider (the account list) refetch so the header re-brands.
   const settle = (state: AccountBrandingState) => {
     queryClient.setQueryData(brandingQueryKey(accountId), state);
-    void queryClient.invalidateQueries({ queryKey: ['accounts'] });
+    void queryClient.invalidateQueries({ queryKey: qk.accounts.scope() });
     void queryClient.invalidateQueries({ queryKey: ['account', accountId] });
   };
 

--- a/apps/web/src/features/accounts/settings/general-tab.tsx
+++ b/apps/web/src/features/accounts/settings/general-tab.tsx
@@ -42,14 +42,13 @@ import {
 import { isBillingEnabled } from '@/lib/config';
 import { createClient } from '@/lib/supabase/client';
 import { cn } from '@/lib/utils';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts } from '@kortix/sdk';
 import {
   ArrowUpRightIcon as ArrowUpRight,
   ClockIcon as Clock,
   WarningIcon as DangerTriangleSolid,
 } from '@phosphor-icons/react';
-import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, m, MotionConfig } from 'motion/react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -62,11 +61,7 @@ export function GeneralTab({ onClose }: { onClose: () => void }) {
   const t = useTranslations('settings.general');
   const tCommon = useTranslations('common');
   const { selectedAccountId, setSelectedAccountId } = useCurrentAccountStore();
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
   const accountId = selectedAccountId ?? accountsQuery.data?.[0]?.account_id ?? null;
 
   useEffect(() => {

--- a/apps/web/src/features/branding/branding-provider.tsx
+++ b/apps/web/src/features/branding/branding-provider.tsx
@@ -14,7 +14,7 @@
  *      project on screen when there is one, else the selected account; and
  *   2. hand that `AccountBranding | null` to every consumer through context.
  *
- * It reads the same `['accounts']` query every other surface already holds
+ * It reads the same `useAccountsList()` query every other surface already holds
  * (`useEnsureSelectedAccount`, `AccountSwitcher`, `UserMenu`, …), so branding
  * costs no extra request. It renders nothing itself; `KortixLogo` swaps its
  * SVG for the org marks, and `BrandingDocumentEffect` (below) swaps the tab
@@ -23,11 +23,10 @@
  * to be branded as until someone signs in.
  */
 
-import { listAccounts, type AccountBranding } from '@kortix/sdk';
-import { useQuery } from '@tanstack/react-query';
+import { type AccountBranding } from '@kortix/sdk';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
-import { useAuth } from '@/features/providers/auth-provider';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { siteMetadata } from '@/lib/site-metadata';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 
@@ -80,17 +79,11 @@ export function useBrandingScope(accountId: string | null | undefined): void {
 }
 
 export function BrandingProvider({ children }: { children: React.ReactNode }) {
-  const { user } = useAuth();
   const selectedAccountId = useCurrentAccountStore((s) => s.selectedAccountId);
   const { scopedAccountId } = useBrandingScopeState();
 
-  // Same key + staleTime as every other consumer → one fetch, shared cache.
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    enabled: !!user,
-    staleTime: 60_000,
-  });
+  // Same hook as every other consumer → one user-scoped fetch, shared cache.
+  const accountsQuery = useAccountsList();
 
   const branding = useMemo<AccountBranding | null>(() => {
     const accounts = accountsQuery.data;

--- a/apps/web/src/features/layout/account-switcher.tsx
+++ b/apps/web/src/features/layout/account-switcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -20,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { CreateAccountModal } from '@/features/accounts/create-account-modal';
 import { Plus } from '@/features/icon/icons/plus';
+import { useAccountsList, useAccountsQueryKey } from '@/hooks/account/use-accounts-list';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
 import { isAccountCreationRestricted, isBillingEnabled } from '@/lib/config';
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
@@ -27,7 +28,7 @@ import { usePermission } from '@/lib/use-permission';
 import { cn } from '@/lib/utils';
 import { buildAccountSettingsHref } from '@/stores/account-settings-modal-store';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts, type KortixAccount } from '@kortix/sdk';
+import { type KortixAccount } from '@kortix/sdk';
 import { qk } from '@kortix/sdk/react';
 import {
   CheckCircleIcon as CheckCircleSolid,
@@ -60,11 +61,9 @@ export function AccountSwitcher({ className }: { className?: string }) {
     if (!menuOpen) setQuery('');
   }, [menuOpen]);
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
+  // The exact key `accountsQuery` reads, for the create-account seed below.
+  const accountsQueryKey = useAccountsQueryKey();
 
   const activeAccount =
     accountsQuery.data?.find((a) => a.account_id === selectedAccountId) ??
@@ -263,13 +262,15 @@ export function AccountSwitcher({ className }: { className?: string }) {
         open={createOpen}
         onOpenChange={setCreateOpen}
         onCreated={(account: KortixAccount) => {
-          queryClient.setQueryData<KortixAccount[]>(['accounts'], (accounts) => {
+          // The reader's OWN key — see the identical seed in
+          // `app/(app)/accounts/page.tsx`.
+          queryClient.setQueryData<KortixAccount[]>(accountsQueryKey, (accounts) => {
             const current = accounts ?? [];
             return current.some((item) => item.account_id === account.account_id)
               ? current.map((item) => (item.account_id === account.account_id ? account : item))
               : [account, ...current];
           });
-          void queryClient.invalidateQueries({ queryKey: ['accounts'] });
+          void queryClient.invalidateQueries({ queryKey: qk.accounts.scope() });
           setSelectedAccountId(account.account_id);
           // qk.projects.scope(): reaches every account's list (and the
           // accountless slot), the same reach the old bare projects-literal

--- a/apps/web/src/features/layout/user-menu-shared.tsx
+++ b/apps/web/src/features/layout/user-menu-shared.tsx
@@ -33,9 +33,8 @@ import {
   DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu';
 
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { openExternalRoute } from '@/lib/desktop';
-import { createClient } from '@/lib/supabase/client';
-import { resetClientState } from '@/lib/utils/reset-client-state';
 import {
   ArticleIcon,
   BookOpenIcon,
@@ -52,9 +51,8 @@ import {
 } from '@phosphor-icons/react';
 import { useTheme } from 'next-themes';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import * as React from 'react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export type MenuLink = {
   label: string;
@@ -210,30 +208,18 @@ export function HelpSubmenu({ onClose }: { onClose: () => void }) {
  * "Log out".
  */
 export function useLogoutFlow(deferAfterClose: (fn: () => void) => void) {
-  const router = useRouter();
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const openConfirm = () => deferAfterClose(() => setConfirmOpen(true));
 
-  // `/auth` cannot be an anchor here: the navigation must run AFTER
-  // `signOut()` and `resetClientState()` resolve, and an anchor would leave on
-  // the click instead. Warm the destination while the confirmation is up, so
-  // the push reads the segment cache rather than running the RSC fetch cold —
-  // the fetch that degrades into a full document load when it answers wrong.
-  // Middleware skips identity resolution on `/auth` entirely
-  // (`middleware.ts:494-500`), so prefetching it from a live session is
-  // answered normally.
-  useEffect(() => {
-    if (confirmOpen) router.prefetch('/auth');
-  }, [confirmOpen, router]);
-
-  const performLogout = async () => {
-    const supabase = createClient();
-    await supabase.auth.signOut();
-    await resetClientState();
-    // nav-contract: prefetch-only — the navigation must follow signOut(), so it
-    // stays a push; the effect above puts /auth in the cache first.
-    router.push('/auth');
+  // `/auth` cannot be an anchor here: the navigation must run AFTER the session
+  // is actually gone, and an anchor would leave on the click instead. It is not
+  // a `router.push` either — `performSignOut` ends on a DOCUMENT load, which is
+  // the only thing that discards the App Router caches across an identity
+  // change. There is nothing to prefetch: a document load does not read the
+  // segment cache.
+  const performLogout = () => {
+    void performSignOut();
   };
 
   const dialog = (

--- a/apps/web/src/features/layout/user-menu-shared.tsx
+++ b/apps/web/src/features/layout/user-menu-shared.tsx
@@ -33,6 +33,7 @@ import {
   DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu';
 
+import Loading from '@/components/ui/loading';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { openExternalRoute } from '@/lib/desktop';
 import {
@@ -209,6 +210,7 @@ export function HelpSubmenu({ onClose }: { onClose: () => void }) {
  */
 export function useLogoutFlow(deferAfterClose: (fn: () => void) => void) {
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pending, setPending] = useState(false);
 
   const openConfirm = () => deferAfterClose(() => setConfirmOpen(true));
 
@@ -218,7 +220,16 @@ export function useLogoutFlow(deferAfterClose: (fn: () => void) => void) {
   // the only thing that discards the App Router caches across an identity
   // change. There is nothing to prefetch: a document load does not read the
   // segment cache.
-  const performLogout = () => {
+  //
+  // `preventDefault` keeps the dialog UP. Radix closes it on click, which used
+  // to leave the user staring at the unchanged app for as long as the sign-out
+  // took — up to the full step budget on a broken network — with nothing on
+  // screen saying anything was happening. The predictable response is a second
+  // click. `performSignOut` refuses re-entry, but the dialog is the honest
+  // place to say so. The document load is what actually closes this.
+  const performLogout = (event: React.MouseEvent) => {
+    event.preventDefault();
+    setPending(true);
     void performSignOut();
   };
 
@@ -232,9 +243,10 @@ export function useLogoutFlow(deferAfterClose: (fn: () => void) => void) {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={performLogout}>
-            Log out
+          <AlertDialogCancel disabled={pending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" disabled={pending} onClick={performLogout}>
+            {pending ? <Loading className="size-4 shrink-0" /> : null}
+            {pending ? 'Signing out' : 'Log out'}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/web/src/features/layout/user-menu.tsx
+++ b/apps/web/src/features/layout/user-menu.tsx
@@ -25,17 +25,16 @@ import {
 import { isBillingEnabled } from '@/lib/config';
 import { usePermission } from '@/lib/use-permission';
 import { cn } from '@/lib/utils';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useEnsureSelectedAccount } from '@/hooks/account/use-ensure-selected-account';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 import { useReferralDialog } from '@/stores/referral-dialog';
-import { listAccounts } from '@kortix/sdk';
 import {
   GearSixIcon as CogOne,
   CreditCardIcon as CreditCard,
   DownloadSimple,
   SignOutIcon as LogOut,
 } from '@phosphor-icons/react';
-import { useQuery } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import * as React from 'react';
@@ -69,16 +68,12 @@ export function UserMenu({
 
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
   // Extracted verbatim to `hooks/account/use-ensure-selected-account.ts` so the
   // standalone `/settings` route — which mounts `SettingsPanel` with no sidebar
   // and therefore no `UserMenu` — can run the same seeding instead of copying
-  // it. Same `['accounts']` key and `staleTime` as the query above, so the two
-  // callers share one fetch.
+  // it. It reads through the same `useAccountsList()` hook as the query above,
+  // so the two callers share one user-scoped cache entry and one fetch.
   useEnsureSelectedAccount();
 
   // In the collapsed sidebar's hover flyout, the menu content portals outside

--- a/apps/web/src/features/marketplace/add-to-project-modal.tsx
+++ b/apps/web/src/features/marketplace/add-to-project-modal.tsx
@@ -39,6 +39,7 @@ import {
   isAccountGitAdmin,
 } from '@/features/projects/modal/github-setup-required-panel';
 import { startTemplateSetupSession } from '@/features/projects/modal/template-setup-session';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useInstallMarketplaceItemAsSession } from '@/hooks/marketplace';
 import type { MarketplaceItem, MarketplaceItemDetail } from '@/lib/marketplace-client';
 import { isManagedGitUnavailableError } from '@/lib/onboarding/ensure-first-project';
@@ -93,12 +94,7 @@ export function AddToProjectModal({
   // Pre-check managed git the same way the New Project modal does — self-host
   // with nothing configured should route to Git settings instead of letting
   // the "new project" target hit the provision 503 first.
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-    enabled: open && target === NEW_PROJECT,
-  });
+  const accountsQuery = useAccountsList({ enabled: open && target === NEW_PROJECT });
   // No `personal_account` flag on this API — the bootstrapped personal
   // account is the one where the caller is the primary owner. Mirrors the
   // resolution in `onConfirm` below.

--- a/apps/web/src/features/providers/auth-provider-identity.test.ts
+++ b/apps/web/src/features/providers/auth-provider-identity.test.ts
@@ -24,12 +24,21 @@ function slice(startAnchor: string, endAnchor: string): string {
   return code.slice(start, end);
 }
 
-describe('the SIGNED_OUT branch keeps the marker it will be compared against', () => {
-  test('it no longer deletes kortix-last-user-id', () => {
-    // The self-disarming guard: `SIGNED_OUT` removed the marker, so the later
-    // `SIGNED_IN` comparison always read "absent" and — with the old
-    // `prev && prev !== next` spelling — concluded "same user". The reset could
-    // therefore never fire after an explicit logout.
+describe('the SIGNED_OUT branch no longer special-cases the marker — resetClientState sweeps it either way', () => {
+  test('it no longer calls safeRemoveItem directly (resetClientState sweeps the key instead)', () => {
+    // The self-disarming guard an earlier revision had: `SIGNED_OUT` removed
+    // the marker directly, so the later `SIGNED_IN` comparison always read
+    // "absent" and — with the old `prev && prev !== next` spelling —
+    // concluded "same user". The reset could therefore never fire after an
+    // explicit logout.
+    //
+    // This does NOT mean the marker survives a sign-out: `resetClientState()`
+    // -> `clearUserLocalStorage()` sweeps every `kortix-`-prefixed key,
+    // `IDENTITY_MARKER_KEY` included, and it is not on `KEEP_STORAGE_KEYS`.
+    // See `identity-marker.test.ts` for why that is safe rather than a hole —
+    // `shouldResetClientState` reads an absent marker as UNKNOWN, and unknown
+    // resets (G3). What this test pins is the MECHANICAL fact that the
+    // branch does not re-add a direct call.
     const branch = slice("case 'SIGNED_OUT':", "case 'TOKEN_REFRESHED':");
     expect(branch).not.toContain('safeRemoveItem');
     // Paired presence check: the branch still does its real job.
@@ -98,6 +107,10 @@ describe("the provider's signOut is the shared one", () => {
   test('useAuth().signOut is performSignOut, not a provider-local cleanup', () => {
     expect(code).toContain("from '@/lib/auth/perform-sign-out'");
     expect(code).toContain('signOut: performSignOut');
-    expect(code).not.toContain('await supabase.auth.signOut();\n      await resetClientState();');
+    // Regex, not a literal two-line string: a hard-coded 6-space indent is
+    // satisfied by any reindent (prettier, a wrapping change) with the same
+    // defect still present. `\s+` tolerates whitespace and line breaks
+    // between the two statements while still anchoring the exact call shape.
+    expect(code).not.toMatch(/await supabase\.auth\.signOut\(\);\s+await resetClientState\(\);/);
   });
 });

--- a/apps/web/src/features/providers/auth-provider-identity.test.ts
+++ b/apps/web/src/features/providers/auth-provider-identity.test.ts
@@ -1,0 +1,103 @@
+// `AuthProvider`'s cross-user reset, pinned at the wiring level.
+//
+// The decision itself lives in `lib/auth/identity-marker.ts` and is tested
+// there against real inputs. What this file proves is that the provider
+// actually ASKS it, at both entry points, and that the marker it compares
+// against still exists when the comparison runs — which is the exact thing the
+// `SIGNED_OUT` branch used to destroy.
+//
+// Source assertions, so comments are stripped before every match: this file's
+// own prose names `safeRemoveItem` and `kortix-last-user-id`, and so does the
+// module it guards.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const raw = readFileSync(resolve(import.meta.dir, 'auth-provider.tsx'), 'utf8');
+const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+function slice(startAnchor: string, endAnchor: string): string {
+  const start = code.indexOf(startAnchor);
+  expect(start).toBeGreaterThan(-1);
+  const end = code.indexOf(endAnchor, start + startAnchor.length);
+  expect(end).toBeGreaterThan(start);
+  return code.slice(start, end);
+}
+
+describe('the SIGNED_OUT branch keeps the marker it will be compared against', () => {
+  test('it no longer deletes kortix-last-user-id', () => {
+    // The self-disarming guard: `SIGNED_OUT` removed the marker, so the later
+    // `SIGNED_IN` comparison always read "absent" and — with the old
+    // `prev && prev !== next` spelling — concluded "same user". The reset could
+    // therefore never fire after an explicit logout.
+    const branch = slice("case 'SIGNED_OUT':", "case 'TOKEN_REFRESHED':");
+    expect(branch).not.toContain('safeRemoveItem');
+    // Paired presence check: the branch still does its real job.
+    expect(branch).toContain('await resetClientState();');
+  });
+
+  test('nothing in the provider removes the marker any more', () => {
+    expect(code).not.toContain('safeRemoveItem');
+  });
+});
+
+describe('the reset decision is the shared one, at BOTH entry points', () => {
+  test('the provider asks shouldResetClientState and never re-spells the guard', () => {
+    expect(code).toContain("from '@/lib/auth/identity-marker'");
+    expect(code).toContain('shouldResetClientState({');
+    // The exact shape that read an ABSENT marker as SAME USER (G3).
+    expect(code).not.toContain('prevUserId && prevUserId !==');
+  });
+
+  test('the cold-load bootstrap adopts the user before publishing it', () => {
+    const bootstrap = slice('const getInitialSession = async ()', 'getInitialSession();');
+    const adopt = bootstrap.indexOf('await adoptUser(');
+    const publish = bootstrap.indexOf('setSession(currentSession);');
+    expect(adopt).toBeGreaterThan(-1);
+    expect(publish).toBeGreaterThan(adopt);
+  });
+
+  test('the auth listener adopts INITIAL_SESSION and SIGNED_IN before publishing', () => {
+    // INITIAL_SESSION matters on its own: a cross-user COLD LOAD arrives as
+    // that event, and it arrives before `getInitialSession()` finishes its
+    // `getUser()` round trip. Without a case here the new user is published
+    // while the previous one's caches are still mounted.
+    const listener = slice('supabase.auth.onAuthStateChange(', 'setIsLoading((prev)');
+    expect(listener).toContain("event === 'INITIAL_SESSION'");
+    expect(listener).toContain("event === 'SIGNED_IN'");
+
+    const adopt = listener.indexOf('await adoptUser(nextUserId);');
+    const publish = listener.indexOf('setSession(newSession);');
+    expect(adopt).toBeGreaterThan(-1);
+    expect(publish).toBeGreaterThan(adopt);
+  });
+});
+
+describe('the marker is held per-document as well as in origin-wide storage', () => {
+  test('a useRef carries the in-document half', () => {
+    // One origin-wide localStorage key cannot describe several tabs: two tabs
+    // signed into two accounts overwrite each other's marker while each keeps
+    // its own React Query cache.
+    expect(code).toContain('const lastUserIdRef = useRef<string | null>(null)');
+    expect(code).toContain('inDocumentUserId: lastUserIdRef.current');
+    expect(code).toContain('persistedUserId: safeGetItem(IDENTITY_MARKER_KEY)');
+    expect(code).toContain('lastUserIdRef.current = nextUserId;');
+  });
+
+  test('a failed reset cannot leave the app parked on the loading frame', () => {
+    // `adoptUser` runs before `setIsLoading(false)`. An escaping rejection
+    // would strand every consumer on the loading state forever.
+    const adopt = slice('const adoptUser = async (', 'const getInitialSession');
+    expect(adopt).toContain('try {');
+    expect(adopt).toContain('await resetClientState();');
+    expect(adopt).toContain('} catch (error) {');
+  });
+});
+
+describe("the provider's signOut is the shared one", () => {
+  test('useAuth().signOut is performSignOut, not a provider-local cleanup', () => {
+    expect(code).toContain("from '@/lib/auth/perform-sign-out'");
+    expect(code).toContain('signOut: performSignOut');
+    expect(code).not.toContain('await supabase.auth.signOut();\n      await resetClientState();');
+  });
+});

--- a/apps/web/src/features/providers/auth-provider.tsx
+++ b/apps/web/src/features/providers/auth-provider.tsx
@@ -149,12 +149,20 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             setBootstrapAuthToken(null);
             setCachedAuthToken(null);
             await resetClientState();
-            // The identity marker is deliberately LEFT IN PLACE. Removing it
-            // here deleted the exact value the next `SIGNED_IN` compares
-            // against, so after an explicit logout the cross-user reset could
-            // never fire — the one moment two accounts are most likely to share
-            // a browser. It is a user id, not a credential, and it is already
-            // rewritten on every sign-in.
+            // This branch no longer calls `safeRemoveItem(IDENTITY_MARKER_KEY)`
+            // directly — an earlier revision did, which deleted the exact
+            // value the next `SIGNED_IN` compares against, so after an
+            // explicit logout the cross-user reset could never fire. But the
+            // marker does NOT survive this branch: `resetClientState()` above
+            // -> `clearUserLocalStorage()` runs a PREFIX sweep, and
+            // `IDENTITY_MARKER_KEY` ('kortix-last-user-id') matches
+            // `APP_STORAGE_PREFIXES[0]` ('kortix-') and is not on
+            // `KEEP_STORAGE_KEYS` — so it is swept like every other per-user
+            // key. That is SAFE, not a residual hole: `shouldResetClientState`
+            // reads an absent marker as UNKNOWN, and unknown resets (see its
+            // own doc comment). The next sign-in rewrites the marker
+            // unconditionally (`safeSetItem` in `adoptUser`, above) regardless
+            // of whether this branch ran.
             break;
           case 'TOKEN_REFRESHED':
             if (newSession?.access_token) {

--- a/apps/web/src/features/providers/auth-provider.tsx
+++ b/apps/web/src/features/providers/auth-provider.tsx
@@ -6,15 +6,17 @@ import React, {
   useState,
   useEffect,
   useMemo,
-  useCallback,
+  useRef,
   ReactNode,
 } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { User, Session } from '@supabase/supabase-js';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { setBootstrapAuthToken, setCachedAuthToken } from '@/lib/auth-token';
+import { IDENTITY_MARKER_KEY, shouldResetClientState } from '@/lib/auth/identity-marker';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { resetClientState } from '@/lib/utils/reset-client-state';
-import { safeGetItem, safeRemoveItem, safeSetItem } from '@/lib/storage/managed-storage';
+import { safeGetItem, safeSetItem } from '@/lib/storage/managed-storage';
 // Auth tracking moved to AuthEventTracker component (handles OAuth redirects)
 
 type AuthContextType = {
@@ -32,8 +34,42 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  /**
+   * The last user THIS document published. The localStorage marker cannot do
+   * this job: it is one origin-wide value, so two tabs signed into two accounts
+   * overwrite each other's while each keeps its own React Query cache. See
+   * `lib/auth/identity-marker.ts` for what each marker is allowed to mean.
+   */
+  const lastUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
+    /**
+     * Make the client state safe to hand to `nextUserId`, then record that it
+     * belongs to them. Resolves only once any wipe has finished, so callers can
+     * publish the new user immediately after awaiting it.
+     */
+    const adoptUser = async (nextUserId: string) => {
+      const mustReset = shouldResetClientState({
+        inDocumentUserId: lastUserIdRef.current,
+        persistedUserId: safeGetItem(IDENTITY_MARKER_KEY),
+        nextUserId,
+      });
+
+      if (mustReset) {
+        try {
+          await resetClientState();
+        } catch (error) {
+          // Swallowed on purpose. This runs BEFORE the user is published and
+          // before `isLoading` is cleared; an escaping rejection would leave
+          // the whole app parked on the loading frame forever.
+          console.error('[AuthProvider] Failed to clear state for the incoming user:', error);
+        }
+      }
+
+      lastUserIdRef.current = nextUserId;
+      safeSetItem(IDENTITY_MARKER_KEY, nextUserId);
+    };
+
     const getInitialSession = async () => {
       try {
         const {
@@ -56,21 +92,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           }
         }
 
+        // Before the publish, not after: the state on screen belongs to
+        // whoever the markers name, and handing it to a different account —
+        // even for the length of one render — is the bug this guard exists for.
+        if (currentSession?.user?.id) {
+          await adoptUser(currentSession.user.id);
+        }
+
         setSession(currentSession);
         setUser(currentSession?.user ?? null);
         if (currentSession?.access_token) {
           setCachedAuthToken(currentSession.access_token);
           setBootstrapAuthToken(null);
-        }
-
-        // Track user ID for cross-account localStorage cleanup
-        if (currentSession?.user?.id) {
-          const prevUserId = safeGetItem('kortix-last-user-id');
-          if (prevUserId && prevUserId !== currentSession.user.id) {
-            console.log('[Auth] Initial session: user changed, clearing stale client state');
-            await resetClientState();
-          }
-          safeSetItem('kortix-last-user-id', currentSession.user.id);
         }
       } catch (error) {
         console.warn('[AuthProvider] Failed to bootstrap initial session:', error);
@@ -83,6 +116,19 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
     const { data: authListener } = supabase.auth.onAuthStateChange(
       async (event, newSession) => {
+        const nextUserId = newSession?.user?.id;
+
+        // INITIAL_SESSION is here, and not only in the switch below, for one
+        // reason: a cross-user COLD LOAD arrives as INITIAL_SESSION, and it
+        // arrives before `getInitialSession()` has finished its `getUser()`
+        // round trip. Publishing first would hand the previous account's
+        // mounted caches to the new user for the whole length of the reset,
+        // which is long enough for every consumer that reads on mount to fetch
+        // against them.
+        if (nextUserId && (event === 'INITIAL_SESSION' || event === 'SIGNED_IN')) {
+          await adoptUser(nextUserId);
+        }
+
         setSession(newSession);
         setUser(newSession?.user ?? null);
 
@@ -97,24 +143,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
               setCachedAuthToken(newSession.access_token);
               setBootstrapAuthToken(null);
             }
-            // Clear stale sandbox/server state if a different user signs in
-            // (e.g. signup in same browser without explicit logout first)
-            const prevUserId = safeGetItem('kortix-last-user-id');
-            const newUserId = newSession?.user?.id;
-            if (newUserId && prevUserId && prevUserId !== newUserId) {
-              console.log('[Auth] User changed, clearing stale client state');
-              await resetClientState();
-            }
-            if (newUserId) {
-              safeSetItem('kortix-last-user-id', newUserId);
-            }
             break;
           }
           case 'SIGNED_OUT':
             setBootstrapAuthToken(null);
             setCachedAuthToken(null);
             await resetClientState();
-            safeRemoveItem('kortix-last-user-id');
+            // The identity marker is deliberately LEFT IN PLACE. Removing it
+            // here deleted the exact value the next `SIGNED_IN` compares
+            // against, so after an explicit logout the cross-user reset could
+            // never fire — the one moment two accounts are most likely to share
+            // a browser. It is a user id, not a credential, and it is already
+            // rewritten on every sign-in.
             break;
           case 'TOKEN_REFRESHED':
             if (newSession?.access_token) {
@@ -138,20 +178,16 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
   }, [supabase]);
 
-  const signOut = useCallback(async () => {
-    try {
-      await supabase.auth.signOut();
-      await resetClientState();
-    } catch (error) {
-      console.error('Error signing out:', error);
-    }
-  }, [supabase]);
-
   // Memoize the context value to prevent cascading re-renders of the entire
   // component tree on every auth state change (e.g. silent token refreshes).
+  //
+  // `signOut` is the shared `performSignOut` itself, not a provider-local
+  // wrapper: it is a module constant, so it is stable across renders, and
+  // routing it through here is what keeps every consumer of `useAuth()` on the
+  // one sign-out path instead of hand-rolling a fifth cleanup.
   const value = useMemo<AuthContextType>(
-    () => ({ supabase, session, user, isLoading, signOut }),
-    [supabase, session, user, isLoading, signOut],
+    () => ({ supabase, session, user, isLoading, signOut: performSignOut }),
+    [supabase, session, user, isLoading],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/web/src/features/session/composer/draft/composer-draft.ts
+++ b/apps/web/src/features/session/composer/draft/composer-draft.ts
@@ -38,14 +38,12 @@ export interface StoredDraft {
   /**
    * Supabase user id of the author.
    *
-   * Sign-out is called from three places and two of them
-   * (`features/layout/user-menu-shared.tsx`, `features/workspace/command-palette.tsx`)
-   * call `supabase.auth.signOut()` directly rather than through
-   * `features/providers/auth-provider.tsx`. A "clear drafts on sign-out" hook
-   * wired to one would silently miss the others, and would miss token expiry
-   * entirely. Checking the author on every READ covers all of them with no
-   * sign-out wiring at all. This matters because project access is shared: two
-   * teammates on one machine can both legitimately open the same project route.
+   * Sign-out is one call now (`lib/auth/perform-sign-out.ts`), but a "clear
+   * drafts on sign-out" hook wired to it would still miss token expiry, which
+   * ends a session without any logout control being pressed. Checking the
+   * author on every READ covers both with no sign-out wiring at all. This
+   * matters because project access is shared: two teammates on one machine can
+   * both legitimately open the same project route.
    */
   u: string;
   /**

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -74,16 +74,15 @@ import {
 import { useSettingsAccountId } from '@/features/workspace/settings/use-settings-account-id';
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { isBillingEnabled } from '@/lib/config';
 import { type MenuItemDef, type SettingsTabId, getItemsForSurface } from '@/lib/menu-registry';
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
 import { PROJECT_ACTIONS } from '@/lib/project-actions';
-import { createClient } from '@/lib/supabase/client';
 import { track } from '@/lib/track';
 import { useProjectCan } from '@/lib/use-project-can';
 import { useProjectFeatureFlags } from '@/lib/use-project-feature-flags';
 import { cn } from '@/lib/utils';
-import { clearUserLocalStorage } from '@/lib/utils/clear-local-storage';
 import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
 import {
   buildWebProxyUrl,
@@ -119,7 +118,6 @@ import {
   updateFeatureFlag,
 } from '@kortix/sdk';
 import { featureFlags } from '@kortix/sdk/feature-flags';
-import { clearSessionIDBCache } from '@kortix/sdk/idb-sync-cache';
 import { normalizeAppPathname } from '@kortix/sdk/instance-routes';
 import {
   contract,
@@ -1609,13 +1607,6 @@ export function CommandPalette() {
     router.prefetch(`/accounts/${inviteMembersAccountId}?tab=access-projects&project=${projectId}`);
   }, [open, projectId, inviteMembersAccountId, router]);
 
-  // Sign out lands on /auth. Warm it while the confirm dialog is up — the push
-  // itself only runs after `signOut()` has resolved.
-  useEffect(() => {
-    if (!logoutConfirmOpen) return;
-    router.prefetch('/auth');
-  }, [logoutConfirmOpen, router]);
-
   const hasSessionResults = rootSessionResults.length > 0;
   const hasWorkspaceResults = rootWorkspaceRows.length > 0;
   const hasSettingsResults = settingsResultCount > 0;
@@ -1921,17 +1912,16 @@ export function CommandPalette() {
     setLogoutConfirmOpen(true);
   }, [close]);
 
-  const performLogout = useCallback(async () => {
+  // This used to clear `localStorage` and the IDB cache — two of the four
+  // things a logout owes, missing the React Query cache and the persisted
+  // account selection. It is `performSignOut` now, the same call every other
+  // logout control makes, and it leaves on a DOCUMENT load rather than a
+  // `router.push`: nothing else discards the App Router route cache across an
+  // identity change.
+  const performLogout = useCallback(() => {
     reopenPaletteRef.current = false;
-    const supabase = createClient();
-    await supabase.auth.signOut();
-    clearUserLocalStorage();
-    await clearSessionIDBCache();
-    // nav-contract: prefetch-only — the push runs after `signOut()` resolves,
-    // so an anchor would leave before the session is cleared. The confirm-open
-    // effect warms /auth.
-    router.push('/auth');
-  }, [router]);
+    void performSignOut();
+  }, []);
 
   const handleSetTheme = useCallback(
     (newTheme: string) => {

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -72,6 +72,7 @@ import {
   resolveSettingsOverlayHref,
 } from '@/features/workspace/settings/settings-tabs';
 import { useSettingsAccountId } from '@/features/workspace/settings/use-settings-account-id';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
 import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
@@ -111,7 +112,6 @@ import {
   type ProjectSession,
   getProject,
   getProjectDetail,
-  listAccounts,
   listProjectSessions,
   listProjectsForAccount,
   systemReload,
@@ -890,12 +890,7 @@ export function CommandPalette() {
   const { data: providers } = useRuntimeProviders();
 
   const selectedAccountId = useCurrentAccountStore((s) => s.selectedAccountId);
-  const { data: accountsList } = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    enabled: open,
-    staleTime: 60_000,
-  });
+  const { data: accountsList } = useAccountsList({ enabled: open });
   const activeAccount =
     accountsList?.find((account) => account.account_id === selectedAccountId) ??
     accountsList?.[0] ??

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -850,6 +850,9 @@ export function CommandPalette() {
   /** The change request whose detail dialog is open, picked on the 'changes' page. */
   const [selectedCrId, setSelectedCrId] = useState<string | null>(null);
   const [logoutConfirmOpen, setLogoutConfirmOpen] = useState(false);
+  // Never cleared: `performSignOut` ends on a document load, so this component
+  // is discarded rather than re-rendered.
+  const [loggingOut, setLoggingOut] = useState(false);
   const [backScale, setBackScale] = useState(false);
   const backScaleTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -1918,8 +1921,14 @@ export function CommandPalette() {
   // logout control makes, and it leaves on a DOCUMENT load rather than a
   // `router.push`: nothing else discards the App Router route cache across an
   // identity change.
-  const performLogout = useCallback(() => {
+  const performLogout = useCallback((event: React.MouseEvent) => {
+    // `preventDefault` keeps the confirm dialog UP. Radix closes it on click,
+    // which left the palette gone, the dialog gone, and the unchanged app on
+    // screen for as long as the sign-out took — up to the full step budget when
+    // the network is broken — with nothing saying anything was happening.
+    event.preventDefault();
     reopenPaletteRef.current = false;
+    setLoggingOut(true);
     void performSignOut();
   }, []);
 
@@ -3198,8 +3207,9 @@ export function CommandPalette() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={performLogout}>
+            <AlertDialogCancel disabled={loggingOut}>Cancel</AlertDialogCancel>
+            <AlertDialogAction variant="destructive" disabled={loggingOut} onClick={performLogout}>
+              {loggingOut ? <Loading className="size-4 shrink-0" /> : null}
               {tHardcodedUi.raw('componentsLayoutUserMenu.line248JsxAttrLabelLogOut')}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/web/src/features/workspace/new/account-picker.test.ts
+++ b/apps/web/src/features/workspace/new/account-picker.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { resolveAccountPickerIdentity } from './account-picker';
+import type { KortixAccount } from '@kortix/sdk';
+
 const source = readFileSync(join(import.meta.dir, 'account-picker.tsx'), 'utf8');
 
 /**
@@ -25,12 +28,26 @@ describe('AccountPicker: collapses below two accounts', () => {
     expect(selectAt).toBeGreaterThan(guardAt);
   });
 
-  test('returns null only when there is nothing to show as identity', () => {
-    // One early return: label missing. The <2 branch itself does not always
-    // null out — it paints fallbackLabel / the sole account name.
+  test('returns null only when there is nothing to show at all', () => {
+    // One early return: both the identity line and the account line are
+    // empty. The <2 branch itself does not always null out — it paints
+    // fallbackLabel and/or the sole account's name as two separate lines.
     const returnNullMatches = code.match(/return null/g) ?? [];
     expect(returnNullMatches).toHaveLength(1);
-    expect(code).toContain('if (!label) return null');
+    expect(code).toContain('if (!identityLabel && !accountLabel) return null');
+  });
+
+  test('identity and account render as two separate elements, never concatenated into one string', () => {
+    // Regression guard for the disclosure this split exists to close: an
+    // account name (which can belong to someone else) must never be
+    // interpolated into the same string as the identity label.
+    expect(code).not.toMatch(/identityLabel\s*\+/);
+    expect(code).not.toMatch(/\$\{identityLabel\}.*\$\{accountLabel\}/);
+    expect(code).toContain('Create in');
+    // Two independently-conditioned spans, not one branch painting either
+    // value into a shared slot.
+    expect(code).toContain('{identityLabel ? (');
+    expect(code).toContain('{accountLabel ? (');
   });
 });
 
@@ -77,6 +94,51 @@ describe('AccountPicker: every account is selectable and reported verbatim', () 
 
   test('passes the raw account id straight through to onChange — no wrapping, no derived object', () => {
     expect(code).toContain('onValueChange={onChange}');
+  });
+});
+
+describe('resolveAccountPickerIdentity: the identity slot never carries an account name', () => {
+  // The exact shape of the disclosure this fix closes: an invited admin's
+  // only creatable account is the OWNER's personal account, stored by
+  // `bootstrap-personal-account.ts` as `"<owner-email>'s Account"`.
+  const ownersPersonalAccount: KortixAccount = {
+    account_id: 'a1',
+    name: "owner@x.com's Account",
+    account_role: 'admin',
+  };
+
+  test('accounts.length < 2 with a non-null fallbackLabel: identityLabel is fallbackLabel, never accounts[0].name', () => {
+    const result = resolveAccountPickerIdentity({
+      accounts: [ownersPersonalAccount],
+      value: null,
+      fallbackLabel: 'admin@invited.com',
+    });
+    expect(result.identityLabel).toBe('admin@invited.com');
+    expect(result.identityLabel).not.toBe(ownersPersonalAccount.name);
+    // The account name is still surfaced — as the SEPARATE "Create in" value.
+    expect(result.accountLabel).toBe(ownersPersonalAccount.name);
+  });
+
+  test('a selected value does not change which field the identity comes from', () => {
+    const result = resolveAccountPickerIdentity({
+      accounts: [ownersPersonalAccount],
+      value: 'a1',
+      fallbackLabel: 'admin@invited.com',
+    });
+    expect(result.identityLabel).toBe('admin@invited.com');
+    expect(result.identityLabel).not.toBe(ownersPersonalAccount.name);
+  });
+
+  test('zero accounts: identityLabel still resolves from fallbackLabel; accountLabel is null', () => {
+    expect(
+      resolveAccountPickerIdentity({ accounts: [], value: null, fallbackLabel: 'me@x.com' }),
+    ).toEqual({ identityLabel: 'me@x.com', accountLabel: null });
+  });
+
+  test('no fallbackLabel and no accounts: both fields are null', () => {
+    expect(
+      resolveAccountPickerIdentity({ accounts: [], value: null, fallbackLabel: null }),
+    ).toEqual({ identityLabel: null, accountLabel: null });
   });
 });
 

--- a/apps/web/src/features/workspace/new/account-picker.test.ts
+++ b/apps/web/src/features/workspace/new/account-picker.test.ts
@@ -227,9 +227,15 @@ describe('AccountPicker + shouldShowAccountLine: the rendered (identity, account
     const showAccountLine = shouldShowAccountLine(accounts, 'me');
     expect(showAccountLine).toBe(true);
     // 2+ accounts with showAccountLine true is the one state AccountPicker
-    // renders the Select, not the identity/account line pair — what matters
-    // here is that the REAL, unfiltered list is what would reach it.
-    expect(accounts).toEqual([own, foreignSole]);
+    // renders the Select — off its own `accounts` PARAMETER, unfiltered. A
+    // previous version of this test asserted `accounts` against itself
+    // (`expect(accounts).toEqual([own, foreignSole])`, comparing the local
+    // variable to a literal copy of what it was constructed from two lines
+    // above) — a tautology that invokes nothing and cannot fail. This checks
+    // the component's actual source instead: the Select branch maps
+    // `accounts` directly, not a filtered/sliced stand-in, so a shrunk list
+    // could never reach it silently.
+    expect(code).toContain('{accounts.map((account) => (');
   });
 
   test('foreign list (2+, none owned): identity line only — no account name and no Select at all (item 2, G2 fail closed)', () => {

--- a/apps/web/src/features/workspace/new/account-picker.test.ts
+++ b/apps/web/src/features/workspace/new/account-picker.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { resolveAccountPickerIdentity } from './account-picker';
+import { shouldShowAccountLine } from './new-workspace-form';
 import type { KortixAccount } from '@kortix/sdk';
 
 const source = readFileSync(join(import.meta.dir, 'account-picker.tsx'), 'utf8');
@@ -48,6 +49,26 @@ describe('AccountPicker: collapses below two accounts', () => {
     // value into a shared slot.
     expect(code).toContain('{identityLabel ? (');
     expect(code).toContain('{accountLabel ? (');
+  });
+});
+
+describe('AccountPicker: showAccountLine suppresses ALL account-specific rendering, not just the sole-account line', () => {
+  // Review round 1, Important 3: `accounts` must always mean the real list —
+  // `/new` used to falsify it (an emptied `pickerAccounts` stand-in) to get
+  // this suppression. `showAccountLine` is the honest, explicit replacement.
+  test('the branch guard covers BOTH the <2 lines AND the 2+ interactive Select', () => {
+    expect(code).toContain('if (!showAccountLine || accounts.length < 2)');
+  });
+
+  test('defaults to true — omitting the prop preserves the pre-existing, fully-revealing behavior', () => {
+    expect(code).toContain('showAccountLine = true');
+  });
+
+  test('the Select branch is reached only past the showAccountLine guard, never independently gated a second time', () => {
+    const guardAt = code.indexOf('if (!showAccountLine || accounts.length < 2)');
+    const selectAt = code.indexOf('<Select');
+    expect(guardAt).toBeGreaterThan(0);
+    expect(selectAt).toBeGreaterThan(guardAt);
   });
 });
 
@@ -140,14 +161,94 @@ describe('resolveAccountPickerIdentity: the identity slot never carries an accou
       resolveAccountPickerIdentity({ accounts: [], value: null, fallbackLabel: null }),
     ).toEqual({ identityLabel: null, accountLabel: null });
   });
+
+  // Review round 1, Important 3: `showAccountLine: false` is the explicit
+  // suppression signal — `accountLabel` must be `null` regardless of how
+  // many real `accounts` were passed, INCLUDING a sole account (A2.2) and a
+  // 2+ list that would otherwise reach the interactive Select (item 2).
+  test('showAccountLine: false suppresses accountLabel unconditionally — a sole account', () => {
+    expect(
+      resolveAccountPickerIdentity({
+        accounts: [ownersPersonalAccount],
+        value: 'a1',
+        fallbackLabel: 'me@x.com',
+        showAccountLine: false,
+      }),
+    ).toEqual({ identityLabel: 'me@x.com', accountLabel: null });
+  });
+
+  test('showAccountLine: false suppresses accountLabel unconditionally — two or more accounts', () => {
+    const second: KortixAccount = { account_id: 'a2', name: 'Acme Inc', account_role: 'admin' };
+    expect(
+      resolveAccountPickerIdentity({
+        accounts: [ownersPersonalAccount, second],
+        value: null,
+        fallbackLabel: 'me@x.com',
+        showAccountLine: false,
+      }),
+    ).toEqual({ identityLabel: 'me@x.com', accountLabel: null });
+  });
+});
+
+describe('AccountPicker + shouldShowAccountLine: the rendered (identity, account) pair across all four /new page states', () => {
+  // Review round 1 ("fold in"): this is the gap the reviewer found by hand —
+  // nothing in the suite previously asserted the rendered pair across these
+  // four real `/new` states, only `resolveAccountPickerIdentity` in
+  // isolation and page.tsx source-text wiring. Composes the REAL two
+  // functions the page composes: `shouldShowAccountLine`
+  // (`new-workspace-form.ts`) decides the prop, `resolveAccountPickerIdentity`
+  // (this file) decides what renders — exactly as `new-workspace-page.tsx`
+  // wires them.
+  const own: KortixAccount = { account_id: 'me', name: "me@x.com's Account", account_role: 'owner' };
+  const foreignSole: KortixAccount = { account_id: 'org-1', name: 'Acme Inc', account_role: 'admin' };
+  const foreignSecond: KortixAccount = { account_id: 'org-2', name: 'Widgets Co', account_role: 'admin' };
+  const fallbackLabel = 'me@x.com';
+
+  test('sole own account: identity line only, account line suppressed (A2.2)', () => {
+    const accounts = [own];
+    const showAccountLine = shouldShowAccountLine(accounts, 'me');
+    expect(showAccountLine).toBe(false);
+    expect(
+      resolveAccountPickerIdentity({ accounts, value: null, fallbackLabel, showAccountLine }),
+    ).toEqual({ identityLabel: fallbackLabel, accountLabel: null });
+  });
+
+  test('sole foreign account: BOTH lines render — the invited-admin case Task 1 protects (A2.2)', () => {
+    const accounts = [foreignSole];
+    const showAccountLine = shouldShowAccountLine(accounts, 'me');
+    expect(showAccountLine).toBe(true);
+    expect(
+      resolveAccountPickerIdentity({ accounts, value: null, fallbackLabel, showAccountLine }),
+    ).toEqual({ identityLabel: fallbackLabel, accountLabel: foreignSole.name });
+  });
+
+  test('multi-account (own + another): showAccountLine true — accounts reach the interactive Select unmodified, real and full', () => {
+    const accounts = [own, foreignSole];
+    const showAccountLine = shouldShowAccountLine(accounts, 'me');
+    expect(showAccountLine).toBe(true);
+    // 2+ accounts with showAccountLine true is the one state AccountPicker
+    // renders the Select, not the identity/account line pair — what matters
+    // here is that the REAL, unfiltered list is what would reach it.
+    expect(accounts).toEqual([own, foreignSole]);
+  });
+
+  test('foreign list (2+, none owned): identity line only — no account name and no Select at all (item 2, G2 fail closed)', () => {
+    const accounts = [foreignSole, foreignSecond];
+    const showAccountLine = shouldShowAccountLine(accounts, 'me');
+    expect(showAccountLine).toBe(false);
+    expect(
+      resolveAccountPickerIdentity({ accounts, value: null, fallbackLabel, showAccountLine }),
+    ).toEqual({ identityLabel: fallbackLabel, accountLabel: null });
+  });
 });
 
 describe('AccountPicker: exports', () => {
-  test('exports AccountPicker taking accounts, value, onChange and optional fallbackLabel', () => {
+  test('exports AccountPicker taking accounts, value, onChange, optional fallbackLabel, and optional showAccountLine', () => {
     expect(code).toContain('export function AccountPicker(');
     expect(code).toContain('accounts: KortixAccount[]');
     expect(code).toContain('value: string | null');
     expect(code).toContain('onChange: (accountId: string) => void');
     expect(code).toContain('fallbackLabel?: string | null');
+    expect(code).toContain('showAccountLine?: boolean');
   });
 });

--- a/apps/web/src/features/workspace/new/account-picker.tsx
+++ b/apps/web/src/features/workspace/new/account-picker.tsx
@@ -20,17 +20,30 @@ import type { KortixAccount } from '@kortix/sdk';
  * separate, explicitly labelled "Create in" value — never merged into one
  * string with the identity line.
  *
+ * `showAccountLine` (default `true`) is the caller's explicit request to
+ * suppress `accountLabel` entirely — used by `/new`
+ * (`shouldShowAccountLine`, `new-workspace-form.ts`) for a sole account that
+ * is the viewer's own (redundant "Create in" line) and for a FOREIGN
+ * creatable-accounts list (no account name at all). `accounts` is always the
+ * REAL, unmodified list either way — the caller must never shrink or empty
+ * it to hide something; this parameter is the honest way to ask for that.
+ *
  * Pure so the split can be asserted directly, without rendering DOM.
  */
 export function resolveAccountPickerIdentity({
   accounts,
   value,
   fallbackLabel,
+  showAccountLine = true,
 }: {
   accounts: KortixAccount[];
   value: string | null;
   fallbackLabel?: string | null;
+  showAccountLine?: boolean;
 }): { identityLabel: string | null; accountLabel: string | null } {
+  if (!showAccountLine) {
+    return { identityLabel: fallbackLabel ?? null, accountLabel: null };
+  }
   const selectedByValue = accounts.find((account) => account.account_id === value) ?? null;
   // Only a SOLE account is implicit enough to name without a pick — with two
   // or more, naming one before the user has chosen would assert a decision
@@ -59,6 +72,14 @@ export function resolveAccountPickerIdentity({
  * accounts the user may actually create a workspace in
  * (`filterCreatableAccounts`, `new-workspace-form.ts`); this component has no
  * opinion on permissions and must not duplicate that filter.
+ *
+ * `accounts` ALWAYS means the real, unfiltered-for-display creatable-
+ * accounts list — never a stand-in shrunk or emptied to hide something from
+ * the caller's side. `showAccountLine` (default `true`) is the explicit way
+ * a caller asks this component to reveal nothing beyond bare identity: when
+ * `false`, the component renders ONLY `fallbackLabel`, ignoring `accounts`
+ * and its length entirely — including bypassing the interactive Select for
+ * two or more accounts, not just the single "Create in" line below one.
  */
 export function AccountPicker({
   accounts,
@@ -66,6 +87,7 @@ export function AccountPicker({
   onChange,
   fallbackLabel,
   className,
+  showAccountLine = true,
 }: {
   accounts: KortixAccount[];
   value: string | null;
@@ -73,12 +95,16 @@ export function AccountPicker({
   /** Shown when there is no selected/sole account (typically the signed-in email). */
   fallbackLabel?: string | null;
   className?: string;
+  /** See the component doc comment above — `false` suppresses ALL account-
+   *  specific rendering, regardless of `accounts.length`. */
+  showAccountLine?: boolean;
 }) {
-  if (accounts.length < 2) {
+  if (!showAccountLine || accounts.length < 2) {
     const { identityLabel, accountLabel } = resolveAccountPickerIdentity({
       accounts,
       value,
       fallbackLabel,
+      showAccountLine,
     });
     if (!identityLabel && !accountLabel) return null;
     return (

--- a/apps/web/src/features/workspace/new/account-picker.tsx
+++ b/apps/web/src/features/workspace/new/account-picker.tsx
@@ -6,13 +6,53 @@ import { cn } from '@/lib/utils';
 import type { KortixAccount } from '@kortix/sdk';
 
 /**
+ * What `AccountPicker` paints below two creatable accounts: the caller's own
+ * identity, and — only once there is a creatable account to name — which one
+ * a workspace would be created in.
+ *
+ * `identityLabel` is ALWAYS `fallbackLabel` (the signed-in user's own email)
+ * and NEVER an account's `name`. An account name can belong to someone else:
+ * `bootstrap-personal-account.ts` stores every personal account as
+ * `"<owner-email>'s Account"`, and an invited admin's only creatable account
+ * can be that owner's personal account. Painting `name` into the identity
+ * slot discloses the owner's email to the admin as if it were their own.
+ * `accountLabel` carries that name instead, for the caller to render as a
+ * separate, explicitly labelled "Create in" value — never merged into one
+ * string with the identity line.
+ *
+ * Pure so the split can be asserted directly, without rendering DOM.
+ */
+export function resolveAccountPickerIdentity({
+  accounts,
+  value,
+  fallbackLabel,
+}: {
+  accounts: KortixAccount[];
+  value: string | null;
+  fallbackLabel?: string | null;
+}): { identityLabel: string | null; accountLabel: string | null } {
+  const selectedByValue = accounts.find((account) => account.account_id === value) ?? null;
+  // Only a SOLE account is implicit enough to name without a pick — with two
+  // or more, naming one before the user has chosen would assert a decision
+  // nobody made yet.
+  const soleAccount = accounts.length === 1 ? accounts[0]! : null;
+  const account = selectedByValue ?? soleAccount;
+  return {
+    identityLabel: fallbackLabel ?? null,
+    accountLabel: account?.name ?? null,
+  };
+}
+
+/**
  * Which account owns the new workspace.
  *
  * Lives in the `/new` top bar — a quiet clickable identity row, not a labeled
- * form field. One account is not a decision: the trigger collapses to static
- * muted text (or `null` when there is nothing to show). Two or more opens a
- * Select on click, same interaction shape as `AccountSwitcher` in the app
- * header, toned down to match the bar's secondary chrome.
+ * form field. One account is not a decision: the trigger collapses to two
+ * static muted lines — the signed-in identity, and (when there is one) the
+ * account it will create into — or `null` when there is nothing to show at
+ * all. Two or more opens a Select on click, same interaction shape as
+ * `AccountSwitcher` in the app header, toned down to match the bar's
+ * secondary chrome.
  *
  * Takes `accounts` as-is and offers every one of them — it does NOT filter by
  * role. The caller (`new-workspace-page.tsx`) is responsible for passing only
@@ -34,20 +74,28 @@ export function AccountPicker({
   fallbackLabel?: string | null;
   className?: string;
 }) {
-  const selectedByValue = accounts.find((account) => account.account_id === value) ?? null;
-  // One account is not a pick — show it as identity. Two or more: only paint
-  // a name once the user (or an explicit value) has actually chosen.
-  const identityAccount = selectedByValue ?? (accounts.length === 1 ? accounts[0]! : null);
-  const label = identityAccount?.name || fallbackLabel || null;
-
   if (accounts.length < 2) {
-    if (!label) return null;
+    const { identityLabel, accountLabel } = resolveAccountPickerIdentity({
+      accounts,
+      value,
+      fallbackLabel,
+    });
+    if (!identityLabel && !accountLabel) return null;
     return (
-      <span className={cn('text-muted-foreground min-w-0 truncate text-sm', className)}>
-        {label}
+      <span className={cn('flex min-w-0 flex-col', className)}>
+        {identityLabel ? (
+          <span className="text-muted-foreground min-w-0 truncate text-sm">{identityLabel}</span>
+        ) : null}
+        {accountLabel ? (
+          <span className="text-muted-foreground/70 min-w-0 truncate text-xs">
+            Create in {accountLabel}
+          </span>
+        ) : null}
       </span>
     );
   }
+
+  const selectedByValue = accounts.find((account) => account.account_id === value) ?? null;
 
   return (
     <Select value={value ?? undefined} onValueChange={onChange}>

--- a/apps/web/src/features/workspace/new/new-workspace-form.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.test.ts
@@ -58,6 +58,23 @@ describe('filterCreatableAccounts', () => {
   test('one owner + one member account leaves exactly one creatable — AccountPicker (accounts.length < 2) renders nothing', () => {
     expect(filterCreatableAccounts([owner, member])).toHaveLength(1);
   });
+
+  test('keeps the possessive suffix — never returns the bare email', () => {
+    // Regression guard: this used to `.replaceAll("'s Account", '')`, which
+    // turned the API's stored `"a@x.com's Account"` into a bare `a@x.com` —
+    // indistinguishable from `user.email` once it reached `AccountPicker`.
+    // The possessive is the only thing marking this as an account name
+    // belonging to someone else, so it must survive this function untouched.
+    const personalAccount: KortixAccount = {
+      account_id: 'a5',
+      name: "a@x.com's Account",
+      account_role: 'owner',
+    };
+    const [result] = filterCreatableAccounts([personalAccount]);
+    expect(result?.name).toContain("'s Account");
+    expect(result?.name).not.toBe('a@x.com');
+    expect(result?.name).toBe("a@x.com's Account");
+  });
 });
 
 describe('resolveDefaultCreatableAccountId', () => {

--- a/apps/web/src/features/workspace/new/new-workspace-form.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.test.ts
@@ -6,8 +6,8 @@ import {
   filterCreatableAccounts,
   isForeignAccountList,
   isSubmittable,
-  resolveAccountsForPicker,
   resolveDefaultCreatableAccountId,
+  shouldShowAccountLine,
 } from './new-workspace-form';
 import type { KortixAccount } from '@kortix/sdk';
 
@@ -193,35 +193,40 @@ describe('isForeignAccountList', () => {
     expect(isForeignAccountList([foreign1, foreign2], 'me')).toBe(true);
   });
 
-  test('true for two or more accounts when the viewer id is not known at all', () => {
+  // `userId` is required and typed `string | null` (no `| undefined`) —
+  // review round 1, Important 2. A caller that genuinely cannot establish
+  // identity must say so explicitly with `null`; `undefined` is no longer a
+  // representable value at the type level, so there is no longer a separate
+  // "omitted" case to test here. `null` already fails closed correctly: no
+  // real `account_id` is ever `null`.
+  test('true for two or more accounts when the viewer id is explicitly unknown (null)', () => {
     expect(isForeignAccountList([foreign1, foreign2], null)).toBe(true);
-    expect(isForeignAccountList([foreign1, foreign2], undefined)).toBe(true);
   });
 });
 
-describe('resolveAccountsForPicker', () => {
+describe('shouldShowAccountLine', () => {
   const ownSole: KortixAccount = { account_id: 'me', name: "me@x.com's Account", account_role: 'owner' };
   const foreignSole: KortixAccount = { account_id: 'org-1', name: 'Acme Inc', account_role: 'admin' };
   const foreignSecond: KortixAccount = { account_id: 'org-2', name: 'Widgets Co', account_role: 'admin' };
 
-  test('sole OWN account: suppressed to an empty array — AccountPicker renders the identity line alone (A2.2)', () => {
-    expect(resolveAccountsForPicker([ownSole], 'me')).toEqual([]);
+  test('sole OWN account: false — AccountPicker renders the identity line alone (A2.2)', () => {
+    expect(shouldShowAccountLine([ownSole], 'me')).toBe(false);
   });
 
-  test('sole FOREIGN account: NOT suppressed — the invited-admin scenario must still name the account (A2.2, do not re-open Task 1s disclosure fix)', () => {
-    expect(resolveAccountsForPicker([foreignSole], 'me')).toEqual([foreignSole]);
+  test('sole FOREIGN account: true — the invited-admin scenario must still name the account (A2.2, do not re-open Task 1s disclosure fix)', () => {
+    expect(shouldShowAccountLine([foreignSole], 'me')).toBe(true);
   });
 
-  test('a FOREIGN list (two or more, none owned): suppressed to an empty array — no account name renders at all', () => {
-    expect(resolveAccountsForPicker([foreignSole, foreignSecond], 'me')).toEqual([]);
+  test('a FOREIGN list (two or more, none owned): false — no account name renders at all', () => {
+    expect(shouldShowAccountLine([foreignSole, foreignSecond], 'me')).toBe(false);
   });
 
-  test("a normal multi-account list that includes the viewer's own: passed through unmodified", () => {
-    expect(resolveAccountsForPicker([ownSole, foreignSole], 'me')).toEqual([ownSole, foreignSole]);
+  test("a normal multi-account list that includes the viewer's own: true — the real list reaches the interactive Select unmodified", () => {
+    expect(shouldShowAccountLine([ownSole, foreignSole], 'me')).toBe(true);
   });
 
-  test('zero accounts: passed through as empty, trivially', () => {
-    expect(resolveAccountsForPicker([], 'me')).toEqual([]);
+  test('zero accounts: true, trivially (AccountPicker itself renders nothing at zero accounts and no fallback label)', () => {
+    expect(shouldShowAccountLine([], 'me')).toBe(true);
   });
 });
 

--- a/apps/web/src/features/workspace/new/new-workspace-form.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.test.ts
@@ -85,7 +85,14 @@ describe('resolveDefaultCreatableAccountId', () => {
   };
   const personal: KortixAccount = {
     account_id: 'a-personal',
-    name: 'jay@kortix.ai',
+    // REAL post-`filterCreatableAccounts` shape as of Task 1: the API always
+    // stores a personal account as `"<email>'s Account"`
+    // (`defaultAccountName`, apps/api/src/accounts/core/app.ts), and Task 1
+    // stopped stripping that possessive. This fixture used to be the bare
+    // email `'jay@kortix.ai'` — a shape `filterCreatableAccounts` can no
+    // longer produce — which let the test below silently stop testing what
+    // its name claimed. See that test for what actually resolves this now.
+    name: "jay@kortix.ai's Account",
     slug: 'jay',
     account_role: 'owner',
     is_primary_owner: true,
@@ -95,7 +102,16 @@ describe('resolveDefaultCreatableAccountId', () => {
     expect(resolveDefaultCreatableAccountId([], 'jay@kortix.ai')).toBeNull();
   });
 
-  test('prefers the account whose name matches the signed-in email (case-insensitive)', () => {
+  test('a personal account no longer matches by name (its name always carries the possessive) — this case still resolves correctly, but only because slug ALSO happens to match', () => {
+    // `byName` (`account.name.trim().toLowerCase() === normalized`) cannot
+    // match `personal.name` any more — it is `"jay@kortix.ai's account"`,
+    // never the bare email. This assertion is UNCHANGED from before Task 1,
+    // because `personal.slug` ('jay') independently matches the email's
+    // local part, so `bySlug` produces the same answer. That is a
+    // coincidence of this fixture, not a guarantee: the `test.todo` below
+    // demonstrates the case where no tier reliably distinguishes a personal
+    // account from an owned team account, and the result depends on list
+    // order instead.
     expect(resolveDefaultCreatableAccountId([team, personal], 'Jay@Kortix.ai')).toBe(
       'a-personal',
     );
@@ -138,6 +154,58 @@ describe('resolveDefaultCreatableAccountId', () => {
   test('returns the sole creatable account even with no email', () => {
     expect(resolveDefaultCreatableAccountId([personal], null)).toBe('a-personal');
   });
+});
+
+describe('resolveDefaultCreatableAccountId: order-dependent default when a user owns both a personal and a team account', () => {
+  // TODO(Task 2): fix ownership. Task 2 deletes this whole name/slug email-
+  // matching approach and replaces it with an identity match on
+  // `account_id === userId`, which is the only thing that can distinguish
+  // "the account that IS the user" from "an account the user happens to
+  // own" — this test cannot be made to pass with the current function
+  // signature (it takes `email`, not `userId`).
+  //
+  // `is_primary_owner` is `accountRole === 'owner'`
+  // (apps/api/src/accounts/core/accounts.ts:126) — true for the user's
+  // bootstrapped personal account AND for any team account the user owns
+  // outright. `resolveDefaultCreatableAccountId`'s `is_primary_owner` tier
+  // (new-workspace-form.ts) returns `accounts.find(a => a.is_primary_owner)`
+  // — the FIRST match in array order. Neither `byName` nor `bySlug` can
+  // break the tie here (see the `personal` fixture's comment above: `byName`
+  // no longer matches a personal account's possessive-suffixed name at all,
+  // now that Task 1 stopped stripping it). So today, run through the REAL
+  // composed pipeline (`filterCreatableAccounts` then
+  // `resolveDefaultCreatableAccountId`), the default silently flips between
+  // the personal and the team account depending on which order the API
+  // happened to list them in.
+  test.todo(
+    'personal account wins regardless of list order',
+    () => {
+      const email = 'jay@kortix.ai';
+      const personalAccount: KortixAccount = {
+        account_id: 'a-personal-order',
+        name: "jay@kortix.ai's Account",
+        account_role: 'owner',
+        is_primary_owner: true,
+      };
+      // A team the SAME user also owns outright — not their personal
+      // account, but `is_primary_owner` cannot tell the two apart.
+      const teamAccountUserOwns: KortixAccount = {
+        account_id: 'a-team-order',
+        name: 'Acme Inc',
+        account_role: 'owner',
+        is_primary_owner: true,
+      };
+
+      const personalFirst = filterCreatableAccounts([personalAccount, teamAccountUserOwns]);
+      const teamFirst = filterCreatableAccounts([teamAccountUserOwns, personalAccount]);
+
+      // Desired behavior once Task 2 lands: the personal account wins
+      // either way. Today, `personalFirst` resolves to 'a-personal-order'
+      // and `teamFirst` resolves to 'a-team-order' — the bug.
+      expect(resolveDefaultCreatableAccountId(personalFirst, email)).toBe('a-personal-order');
+      expect(resolveDefaultCreatableAccountId(teamFirst, email)).toBe('a-personal-order');
+    },
+  );
 });
 
 describe('isSubmittable', () => {

--- a/apps/web/src/features/workspace/new/new-workspace-form.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.test.ts
@@ -4,7 +4,9 @@ import {
   INITIAL_FORM_STATE,
   buildProvisionPayload,
   filterCreatableAccounts,
+  isForeignAccountList,
   isSubmittable,
+  resolveAccountsForPicker,
   resolveDefaultCreatableAccountId,
 } from './new-workspace-form';
 import type { KortixAccount } from '@kortix/sdk';
@@ -87,62 +89,39 @@ describe('resolveDefaultCreatableAccountId', () => {
     account_id: 'a-personal',
     // REAL post-`filterCreatableAccounts` shape as of Task 1: the API always
     // stores a personal account as `"<email>'s Account"`
-    // (`defaultAccountName`, apps/api/src/accounts/core/app.ts), and Task 1
-    // stopped stripping that possessive. This fixture used to be the bare
-    // email `'jay@kortix.ai'` — a shape `filterCreatableAccounts` can no
-    // longer produce — which let the test below silently stop testing what
-    // its name claimed. See that test for what actually resolves this now.
+    // (`defaultAccountName`, apps/api/src/accounts/core/app.ts). Personal
+    // accounts use `accountId === userId` by construction
+    // (`bootstrap-personal-account.ts`), so `'a-personal'` doubles as both
+    // this account's id and the signed-in user's id in the tests below.
     name: "jay@kortix.ai's Account",
-    slug: 'jay',
     account_role: 'owner',
     is_primary_owner: true,
   };
 
+  // Task 2 replaced the `byName`/`bySlug` email-matching tiers entirely —
+  // both were permanently dead against the real `GET /v1/accounts` shape
+  // (see `resolveDefaultCreatableAccountId`'s doc comment in
+  // `new-workspace-form.ts`). There is no successor test for "matches by
+  // name" or "matches by slug": that behavior no longer exists, on purpose.
+  // The identity tier below (`account_id === userId`) is what replaces it.
+
   test('returns null when there are no creatable accounts', () => {
-    expect(resolveDefaultCreatableAccountId([], 'jay@kortix.ai')).toBeNull();
+    expect(resolveDefaultCreatableAccountId([], 'a-personal')).toBeNull();
   });
 
-  test('a personal account no longer matches by name (its name always carries the possessive) — this case still resolves correctly, but only because slug ALSO happens to match', () => {
-    // `byName` (`account.name.trim().toLowerCase() === normalized`) cannot
-    // match `personal.name` any more — it is `"jay@kortix.ai's account"`,
-    // never the bare email. This assertion is UNCHANGED from before Task 1,
-    // because `personal.slug` ('jay') independently matches the email's
-    // local part, so `bySlug` produces the same answer. That is a
-    // coincidence of this fixture, not a guarantee: the `test.todo` below
-    // demonstrates the case where no tier reliably distinguishes a personal
-    // account from an owned team account, and the result depends on list
-    // order instead.
-    expect(resolveDefaultCreatableAccountId([team, personal], 'Jay@Kortix.ai')).toBe(
-      'a-personal',
-    );
+  test('prefers the account whose account_id equals the signed-in user id, regardless of list order', () => {
+    expect(resolveDefaultCreatableAccountId([team, personal], 'a-personal')).toBe('a-personal');
+    expect(resolveDefaultCreatableAccountId([personal, team], 'a-personal')).toBe('a-personal');
   });
 
-  test('falls back to slug match against the email or its local-part', () => {
-    const bySlug: KortixAccount = {
-      account_id: 'a-slug',
-      name: 'Personal',
-      slug: 'jay@kortix.ai',
-      account_role: 'owner',
-    };
-    expect(resolveDefaultCreatableAccountId([team, bySlug], 'jay@kortix.ai')).toBe('a-slug');
-
-    const byLocal: KortixAccount = {
-      account_id: 'a-local',
-      name: 'Personal',
-      slug: 'jay',
-      account_role: 'admin',
-    };
-    expect(resolveDefaultCreatableAccountId([team, byLocal], 'jay@kortix.ai')).toBe('a-local');
-  });
-
-  test('falls back to is_primary_owner when nothing matches the email', () => {
+  test('falls back to is_primary_owner when identity does not match any account', () => {
     const primary: KortixAccount = {
       account_id: 'a-primary',
       name: 'Me',
       account_role: 'owner',
       is_primary_owner: true,
     };
-    expect(resolveDefaultCreatableAccountId([team, primary], 'other@kortix.ai')).toBe(
+    expect(resolveDefaultCreatableAccountId([team, primary], 'someone-elses-id')).toBe(
       'a-primary',
     );
   });
@@ -151,61 +130,99 @@ describe('resolveDefaultCreatableAccountId', () => {
     expect(resolveDefaultCreatableAccountId([team, admin], null)).toBe('a-team');
   });
 
-  test('returns the sole creatable account even with no email', () => {
+  test('returns the sole creatable account even with no userId', () => {
     expect(resolveDefaultCreatableAccountId([personal], null)).toBe('a-personal');
   });
 });
 
-describe('resolveDefaultCreatableAccountId: order-dependent default when a user owns both a personal and a team account', () => {
-  // TODO(Task 2): fix ownership. Task 2 deletes this whole name/slug email-
-  // matching approach and replaces it with an identity match on
-  // `account_id === userId`, which is the only thing that can distinguish
-  // "the account that IS the user" from "an account the user happens to
-  // own" — this test cannot be made to pass with the current function
-  // signature (it takes `email`, not `userId`).
-  //
-  // `is_primary_owner` is `accountRole === 'owner'`
-  // (apps/api/src/accounts/core/accounts.ts:126) — true for the user's
-  // bootstrapped personal account AND for any team account the user owns
-  // outright. `resolveDefaultCreatableAccountId`'s `is_primary_owner` tier
-  // (new-workspace-form.ts) returns `accounts.find(a => a.is_primary_owner)`
-  // — the FIRST match in array order. Neither `byName` nor `bySlug` can
-  // break the tie here (see the `personal` fixture's comment above: `byName`
-  // no longer matches a personal account's possessive-suffixed name at all,
-  // now that Task 1 stopped stripping it). So today, run through the REAL
-  // composed pipeline (`filterCreatableAccounts` then
-  // `resolveDefaultCreatableAccountId`), the default silently flips between
-  // the personal and the team account depending on which order the API
-  // happened to list them in.
-  test.todo(
-    'personal account wins regardless of list order',
-    () => {
-      const email = 'jay@kortix.ai';
-      const personalAccount: KortixAccount = {
-        account_id: 'a-personal-order',
-        name: "jay@kortix.ai's Account",
-        account_role: 'owner',
-        is_primary_owner: true,
-      };
-      // A team the SAME user also owns outright — not their personal
-      // account, but `is_primary_owner` cannot tell the two apart.
-      const teamAccountUserOwns: KortixAccount = {
-        account_id: 'a-team-order',
-        name: 'Acme Inc',
-        account_role: 'owner',
-        is_primary_owner: true,
-      };
+describe('resolveDefaultCreatableAccountId: order-independent default when a user owns both a personal and a team account', () => {
+  // Converts Task 1's `test.todo` (ruling R5 / Task 2 controller addendum
+  // A2.1). `is_primary_owner` is `accountRole === 'owner'`
+  // (apps/api/src/accounts/core/accounts.ts:126) — true for BOTH the user's
+  // bootstrapped personal account and any team account they own outright, so
+  // it cannot break the tie between the two. Only `account_id === userId`
+  // can: it is true for the personal account by construction
+  // (`bootstrap-personal-account.ts`) and never true for a team account,
+  // which always gets its own freshly generated account id. Run through the
+  // REAL composed pipeline (`filterCreatableAccounts` then
+  // `resolveDefaultCreatableAccountId`), exactly as `/new` calls them.
+  test('personal account wins regardless of list order', () => {
+    const userId = 'a-personal-order';
+    const personalAccount: KortixAccount = {
+      account_id: 'a-personal-order',
+      name: "jay@kortix.ai's Account",
+      account_role: 'owner',
+      is_primary_owner: true,
+    };
+    // A team the SAME user also owns outright — not their personal account,
+    // but `is_primary_owner` cannot tell the two apart.
+    const teamAccountUserOwns: KortixAccount = {
+      account_id: 'a-team-order',
+      name: 'Acme Inc',
+      account_role: 'owner',
+      is_primary_owner: true,
+    };
 
-      const personalFirst = filterCreatableAccounts([personalAccount, teamAccountUserOwns]);
-      const teamFirst = filterCreatableAccounts([teamAccountUserOwns, personalAccount]);
+    const personalFirst = filterCreatableAccounts([personalAccount, teamAccountUserOwns]);
+    const teamFirst = filterCreatableAccounts([teamAccountUserOwns, personalAccount]);
 
-      // Desired behavior once Task 2 lands: the personal account wins
-      // either way. Today, `personalFirst` resolves to 'a-personal-order'
-      // and `teamFirst` resolves to 'a-team-order' — the bug.
-      expect(resolveDefaultCreatableAccountId(personalFirst, email)).toBe('a-personal-order');
-      expect(resolveDefaultCreatableAccountId(teamFirst, email)).toBe('a-personal-order');
-    },
-  );
+    expect(resolveDefaultCreatableAccountId(personalFirst, userId)).toBe('a-personal-order');
+    expect(resolveDefaultCreatableAccountId(teamFirst, userId)).toBe('a-personal-order');
+  });
+});
+
+describe('isForeignAccountList', () => {
+  const own: KortixAccount = { account_id: 'me', name: "me@x.com's Account", account_role: 'owner' };
+  const foreign1: KortixAccount = { account_id: 'org-1', name: 'Acme Inc', account_role: 'admin' };
+  const foreign2: KortixAccount = { account_id: 'org-2', name: 'Widgets Co', account_role: 'admin' };
+
+  test('false for zero creatable accounts', () => {
+    expect(isForeignAccountList([], 'me')).toBe(false);
+  });
+
+  test("false for a SOLE account that is not the viewer's own — the ordinary invited-admin case, not FOREIGN", () => {
+    expect(isForeignAccountList([foreign1], 'me')).toBe(false);
+  });
+
+  test("false for two or more accounts once at least one is the viewer's own, regardless of order", () => {
+    expect(isForeignAccountList([own, foreign1], 'me')).toBe(false);
+    expect(isForeignAccountList([foreign1, own], 'me')).toBe(false);
+  });
+
+  test("true for two or more accounts, none of them the viewer's own", () => {
+    expect(isForeignAccountList([foreign1, foreign2], 'me')).toBe(true);
+  });
+
+  test('true for two or more accounts when the viewer id is not known at all', () => {
+    expect(isForeignAccountList([foreign1, foreign2], null)).toBe(true);
+    expect(isForeignAccountList([foreign1, foreign2], undefined)).toBe(true);
+  });
+});
+
+describe('resolveAccountsForPicker', () => {
+  const ownSole: KortixAccount = { account_id: 'me', name: "me@x.com's Account", account_role: 'owner' };
+  const foreignSole: KortixAccount = { account_id: 'org-1', name: 'Acme Inc', account_role: 'admin' };
+  const foreignSecond: KortixAccount = { account_id: 'org-2', name: 'Widgets Co', account_role: 'admin' };
+
+  test('sole OWN account: suppressed to an empty array — AccountPicker renders the identity line alone (A2.2)', () => {
+    expect(resolveAccountsForPicker([ownSole], 'me')).toEqual([]);
+  });
+
+  test('sole FOREIGN account: NOT suppressed — the invited-admin scenario must still name the account (A2.2, do not re-open Task 1s disclosure fix)', () => {
+    expect(resolveAccountsForPicker([foreignSole], 'me')).toEqual([foreignSole]);
+  });
+
+  test('a FOREIGN list (two or more, none owned): suppressed to an empty array — no account name renders at all', () => {
+    expect(resolveAccountsForPicker([foreignSole, foreignSecond], 'me')).toEqual([]);
+  });
+
+  test("a normal multi-account list that includes the viewer's own: passed through unmodified", () => {
+    expect(resolveAccountsForPicker([ownSole, foreignSole], 'me')).toEqual([ownSole, foreignSole]);
+  });
+
+  test('zero accounts: passed through as empty, trivially', () => {
+    expect(resolveAccountsForPicker([], 'me')).toEqual([]);
+  });
 });
 
 describe('isSubmittable', () => {

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -150,21 +150,31 @@ export function resolveDefaultCreatableAccountId(
  * legitimate shape: once the viewer's own personal account exists it is
  * always one of their membership rows, and therefore always present. Two or
  * more accounts with zero anchor to the viewer is the signature a stale or
- * wrong `['accounts']` cache entry would produce (a leftover list from a
+ * wrong account-list cache entry would produce (a leftover list from a
  * DIFFERENT signed-in user), not a genuine response for this identity — so
  * this is the fail-closed branch (G2): treat it as untrustworthy rather than
  * guess which entry, if any, is safe to default into.
  *
- * RESIDUAL RISK, stated plainly rather than assumed away: a SOLE foreign
- * account (the branch above that returns `false`) is INDISTINGUISHABLE, from
- * this function's inputs alone, from a stale `['accounts']` cache entry that
- * still holds a DIFFERENT, previously-signed-in user's single-account list.
- * Both shapes are exactly one account, `account_id !== userId`. If
- * `['accounts']` is not scoped per signed-in user, that instance of symptom 3
- * reaches this function looking identical to the legitimate invited-admin
- * case and is NOT caught here. Closing that gap is Task 10's job (a
- * user-scoped `['accounts']` query key), not this function's — do not
- * de-scope Task 10 on the belief that Task 2 already covers the N=1 case.
+ * The N=1 case this function CANNOT catch, and no longer has to: a SOLE
+ * foreign account (the branch above that returns `false`) is
+ * INDISTINGUISHABLE, from this function's inputs alone, from a stale account
+ * list still holding a DIFFERENT, previously-signed-in user's single-account
+ * list. Both shapes are exactly one account, `account_id !== userId`, so
+ * rejecting one would permanently lock legitimate invited admins out of
+ * creating any workspace.
+ *
+ * That gap is now closed one layer up instead, structurally: the account list
+ * is cached under `qk.accounts.list(userId)` (`packages/sdk/src/react/
+ * query-keys.ts`), read only through `useAccountsList()`
+ * (`hooks/account/use-accounts-list.ts`), and every reader is gated
+ * `enabled: !!user`. A previous user's list is not ADDRESSABLE from this
+ * user's session, so it can no longer reach this function at all.
+ *
+ * This check still earns its place and must NOT be deleted: it is the
+ * fail-closed guard for a 2+-account list with no anchor to the viewer, which
+ * the key cannot rule out (a genuine response can legitimately contain
+ * accounts the viewer does not own). Key scoping and this check cover
+ * different shapes.
  *
  * `userId` is required, not optional: an omitted argument used to compile
  * clean and silently degrade to `undefined`, which made every 2+-account

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -60,6 +60,16 @@ export const INITIAL_FORM_STATE: NewWorkspaceFormState = {
  * feeds both `AccountPicker` and `isSubmittable` below — never the raw list
  * to one and this to the other, which would let "what the user can pick" and
  * "what gates submit" disagree.
+ *
+ * Does NOT strip the `'s Account` possessive `bootstrap-personal-account.ts`
+ * stores on every personal account's `name`. That possessive is the only
+ * thing that marks the string as an account name rather than a bare email —
+ * stripping it here used to hand `AccountPicker` a value indistinguishable
+ * from `user.email`, which it then painted straight into the identity slot.
+ * An invited admin whose one creatable account is the owner's personal
+ * account saw the account owner's address labelled as their own identity.
+ * `AccountPicker` now renders `fallbackLabel` in that slot and this `name`
+ * only in the separate, explicitly labelled "Create in" line — never merged.
  */
 export function filterCreatableAccounts(accounts: KortixAccount[]): KortixAccount[] {
   const creatable: KortixAccount[] = [];
@@ -67,7 +77,7 @@ export function filterCreatableAccounts(accounts: KortixAccount[]): KortixAccoun
     if (account.account_role === 'owner' || account.account_role === 'admin') {
       creatable.push({
         ...account,
-        name: account.name.trim().replaceAll("'s Account", ''),
+        name: account.name.trim(),
       });
     }
   }

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -146,35 +146,46 @@ export function resolveDefaultCreatableAccountId(
  * not a leak — it is exactly the scenario Task 1's fix protects (Task 2
  * controller addendum A2.2), so it is never FOREIGN on its own.
  *
- * A MULTI-account list with no anchor to the viewer at all has no such
- * legitimate shape: once the viewer's own personal account exists it is
- * always one of their membership rows, and therefore always present. Two or
- * more accounts with zero anchor to the viewer is the signature a stale or
- * wrong account-list cache entry would produce (a leftover list from a
- * DIFFERENT signed-in user), not a genuine response for this identity — so
- * this is the fail-closed branch (G2): treat it as untrustworthy rather than
- * guess which entry, if any, is safe to default into.
- *
  * The N=1 case this function CANNOT catch, and no longer has to: a SOLE
- * foreign account (the branch above that returns `false`) is
+ * foreign account (the branch above that returns `false`) used to be
  * INDISTINGUISHABLE, from this function's inputs alone, from a stale account
  * list still holding a DIFFERENT, previously-signed-in user's single-account
  * list. Both shapes are exactly one account, `account_id !== userId`, so
- * rejecting one would permanently lock legitimate invited admins out of
- * creating any workspace.
+ * rejecting one would have permanently locked legitimate invited admins out
+ * of creating any workspace. That gap is closed one layer up instead,
+ * structurally: the account list is cached under `qk.accounts.list(userId)`
+ * (`packages/sdk/src/react/query-keys.ts`), read only through
+ * `useAccountsList()` (`hooks/account/use-accounts-list.ts`), and every
+ * reader is gated `enabled: !!user`. A previous user's list — of ANY size,
+ * not only one account — is not ADDRESSABLE from this user's session, so it
+ * cannot reach this function at all any more.
  *
- * That gap is now closed one layer up instead, structurally: the account list
- * is cached under `qk.accounts.list(userId)` (`packages/sdk/src/react/
- * query-keys.ts`), read only through `useAccountsList()`
- * (`hooks/account/use-accounts-list.ts`), and every reader is gated
- * `enabled: !!user`. A previous user's list is not ADDRESSABLE from this
- * user's session, so it can no longer reach this function at all.
+ * WHAT THAT MEANS FOR THE 2+-ACCOUNT CASE THIS FUNCTION ACTUALLY GUARDS:
+ * before the key scoping above, a 2+-account list with no anchor to the
+ * viewer had TWO possible causes — (a) a stale or wrong cache entry left by a
+ * DIFFERENT signed-in user, or (b) a genuine, still-rare shape: a user who
+ * owns/admins 2+ team accounts and has no personal account of their own, so
+ * none of their creatable accounts is `account_id === userId`. The key
+ * scoping above closes (a) the same way it closes the N=1 case — a previous
+ * user's list cannot reach this function at all. It does NOT close (b): that
+ * user's OWN list, correctly scoped to their OWN session, still has zero
+ * anchor to their identity, because their identity genuinely has no
+ * creatable account of its own. So today the ONLY reachable trigger for this
+ * predicate is (b), a legitimate user, not a caching defect — reachable via
+ * SAML JIT provisioning (`iam/sso-sync.ts` inserting a membership directly)
+ * or direct invite acceptance (`accounts/invites.ts`), either of which can
+ * add someone as owner/admin on 2+ accounts without ever running the
+ * `memberships.length === 0` personal-account bootstrap gate.
  *
- * This check still earns its place and must NOT be deleted: it is the
- * fail-closed guard for a 2+-account list with no anchor to the viewer, which
- * the key cannot rule out (a genuine response can legitimately contain
- * accounts the viewer does not own). Key scoping and this check cover
- * different shapes.
+ * This check still earns its place and must NOT be deleted or relaxed: (b)
+ * is real, and this function still cannot tell "a genuine multi-account user
+ * with no personal account" apart from any other reason a response might
+ * carry zero anchor to the viewer — guessing which of 2+ unrelated accounts
+ * is safe to default into is worse than refusing to guess (G2, fail-closed).
+ * What changed is the caller's obligation: since the reachable trigger is now
+ * a LEGITIMATE user rather than a caching artifact, `new-workspace-page.tsx`
+ * must render that user a REASON, not a silently disabled form — see its own
+ * comment where `foreignAccountList` is read.
  *
  * `userId` is required, not optional: an omitted argument used to compile
  * clean and silently degrade to `undefined`, which made every 2+-account

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -88,41 +88,111 @@ export function filterCreatableAccounts(accounts: KortixAccount[]): KortixAccoun
  * Which creatable account `/new` should pre-select.
  *
  * Preference order:
- * 1. Account `name` equals the signed-in email (case-insensitive) — the
- *    personal / bootstrapped account is often titled with the email.
- * 2. Account `slug` equals the email or its local-part.
- * 3. `is_primary_owner` — same proxy marketplace/install dialogs use when
- *    there is no `personal_account` flag on the API.
- * 4. The first creatable account.
+ * 1. Identity — `account_id === userId`. Personal accounts are created with
+ *    `accountId === userId` by construction
+ *    (`apps/api/src/accounts/core/bootstrap-personal-account.ts`: "Personal
+ *    accounts use `accountId === userId`"), so this is the only tier that can
+ *    distinguish the account that IS the user from an account the user
+ *    merely owns or administers. Replaces two tiers that were permanently
+ *    dead against the real `GET /v1/accounts` shape: `name` always carries
+ *    the `'s Account` possessive (`filterCreatableAccounts` stopped
+ *    stripping it, Task 1), and `slug` is `accountId.slice(0, 8)`
+ *    (`apps/api/src/accounts/core/accounts.ts:122`) — never an email or its
+ *    local part.
+ * 2. `is_primary_owner` — true for any account this user owns outright
+ *    (`accountRole === 'owner'`, `apps/api/src/accounts/core/accounts.ts:126`),
+ *    including a team account that is NOT their personal one. Kept as a
+ *    fallback for when identity does not resolve (`userId` not loaded yet,
+ *    or the sole owned account is a team account) — the same proxy
+ *    marketplace/install dialogs use when there is no `personal_account`
+ *    flag on the API.
+ * 3. The first creatable account — no signal at all to prefer one over
+ *    another.
  *
  * Pure and Effect-free so `/new` can derive the default without writing to
  * state on mount (the page forbids `useEffect`).
  */
 export function resolveDefaultCreatableAccountId(
   accounts: KortixAccount[],
-  email?: string | null,
+  userId?: string | null,
 ): string | null {
   if (accounts.length === 0) return null;
   if (accounts.length === 1) return accounts[0]!.account_id;
 
-  const normalized = email?.trim().toLowerCase() ?? '';
-  if (normalized) {
-    const byName = accounts.find((account) => account.name.trim().toLowerCase() === normalized);
-    if (byName) return byName.account_id;
-
-    const localPart = normalized.split('@')[0] ?? '';
-    const bySlug = accounts.find((account) => {
-      const slug = account.slug?.trim().toLowerCase() ?? '';
-      if (!slug) return false;
-      return slug === normalized || (localPart.length > 0 && slug === localPart);
-    });
-    if (bySlug) return bySlug.account_id;
+  if (userId) {
+    const own = accounts.find((account) => account.account_id === userId);
+    if (own) return own.account_id;
   }
 
   const primary = accounts.find((account) => account.is_primary_owner);
   if (primary) return primary.account_id;
 
   return accounts[0]!.account_id;
+}
+
+/**
+ * A creatable-accounts list the viewer's identity cannot be anchored to: two
+ * or more accounts, none of them the viewer's own (`account_id === userId`).
+ *
+ * Deliberately excludes a SOLE foreign account. `GET /v1/accounts` only ever
+ * returns accounts this specific signed-in user is a genuine member of
+ * (`accountMembers.userId = userId`, `apps/api/src/accounts/core/accounts.ts`),
+ * and `filterCreatableAccounts` further narrows that to owner/admin roles —
+ * so a SOLE creatable account that is not the viewer's own is the ordinary
+ * invited-admin shape: someone added as admin on an account before ever
+ * having their own personal account bootstrapped (`bootstrapPersonalAccount`
+ * only fires when the caller has ZERO existing memberships,
+ * `apps/api/src/accounts/core/accounts.ts`). That is legitimate and common,
+ * not a leak — it is exactly the scenario Task 1's fix protects (Task 2
+ * controller addendum A2.2), so it is never FOREIGN on its own.
+ *
+ * A MULTI-account list with no anchor to the viewer at all has no such
+ * legitimate shape: once the viewer's own personal account exists it is
+ * always one of their membership rows, and therefore always present. Two or
+ * more accounts with zero anchor to the viewer is the signature a stale or
+ * wrong `['accounts']` cache entry would produce (a leftover list from a
+ * DIFFERENT signed-in user), not a genuine response for this identity — so
+ * this is the fail-closed branch (G2): treat it as untrustworthy rather than
+ * guess which entry, if any, is safe to default into.
+ */
+export function isForeignAccountList(
+  creatableAccounts: KortixAccount[],
+  userId?: string | null,
+): boolean {
+  if (creatableAccounts.length < 2) return false;
+  return !creatableAccounts.some((account) => account.account_id === userId);
+}
+
+/**
+ * Accounts to hand `AccountPicker`'s `accounts` prop — identical to
+ * `creatableAccounts` except the two cases that must render LESS than the
+ * real list.
+ *
+ * `AccountPicker`'s `accounts.length === 1` branch
+ * (`resolveAccountPickerIdentity`, `account-picker.tsx`) always paints a
+ * "Create in {name}" line for a sole account — there is no prop that
+ * suppresses just that line while leaving the account in the list. So:
+ *
+ * - A SOLE account that IS the viewer's own (`account_id === userId`): an
+ *   empty array, so `AccountPicker` falls into its zero-account shape and
+ *   renders the identity line alone (Task 2 controller addendum A2.2) — a
+ *   user's own email directly above "Create in jay@kortix.ai's Account" is
+ *   redundant, not informative.
+ * - A FOREIGN list (`isForeignAccountList`): also an empty array — no
+ *   account name renders at all (Task 2 item 2, G2 fail-closed).
+ * - Everything else, INCLUDING a sole foreign account (the invited-admin
+ *   case): `creatableAccounts`, unmodified. That account's name must still
+ *   render — suppressing it here would re-open the exact disclosure Task 1
+ *   closed.
+ */
+export function resolveAccountsForPicker(
+  creatableAccounts: KortixAccount[],
+  userId?: string | null,
+): KortixAccount[] {
+  if (isForeignAccountList(creatableAccounts, userId)) return [];
+  const sole = creatableAccounts.length === 1 ? creatableAccounts[0]! : null;
+  if (sole && userId && sole.account_id === userId) return [];
+  return creatableAccounts;
 }
 
 export function isSubmittable(state: NewWorkspaceFormState, accountCount: number): boolean {

--- a/apps/web/src/features/workspace/new/new-workspace-form.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-form.ts
@@ -154,45 +154,68 @@ export function resolveDefaultCreatableAccountId(
  * DIFFERENT signed-in user), not a genuine response for this identity — so
  * this is the fail-closed branch (G2): treat it as untrustworthy rather than
  * guess which entry, if any, is safe to default into.
+ *
+ * RESIDUAL RISK, stated plainly rather than assumed away: a SOLE foreign
+ * account (the branch above that returns `false`) is INDISTINGUISHABLE, from
+ * this function's inputs alone, from a stale `['accounts']` cache entry that
+ * still holds a DIFFERENT, previously-signed-in user's single-account list.
+ * Both shapes are exactly one account, `account_id !== userId`. If
+ * `['accounts']` is not scoped per signed-in user, that instance of symptom 3
+ * reaches this function looking identical to the legitimate invited-admin
+ * case and is NOT caught here. Closing that gap is Task 10's job (a
+ * user-scoped `['accounts']` query key), not this function's — do not
+ * de-scope Task 10 on the belief that Task 2 already covers the N=1 case.
+ *
+ * `userId` is required, not optional: an omitted argument used to compile
+ * clean and silently degrade to `undefined`, which made every 2+-account
+ * list FOREIGN by accident (a functional break for real multi-account users,
+ * not a security hole, but one no single-account test could catch). The type
+ * also does not accept `undefined` at all — only `string | null` — so a
+ * caller that cannot yet establish identity must say so explicitly with
+ * `null` rather than by omission. `null` already fails closed correctly: no
+ * real `account_id` is ever `null`, so `!some(...)` is `true` for any 2+
+ * list, exactly the G2 fail-closed direction this function exists for.
  */
 export function isForeignAccountList(
   creatableAccounts: KortixAccount[],
-  userId?: string | null,
+  userId: string | null,
 ): boolean {
   if (creatableAccounts.length < 2) return false;
   return !creatableAccounts.some((account) => account.account_id === userId);
 }
 
 /**
- * Accounts to hand `AccountPicker`'s `accounts` prop — identical to
- * `creatableAccounts` except the two cases that must render LESS than the
- * real list.
+ * Whether `AccountPicker` should reveal any account-specific info beyond
+ * bare identity — the caller-side half of A2.2 / item 2's suppression rules.
  *
- * `AccountPicker`'s `accounts.length === 1` branch
- * (`resolveAccountPickerIdentity`, `account-picker.tsx`) always paints a
- * "Create in {name}" line for a sole account — there is no prop that
- * suppresses just that line while leaving the account in the list. So:
+ * `AccountPicker` always receives the REAL, unmodified `creatableAccounts` —
+ * this function returns a boolean, never a shrunk stand-in list, precisely
+ * because handing the component a falsified `accounts` array (this used to
+ * return `[]` to suppress) makes `accounts` stop meaning "the accounts the
+ * user can create in" while `value` still names one of them, a standing trap
+ * for anyone who later changes `AccountPicker`'s own length thresholds or
+ * adds a second consumer of `accounts`. `AccountPicker`'s own
+ * `showAccountLine` prop is what actually acts on this.
  *
- * - A SOLE account that IS the viewer's own (`account_id === userId`): an
- *   empty array, so `AccountPicker` falls into its zero-account shape and
- *   renders the identity line alone (Task 2 controller addendum A2.2) — a
+ * `false` (suppress) for:
+ * - A SOLE account that IS the viewer's own (`account_id === userId`): a
  *   user's own email directly above "Create in jay@kortix.ai's Account" is
- *   redundant, not informative.
- * - A FOREIGN list (`isForeignAccountList`): also an empty array — no
- *   account name renders at all (Task 2 item 2, G2 fail-closed).
- * - Everything else, INCLUDING a sole foreign account (the invited-admin
- *   case): `creatableAccounts`, unmodified. That account's name must still
- *   render — suppressing it here would re-open the exact disclosure Task 1
- *   closed.
+ *   redundant, not informative (Task 2 controller addendum A2.2).
+ * - A FOREIGN list (`isForeignAccountList`): no account name renders at all
+ *   (Task 2 item 2, G2 fail-closed).
+ *
+ * `true` (reveal) for everything else, INCLUDING a sole foreign account (the
+ * invited-admin case) — that account's name must still render; suppressing
+ * it would re-open the exact disclosure Task 1 closed.
  */
-export function resolveAccountsForPicker(
+export function shouldShowAccountLine(
   creatableAccounts: KortixAccount[],
-  userId?: string | null,
-): KortixAccount[] {
-  if (isForeignAccountList(creatableAccounts, userId)) return [];
+  userId: string | null,
+): boolean {
+  if (isForeignAccountList(creatableAccounts, userId)) return false;
   const sole = creatableAccounts.length === 1 ? creatableAccounts[0]! : null;
-  if (sole && userId && sole.account_id === userId) return [];
-  return creatableAccounts;
+  if (sole && sole.account_id === userId) return false;
+  return true;
 }
 
 export function isSubmittable(state: NewWorkspaceFormState, accountCount: number): boolean {

--- a/apps/web/src/features/workspace/new/new-workspace-page.onboarding.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.onboarding.test.ts
@@ -89,7 +89,7 @@ describe('/new hosts the onboarding wizard', () => {
  * 'idle'`, so the page used to paint the live create FORM while
  * `getProjectDetail` was still in flight. The Name input carries `autoFocus`
  * and is fully interactive in that window: a user who reloads mid-onboarding
- * can start typing, and if `['accounts']` resolves first, Enter fires a SECOND
+ * can start typing, and if the account list resolves first, Enter fires a SECOND
  * `runCreate`.
  */
 describe('/new: the onboarding param owns the page', () => {

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -57,24 +57,24 @@ describe('/new page: no invented constraints', () => {
     // of assertion a second effect slips past when it is relaxed to a
     // `toContain`. The body is pinned too, so this stays a WRITE ban rather
     // than an effect budget.
-    const effects = code.match(/useEffect\(/g) ?? [];
-    expect(effects.length).toBe(1);
-    expect(code).toContain("if (!authLoading && !user) router.replace('/auth');");
-    // ...and it stands down during our OWN sign-out, so the soft replace cannot
-    // beat `performSignOut`'s document load to `/auth` and carry the route
-    // cache across the identity change.
-    expect(code).toContain('if (isSigningOut()) return;');
+    // Back to ZERO effects. The signed-out guard this page needs is the shared
+    // `useSignedOutRedirect()` hook — one copy for all eight surfaces that had
+    // hand-rolled it, and the only place the `isSigningOut()` stand-down has to
+    // be written.
+    expect(code).not.toContain('useEffect(');
+    expect(code).toContain('useSignedOutRedirect();');
 
     // Paired presence check: there IS a submit path, just not an eager one.
     expect(code).toContain('onSubmit');
   });
 
   test('a session that dies while the page is mounted does not leave a dead form up', () => {
-    // The same guard `/projects/start` carries. Middleware gates the REQUEST,
-    // not the mounted document: a token that expires here, or a sign-out in
-    // another tab, otherwise leaves a signed-out user on a create form whose
-    // submit can only 401.
-    expect(code).toContain('const { user, isLoading: authLoading } = useAuth();');
+    // Middleware gates the REQUEST, not the mounted document: a token that
+    // expires here, or a sign-out in another tab, otherwise leaves a signed-out
+    // user on a create form whose submit can only 401. The hook owns the
+    // redirect; this page only has to call it.
+    expect(code).toContain("from '@/lib/auth/use-signed-out-redirect'");
+    expect(code).toContain('useSignedOutRedirect();');
   });
 
   test('reads the account list on mount through the shared ["accounts"] cache key, not a page-local one', () => {
@@ -98,7 +98,12 @@ describe('/new page: escape hatch for a user with zero workspaces', () => {
     // assertion could not tell the fixed control from the broken one — which
     // neither awaited the sign-out nor navigated, and so signed the user out
     // and left them sitting on this form.
-    expect(code).toContain('onClick={() => void performSignOut()}');
+    expect(code).toContain('void performSignOut();');
+    // ...and it now says so while it works. The sign-out makes a server round
+    // trip this control never made before and is bounded at four steps, which
+    // is long enough that a silent button reads as a dead one.
+    expect(code).toContain('disabled={signingOut}');
+    expect(code).toContain("{signingOut ? 'Signing out' : 'Log out'}");
 
     // Rendered ahead of the <form>, not gated behind form state — a user
     // blocked by an invalid/incomplete form must still be able to leave.

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -282,14 +282,16 @@ describe('/new page: AccountPicker wiring', () => {
     expect(pickerIndex).toBeGreaterThan(0);
     expect(pickerIndex).toBeLessThan(formIndex);
 
-    // `pickerAccounts` (`resolveAccountsForPicker(creatableAccounts, user?.id)`,
-    // asserted below), not `creatableAccounts` directly — Task 2 needs the
-    // page to hand AccountPicker LESS than the real list for a sole own
-    // account (A2.2) and for a FOREIGN list (item 2), and `pickerAccounts` is
-    // the one place both collapse to before the picker ever sees them.
-    expect(picker).toContain('accounts={pickerAccounts}');
+    // Review round 1, Important 3: `accounts` is ALWAYS the REAL
+    // `creatableAccounts` list — the page used to hand AccountPicker a
+    // falsified, sometimes-emptied stand-in (`pickerAccounts`,
+    // `resolveAccountsForPicker`) to suppress rendering, which made
+    // `accounts` stop meaning "the accounts the user can create in" while
+    // `value` still named one of them. Suppression is now the EXPLICIT
+    // `showAccountLine` prop below, decided once by `shouldShowAccountLine`.
+    expect(picker).toContain('accounts={creatableAccounts}');
     expect(picker).not.toContain('accounts={accounts}');
-    expect(picker).not.toContain('accounts={creatableAccounts}');
+    expect(picker).not.toContain('accounts={pickerAccounts}');
     // Effective id = explicit pick OR identity-matched / primary default —
     // null outright for a FOREIGN list (Task 2 item 2).
     expect(picker).toContain('value={effectiveAccountId}');
@@ -297,8 +299,9 @@ describe('/new page: AccountPicker wiring', () => {
       "onChange={(accountId) => setState((s) => ({ ...s, accountId }))}",
     );
     expect(picker).toContain('fallbackLabel={user?.email}');
-    expect(code).toContain('resolveAccountsForPicker(creatableAccounts, user?.id)');
-    expect(code).toContain('resolveDefaultCreatableAccountId(creatableAccounts, user?.id)');
+    expect(picker).toContain('showAccountLine={showAccountLine}');
+    expect(code).toContain('shouldShowAccountLine(creatableAccounts, userId)');
+    expect(code).toContain('resolveDefaultCreatableAccountId(creatableAccounts, userId)');
     expect(code).toContain('void create(effectiveState)');
   });
 
@@ -306,22 +309,34 @@ describe('/new page: AccountPicker wiring', () => {
     expect(code).toContain("from '@/features/workspace/new/account-picker'");
   });
 
-  test('the SAME creatableAccounts value feeds the picker (via pickerAccounts), the default resolver, the foreign-list check, and the submit gate — no count mismatch', () => {
+  // Review round 1, Important 2: `user?.id` (`string | undefined`) is
+  // normalized to `string | null` exactly once, so every identity-aware call
+  // below shares one coercion instead of each caller silently omitting it.
+  test('user?.id is normalized to a required, non-omittable userId exactly once, and every identity-aware call uses it', () => {
+    expect(code).toContain('const userId = user?.id ?? null;');
+    expect(code).not.toContain('isForeignAccountList(creatableAccounts, user?.id)');
+    expect(code).not.toContain('shouldShowAccountLine(creatableAccounts, user?.id)');
+    expect(code).not.toContain('resolveDefaultCreatableAccountId(creatableAccounts, user?.id)');
+  });
+
+  test('the SAME creatableAccounts value feeds AccountPicker directly, the default resolver, the foreign-list check, the show-line decision, and the submit gate — no count mismatch', () => {
     // "What the user can pick" and "what gates submit" must be derived from
     // the exact same list. Counting references to the shared variable, rather
     // than checking each site in isolation, is what catches a future edit
     // that reintroduces two different lists (e.g. a second, slightly
     // different filter for one of the call sites).
     const creatableRefs = code.match(/creatableAccounts/g) ?? [];
-    // Declaration + isForeignAccountList + resolveAccountsForPicker +
-    // default resolver + isSubmittable length + zero-state note length === 0
-    // = 6.
-    expect(creatableRefs).toHaveLength(6);
+    // Declaration + isForeignAccountList + shouldShowAccountLine +
+    // default resolver + AccountPicker's own accounts= (review round 1,
+    // Important 3 — reverted from the falsified `pickerAccounts` stand-in
+    // back to the real list) + isSubmittable length + zero-state note
+    // length === 0 = 7.
+    expect(creatableRefs).toHaveLength(7);
   });
 
   test('a FOREIGN accounts list (item 2, G2 fail closed) nulls the effective account id and blocks submit', () => {
     expect(code).toContain(
-      'const foreignAccountList = isForeignAccountList(creatableAccounts, user?.id);',
+      'const foreignAccountList = isForeignAccountList(creatableAccounts, userId);',
     );
     expect(code).toContain('const defaultAccountId = foreignAccountList');
     expect(code).toContain(

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -77,14 +77,26 @@ describe('/new page: no invented constraints', () => {
     expect(code).toContain('useSignedOutRedirect();');
   });
 
-  test('reads the account list on mount through the shared ["accounts"] cache key, not a page-local one', () => {
+  test('reads the account list through the shared user-scoped hook, not a page-local query', () => {
     // Regression pin: an idempotent GET is allowed and expected here — it is
-    // what makes AccountPicker and the real submit-gate count possible. A
-    // page-local query key would duplicate the request WorkspaceSwitcher /
-    // AccountSwitcher already make instead of sharing their cache entry.
-    expect(code).toContain('useQuery({');
-    expect(code).toContain("queryKey: ['accounts']");
-    expect(code).toContain('queryFn: listAccounts');
+    // what makes AccountPicker and the real submit-gate count possible.
+    //
+    // The bar CHANGED, and not for style. This page used to hand-type
+    // `useQuery({ queryKey: ['accounts'], queryFn: listAccounts })`. That key
+    // carries no signed-in user, so a leftover single-account list belonging
+    // to the PREVIOUS user was readable here byte-for-byte — and this page
+    // resolves its create target out of that list, so the create went out
+    // with a foreign `account_id` under the new user's JWT (403). A
+    // page-local `useQuery` is now banned on both counts: it duplicates the
+    // request WorkspaceSwitcher / AccountSwitcher already make, AND it
+    // re-opens that hole. `useAccountsList()` is the only reader.
+    expect(code).toContain('const accountsQuery = useAccountsList();');
+    expect(code).toContain("from '@/hooks/account/use-accounts-list'");
+
+    // The ban, asserted as an absence AND paired with the presence above, so
+    // deleting the read outright cannot make this test pass.
+    expect(code).not.toContain('useQuery(');
+    expect(code).not.toContain('listAccounts');
   });
 });
 

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -411,6 +411,37 @@ describe('/new page: zero-creatable-accounts state', () => {
   });
 });
 
+describe('/new page: foreign-accounts-list state (B3)', () => {
+  // Before this, `foreignAccountList` (2+ creatable accounts, none the
+  // user's own) nulled the account id and blocked submit with NOTHING telling
+  // the user why: no picker (the top bar collapses to bare identity text via
+  // `showAccountLine={false}`), no "Create in" line, a permanently disabled
+  // button. After Task 10 scoped `['accounts']` to the signed-in user, the
+  // only user who can still reach this state is a legitimate one (no
+  // personal account, owner/admin on 2+ team accounts via SAML JIT or a
+  // direct invite acceptance) — a silent dead end for a real user is strictly
+  // worse than the 403 this branch set out to fix.
+  test('renders a reason with an escape hatch instead of a silent dead end', () => {
+    expect(code).toContain('!accountsQuery.isLoading && foreignAccountList');
+    expect(code).toContain("We can't tell which of your accounts is yours");
+    expect(code).toContain('mailto:support@kortix.ai');
+    // Same restrained treatment as the sibling zero-accounts note — no new
+    // chrome introduced for this one state.
+    expect(code).not.toContain('<InfoBanner');
+  });
+
+  test('the note is gated on accountsQuery.isLoading, same reason as the zero-accounts note', () => {
+    // `foreignAccountList` is computed from `creatableAccounts`, which is
+    // `[]` for every user during the load window — `isForeignAccountList`
+    // returns `false` for an empty list (length < 2), so this specific note
+    // cannot flash on its own; the gate still has to be asserted directly so
+    // a future change to that short-circuit cannot silently drop it.
+    const noteGuard = code.match(/\{[^{}]*foreignAccountList[^{}]*\? \(/)?.[0];
+    expect(noteGuard).toBeDefined();
+    expect(noteGuard).toContain('!accountsQuery.isLoading');
+  });
+});
+
 describe('/new page: exports', () => {
   test('exports NewWorkspacePage', () => {
     expect(code).toContain('export function NewWorkspacePage()');

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -282,15 +282,23 @@ describe('/new page: AccountPicker wiring', () => {
     expect(pickerIndex).toBeGreaterThan(0);
     expect(pickerIndex).toBeLessThan(formIndex);
 
-    expect(picker).toContain('accounts={creatableAccounts}');
+    // `pickerAccounts` (`resolveAccountsForPicker(creatableAccounts, user?.id)`,
+    // asserted below), not `creatableAccounts` directly — Task 2 needs the
+    // page to hand AccountPicker LESS than the real list for a sole own
+    // account (A2.2) and for a FOREIGN list (item 2), and `pickerAccounts` is
+    // the one place both collapse to before the picker ever sees them.
+    expect(picker).toContain('accounts={pickerAccounts}');
     expect(picker).not.toContain('accounts={accounts}');
-    // Effective id = explicit pick OR email-matched / primary default.
+    expect(picker).not.toContain('accounts={creatableAccounts}');
+    // Effective id = explicit pick OR identity-matched / primary default —
+    // null outright for a FOREIGN list (Task 2 item 2).
     expect(picker).toContain('value={effectiveAccountId}');
     expect(picker).toContain(
       "onChange={(accountId) => setState((s) => ({ ...s, accountId }))}",
     );
     expect(picker).toContain('fallbackLabel={user?.email}');
-    expect(code).toContain('resolveDefaultCreatableAccountId(creatableAccounts, user?.email)');
+    expect(code).toContain('resolveAccountsForPicker(creatableAccounts, user?.id)');
+    expect(code).toContain('resolveDefaultCreatableAccountId(creatableAccounts, user?.id)');
     expect(code).toContain('void create(effectiveState)');
   });
 
@@ -298,16 +306,28 @@ describe('/new page: AccountPicker wiring', () => {
     expect(code).toContain("from '@/features/workspace/new/account-picker'");
   });
 
-  test('the SAME creatableAccounts value feeds both the picker and the submit gate — no count mismatch', () => {
-    // "What the user can pick" and "what gates submit" must be the exact same
-    // list. Counting references to the shared variable, rather than checking
-    // each site in isolation, is what catches a future edit that reintroduces
-    // two different lists (e.g. a second, slightly different filter for one
-    // of the two call sites).
+  test('the SAME creatableAccounts value feeds the picker (via pickerAccounts), the default resolver, the foreign-list check, and the submit gate — no count mismatch', () => {
+    // "What the user can pick" and "what gates submit" must be derived from
+    // the exact same list. Counting references to the shared variable, rather
+    // than checking each site in isolation, is what catches a future edit
+    // that reintroduces two different lists (e.g. a second, slightly
+    // different filter for one of the call sites).
     const creatableRefs = code.match(/creatableAccounts/g) ?? [];
-    // Declaration + default resolver + AccountPicker accounts= +
-    // isSubmittable length + zero-state note length === 0 = 5.
-    expect(creatableRefs).toHaveLength(5);
+    // Declaration + isForeignAccountList + resolveAccountsForPicker +
+    // default resolver + isSubmittable length + zero-state note length === 0
+    // = 6.
+    expect(creatableRefs).toHaveLength(6);
+  });
+
+  test('a FOREIGN accounts list (item 2, G2 fail closed) nulls the effective account id and blocks submit', () => {
+    expect(code).toContain(
+      'const foreignAccountList = isForeignAccountList(creatableAccounts, user?.id);',
+    );
+    expect(code).toContain('const defaultAccountId = foreignAccountList');
+    expect(code).toContain(
+      'const effectiveAccountId = foreignAccountList ? null : (state.accountId ?? defaultAccountId);',
+    );
+    expect(code).toContain('!foreignAccountList');
   });
 });
 

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -60,6 +60,10 @@ describe('/new page: no invented constraints', () => {
     const effects = code.match(/useEffect\(/g) ?? [];
     expect(effects.length).toBe(1);
     expect(code).toContain("if (!authLoading && !user) router.replace('/auth');");
+    // ...and it stands down during our OWN sign-out, so the soft replace cannot
+    // beat `performSignOut`'s document load to `/auth` and carry the route
+    // cache across the identity change.
+    expect(code).toContain('if (isSigningOut()) return;');
 
     // Paired presence check: there IS a submit path, just not an eager one.
     expect(code).toContain('onSubmit');

--- a/apps/web/src/features/workspace/new/new-workspace-page.test.ts
+++ b/apps/web/src/features/workspace/new/new-workspace-page.test.ts
@@ -47,13 +47,30 @@ describe('/new page: no invented constraints', () => {
   });
 
   test('issues no MUTATING request on mount — only reads, and only submit ever writes', () => {
-    // Task 12 wires an accounts READ on mount (below), so "zero requests" is
-    // no longer the right bar. The bar this page must hold is "zero WRITES":
-    // no effect, and no mutation, can fire without the user pressing submit.
-    expect(code).not.toContain('useEffect(');
+    // Task 12 wires an accounts READ on mount, so "zero requests" is no longer
+    // the right bar. The bar this page must hold is "zero WRITES": nothing can
+    // fire without the user pressing submit.
     expect(code).not.toContain('useMutation(');
+
+    // ONE effect is allowed, and it is the signed-out guard. Counted, not
+    // spot-checked: "no useEffect" was the old bar and it is exactly the kind
+    // of assertion a second effect slips past when it is relaxed to a
+    // `toContain`. The body is pinned too, so this stays a WRITE ban rather
+    // than an effect budget.
+    const effects = code.match(/useEffect\(/g) ?? [];
+    expect(effects.length).toBe(1);
+    expect(code).toContain("if (!authLoading && !user) router.replace('/auth');");
+
     // Paired presence check: there IS a submit path, just not an eager one.
     expect(code).toContain('onSubmit');
+  });
+
+  test('a session that dies while the page is mounted does not leave a dead form up', () => {
+    // The same guard `/projects/start` carries. Middleware gates the REQUEST,
+    // not the mounted document: a token that expires here, or a sign-out in
+    // another tab, otherwise leaves a signed-out user on a create form whose
+    // submit can only 401.
+    expect(code).toContain('const { user, isLoading: authLoading } = useAuth();');
   });
 
   test('reads the account list on mount through the shared ["accounts"] cache key, not a page-local one', () => {
@@ -72,7 +89,12 @@ describe('/new page: escape hatch for a user with zero workspaces', () => {
     expect(code).toContain('<AccountPicker');
     expect(code).toContain('fallbackLabel={user?.email}');
     expect(code).toContain('Log out');
-    expect(code).toContain('signOut()');
+    // `performSignOut()`, not the old bare `void signOut()`. Spelled in full on
+    // purpose: `signOut()` is a SUBSTRING of `performSignOut()`, so the previous
+    // assertion could not tell the fixed control from the broken one — which
+    // neither awaited the sign-out nor navigated, and so signed the user out
+    // and left them sitting on this form.
+    expect(code).toContain('onClick={() => void performSignOut()}');
 
     // Rendered ahead of the <form>, not gated behind form state — a user
     // blocked by an invalid/incomplete form must still be able to leave.

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -23,8 +23,8 @@ import {
   filterCreatableAccounts,
   isForeignAccountList,
   isSubmittable,
-  resolveAccountsForPicker,
   resolveDefaultCreatableAccountId,
+  shouldShowAccountLine,
   type NewWorkspaceFormState,
 } from '@/features/workspace/new/new-workspace-form';
 import { useCreateWorkspace } from '@/features/workspace/new/use-create-workspace';
@@ -182,18 +182,28 @@ export function NewWorkspacePage() {
   // the user can pick" and "what gates submit" disagree.
   const creatableAccounts = filterCreatableAccounts(accounts);
 
+  // `user?.id` is `string | undefined`; the identity helpers below require an
+  // explicit `string | null` — an omitted/undefined argument used to compile
+  // clean and silently degrade to "cannot establish identity", which failed
+  // closed for the wrong reason (an accident, not a decision, G4). Normalized
+  // once here and reused for every identity-aware call on this page.
+  const userId = user?.id ?? null;
+
   // A creatableAccounts list the signed-in user's identity cannot be
   // anchored to (Task 2, G2 fail-closed) — see `isForeignAccountList`'s own
-  // doc comment for exactly which shape this is, and why a SOLE foreign
-  // account (the ordinary invited-admin case) is deliberately excluded.
-  const foreignAccountList = isForeignAccountList(creatableAccounts, user?.id);
+  // doc comment for exactly which shape this is, why a SOLE foreign account
+  // (the ordinary invited-admin case) is deliberately excluded, and why that
+  // exclusion does NOT cover a stale single-account `['accounts']` cache
+  // entry belonging to a different user — that instance of symptom 3 is
+  // closed by Task 10's user-scoped query key, not here.
+  const foreignAccountList = isForeignAccountList(creatableAccounts, userId);
 
-  // Accounts to hand `AccountPicker` — `creatableAccounts` with the two cases
-  // that must render less than the real list already collapsed
-  // (`resolveAccountsForPicker`): a sole account that is the viewer's own
-  // (redundant "Create in" line, Task 2 controller addendum A2.2) and a
-  // FOREIGN list (no account name at all, Task 2 item 2).
-  const pickerAccounts = resolveAccountsForPicker(creatableAccounts, user?.id);
+  // Whether `AccountPicker` should reveal any account-specific info beyond
+  // bare identity (Task 2 controller addendum A2.2 / item 2). `AccountPicker`
+  // always gets the REAL `creatableAccounts` below — never a shrunk stand-in
+  // — so `accounts` keeps meaning "the accounts the user can create in" and
+  // this flag is the sole, explicit place suppression is decided.
+  const showAccountLine = shouldShowAccountLine(creatableAccounts, userId);
 
   // Pre-select the personal / identity-matching account when the user has not
   // picked yet. Derived, not Effect-written — this page forbids useEffect
@@ -203,7 +213,7 @@ export function NewWorkspacePage() {
   // list — nothing in it can be trusted enough to pre-fill or submit.
   const defaultAccountId = foreignAccountList
     ? null
-    : resolveDefaultCreatableAccountId(creatableAccounts, user?.id);
+    : resolveDefaultCreatableAccountId(creatableAccounts, userId);
   const effectiveAccountId = foreignAccountList ? null : (state.accountId ?? defaultAccountId);
   const effectiveState: NewWorkspaceFormState = {
     ...state,
@@ -256,10 +266,11 @@ export function NewWorkspacePage() {
             collapses to muted identity text (email when none); two or more
             opens the Select on click. */}
         <AccountPicker
-          accounts={pickerAccounts}
+          accounts={creatableAccounts}
           value={effectiveAccountId}
           onChange={(accountId) => setState((s) => ({ ...s, accountId }))}
           fallbackLabel={user?.email}
+          showAccountLine={showAccountLine}
           className="min-w-0"
         />
         {/* `text-muted-foreground hover:text-foreground` (not the bare `ghost`

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -34,6 +34,7 @@ import {
   validateWorkspaceName,
 } from '@/features/workspace/new/workspace-name';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
+import { isSigningOut } from '@/lib/auth/sign-out-sequence';
 import { isBillingEnabled } from '@/lib/config';
 import { cn } from '@/lib/utils';
 import { listAccounts } from '@kortix/sdk';
@@ -128,7 +129,14 @@ export function NewWorkspacePage() {
   // leaves a signed-out user looking at a form whose submit can only 401. A
   // soft replace is right here and a document load is not — there is no
   // identity to flush, only a screen to leave.
+  //
+  // EXCEPT during our own sign-out, which is why `isSigningOut()` is checked
+  // first. `performSignOut` fires `SIGNED_OUT` before its document load starts,
+  // so without this the guard wins the race and the user reaches `/auth` by
+  // SOFT navigation with the App Router route cache intact — reintroducing on
+  // this one control the exact defect the hard navigation exists to remove.
   useEffect(() => {
+    if (isSigningOut()) return;
     if (!authLoading && !user) router.replace('/auth');
   }, [authLoading, user, router]);
 

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { readCloneParam } from '@/features/workspace/new/clone-param';
 import { readOnboardingParam } from '@/features/workspace/new/onboarding-param';
@@ -33,6 +33,7 @@ import {
   WORKSPACE_NAME_MAX_LENGTH,
   validateWorkspaceName,
 } from '@/features/workspace/new/workspace-name';
+import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { isBillingEnabled } from '@/lib/config';
 import { cn } from '@/lib/utils';
 import { listAccounts } from '@kortix/sdk';
@@ -116,10 +117,21 @@ const ICON_WIDTH = '2.5rem';
  * top-right, independent of the form below.
  */
 export function NewWorkspacePage() {
-  const { user, signOut } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
   const searchParams = useSearchParams();
   const cloneItemId = readCloneParam(new URLSearchParams(searchParams?.toString() ?? ''));
   const router = useRouter();
+
+  // The same guard `/projects/start` has. `/new` is a create surface behind the
+  // middleware, but the middleware only gates the REQUEST: a session that dies
+  // while this page is mounted (an expired token, a sign-out in another tab)
+  // leaves a signed-out user looking at a form whose submit can only 401. A
+  // soft replace is right here and a document load is not — there is no
+  // identity to flush, only a screen to leave.
+  useEffect(() => {
+    if (!authLoading && !user) router.replace('/auth');
+  }, [authLoading, user, router]);
+
   // Same `useSearchParams()` result the clone param reads — one subscription,
   // two params. Non-null only between "the workspace was created" and "the
   // user finished or skipped onboarding for it".
@@ -206,11 +218,12 @@ export function NewWorkspacePage() {
   const showAccountLine = shouldShowAccountLine(creatableAccounts, userId);
 
   // Pre-select the personal / identity-matching account when the user has not
-  // picked yet. Derived, not Effect-written — this page forbids useEffect
-  // (no eager side effects on mount). `isSubmittable` and submit both read
-  // the effective id so multi-account users are not blocked on "Choose an
-  // account" when a clear default exists. `null` outright for a FOREIGN
-  // list — nothing in it can be trusted enough to pre-fill or submit.
+  // picked yet. Derived, not Effect-written — the signed-out guard above is the
+  // only Effect this page is allowed, and no Effect here may perform a WRITE.
+  // `isSubmittable` and submit both read the effective id so multi-account users
+  // are not blocked on "Choose an account" when a clear default exists. `null`
+  // outright for a FOREIGN list — nothing in it can be trusted enough to
+  // pre-fill or submit.
   const defaultAccountId = foreignAccountList
     ? null
     : resolveDefaultCreatableAccountId(creatableAccounts, userId);
@@ -278,13 +291,17 @@ export function NewWorkspacePage() {
             treatment as `(auth)/auth/phone-verification/page.tsx:223-227` —
             otherwise it sits at full-contrast `text-foreground` beside the
             identity's dim muted text and reads louder than the page's actual
-            primary action. */}
+            primary action.
+
+            `performSignOut`, not the old bare `void signOut()`: that neither
+            awaited the sign-out nor navigated, so pressing Log out here signed
+            the user out and left them sitting on the create form. */}
         <Button
           type="button"
           variant="ghost"
           size="sm"
           className="text-muted-foreground hover:text-foreground shrink-0"
-          onClick={() => void signOut()}
+          onClick={() => void performSignOut()}
         >
           Log out
         </Button>

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -21,7 +21,9 @@ import { AdvancedFields } from '@/features/workspace/new/advanced-fields';
 import {
   INITIAL_FORM_STATE,
   filterCreatableAccounts,
+  isForeignAccountList,
   isSubmittable,
+  resolveAccountsForPicker,
   resolveDefaultCreatableAccountId,
   type NewWorkspaceFormState,
 } from '@/features/workspace/new/new-workspace-form';
@@ -180,13 +182,29 @@ export function NewWorkspacePage() {
   // the user can pick" and "what gates submit" disagree.
   const creatableAccounts = filterCreatableAccounts(accounts);
 
-  // Pre-select the personal / email-matching account when the user has not
+  // A creatableAccounts list the signed-in user's identity cannot be
+  // anchored to (Task 2, G2 fail-closed) — see `isForeignAccountList`'s own
+  // doc comment for exactly which shape this is, and why a SOLE foreign
+  // account (the ordinary invited-admin case) is deliberately excluded.
+  const foreignAccountList = isForeignAccountList(creatableAccounts, user?.id);
+
+  // Accounts to hand `AccountPicker` — `creatableAccounts` with the two cases
+  // that must render less than the real list already collapsed
+  // (`resolveAccountsForPicker`): a sole account that is the viewer's own
+  // (redundant "Create in" line, Task 2 controller addendum A2.2) and a
+  // FOREIGN list (no account name at all, Task 2 item 2).
+  const pickerAccounts = resolveAccountsForPicker(creatableAccounts, user?.id);
+
+  // Pre-select the personal / identity-matching account when the user has not
   // picked yet. Derived, not Effect-written — this page forbids useEffect
   // (no eager side effects on mount). `isSubmittable` and submit both read
   // the effective id so multi-account users are not blocked on "Choose an
-  // account" when a clear default exists.
-  const defaultAccountId = resolveDefaultCreatableAccountId(creatableAccounts, user?.email);
-  const effectiveAccountId = state.accountId ?? defaultAccountId;
+  // account" when a clear default exists. `null` outright for a FOREIGN
+  // list — nothing in it can be trusted enough to pre-fill or submit.
+  const defaultAccountId = foreignAccountList
+    ? null
+    : resolveDefaultCreatableAccountId(creatableAccounts, user?.id);
+  const effectiveAccountId = foreignAccountList ? null : (state.accountId ?? defaultAccountId);
   const effectiveState: NewWorkspaceFormState = {
     ...state,
     accountId: effectiveAccountId,
@@ -217,7 +235,13 @@ export function NewWorkspacePage() {
   const canSubmit =
     isSubmittable(effectiveState, creatableAccounts.length) &&
     !accountsQuery.isLoading &&
-    !submitting;
+    !submitting &&
+    // Belt and braces on top of `effectiveAccountId` already being forced
+    // null above for a FOREIGN list — `isSubmittable`'s own
+    // `accountCount > 1 && !accountId` check already fails on that null, but
+    // naming the condition here directly means a future edit to either
+    // function cannot silently reopen the disclosure by accident.
+    !foreignAccountList;
 
   return (
     <main className="mx-auto flex min-h-svh w-full max-w-md flex-col justify-center gap-6 px-6 py-16">
@@ -232,7 +256,7 @@ export function NewWorkspacePage() {
             collapses to muted identity text (email when none); two or more
             opens the Select on click. */}
         <AccountPicker
-          accounts={creatableAccounts}
+          accounts={pickerAccounts}
           value={effectiveAccountId}
           onChange={(accountId) => setState((s) => ({ ...s, accountId }))}
           fallbackLabel={user?.email}

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -488,6 +488,31 @@ export function NewWorkspacePage() {
                   </p>
                 ) : null}
 
+                {/* The `isForeignAccountList` case (`new-workspace-form.ts`) —
+                      2+ creatable accounts, none of them this user's own. Its
+                      only reachable trigger today is a LEGITIMATE user with no
+                      personal account (SAML JIT or a direct invite acceptance
+                      that bypassed the personal-account bootstrap gate), not a
+                      caching defect — see that function's own doc comment. Before
+                      this note the page went silent here: no picker (the top
+                      bar collapses to bare identity text), no "Create in" line,
+                      and a permanently disabled submit with nothing explaining
+                      why. Same treatment as the sibling message above —
+                      gated on `!accountsQuery.isLoading` for the same reason. */}
+                {!accountsQuery.isLoading && foreignAccountList ? (
+                  <p className="text-muted-foreground text-xs">
+                    We can't tell which of your accounts is yours, so we're not guessing.
+                    Email{' '}
+                    <a
+                      href="mailto:support@kortix.ai"
+                      className="text-foreground underline underline-offset-2"
+                    >
+                      support@kortix.ai
+                    </a>{' '}
+                    and we'll get it fixed.
+                  </p>
+                ) : null}
+
                 {/* `effectiveAccountId`, not `state.accountId`: the GitHub
                       queries inside are account-scoped, and `state.accountId`
                       is legitimately null for a single-account user (the

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -3,14 +3,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
-
+import { useMemo, useState } from 'react';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { readCloneParam } from '@/features/workspace/new/clone-param';
 import { readOnboardingParam } from '@/features/workspace/new/onboarding-param';
 import { readSourceParam } from '@/features/workspace/new/source-param';
 
 import { ProjectOnboardingWizard } from '@/components/projects/project-onboarding-wizard';
 import { Button } from '@/components/ui/button';
+import Loading from '@/components/ui/loading';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { GlobalUpgradeModal } from '@/features/billing/global-upgrade-modal';
@@ -34,7 +35,6 @@ import {
   validateWorkspaceName,
 } from '@/features/workspace/new/workspace-name';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
-import { isSigningOut } from '@/lib/auth/sign-out-sequence';
 import { isBillingEnabled } from '@/lib/config';
 import { cn } from '@/lib/utils';
 import { listAccounts } from '@kortix/sdk';
@@ -123,22 +123,7 @@ export function NewWorkspacePage() {
   const cloneItemId = readCloneParam(new URLSearchParams(searchParams?.toString() ?? ''));
   const router = useRouter();
 
-  // The same guard `/projects/start` has. `/new` is a create surface behind the
-  // middleware, but the middleware only gates the REQUEST: a session that dies
-  // while this page is mounted (an expired token, a sign-out in another tab)
-  // leaves a signed-out user looking at a form whose submit can only 401. A
-  // soft replace is right here and a document load is not — there is no
-  // identity to flush, only a screen to leave.
-  //
-  // EXCEPT during our own sign-out, which is why `isSigningOut()` is checked
-  // first. `performSignOut` fires `SIGNED_OUT` before its document load starts,
-  // so without this the guard wins the race and the user reaches `/auth` by
-  // SOFT navigation with the App Router route cache intact — reintroducing on
-  // this one control the exact defect the hard navigation exists to remove.
-  useEffect(() => {
-    if (isSigningOut()) return;
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   // Same `useSearchParams()` result the clone param reads — one subscription,
   // two params. Non-null only between "the workspace was created" and "the
@@ -159,6 +144,8 @@ export function NewWorkspacePage() {
     ...(initialSource ? { source: initialSource } : {}),
   }));
   const [touched, setTouched] = useState(false);
+  // Never cleared: the document is replaced, not re-rendered.
+  const [signingOut, setSigningOut] = useState(false);
   const reduceMotion = useReducedMotion();
   // One source for "is the icon column open" — the animation, the a11y
   // attributes and the inert gate all read the same value.
@@ -309,9 +296,14 @@ export function NewWorkspacePage() {
           variant="ghost"
           size="sm"
           className="text-muted-foreground hover:text-foreground shrink-0"
-          onClick={() => void performSignOut()}
+          disabled={signingOut}
+          onClick={() => {
+            setSigningOut(true);
+            void performSignOut();
+          }}
         >
-          Log out
+          {signingOut ? <Loading className="size-4 shrink-0" /> : null}
+          {signingOut ? 'Signing out' : 'Log out'}
         </Button>
       </div>
 

--- a/apps/web/src/features/workspace/new/new-workspace-page.tsx
+++ b/apps/web/src/features/workspace/new/new-workspace-page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import { AnimatePresence, m, useReducedMotion } from 'motion/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
@@ -17,6 +16,7 @@ import { Label } from '@/components/ui/label';
 import { GlobalUpgradeModal } from '@/features/billing/global-upgrade-modal';
 import { ProjectIconField } from '@/features/projects/modal/project-icon-field';
 import { useAuth } from '@/features/providers/auth-provider';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { AccountPicker } from '@/features/workspace/new/account-picker';
 import { AdvancedFields } from '@/features/workspace/new/advanced-fields';
 import {
@@ -37,7 +37,6 @@ import {
 import { performSignOut } from '@/lib/auth/perform-sign-out';
 import { isBillingEnabled } from '@/lib/config';
 import { cn } from '@/lib/utils';
-import { listAccounts } from '@kortix/sdk';
 
 /**
  * The form <-> `WorkspaceHandoff` swap's ONLY transition — a plain opacity
@@ -82,11 +81,11 @@ const ICON_WIDTH = '2.5rem';
  * that creates something because you looked at it is a page nobody can link
  * to safely.
  *
- * It DOES read the account list on mount (`useQuery(['accounts'],
- * listAccounts)`) — an idempotent GET, needed to know whether there is
- * anything to disambiguate (`AccountPicker`) and to gate submission on the
- * REAL account count instead of a placeholder. `['accounts']` is the exact
- * cache key `WorkspaceSwitcher` and `AccountSwitcher` already use, so a user
+ * It DOES read the account list on mount (`useAccountsList()`) — an
+ * idempotent GET, needed to know whether there is anything to disambiguate
+ * (`AccountPicker`) and to gate submission on the REAL account count instead
+ * of a placeholder. That hook is the exact
+ * cache entry `WorkspaceSwitcher` and `AccountSwitcher` already use, so a user
  * who reaches `/new` from either menu (the common path) hits a warm cache,
  * not a second request. That list is filtered to `creatableAccounts` (owner
  * or admin — `POST /provision` 403s on anything else, same predicate as
@@ -172,13 +171,12 @@ export function NewWorkspacePage() {
     return result.ok ? null : result.error;
   }, [state.name, touched]);
 
-  // Same `['accounts']` cache entry `WorkspaceSwitcher`/`AccountSwitcher` read
-  // — one shared query, not a page-local duplicate.
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  // Same user-scoped cache entry `WorkspaceSwitcher`/`AccountSwitcher` read —
+  // one shared query, not a page-local duplicate. `useAccountsList` is also
+  // what makes the stale-list instance of symptom 3 unreachable here: the key
+  // carries the signed-in user, so a previous user's list is not addressable
+  // from this page at all.
+  const accountsQuery = useAccountsList();
   const accounts = accountsQuery.data ?? [];
 
   // `filterCreatableAccounts` (`new-workspace-form.ts`) matches
@@ -199,10 +197,11 @@ export function NewWorkspacePage() {
   // A creatableAccounts list the signed-in user's identity cannot be
   // anchored to (Task 2, G2 fail-closed) — see `isForeignAccountList`'s own
   // doc comment for exactly which shape this is, why a SOLE foreign account
-  // (the ordinary invited-admin case) is deliberately excluded, and why that
-  // exclusion does NOT cover a stale single-account `['accounts']` cache
-  // entry belonging to a different user — that instance of symptom 3 is
-  // closed by Task 10's user-scoped query key, not here.
+  // (the ordinary invited-admin case) is deliberately excluded, and why the
+  // stale single-account instance of symptom 3 is closed by the user-scoped
+  // `qk.accounts.list(userId)` key above rather than here. This check is
+  // still live and still required: it covers a 2+-account list with no anchor
+  // to the viewer, a shape the key cannot rule out.
   const foreignAccountList = isForeignAccountList(creatableAccounts, userId);
 
   // Whether `AccountPicker` should reveal any account-specific info beyond
@@ -317,8 +316,8 @@ export function NewWorkspacePage() {
           RELOAD the create hook restarts at `status: 'idle'`, so `submitting`
           alone would paint the live form (Name input, `autoFocus`, fully
           interactive) in the window before `getProjectDetail` settles. A user
-          who reloaded mid-onboarding could type into it, and if `['accounts']`
-          resolved first, Enter fired a SECOND `runCreate`.
+          who reloaded mid-onboarding could type into it, and if the account
+          list resolved first, Enter fired a SECOND `runCreate`.
 
           The header lives INSIDE the form branch, not above the swap. It is
           the form's title — "Create a workspace" above a screen that is already

--- a/apps/web/src/features/workspace/new/use-create-workspace.test.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.test.ts
@@ -93,6 +93,7 @@ describe('buildCreatePayload: account_id is always sent explicitly', () => {
       { ...INITIAL_FORM_STATE, name: 'suna-web', accountId: null },
       [OWNER_ACCOUNT],
       'key-1',
+      'user-1',
     );
     expect(payload.account_id).toBe('acct-owner');
   });
@@ -125,12 +126,18 @@ describe('buildCreatePayload: account_id is always sent explicitly', () => {
         { ...INITIAL_FORM_STATE, name: 'suna-web', accountId: 'acct-picked' },
         [OWNER_ACCOUNT],
         'key-1',
+        'user-1',
       ),
     ).toThrow();
   });
 
   test('always carries the passed idempotency_key', () => {
-    const payload = buildCreatePayload({ ...INITIAL_FORM_STATE, name: 'x' }, [OWNER_ACCOUNT], 'the-key');
+    const payload = buildCreatePayload(
+      { ...INITIAL_FORM_STATE, name: 'x' },
+      [OWNER_ACCOUNT],
+      'the-key',
+      'user-1',
+    );
     expect(payload.idempotency_key).toBe('the-key');
   });
 
@@ -139,6 +146,7 @@ describe('buildCreatePayload: account_id is always sent explicitly', () => {
       { ...INITIAL_FORM_STATE, name: '  suna-web  ' },
       [OWNER_ACCOUNT],
       'key-1',
+      'user-1',
     );
     expect(payload.name).toBe('suna-web');
     expect(payload.seed_starter).toBe(true);

--- a/apps/web/src/features/workspace/new/use-create-workspace.test.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.test.ts
@@ -6,6 +6,7 @@ import {
   isRetryableError,
   isTransportFailure,
   messageFor,
+  resolveTargetAccountId,
   RETRY_DELAY_MS,
   runCreate,
   runCreateAttempt,
@@ -96,13 +97,36 @@ describe('buildCreatePayload: account_id is always sent explicitly', () => {
     expect(payload.account_id).toBe('acct-owner');
   });
 
-  test('prefers the explicitly picked account over the creatableAccounts fallback', () => {
+  test('prefers the explicitly picked account over the default, when that pick is one of creatableAccounts', () => {
+    // `userId: 'acct-owner'` anchors this list to the viewer (matches
+    // `OWNER_ACCOUNT`) so it is a normal multi-account list, not a FOREIGN
+    // one — the user is explicitly picking the OTHER account they can also
+    // create in (e.g. personal account owned, team account picked).
+    const picked: KortixAccount = { account_id: 'acct-picked', name: 'Picked Co', account_role: 'owner' };
     const payload = buildCreatePayload(
       { ...INITIAL_FORM_STATE, name: 'suna-web', accountId: 'acct-picked' },
-      [OWNER_ACCOUNT],
+      [OWNER_ACCOUNT, picked],
       'key-1',
+      'acct-owner',
     );
     expect(payload.account_id).toBe('acct-picked');
+  });
+
+  test('Task 2 item 3 (G2 fail closed): throws rather than send when the resolved account is NOT one of creatableAccounts', () => {
+    // Was previously "prefers the explicitly picked account over the
+    // creatableAccounts fallback" and asserted `accountId: 'acct-picked'`
+    // resolved even though `'acct-picked'` was absent from `[OWNER_ACCOUNT]`
+    // — trusting `state.accountId` unconditionally, with no check that it is
+    // an account the current user can actually create in. That is precisely
+    // the shape a stale/foreign `accountId` would take, so `buildCreatePayload`
+    // (via `resolveTargetAccountId`) now refuses to send it at all.
+    expect(() =>
+      buildCreatePayload(
+        { ...INITIAL_FORM_STATE, name: 'suna-web', accountId: 'acct-picked' },
+        [OWNER_ACCOUNT],
+        'key-1',
+      ),
+    ).toThrow();
   });
 
   test('always carries the passed idempotency_key', () => {
@@ -118,6 +142,73 @@ describe('buildCreatePayload: account_id is always sent explicitly', () => {
     );
     expect(payload.name).toBe('suna-web');
     expect(payload.seed_starter).toBe(true);
+  });
+});
+
+describe('resolveTargetAccountId', () => {
+  test('an explicit pick present in creatableAccounts wins', () => {
+    expect(
+      resolveTargetAccountId(
+        { ...INITIAL_FORM_STATE, accountId: 'acct-owner' },
+        [OWNER_ACCOUNT],
+        'user-1',
+      ),
+    ).toBe('acct-owner');
+  });
+
+  test('identity match resolves the default when nothing is explicitly picked', () => {
+    const personal: KortixAccount = { account_id: 'user-1', name: "me's Account", account_role: 'owner' };
+    const team: KortixAccount = { account_id: 'acct-team', name: 'Acme', account_role: 'owner' };
+    expect(
+      resolveTargetAccountId({ ...INITIAL_FORM_STATE, accountId: null }, [team, personal], 'user-1'),
+    ).toBe('user-1');
+  });
+
+  // Task 2's Tests section: "a member-only user with no owned account
+  // resolves to `undefined` rather than a stranger's account."
+  // `filterCreatableAccounts` excludes a member-role account entirely, so a
+  // member-only user's `creatableAccounts` is always `[]` — there is nothing
+  // to default into, and nothing was ever explicitly picked either.
+  test('a member-only user (empty creatableAccounts) resolves to undefined, never a stranger\'s account', () => {
+    expect(
+      resolveTargetAccountId({ ...INITIAL_FORM_STATE, accountId: null }, [], 'user-1'),
+    ).toBeUndefined();
+  });
+
+  test('G2 fail closed: throws when the resolved id is not one of creatableAccounts', () => {
+    expect(() =>
+      resolveTargetAccountId(
+        { ...INITIAL_FORM_STATE, accountId: 'acct-stale' },
+        [OWNER_ACCOUNT],
+        'user-1',
+      ),
+    ).toThrow();
+  });
+
+  test('G2 fail closed: throws for a FOREIGN accounts list even when the resolved id IS technically in it', () => {
+    // The gap this closes: a 2+-account list with none owned by the viewer
+    // still has an `is_primary_owner`/first-creatable default that resolves
+    // to SOME entry — and that entry is trivially "in creatableAccounts",
+    // since it came from that exact list. The plain membership check above
+    // cannot catch this; only asking whether the list itself is FOREIGN can.
+    const foreign1: KortixAccount = { account_id: 'org-1', name: 'Acme Inc', account_role: 'admin' };
+    const foreign2: KortixAccount = { account_id: 'org-2', name: 'Widgets Co', account_role: 'admin' };
+    expect(() =>
+      resolveTargetAccountId(
+        { ...INITIAL_FORM_STATE, accountId: null },
+        [foreign1, foreign2],
+        'user-1',
+      ),
+    ).toThrow();
+    // Even an EXPLICIT pick cannot escape a FOREIGN list — the whole list is
+    // untrustworthy, not just the default tier.
+    expect(() =>
+      resolveTargetAccountId(
+        { ...INITIAL_FORM_STATE, accountId: 'org-1' },
+        [foreign1, foreign2],
+        'user-1',
+      ),
+    ).toThrow();
   });
 });
 

--- a/apps/web/src/features/workspace/new/use-create-workspace.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildProvisionPayload,
   filterCreatableAccounts,
+  isForeignAccountList,
   resolveDefaultCreatableAccountId,
   type NewWorkspaceFormState,
 } from '@/features/workspace/new/new-workspace-form';
@@ -93,9 +94,29 @@ export function fingerprintOf(state: NewWorkspaceFormState): string {
  * the server and 403 "Owner or admin role required" — precisely the failure
  * the picker's owner/admin filter (Task 12) exists to prevent, reopened
  * through the server's default path. So the fallback is
- * `resolveDefaultCreatableAccountId` (email match → primary owner → first
+ * `resolveDefaultCreatableAccountId` (identity match → primary owner → first
  * creatable) against the SAME filtered list the picker itself renders from —
  * never the raw, unfiltered account list.
+ *
+ * Two independent fail-closed checks (Task 2 item 3, G2), both of which
+ * throw rather than let a create proceed:
+ *
+ * 1. `creatableAccounts` itself must not be FOREIGN
+ *    (`isForeignAccountList` — two or more accounts, none of them
+ *    `userId`'s own). Checked BEFORE looking at `state.accountId` at all: a
+ *    poisoned list taints every id it could produce, including one an
+ *    explicit (but stale) pick already carried, not only the default tier.
+ *    `new-workspace-page.tsx` already disables submit and hides the account
+ *    name for this case (item 2) — this is the second, independent layer
+ *    for any caller that resolves a target id without going through that
+ *    page-level gate, e.g. a future host of `useCreateWorkspace`.
+ * 2. The resolved id — from an explicit `state.accountId` or from the
+ *    default below — must actually be one of `creatableAccounts`.
+ *    `state.accountId` is normally only ever set from an `AccountPicker`
+ *    selection, itself built from this exact list, so this should never fire
+ *    in ordinary use; it is the last line of defense against a resolved id
+ *    that is stale, or a caller that skipped the page's own gating, ever
+ *    reaching the network with the signed-in user's JWT.
  *
  * Extracted out of `buildCreatePayload` (below) as its own function so the
  * account a create actually targets is resolved in exactly one place.
@@ -103,13 +124,19 @@ export function fingerprintOf(state: NewWorkspaceFormState): string {
 export function resolveTargetAccountId(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
-  email?: string | null,
+  userId?: string | null,
 ): string | undefined {
-  return (
-    state.accountId ??
-    resolveDefaultCreatableAccountId(creatableAccounts, email) ??
-    undefined
-  );
+  if (isForeignAccountList(creatableAccounts, userId)) {
+    throw new Error('Could not verify the target account for this workspace. Refresh and try again.');
+  }
+  const resolved =
+    state.accountId ?? resolveDefaultCreatableAccountId(creatableAccounts, userId) ?? undefined;
+  if (resolved === undefined) return undefined;
+  const isCreatable = creatableAccounts.some((account) => account.account_id === resolved);
+  if (!isCreatable) {
+    throw new Error('Could not verify the target account for this workspace. Refresh and try again.');
+  }
+  return resolved;
 }
 
 /** The exact `POST /projects/provision` request body for one create attempt. */
@@ -117,10 +144,11 @@ export function buildCreatePayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
   idempotencyKey: string,
+  userId?: string | null,
 ): Record<string, unknown> {
   return {
     ...buildProvisionPayload(state),
-    account_id: resolveTargetAccountId(state, creatableAccounts),
+    account_id: resolveTargetAccountId(state, creatableAccounts, userId),
     idempotency_key: idempotencyKey,
   };
 }
@@ -139,16 +167,18 @@ export function buildCreatePayload(
 export function buildGitHubCreatePayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
+  userId?: string | null,
 ): CreateProjectRepoInput {
-  return buildCreateRepoPayload(state, resolveTargetAccountId(state, creatableAccounts));
+  return buildCreateRepoPayload(state, resolveTargetAccountId(state, creatableAccounts, userId));
 }
 
 /** The `POST /projects/link-repository` body. Same account resolution. */
 export function buildGitHubImportPayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
+  userId?: string | null,
 ): LinkRepositoryInput {
-  return buildLinkRepositoryPayload(state, resolveTargetAccountId(state, creatableAccounts));
+  return buildLinkRepositoryPayload(state, resolveTargetAccountId(state, creatableAccounts, userId));
 }
 
 /**
@@ -512,19 +542,24 @@ async function runSourceAttempt(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
   idempotencyKey: string | null,
+  userId: string | null | undefined,
   client: CreateOrchestrationClient,
 ): Promise<KortixProject> {
   if (state.source === 'github-create') {
-    return client.createGitHubRepoProject(buildGitHubCreatePayload(state, creatableAccounts));
+    return client.createGitHubRepoProject(
+      buildGitHubCreatePayload(state, creatableAccounts, userId),
+    );
   }
   if (state.source === 'github-import') {
-    return client.importGitHubRepoProject(buildGitHubImportPayload(state, creatableAccounts));
+    return client.importGitHubRepoProject(
+      buildGitHubImportPayload(state, creatableAccounts, userId),
+    );
   }
   if (!idempotencyKey) {
     throw new Error('runCreate: the managed source requires an idempotency key');
   }
   return client.runCreateAttempt(
-    buildCreatePayload(state, creatableAccounts, idempotencyKey) as unknown as ProvisionProjectInput,
+    buildCreatePayload(state, creatableAccounts, idempotencyKey, userId) as unknown as ProvisionProjectInput,
   );
 }
 
@@ -578,7 +613,7 @@ export async function runCreate(
     : null;
 
   try {
-    const project = await runSourceAttempt(state, creatableAccounts, idempotencyKey, client);
+    const project = await runSourceAttempt(state, creatableAccounts, idempotencyKey, userId, client);
     if (usesIdempotencyKey) client.clearAttemptKey(fingerprint);
     client.primeProjectCache(project.account_id, project);
     client.invalidateProjects();

--- a/apps/web/src/features/workspace/new/use-create-workspace.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.ts
@@ -22,11 +22,11 @@ import {
   isManagedGitUnavailableError,
   isProjectLimitError,
 } from '@/lib/onboarding/ensure-first-project';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { writeLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import {
   createProjectRepo,
   linkRepository,
-  listAccounts,
   provisionProject,
   provisionProjectStream,
   PROVISION_IN_FLIGHT_CODE,
@@ -286,7 +286,7 @@ export function messageFor(error: unknown): string {
  * - `403` (wrong account / insufficient role) — retryable. Role and account
  *   membership are external state that CAN genuinely change between the
  *   failure and a later click, and `retry` re-closes over `creatableAccounts`
- *   (`useCreateWorkspace`'s own `['accounts']` query), which is refetched —
+ *   (`useCreateWorkspace`'s own `useAccountsList()` query), which is refetched —
  *   so a role grant made in the meantime can turn this into a success.
  * - `502` (bad gateway) — retryable. A transient upstream/gateway fault; a
  *   later attempt can land differently with no change on the client at all.
@@ -645,7 +645,8 @@ export async function runCreate(
  * only wires it to the live `queryClient`/`router`/`user` and to component
  * state.
  *
- * Fetches `['accounts']` itself — the same cache entry `new-workspace-page.tsx`,
+ * Reads the account list itself — the same user-scoped cache entry
+ * `new-workspace-page.tsx`,
  * `WorkspaceSwitcher` and `AccountSwitcher` already read — rather than taking
  * `creatableAccounts` as a parameter, so this hook can resolve the create's
  * target account (`resolveTargetAccountId`) without a second, page-specific
@@ -670,7 +671,7 @@ export function useCreateWorkspace(): {
   const [lastError, setLastError] = useState<unknown>(null);
   const [lastState, setLastState] = useState<NewWorkspaceFormState | null>(null);
 
-  const accountsQuery = useQuery({ queryKey: ['accounts'], queryFn: listAccounts, staleTime: 60_000 });
+  const accountsQuery = useAccountsList();
   const creatableAccounts = filterCreatableAccounts(accountsQuery.data ?? []);
 
   const create = useCallback(

--- a/apps/web/src/features/workspace/new/use-create-workspace.ts
+++ b/apps/web/src/features/workspace/new/use-create-workspace.ts
@@ -120,11 +120,20 @@ export function fingerprintOf(state: NewWorkspaceFormState): string {
  *
  * Extracted out of `buildCreatePayload` (below) as its own function so the
  * account a create actually targets is resolved in exactly one place.
+ *
+ * `userId` is required, not optional (G4): an omitted argument used to
+ * compile clean and silently degrade to `undefined`, which made
+ * `isForeignAccountList` treat ANY 2+-account list as foreign and throw —
+ * a functional break for real multi-account users that every single-
+ * account test passed straight through. The type is `string | null`, not
+ * `| undefined`: a caller that genuinely cannot establish identity yet must
+ * say so explicitly with `null`, which already fails closed correctly (see
+ * `isForeignAccountList`'s doc comment) rather than by accidental omission.
  */
 export function resolveTargetAccountId(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
-  userId?: string | null,
+  userId: string | null,
 ): string | undefined {
   if (isForeignAccountList(creatableAccounts, userId)) {
     throw new Error('Could not verify the target account for this workspace. Refresh and try again.');
@@ -144,7 +153,7 @@ export function buildCreatePayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
   idempotencyKey: string,
-  userId?: string | null,
+  userId: string | null,
 ): Record<string, unknown> {
   return {
     ...buildProvisionPayload(state),
@@ -167,7 +176,7 @@ export function buildCreatePayload(
 export function buildGitHubCreatePayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
-  userId?: string | null,
+  userId: string | null,
 ): CreateProjectRepoInput {
   return buildCreateRepoPayload(state, resolveTargetAccountId(state, creatableAccounts, userId));
 }
@@ -176,7 +185,7 @@ export function buildGitHubCreatePayload(
 export function buildGitHubImportPayload(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
-  userId?: string | null,
+  userId: string | null,
 ): LinkRepositoryInput {
   return buildLinkRepositoryPayload(state, resolveTargetAccountId(state, creatableAccounts, userId));
 }
@@ -542,7 +551,10 @@ async function runSourceAttempt(
   state: NewWorkspaceFormState,
   creatableAccounts: KortixAccount[],
   idempotencyKey: string | null,
-  userId: string | null | undefined,
+  // `string | null`, not `| undefined`: normalized once at the `runCreate`
+  // call site below so every `build*Payload` this function calls receives
+  // the same required, non-omittable identity argument they now require.
+  userId: string | null,
   client: CreateOrchestrationClient,
 ): Promise<KortixProject> {
   if (state.source === 'github-create') {
@@ -613,7 +625,7 @@ export async function runCreate(
     : null;
 
   try {
-    const project = await runSourceAttempt(state, creatableAccounts, idempotencyKey, userId, client);
+    const project = await runSourceAttempt(state, creatableAccounts, idempotencyKey, userId ?? null, client);
     if (usesIdempotencyKey) client.clearAttemptKey(fingerprint);
     client.primeProjectCache(project.account_id, project);
     client.invalidateProjects();

--- a/apps/web/src/features/workspace/project-layout/project-shell.tsx
+++ b/apps/web/src/features/workspace/project-layout/project-shell.tsx
@@ -9,6 +9,7 @@ import { ProjectOnboardingWizard } from '@/components/projects/project-onboardin
 import { Button } from '@/components/ui/button';
 import Hint from '@/components/ui/hint';
 import { SidebarEdgePeek, useSidebar } from '@/components/ui/sidebar';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { useBrandingScope } from '@/features/branding/branding-provider';
 import { AppProviders } from '@/features/layout/app-providers';
 import { useAuth } from '@/features/providers/auth-provider';
@@ -101,9 +102,7 @@ export function ProjectShell({ projectId, initialSidebarOpen, children }: Projec
     routeParams?.sessionId ?? null,
   );
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/auth');
-  }, [authLoading, user, router]);
+  useSignedOutRedirect();
 
   // Remember the project so the next `/` hit and the next sign-in land straight
   // back here instead of going through the id-free landing door. Gated on a

--- a/apps/web/src/features/workspace/project-sidebar/workspace-menu-section.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/workspace-menu-section.tsx
@@ -24,7 +24,7 @@
  */
 
 import { GearSixIcon as CogOne, MagnifyingGlassIcon as Search } from '@phosphor-icons/react';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useParams, usePathname } from 'next/navigation';
 import { useMemo, useState, type MouseEvent } from 'react';
@@ -47,6 +47,7 @@ import {
   resolveWorkspaceRowNavigation,
   type WorkspaceRowNavigation,
 } from '@/features/workspace/project-sidebar/workspace-grouping';
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { isModifiedClick } from '@/lib/navigation/modified-click';
 import { cn } from '@/lib/utils';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
@@ -54,7 +55,7 @@ import {
   shouldShowProjectSwitchLoading,
   useProjectSwitchStore,
 } from '@/stores/project-switch-store';
-import { listAccounts, listProjectsForAccount, type KortixProject } from '@kortix/sdk';
+import { listProjectsForAccount, type KortixProject } from '@kortix/sdk';
 import { contract, qk } from '@kortix/sdk/react';
 import { CheckCircleIcon as CheckCircleSolid } from '@phosphor-icons/react';
 
@@ -68,11 +69,7 @@ export function WorkspaceMenuSection() {
 
   const activeProjectId = pathname?.startsWith('/projects/') ? params?.id : undefined;
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
 
   // Every account the user belongs to, and every workspace in each. This menu is
   // the ONLY complete workspace directory now that the /projects index is gone,

--- a/apps/web/src/features/workspace/project-sidebar/workspace-switcher.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/workspace-switcher.tsx
@@ -91,8 +91,8 @@ export function WorkspaceSwitcher({ projectId }: { projectId: string }) {
   // than being silently dropped: without it, every account-scoped settings tab
   // opened on a project whose detail query has not resolved yet has no account
   // id to probe with, and renders as though the permission were denied. Same
-  // `['accounts']` key and `staleTime` as every other caller, so React Query
-  // serves them all from one fetch.
+  // `useAccountsList()` hook as every other caller, so React Query serves them
+  // all from one user-scoped fetch.
   useEnsureSelectedAccount();
 
   // For the rows that OPEN something in place — the settings panel, the log-out

--- a/apps/web/src/features/workspace/settings/tabs/account-memberships.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/account-memberships.tsx
@@ -36,14 +36,15 @@
  * more attention than the shortcut is worth.
  */
 
-import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
 import { SettingsRow, SettingsRowGroup } from '@/components/ui/settings-row';
 import { SettingsSubsectionHeader } from '@/components/ui/settings-subsection-header';
 import { Skeleton } from '@/components/ui/skeleton';
-import { type KortixAccount, listAccounts } from '@kortix/sdk';
+import { type KortixAccount } from '@kortix/sdk';
+
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 
 /** Exactly the fields this list reads — nothing else from `KortixAccount`. */
 export type AccountMembership = Pick<KortixAccount, 'account_id' | 'name' | 'account_role'>;
@@ -125,17 +126,13 @@ export function AccountMembershipsSection({
 /**
  * The accounts the user belongs to.
  *
- * The SAME `['accounts']` key, `queryFn` and `staleTime` every other caller
- * uses (`use-ensure-selected-account.ts`, `workspace-menu-section.tsx`), so
- * React Query serves all of them from one fetch — opening this pane inside a
- * project shell costs no request at all, because `WorkspaceSwitcher` already
- * primed that entry on mount.
+ * Reads through `useAccountsList()`, the one definition of that query, so this
+ * pane, `use-ensure-selected-account.ts` and `workspace-menu-section.tsx` all
+ * share one user-scoped cache entry — opening this pane inside a project shell
+ * costs no request at all, because `WorkspaceSwitcher` already primed that
+ * entry on mount.
  */
 export function useAccountMemberships(): { accounts: AccountMembership[]; isLoading: boolean } {
-  const query = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const query = useAccountsList();
   return { accounts: query.data ?? [], isLoading: query.isLoading };
 }

--- a/apps/web/src/features/workspace/settings/tabs/profile-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/profile-tab.tsx
@@ -833,7 +833,7 @@ export function ProfileTab() {
   };
 
   // --- Organizations ----------------------------------------------------
-  // Same `['accounts']` entry `WorkspaceSwitcher` already primed on mount, so
+  // Same account-list entry `WorkspaceSwitcher` already primed on mount, so
   // this costs no extra request inside a project shell.
   const { accounts, isLoading: accountsLoading } = useAccountMemberships();
 

--- a/apps/web/src/hooks/account/use-accounts-list.test.ts
+++ b/apps/web/src/hooks/account/use-accounts-list.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * `useAccountsList` is the ONE reader of the account list, and the reason it
+ * exists is a live cross-account defect, not tidiness.
+ *
+ * Before it, 13 components each hand-typed `useQuery({ queryKey: ['accounts'],
+ * queryFn: listAccounts, staleTime: 60_000 })`. That literal carries no user,
+ * so one document that saw two users held ONE cache entry for both. `/new`
+ * resolves its create target out of that list, so a leftover single-account
+ * list belonging to the PREVIOUS user made `POST /projects/provision` go out
+ * with a foreign `account_id` under the new user's JWT — a 403.
+ *
+ * Eight of those 13 readers also had no `enabled` gate at all, so they fired
+ * before `useAuth()` had resolved and wrote whatever came back into the shared
+ * slot. Both halves of the fix — the user-scoped key and the identity gate —
+ * are asserted here against the REAL object the hook hands `useQuery`, not
+ * against its source text.
+ */
+
+// ── the pure half: options builder ──────────────────────────────────────────
+
+const { accountsListQueryOptions, ACCOUNTS_STALE_TIME } = await import('./use-accounts-list');
+
+describe('accountsListQueryOptions', () => {
+  test('partitions the cache entry by signed-in user', () => {
+    const a = accountsListQueryOptions('user_a').queryKey;
+    const b = accountsListQueryOptions('user_b').queryKey;
+    expect(a).not.toEqual(b as never);
+    expect(a).toContain('user_a');
+    expect(b).not.toContain('user_a');
+  });
+
+  // G2, fail closed. `undefined` is the real pre-auth render, not a
+  // hypothetical: `AuthProvider` publishes `user: null` for at least one paint.
+  test('is DISABLED while the signed-in user is unknown', () => {
+    expect(accountsListQueryOptions(undefined).enabled).toBe(false);
+    expect(accountsListQueryOptions(null).enabled).toBe(false);
+  });
+
+  test('is enabled once the user is known', () => {
+    expect(accountsListQueryOptions('user_a').enabled).toBe(true);
+  });
+
+  // Two callers (`command-palette`, `add-to-project-modal`) only want the list
+  // while a surface is open. Their condition must AND with the identity gate,
+  // never replace it.
+  test("ANDs the caller's own gate with the identity gate", () => {
+    expect(accountsListQueryOptions('user_a', false).enabled).toBe(false);
+    expect(accountsListQueryOptions('user_a', true).enabled).toBe(true);
+    expect(accountsListQueryOptions(undefined, true).enabled).toBe(false);
+  });
+
+  // One shared freshness contract. `staleTime` is per-observer in React Query,
+  // so 13 hand-written copies could drift apart and re-fetch each other's
+  // entry; one constant is what makes "13 readers, one request" true.
+  test('pins one shared staleTime for every reader', () => {
+    expect(ACCOUNTS_STALE_TIME).toBe(60_000);
+    expect(accountsListQueryOptions('user_a').staleTime).toBe(60_000);
+  });
+});
+
+// ── the wired half: what the hook actually hands useQuery ────────────────────
+
+describe('useAccountsList — the object handed to useQuery', () => {
+  async function callHook(
+    user: { id: string } | null,
+    options?: Parameters<typeof import('./use-accounts-list').useAccountsList>[0],
+  ) {
+    const realQuery = await import('@tanstack/react-query');
+    const realSdk = await import('@kortix/sdk');
+    let captured: Record<string, unknown> | null = null;
+
+    mock.module('@/features/providers/auth-provider', () => ({ useAuth: () => ({ user }) }));
+    mock.module('@tanstack/react-query', () => ({
+      ...realQuery,
+      useQuery: (opts: Record<string, unknown>) => {
+        captured = opts;
+        return { data: undefined, isLoading: false };
+      },
+    }));
+
+    const mod = await import('./use-accounts-list');
+    mod.useAccountsList(options);
+    if (!captured) throw new Error('useQuery was never called');
+    return { captured: captured as Record<string, unknown>, listAccounts: realSdk.listAccounts };
+  }
+
+  test('keys the query by the signed-in user id', async () => {
+    const { captured } = await callHook({ id: 'user_a' });
+    expect(captured.queryKey).toContain('user_a');
+  });
+
+  test('two users never share a cache entry', async () => {
+    const a = await callHook({ id: 'user_a' });
+    const b = await callHook({ id: 'user_b' });
+    expect(a.captured.queryKey).not.toEqual(b.captured.queryKey as never);
+  });
+
+  test('does not run at all while the user is unknown', async () => {
+    const { captured } = await callHook(null);
+    expect(captured.enabled).toBe(false);
+  });
+
+  test("ANDs a caller's gate with the identity gate", async () => {
+    expect((await callHook({ id: 'user_a' }, { enabled: false })).captured.enabled).toBe(false);
+    expect((await callHook(null, { enabled: true })).captured.enabled).toBe(false);
+    expect((await callHook({ id: 'user_a' }, { enabled: true })).captured.enabled).toBe(true);
+  });
+
+  test('fetches through the SDK listAccounts, not a hand-rolled request', async () => {
+    const { captured, listAccounts } = await callHook({ id: 'user_a' });
+    expect(captured.queryFn).toBe(listAccounts);
+  });
+
+  // `/projects/start` is the one reader that retried; keeping its retry budget
+  // is what makes this migration a key change and not a behaviour change (G1).
+  test('passes a caller retry budget through, and sets none otherwise', async () => {
+    expect((await callHook({ id: 'user_a' }, { retry: 3 })).captured.retry).toBe(3);
+    expect((await callHook({ id: 'user_a' })).captured.retry).toBeUndefined();
+  });
+});
+
+describe('useAccountsQueryKey', () => {
+  // The two `setQueryData` writers seed the SAME entry the readers read. If
+  // this key and the hook's key could ever differ, a freshly created account
+  // would be written into a slot nothing renders.
+  test('is byte-identical to the key useAccountsList reads', async () => {
+    const realQuery = await import('@tanstack/react-query');
+    let captured: Record<string, unknown> | null = null;
+
+    mock.module('@/features/providers/auth-provider', () => ({
+      useAuth: () => ({ user: { id: 'user_a' } }),
+    }));
+    mock.module('@tanstack/react-query', () => ({
+      ...realQuery,
+      useQuery: (opts: Record<string, unknown>) => {
+        captured = opts;
+        return { data: undefined };
+      },
+    }));
+
+    const mod = await import('./use-accounts-list');
+    mod.useAccountsList();
+    expect(mod.useAccountsQueryKey()).toEqual(
+      (captured as unknown as Record<string, unknown>).queryKey as never,
+    );
+  });
+});
+
+// ── the migration is total, and stays total ─────────────────────────────────
+
+/**
+ * Default-deny scan, the same shape as `packages/sdk/src/react/
+ * query-key-literals.test.ts`. `apps/web/eslint.config.mjs` also bans this
+ * literal, but eslint is a separate command from `bun test`; this makes a
+ * reintroduced literal fail the SAME gate a broken unit test would.
+ *
+ * A PARTIAL migration is the thing being guarded against, not a stylistic
+ * preference: two keyspaces for one resource means
+ * `invalidateQueries({ queryKey: ['accounts'] })` from an unconverted surface
+ * silently misses the user-scoped entry every reader is now on, and the list
+ * renders stale with no error anywhere.
+ */
+function tsFilesUnder(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) tsFilesUnder(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+describe("the bare ['accounts'] query key is gone from apps/web", () => {
+  const SRC = join(import.meta.dir, '..', '..');
+
+  test('no file constructs a query key from the bare accounts literal', () => {
+    const offenders: string[] = [];
+    for (const file of tsFilesUnder(SRC)) {
+      const code = readFileSync(file, 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/.*$/gm, '$1');
+      for (const line of code.split('\n')) {
+        // `'accounts'` only, never `'account'`: `['account', accountId]` is a
+        // DIFFERENT, still-live family (one account's detail row, keyed by
+        // account id, which already carries its own scope). Widening this to
+        // `accounts?` swept nine of those in and would have turned a defect
+        // fix into an unrelated migration.
+        if (/queryKey:\s*\[\s*['"]accounts['"]/.test(line)) offenders.push(`${file}: ${line.trim()}`);
+        if (/(setQueryData|getQueryData)\s*(<[^>]*>)?\(\s*\[\s*['"]accounts['"]\s*\]/.test(line)) {
+          offenders.push(`${file}: ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/account/use-accounts-list.test.ts
+++ b/apps/web/src/hooks/account/use-accounts-list.test.ts
@@ -178,20 +178,37 @@ describe("the bare ['accounts'] query key is gone from apps/web", () => {
   const SRC = join(import.meta.dir, '..', '..');
 
   test('no file constructs a query key from the bare accounts literal', () => {
+    const files = tsFilesUnder(SRC);
+    // A floor on the walk itself, same shape as
+    // `persisted-store-coverage.test.ts:148` — an empty or broken walk
+    // (a renamed directory, a changed exclude list) would otherwise let this
+    // test pass by examining zero files. 2000 as a floor against 2560 real
+    // files as of this test's writing, generous slack against unrelated
+    // deletions.
+    expect(files.length).toBeGreaterThanOrEqual(2000);
+
     const offenders: string[] = [];
-    for (const file of tsFilesUnder(SRC)) {
+    // `\s` (not a line split) so a multi-line construct —
+    // `queryKey: [\n  'accounts'\n]`, which prettier can produce as readily
+    // as the single-line form — is caught too. The previous, line-based
+    // version split the file into lines FIRST and matched each line alone,
+    // so a literal broken across lines evaded both patterns below entirely.
+    const patterns = [
+      /queryKey:\s*\[\s*['"]accounts['"]/g,
+      /(setQueryData|getQueryData)\s*(<[^>]*>)?\(\s*\[\s*['"]accounts['"]\s*\]/g,
+    ];
+    for (const file of files) {
       const code = readFileSync(file, 'utf8')
         .replace(/\/\*[\s\S]*?\*\//g, '')
         .replace(/(^|[^:])\/\/.*$/gm, '$1');
-      for (const line of code.split('\n')) {
-        // `'accounts'` only, never `'account'`: `['account', accountId]` is a
-        // DIFFERENT, still-live family (one account's detail row, keyed by
-        // account id, which already carries its own scope). Widening this to
-        // `accounts?` swept nine of those in and would have turned a defect
-        // fix into an unrelated migration.
-        if (/queryKey:\s*\[\s*['"]accounts['"]/.test(line)) offenders.push(`${file}: ${line.trim()}`);
-        if (/(setQueryData|getQueryData)\s*(<[^>]*>)?\(\s*\[\s*['"]accounts['"]\s*\]/.test(line)) {
-          offenders.push(`${file}: ${line.trim()}`);
+      // `'accounts'` only, never `'account'`: `['account', accountId]` is a
+      // DIFFERENT, still-live family (one account's detail row, keyed by
+      // account id, which already carries its own scope). Widening this to
+      // `accounts?` swept nine of those in and would have turned a defect
+      // fix into an unrelated migration.
+      for (const pattern of patterns) {
+        for (const match of code.matchAll(pattern)) {
+          offenders.push(`${file}: ${match[0].replace(/\s+/g, ' ').trim()}`);
         }
       }
     }

--- a/apps/web/src/hooks/account/use-accounts-list.ts
+++ b/apps/web/src/hooks/account/use-accounts-list.ts
@@ -1,0 +1,132 @@
+/**
+ * The account list — `listAccounts()`, `GET /accounts` — read through ONE
+ * user-scoped cache entry.
+ *
+ * ## Why this hook exists
+ *
+ * Thirteen components used to hand-type the identical four lines:
+ *
+ * ```ts
+ * useQuery({ queryKey: ['accounts'], queryFn: listAccounts, staleTime: 60_000 })
+ * ```
+ *
+ * Two things were wrong with that, and only one of them was cosmetic.
+ *
+ * **1. The key carried no identity.** `['accounts']` is the same array for
+ * every user, so one document that saw two users held ONE entry for both. The
+ * only thing separating user B from user A's list was an imperative
+ * `queryClient.clear()` on the sign-out path — which has to fire on every
+ * exit, finish before anything refetches, never be undone, and which leaves
+ * mounted observers attached so they immediately refetch anyway.
+ *
+ * That gap was not theoretical. `/new` resolves its create target out of this
+ * list (`resolveTargetAccountId`, `new-workspace-form.ts`), so a leftover
+ * single-account list belonging to the previous user made
+ * `POST /projects/provision` go out with a foreign `account_id` under the new
+ * user's JWT, which the API answers 403. It could not be closed by inspecting
+ * the list: a legitimate invited admin — no personal account, administers
+ * someone else's org — produces a byte-identical single foreign
+ * `KortixAccount`, and rejecting that shape would lock that population out of
+ * creating any workspace. Only the KEY distinguishes them, which is what
+ * `qk.accounts.list(userId)` adds.
+ *
+ * **2. Eight of the thirteen had no `enabled` gate.** They fired before
+ * `useAuth()` had resolved and wrote whatever came back into the shared slot.
+ * Every reader now fails CLOSED: no user id, no query, no data — never
+ * another user's data.
+ *
+ * ## Why one hook rather than thirteen corrected copies
+ *
+ * `staleTime` is per-observer in React Query, and the key, the fetcher and the
+ * gate all have to agree across every caller or the "13 readers, one request"
+ * property silently becomes "13 requests". Thirteen hand-written copies is how
+ * the original drift happened. There is one definition here, and
+ * `apps/web/eslint.config.mjs` makes a reintroduced `queryKey: ['accounts']`
+ * a build failure.
+ *
+ * The KEY itself is not defined here — it comes from `qk` in `@kortix/sdk/react`,
+ * which is the source of truth for every Kortix cache key. This hook only binds
+ * it to the host's own auth context, which the framework-free SDK cannot see.
+ */
+
+import { useAuth } from '@/features/providers/auth-provider';
+import { listAccounts, type KortixAccount } from '@kortix/sdk';
+import { qk } from '@kortix/sdk/react';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * The one freshness contract for the account list. Exported so the value is a
+ * single constant rather than thirteen copies of the number `60_000`, which is
+ * exactly how per-observer `staleTime` drifted apart before.
+ */
+export const ACCOUNTS_STALE_TIME = 60_000;
+
+export type AccountsListQueryKey = ReturnType<typeof qk.accounts.list>;
+
+export interface UseAccountsListOptions {
+  /**
+   * The caller's own gate — "only while this modal is open". ANDed with the
+   * identity gate, never a replacement for it: a surface being open says
+   * nothing about whether we know who is looking at it.
+   */
+  enabled?: boolean;
+  /**
+   * Retry budget. Only `/projects/start` sets one (it resolves a landing
+   * destination from this list, so a single transient failure there strands
+   * the user on a spinner). Left `undefined` elsewhere so React Query's
+   * default applies — passing a value here would be a behaviour change, not a
+   * key change.
+   */
+  retry?: number;
+}
+
+/**
+ * The query options every reader shares, with identity already folded in.
+ *
+ * Split out from the hook so the gate and the key can be asserted directly,
+ * without a React renderer — `apps/web` has no React test harness, and a
+ * source-text assertion would not be able to tell a working gate from a
+ * deleted one.
+ */
+export function accountsListQueryOptions(
+  userId: string | null | undefined,
+  enabled = true,
+): { queryKey: AccountsListQueryKey; enabled: boolean; staleTime: number } {
+  return {
+    queryKey: qk.accounts.list(userId),
+    // Fail closed (G2). `!!userId` is the whole point: the key alone stops a
+    // reader SEEING another user's entry, and this stops it WRITING into a
+    // slot before we know whose slot it is.
+    enabled: !!userId && enabled,
+    staleTime: ACCOUNTS_STALE_TIME,
+  };
+}
+
+/**
+ * The exact cache key `useAccountsList` reads, for the two `setQueryData`
+ * writers that seed a newly created account into the list.
+ *
+ * Those writers must never construct the key themselves — a writer and a
+ * reader on different keys is silent: the create appears to succeed and the
+ * list never changes. Invalidation is a different job and uses
+ * `qk.accounts.scope()` instead; see the note on that member.
+ */
+export function useAccountsQueryKey(): AccountsListQueryKey {
+  const { user } = useAuth();
+  return qk.accounts.list(user?.id);
+}
+
+/**
+ * The account list for the signed-in user. Returns `undefined` data — never
+ * another user's list — until identity is known.
+ */
+export function useAccountsList(
+  options: UseAccountsListOptions = {},
+): UseQueryResult<KortixAccount[]> {
+  const { user } = useAuth();
+  return useQuery({
+    ...accountsListQueryOptions(user?.id, options.enabled),
+    queryFn: listAccounts,
+    ...(options.retry === undefined ? {} : { retry: options.retry }),
+  });
+}

--- a/apps/web/src/hooks/account/use-ensure-selected-account.ts
+++ b/apps/web/src/hooks/account/use-ensure-selected-account.ts
@@ -31,26 +31,21 @@
  * - `UserMenu`, for the accounts pages.
  *
  * Idempotent and safe to call from more than one mounted component: the
- * `['accounts']` query key and `staleTime` match every caller's, so React Query
- * serves them all from one fetch, and the write is skipped once the stored id
- * is valid.
+ * shared `useAccountsList()` hook is the same query every other caller reads,
+ * so React Query serves them all from one fetch, and the write is skipped once
+ * the stored id is valid.
  */
 
 import { useEffect } from 'react';
 
+import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { listAccounts } from '@kortix/sdk';
-import { useQuery } from '@tanstack/react-query';
 
 export function useEnsureSelectedAccount(): void {
   const selectedAccountId = useCurrentAccountStore((s) => s.selectedAccountId);
   const setSelectedAccountId = useCurrentAccountStore((s) => s.setSelectedAccountId);
 
-  const accountsQuery = useQuery({
-    queryKey: ['accounts'],
-    queryFn: listAccounts,
-    staleTime: 60_000,
-  });
+  const accountsQuery = useAccountsList();
 
   useEffect(() => {
     const accounts = accountsQuery.data;

--- a/apps/web/src/lib/auth-token.test.ts
+++ b/apps/web/src/lib/auth-token.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  __resetAuthTokenCacheForTests,
+  __setFetchTokenForTests,
+  getSupabaseAccessToken,
+  setCachedAuthToken,
+} from './auth-token';
+
+/**
+ * JAY: the audit's PLAUSIBLE (not CONFIRMED) finding on `auth-token.ts` —
+ * `getSupabaseAccessToken()` used to commit `cachedToken = token` after an
+ * `await` with no generation check, and `setCachedAuthToken(null)` neither
+ * bumped a generation nor cleared `inflight`. A fetch started under one
+ * identity that resolved AFTER a later invalidation (a 401, a sign-out) could
+ * land its stale answer on top of whatever replaced it. `authEpoch` closes
+ * that gap.
+ *
+ * Uses dependency injection (`__setFetchTokenForTests`), not
+ * `mock.module('@/lib/supabase/client', ...)` — a module mock in this repo is
+ * process-wide (see `sign-out-sequence.test.ts`), and this file's own state
+ * (`cachedToken`, `authEpoch`, `inflight`) is likewise module-level, so every
+ * test resets it explicitly.
+ */
+
+afterEach(() => {
+  __resetAuthTokenCacheForTests();
+});
+
+/** A promise this test can resolve/reject on its own schedule. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('getSupabaseAccessToken: stale in-flight fetch vs. a later invalidation', () => {
+  test('a fetch that resolves AFTER setCachedAuthToken(null) is discarded — returns null, does not repopulate the cache', async () => {
+    __resetAuthTokenCacheForTests();
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => fetch.promise);
+
+    // Starts the in-flight fetch (nothing cached yet).
+    const pending = getSupabaseAccessToken();
+
+    // The identity boundary: something invalidates the cache — e.g. a 401
+    // handler, or a sign-out — WHILE the fetch above is still in flight.
+    setCachedAuthToken(null);
+
+    // The stale fetch finally resolves, carrying a token for the identity
+    // that existed BEFORE the invalidation above.
+    fetch.resolve('stale-token-from-before-invalidation');
+
+    await expect(pending).resolves.toBeNull();
+
+    // Prove the cache itself was never repopulated with the stale value —
+    // not just that this one call's return value was null. A fresh call
+    // must fetch again (hitting the NEW fetchTokenImpl below) rather than
+    // fast-pathing on a poisoned `cachedToken`.
+    __setFetchTokenForTests(() => Promise.resolve('fresh-token-after-invalidation'));
+    await expect(getSupabaseAccessToken()).resolves.toBe('fresh-token-after-invalidation');
+  });
+
+  test('control: a fetch that resolves BEFORE any invalidation still commits normally', async () => {
+    __resetAuthTokenCacheForTests();
+    __setFetchTokenForTests(() => Promise.resolve('normal-token'));
+
+    await expect(getSupabaseAccessToken()).resolves.toBe('normal-token');
+
+    // Cached: a second call must not need another fetch. Swap the
+    // implementation to something that would prove a re-fetch happened.
+    __setFetchTokenForTests(() => Promise.resolve('should-not-be-seen'));
+    await expect(getSupabaseAccessToken()).resolves.toBe('normal-token');
+  });
+
+  test('setCachedAuthToken(null) drops the abandoned in-flight promise so the NEXT caller starts its own fetch', async () => {
+    __resetAuthTokenCacheForTests();
+    const firstFetch = deferred<string | null>();
+    __setFetchTokenForTests(() => firstFetch.promise);
+
+    const pending = getSupabaseAccessToken();
+    setCachedAuthToken(null);
+
+    // A caller arriving AFTER the invalidation must get a token resolved
+    // under the NEW fetch, never a value piggybacked off the abandoned one —
+    // even though the abandoned fetch has not resolved yet.
+    __setFetchTokenForTests(() => Promise.resolve('second-caller-token'));
+    await expect(getSupabaseAccessToken()).resolves.toBe('second-caller-token');
+
+    firstFetch.resolve('first-caller-stale-token');
+    await expect(pending).resolves.toBeNull();
+  });
+
+  test('concurrent callers with no invalidation between them still dedupe onto one fetch', async () => {
+    __resetAuthTokenCacheForTests();
+    let fetchCount = 0;
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => {
+      fetchCount += 1;
+      return fetch.promise;
+    });
+
+    const first = getSupabaseAccessToken();
+    const second = getSupabaseAccessToken();
+    fetch.resolve('shared-token');
+
+    await expect(first).resolves.toBe('shared-token');
+    await expect(second).resolves.toBe('shared-token');
+    expect(fetchCount).toBe(1);
+  });
+});

--- a/apps/web/src/lib/auth-token.test.ts
+++ b/apps/web/src/lib/auth-token.test.ts
@@ -96,6 +96,31 @@ describe('getSupabaseAccessToken: stale in-flight fetch vs. a later invalidation
     await expect(pending).resolves.toBeNull();
   });
 
+  // JAY: CRITICAL regression found by review round 1. `if (inflight) return
+  // inflight;` returned the RAW in-flight promise to a piggybacking caller,
+  // bypassing the epoch check entirely — only the caller that STARTED the
+  // fetch ever ran it. Piggybacking is the module's NORMAL case (the doc
+  // comment's "5+ parallel Supabase auth roundtrips" collapsed to one), so
+  // this was the common path, not an edge case.
+  test('a piggybacking (deduped) caller also gets null on a mid-flight invalidation — not the raw stale token', async () => {
+    __resetAuthTokenCacheForTests();
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => fetch.promise);
+
+    const callerA = getSupabaseAccessToken(); // starts the fetch
+    const callerB = getSupabaseAccessToken(); // dedupes onto the SAME in-flight fetch
+
+    // The identity boundary lands while BOTH callers are still waiting.
+    setCachedAuthToken(null);
+
+    // The shared fetch finally resolves, carrying a token for the identity
+    // that existed BEFORE the invalidation above.
+    fetch.resolve('stale-token-from-before-invalidation');
+
+    await expect(callerA).resolves.toBeNull();
+    await expect(callerB).resolves.toBeNull();
+  });
+
   test('concurrent callers with no invalidation between them still dedupe onto one fetch', async () => {
     __resetAuthTokenCacheForTests();
     let fetchCount = 0;

--- a/apps/web/src/lib/auth-token.ts
+++ b/apps/web/src/lib/auth-token.ts
@@ -54,6 +54,11 @@ let authEpoch = 0;
 
 // ── Inflight deduplication ──
 let inflight: Promise<string | null> | null = null;
+/** The epoch that was current when `inflight` was started. Captured once, by
+ *  whichever caller starts the fetch, and read by every caller that dedupes
+ *  onto it (see `getSupabaseAccessToken`) — a piggybacker must run the same
+ *  epoch check as the caller that started the fetch, not skip it. */
+let inflightEpoch = 0;
 
 /**
  * Test-only seam for the real Supabase fetch (`fetchToken`, defined below).
@@ -88,29 +93,50 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
 		return cachedToken;
 	}
 
-	// Deduplicate: if another call is already fetching, piggyback on it
-	if (inflight) return inflight;
+	// Deduplicate: if another call is already fetching, piggyback on the
+	// SAME promise. CRITICAL: piggybacking is the NORMAL case here, not an
+	// edge case (see the dedup note in the module doc comment — "5+
+	// parallel Supabase auth roundtrips" collapsed to one). The old code
+	// returned the raw in-flight promise directly to a piggybacker
+	// (`if (inflight) return inflight;`), which bypassed the epoch check
+	// below entirely for every caller except whichever one happened to
+	// start the fetch: a piggybacker awaiting that raw promise got the
+	// stale token STRING even when an invalidation landed while it waited.
+	// Every caller — starter and piggybacker alike — now runs the same
+	// epoch check against the SAME captured `inflightEpoch`.
+	if (!inflight) {
+		// Captured BEFORE the fetch starts: if an authoritative write
+		// (setCachedAuthToken / setBootstrapAuthToken) lands while this
+		// fetch is still in flight, the epoch below will have moved by the
+		// time it resolves, and this call's result is stale relative to
+		// whatever that write established.
+		inflightEpoch = authEpoch;
+		inflight = fetchTokenImpl();
+	}
+	const epochAtStart = inflightEpoch;
+	const pending = inflight;
 
-	// Captured BEFORE the fetch starts: if an authoritative write
-	// (setCachedAuthToken / setBootstrapAuthToken) lands while this fetch is
-	// still in flight, the epoch below will have moved by the time it
-	// resolves, and this call's result is stale relative to whatever that
-	// write established.
-	const epochAtStart = authEpoch;
-	inflight = fetchTokenImpl();
 	try {
-		const token = await inflight;
+		const token = await pending;
 		if (authEpoch !== epochAtStart) {
 			// Invalidated (or reseeded) mid-flight. This result's provenance
 			// can't be trusted against whichever identity is current now —
 			// never commit it to the cache, and never hand it back either.
+			// Applies to EVERY caller waiting on this fetch, not just the
+			// one that started it.
 			return null;
 		}
 		cachedToken = token;
 		cachedAt = Date.now();
 		return token;
 	} finally {
-		inflight = null;
+		// Guarded, not unconditional: if a LATER caller already started a
+		// NEW fetch (its own `if (!inflight)` branch, after an
+		// invalidation) while this one was still resolving, clearing
+		// `inflight` unconditionally here would clobber that newer
+		// in-flight promise and make the next caller after THIS one start
+		// a redundant third fetch instead of joining the newer one.
+		if (inflight === pending) inflight = null;
 	}
 }
 
@@ -200,6 +226,7 @@ export function __resetAuthTokenCacheForTests(): void {
 	bootstrapToken = null;
 	authEpoch = 0;
 	inflight = null;
+	inflightEpoch = 0;
 	fetchTokenImpl = () => fetchToken();
 }
 

--- a/apps/web/src/lib/auth-token.ts
+++ b/apps/web/src/lib/auth-token.ts
@@ -38,8 +38,32 @@ let cachedToken: string | null = null;
 let cachedAt = 0;
 let bootstrapToken: string | null = null;
 
+/**
+ * Monotonic generation counter for the token cache. Bumped by every
+ * AUTHORITATIVE write to the cache — `setCachedAuthToken` and
+ * `setBootstrapAuthToken`, which run at every identity boundary (sign-in,
+ * sign-out, token refresh, 401 recovery).
+ *
+ * `getSupabaseAccessToken()` captures the epoch before starting a fetch and
+ * checks it again after that fetch resolves. If the epoch moved in between,
+ * an authoritative write already happened while this fetch was in flight, so
+ * its result is discarded rather than committed: a fetch started against one
+ * identity must never land its answer on top of whatever replaced it.
+ */
+let authEpoch = 0;
+
 // ── Inflight deduplication ──
 let inflight: Promise<string | null> | null = null;
+
+/**
+ * Test-only seam for the real Supabase fetch (`fetchToken`, defined below).
+ * Production code always leaves this pointed at the real implementation —
+ * only `__setFetchTokenForTests` ever reassigns it, so a test can resolve or
+ * reject a fetch on its own schedule to exercise the race above without
+ * mocking `@/lib/supabase/client` (a process-wide `mock.module` in this repo
+ * — see `sign-out-sequence.test.ts`'s doc comment for why DI is preferred).
+ */
+let fetchTokenImpl: () => Promise<string | null> = () => fetchToken();
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -67,9 +91,21 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
 	// Deduplicate: if another call is already fetching, piggyback on it
 	if (inflight) return inflight;
 
-	inflight = fetchToken();
+	// Captured BEFORE the fetch starts: if an authoritative write
+	// (setCachedAuthToken / setBootstrapAuthToken) lands while this fetch is
+	// still in flight, the epoch below will have moved by the time it
+	// resolves, and this call's result is stale relative to whatever that
+	// write established.
+	const epochAtStart = authEpoch;
+	inflight = fetchTokenImpl();
 	try {
 		const token = await inflight;
+		if (authEpoch !== epochAtStart) {
+			// Invalidated (or reseeded) mid-flight. This result's provenance
+			// can't be trusted against whichever identity is current now —
+			// never commit it to the cache, and never hand it back either.
+			return null;
+		}
 		cachedToken = token;
 		cachedAt = Date.now();
 		return token;
@@ -114,10 +150,21 @@ export function invalidateTokenCache(): void {
 
 /**
  * Sync the resolved auth token cache without affecting bootstrap mode.
+ *
+ * Bumps `authEpoch` unconditionally — this is an authoritative write, so any
+ * fetch already in flight was started against the PREVIOUS identity state.
+ * On a clear (`token === null`) that fetch's eventual result must not even be
+ * handed to whoever is piggybacking on it, so `inflight` is dropped too: the
+ * next caller starts its own fetch under the new epoch instead of inheriting
+ * a promise that predates this invalidation.
  */
 export function setCachedAuthToken(token: string | null): void {
+	authEpoch++;
 	cachedToken = token;
 	cachedAt = token ? Date.now() : 0;
+	if (!token) {
+		inflight = null;
+	}
 }
 
 /**
@@ -125,10 +172,35 @@ export function setCachedAuthToken(token: string | null): void {
  * before the browser Supabase client has established local session state.
  */
 export function setBootstrapAuthToken(token: string | null): void {
+	authEpoch++;
 	bootstrapToken = token;
 	if (token) {
 		setCachedAuthToken(token);
 	}
+}
+
+/**
+ * Test-only: point `fetchTokenImpl` at a caller-supplied stand-in, or restore
+ * the real `fetchToken` when called with no argument / `undefined`. See the
+ * doc comment on `fetchTokenImpl` for why this exists instead of a
+ * `mock.module('@/lib/supabase/client', ...)`.
+ */
+export function __setFetchTokenForTests(impl?: () => Promise<string | null>): void {
+	fetchTokenImpl = impl ?? (() => fetchToken());
+}
+
+/**
+ * Test-only: reset every module-level cache field to its startup value.
+ * Module state here is never cleared in production — the tab just reloads —
+ * so each test that exercises the cache needs a clean slate.
+ */
+export function __resetAuthTokenCacheForTests(): void {
+	cachedToken = null;
+	cachedAt = 0;
+	bootstrapToken = null;
+	authEpoch = 0;
+	inflight = null;
+	fetchTokenImpl = () => fetchToken();
 }
 
 /**

--- a/apps/web/src/lib/auth/bounce-attribution.test.ts
+++ b/apps/web/src/lib/auth/bounce-attribution.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  parseAuthBounceOwner,
+  parseLastProjectOwner,
+  serializeAuthBounce,
+} from '@/lib/onboarding/landing-destination';
+import { shouldDemoteReturnUrl } from './return-url';
+
+/**
+ * The decision behind the middleware bounce cookie.
+ *
+ * Two rules meet here and they pull in opposite directions:
+ *  - fail CLOSED on identity — a return URL bounced from a named session must
+ *    not be replayed for a different account;
+ *  - fail OPEN on absence — a bounce that names nobody, and a pasted or
+ *    bookmarked `/auth?redirect=…` link with no cookie at all, must keep
+ *    working. "Unknown" is not "foreign".
+ *
+ * Collapsing either into the other breaks a real flow, so both are pinned.
+ */
+
+const USER_A = '11111111-1111-1111-1111-111111111111';
+const USER_B = '22222222-2222-2222-2222-222222222222';
+
+describe('shouldDemoteReturnUrl', () => {
+  test('demotes when the bounce names someone other than the signer', () => {
+    // The reported bug, reduced: A was bounced, B signed in.
+    expect(
+      shouldDemoteReturnUrl({
+        bouncedOwnerId: USER_A,
+        signedInUserId: USER_B,
+        isNewUser: false,
+      }),
+    ).toBe(true);
+  });
+
+  test('keeps the path when the signer IS the bounced user', () => {
+    // A session that expired and came straight back. This is the single-account
+    // happy path and must be untouched.
+    expect(
+      shouldDemoteReturnUrl({
+        bouncedOwnerId: USER_A,
+        signedInUserId: USER_A,
+        isNewUser: false,
+      }),
+    ).toBe(false);
+  });
+
+  test('an UNATTRIBUTED bounce does not demote', () => {
+    // Middleware cannot always name an owner: the stale-session self-heal may
+    // have nulled the user before the bounce is built, and nothing may remember
+    // a project. Demoting on that would break every one of those returns.
+    for (const bouncedOwnerId of ['', null, undefined]) {
+      expect(
+        shouldDemoteReturnUrl({ bouncedOwnerId, signedInUserId: USER_B, isNewUser: false }),
+      ).toBe(false);
+    }
+  });
+
+  test('a signup always demotes, attributed or not', () => {
+    // The rule that already shipped. A seconds-old account cannot own anything
+    // that predates it, whoever was bounced.
+    expect(shouldDemoteReturnUrl({ isNewUser: true })).toBe(true);
+    expect(
+      shouldDemoteReturnUrl({ bouncedOwnerId: USER_A, signedInUserId: USER_A, isNewUser: true }),
+    ).toBe(true);
+  });
+
+  test('an attributed bounce with no known signer demotes — fail closed', () => {
+    // The link-mint case: `sendEmailCode` bakes the return path into an email
+    // before any identity exists, and that link can be opened on a device that
+    // never held the bounced session. There is nothing to compare against, so
+    // the path does not travel.
+    expect(shouldDemoteReturnUrl({ bouncedOwnerId: USER_A, signedInUserId: null })).toBe(true);
+    expect(shouldDemoteReturnUrl({ bouncedOwnerId: USER_A, signedInUserId: '' })).toBe(true);
+  });
+});
+
+describe('bounce cookie format', () => {
+  test('round-trips the owner', () => {
+    expect(parseAuthBounceOwner(serializeAuthBounce(USER_A, '/projects/x'))).toBe(USER_A);
+  });
+
+  test('an absent owner serializes to an empty owner half, not to nothing', () => {
+    const value = serializeAuthBounce(null, '/projects/x');
+
+    expect(value.startsWith(':')).toBe(true);
+    expect(parseAuthBounceOwner(value)).toBe('');
+  });
+
+  test('the cookie is browser-written, so a non-user-id owner is discarded', () => {
+    // Anything but a well-formed id attributes nobody. The worst a tampered
+    // cookie can do is send its own browser to the landing door.
+    expect(parseAuthBounceOwner('../../etc:%2Fx')).toBe('');
+    expect(parseAuthBounceOwner('no-separator')).toBe('');
+    expect(parseAuthBounceOwner(undefined)).toBe('');
+    expect(parseAuthBounceOwner('')).toBe('');
+  });
+
+  test('the path half never carries a character a cookie cannot', () => {
+    const value = serializeAuthBounce(USER_A, '/projects/x?a=1,2;b=3 4');
+
+    expect(/[,; ]/.test(value)).toBe(false);
+    expect(decodeURIComponent(value.slice(value.indexOf(':') + 1))).toBe('/projects/x?a=1,2;b=3 4');
+  });
+});
+
+describe('parseLastProjectOwner (the middleware fallback)', () => {
+  test('reads the owner half of the remembered project', () => {
+    expect(parseLastProjectOwner(`${USER_A}:319395c1-9c3f-41b4-ac6c-9539a12dbb7c`)).toBe(USER_A);
+  });
+
+  test('a legacy bare project id names no owner', () => {
+    expect(parseLastProjectOwner('319395c1-9c3f-41b4-ac6c-9539a12dbb7c')).toBe('');
+  });
+});

--- a/apps/web/src/lib/auth/identity-marker.test.ts
+++ b/apps/web/src/lib/auth/identity-marker.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'bun:test';
+
+import { IDENTITY_MARKER_KEY, shouldResetClientState } from './identity-marker';
+
+const USER_A = '11111111-1111-1111-1111-111111111111';
+const USER_B = '22222222-2222-2222-2222-222222222222';
+
+/**
+ * The rule both `AuthProvider` guards used to get backwards.
+ *
+ * They were spelled `if (prev && prev !== next)`, which short-circuits on an
+ * ABSENT marker and therefore treats "I have no idea whose state this is" as
+ * "it is the same user". Absent is UNKNOWN, and unknown state may belong to
+ * anyone, so it resets.
+ *
+ * That was not a theoretical hole: the `SIGNED_OUT` branch deleted the marker,
+ * so after an explicit logout the next `SIGNED_IN` always read `prev === null`
+ * and the cross-user reset could never fire — at exactly the moment two
+ * accounts are most likely to be sharing one browser.
+ */
+describe('shouldResetClientState — an absent marker is UNKNOWN, not SAME', () => {
+  test('no persisted marker resets, even though nothing names another user', () => {
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: null,
+        persistedUserId: null,
+        nextUserId: USER_A,
+      }),
+    ).toBe(true);
+  });
+
+  test('a persisted marker naming somebody else resets', () => {
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: null,
+        persistedUserId: USER_B,
+        nextUserId: USER_A,
+      }),
+    ).toBe(true);
+  });
+
+  test('a persisted marker naming this same user does NOT reset', () => {
+    // The paired negative. Without it, `return true` passes every case above.
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: null,
+        persistedUserId: USER_A,
+        nextUserId: USER_A,
+      }),
+    ).toBe(false);
+  });
+});
+
+/**
+ * The per-document marker exists because the persisted one cannot describe
+ * several tabs: it is a single origin-wide value, so two tabs signed into two
+ * accounts overwrite each other's while each keeps its own React Query cache.
+ */
+describe('shouldResetClientState — the in-document marker is per-tab', () => {
+  test('a tab that already published another user resets, even when storage agrees', () => {
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: USER_B,
+        persistedUserId: USER_A,
+        nextUserId: USER_A,
+      }),
+    ).toBe(true);
+  });
+
+  test('a tab that has published nobody yet holds no stale cache of its own', () => {
+    // `null` here means EMPTY, not unknown — a document that published no user
+    // is holding no other user's in-memory state. The persisted marker still
+    // decides, which is why this case turns on it.
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: null,
+        persistedUserId: USER_A,
+        nextUserId: USER_A,
+      }),
+    ).toBe(false);
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: null,
+        persistedUserId: USER_B,
+        nextUserId: USER_A,
+      }),
+    ).toBe(true);
+  });
+
+  test('both markers agreeing with the incoming user is the only no-reset case', () => {
+    expect(
+      shouldResetClientState({
+        inDocumentUserId: USER_A,
+        persistedUserId: USER_A,
+        nextUserId: USER_A,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('the marker key', () => {
+  test('is the value already written in browsers today, so no user is re-reset', () => {
+    expect(IDENTITY_MARKER_KEY).toBe('kortix-last-user-id');
+  });
+});

--- a/apps/web/src/lib/auth/identity-marker.ts
+++ b/apps/web/src/lib/auth/identity-marker.ts
@@ -1,0 +1,58 @@
+/**
+ * Who the client state currently in front of the user belongs to.
+ *
+ * `AuthProvider` keeps two markers because they answer two different questions,
+ * and neither one can answer the other's:
+ *
+ *  - **`persistedUserId`** — `localStorage['kortix-last-user-id']`. It describes
+ *    the ORIGIN-WIDE persisted state: `localStorage` itself and the IndexedDB
+ *    session cache. One bucket, shared by every tab and every document.
+ *  - **`inDocumentUserId`** — a `useRef` inside the provider. It describes the
+ *    IN-MEMORY caches of THIS document: the React Query cache and the
+ *    `current-account` store. Those are per-document, and a single origin-wide
+ *    localStorage key cannot describe several tabs at once — two tabs signed
+ *    into two accounts overwrite each other's marker while each keeps its own
+ *    query cache intact.
+ *
+ * Either marker disagreeing means the state on screen is not this user's.
+ */
+/** The origin-wide marker key. One name, read and written in one place. */
+export const IDENTITY_MARKER_KEY = 'kortix-last-user-id';
+
+export type IdentityMarkers = {
+  /** The last user this DOCUMENT published, or `null` if it has published none. */
+  inDocumentUserId: string | null;
+  /** The marker in origin-wide storage, or `null` when absent or unreadable. */
+  persistedUserId: string | null;
+  /** The user who is signing in now. */
+  nextUserId: string;
+};
+
+/**
+ * Whether the client state must be wiped before `nextUserId` is published.
+ *
+ * The rule the previous guards got backwards was `if (prev && prev !== next)`:
+ * an ABSENT marker short-circuited to "no reset", i.e. it was read as SAME
+ * USER. Absent is not same — it is UNKNOWN, and unknown state may belong to
+ * anyone, so it resets. That mattered because the `SIGNED_OUT` branch deleted
+ * the very marker the later `SIGNED_IN` comparison needed, so after an explicit
+ * logout the cross-user reset could never fire at all.
+ *
+ * `inDocumentUserId` is the one place `null` legitimately means "nothing", not
+ * "unknown": a document that has published no user is holding no other user's
+ * in-memory cache. Its absence therefore does not force a reset on its own —
+ * the persisted marker still has to agree.
+ *
+ * Cost of erring this way: a first-ever sign-in in a clean browser runs one
+ * reset over empty caches, and a browser that blocks storage runs one per cold
+ * load. Both are wasted work, never wrong state. The opposite error hands one
+ * account another account's cached workspaces.
+ */
+export function shouldResetClientState({
+  inDocumentUserId,
+  persistedUserId,
+  nextUserId,
+}: IdentityMarkers): boolean {
+  if (inDocumentUserId !== null && inDocumentUserId !== nextUserId) return true;
+  return persistedUserId !== nextUserId;
+}

--- a/apps/web/src/lib/auth/identity-marker.ts
+++ b/apps/web/src/lib/auth/identity-marker.ts
@@ -47,6 +47,18 @@ export type IdentityMarkers = {
  * reset over empty caches, and a browser that blocks storage runs one per cold
  * load. Both are wasted work, never wrong state. The opposite error hands one
  * account another account's cached workspaces.
+ *
+ * The persisted marker does NOT survive a reset, on `SIGNED_OUT` or anywhere
+ * else. `resetClientState()` sweeps every `localStorage`/`sessionStorage` key
+ * this app owns (`clear-local-storage.ts`'s prefix sweep), and
+ * `IDENTITY_MARKER_KEY` ('kortix-last-user-id') matches that sweep's own
+ * `'kortix-'` prefix and is not on `KEEP_STORAGE_KEYS` — so any caller that
+ * resets deletes the very key it is about to compare against on the next
+ * call. That is exactly why absent must read as UNKNOWN rather than as "no
+ * marker, so no previous user, so nothing to reset": a real explicit sign-out
+ * sweeps this key as a SIDE EFFECT of resetting, not as a special case coded
+ * for it, and the UNKNOWN-resets rule above is what keeps that side effect
+ * safe instead of self-disarming.
  */
 export function shouldResetClientState({
   inDocumentUserId,

--- a/apps/web/src/lib/auth/perform-sign-out.ts
+++ b/apps/web/src/lib/auth/perform-sign-out.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { runSignOut, SIGN_OUT_DESTINATION } from '@/lib/auth/sign-out-sequence';
+import { finalizeServerSignOut } from '@/lib/auth/sign-out-actions';
+import { createClient } from '@/lib/supabase/client';
+import { resetClientState } from '@/lib/utils/reset-client-state';
+
+export { SIGN_OUT_DESTINATION };
+
+/**
+ * The ONE sign-out in the product. Every logout control calls this.
+ *
+ * The navigation is a DOCUMENT LOAD, deliberately, and not `router.push` /
+ * `router.replace`. An identity change must not carry a single byte of the
+ * previous user's rendering across, and a soft navigation carries three caches
+ * that `resetClientState()` cannot reach:
+ *
+ *  - the App Router ROUTE CACHE, holding rendered RSC payloads for visited
+ *    segments. `router.refresh()` does not clear it — only Next's internal
+ *    `invalidateEntirePrefetchCache` does, which no application code can call;
+ *  - the SEGMENT CACHE of prefetched payloads, which `staleTimes` bounds but
+ *    does not empty;
+ *  - BFCACHE, whose restores bypass staleness entirely, so no `staleTimes`
+ *    value can substitute.
+ *
+ * The sign-IN side adopted `window.location.assign` for the same reason
+ * (`(auth)/auth/page.tsx`, `establishSessionAndRedirect`).
+ *
+ * The sequence itself, and what each failure is allowed to prevent, lives in
+ * `sign-out-sequence.ts`.
+ */
+export async function performSignOut(): Promise<void> {
+  const supabase = createClient();
+  await runSignOut({
+    finalizeServerSession: finalizeServerSignOut,
+    endSession: (scope) => (scope ? supabase.auth.signOut({ scope }) : supabase.auth.signOut()),
+    resetClientState,
+    leave: (destination) => {
+      // `@next/next/no-location-assign-relative-destination` inspects string
+      // LITERALS, so it does not fire on this identifier — that is a property of
+      // the rule, not an exemption taken here. The document load is the fix, and
+      // it is what the rule would be waved through for.
+      window.location.assign(destination);
+    },
+  });
+}

--- a/apps/web/src/lib/auth/perform-sign-out.ts
+++ b/apps/web/src/lib/auth/perform-sign-out.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import { runSignOut, SIGN_OUT_DESTINATION } from '@/lib/auth/sign-out-sequence';
+import {
+  markSignOutStarted,
+  runSignOut,
+  SIGN_OUT_DESTINATION,
+} from '@/lib/auth/sign-out-sequence';
 import { finalizeServerSignOut } from '@/lib/auth/sign-out-actions';
 import { createClient } from '@/lib/supabase/client';
 import { resetClientState } from '@/lib/utils/reset-client-state';
@@ -30,6 +34,12 @@ export { SIGN_OUT_DESTINATION };
  * `sign-out-sequence.ts`.
  */
 export async function performSignOut(): Promise<void> {
+  // Before the first await. Signed-out route guards read `isSigningOut()` so a
+  // `SIGNED_OUT` event cannot fire their soft `router.replace('/auth')` while
+  // this document load is still being set up — a soft navigation there would
+  // reach `/auth` with the App Router route cache intact, which is the exact
+  // defect this whole path exists to remove.
+  markSignOutStarted();
   const supabase = createClient();
   await runSignOut({
     finalizeServerSession: finalizeServerSignOut,

--- a/apps/web/src/lib/auth/perform-sign-out.ts
+++ b/apps/web/src/lib/auth/perform-sign-out.ts
@@ -1,12 +1,14 @@
 'use client';
 
 import {
+  isSigningOut,
   markSignOutStarted,
   runSignOut,
   SIGN_OUT_DESTINATION,
 } from '@/lib/auth/sign-out-sequence';
 import { finalizeServerSignOut } from '@/lib/auth/sign-out-actions';
 import { createClient } from '@/lib/supabase/client';
+import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
 import { resetClientState } from '@/lib/utils/reset-client-state';
 
 export { SIGN_OUT_DESTINATION };
@@ -33,24 +35,79 @@ export { SIGN_OUT_DESTINATION };
  * The sequence itself, and what each failure is allowed to prevent, lives in
  * `sign-out-sequence.ts`.
  */
+/**
+ * Expire this browser's Supabase auth cookie, chunks included.
+ *
+ * `@supabase/ssr` splits a session that outgrows the ~4KB cookie limit across
+ * `<name>.0`, `<name>.1`, … so clearing only the base name leaves a signed-in
+ * browser whenever the JWT is large — which is the normal case once a user
+ * carries app metadata. Every variant is expired, at the same `path: '/'` the
+ * client writes them with (`lib/supabase/client.ts`, `cookieOptions`); a
+ * mismatched path silently expires nothing.
+ *
+ * Not `httpOnly`, by design in `@supabase/ssr` — the browser client has to read
+ * it — which is exactly what makes this possible from here.
+ */
+function expireSupabaseAuthCookie(): void {
+  const names = [
+    KORTIX_SUPABASE_AUTH_COOKIE,
+    // Generous: `@supabase/ssr` has never needed more than a couple of chunks,
+    // and expiring a cookie that does not exist costs nothing.
+    ...Array.from({ length: 6 }, (_, index) => `${KORTIX_SUPABASE_AUTH_COOKIE}.${index}`),
+  ];
+
+  for (const name of names) {
+    document.cookie = `${name}=; Max-Age=0; path=/; SameSite=Lax`;
+  }
+}
+
+/**
+ * The ONE sign-out in the product. Every logout control calls this.
+ *
+ * Re-entrant by refusal, not by queueing. The bounded sequence below can take
+ * several seconds when the network is broken, which is long enough for a user
+ * to press Log out again; a second pass would re-issue every request and race
+ * the first one's navigation. The first call owns the exit.
+ */
 export async function performSignOut(): Promise<void> {
-  // Before the first await. Signed-out route guards read `isSigningOut()` so a
+  if (isSigningOut()) return;
+
+  // Before the first await, and before anything that can throw. Signed-out
+  // route guards read `isSigningOut()` (see `useSignedOutRedirect`) so a
   // `SIGNED_OUT` event cannot fire their soft `router.replace('/auth')` while
   // this document load is still being set up — a soft navigation there would
   // reach `/auth` with the App Router route cache intact, which is the exact
   // defect this whole path exists to remove.
   markSignOutStarted();
-  const supabase = createClient();
-  await runSignOut({
-    finalizeServerSession: finalizeServerSignOut,
-    endSession: (scope) => (scope ? supabase.auth.signOut({ scope }) : supabase.auth.signOut()),
-    resetClientState,
-    leave: (destination) => {
-      // `@next/next/no-location-assign-relative-destination` inspects string
-      // LITERALS, so it does not fire on this identifier — that is a property of
-      // the rule, not an exemption taken here. The document load is the fix, and
-      // it is what the rule would be waved through for.
-      window.location.assign(destination);
-    },
-  });
+
+  let left = false;
+  try {
+    const supabase = createClient();
+    await runSignOut({
+      finalizeServerSession: finalizeServerSignOut,
+      endSession: (scope) => (scope ? supabase.auth.signOut({ scope }) : supabase.auth.signOut()),
+      resetClientState,
+      dropAuthCookie: expireSupabaseAuthCookie,
+      leave: (destination) => {
+        left = true;
+        // `@next/next/no-location-assign-relative-destination` inspects string
+        // LITERALS, so it does not fire on this identifier — that is a property
+        // of the rule, not an exemption taken here. The document load is the
+        // fix, and it is what the rule would be waved through for.
+        window.location.assign(destination);
+      },
+    });
+  } finally {
+    // `runSignOut` cannot fail to leave, but everything BEFORE it can:
+    // `createClient()` throws synchronously when the runtime env is
+    // unparseable (`lib/supabase/client.ts`). Callers say `void
+    // performSignOut()`, so that throw would strand a user who has already
+    // tripped the in-flight latch, on a page whose guard now stands down for
+    // them. The invariant is "a sign-out always leaves", from any state of the
+    // world — so the exit is in a `finally`, taken only if the sequence did not
+    // already take it.
+    if (!left) {
+      window.location.assign(SIGN_OUT_DESTINATION);
+    }
+  }
 }

--- a/apps/web/src/lib/auth/perform-sign-out.ts
+++ b/apps/web/src/lib/auth/perform-sign-out.ts
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  isSigningOut,
-  markSignOutStarted,
-  runSignOut,
-  SIGN_OUT_DESTINATION,
-} from '@/lib/auth/sign-out-sequence';
+import { runSignOut, SIGN_OUT_DESTINATION } from '@/lib/auth/sign-out-sequence';
 import { finalizeServerSignOut } from '@/lib/auth/sign-out-actions';
 import { createClient } from '@/lib/supabase/client';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
@@ -13,28 +8,6 @@ import { resetClientState } from '@/lib/utils/reset-client-state';
 
 export { SIGN_OUT_DESTINATION };
 
-/**
- * The ONE sign-out in the product. Every logout control calls this.
- *
- * The navigation is a DOCUMENT LOAD, deliberately, and not `router.push` /
- * `router.replace`. An identity change must not carry a single byte of the
- * previous user's rendering across, and a soft navigation carries three caches
- * that `resetClientState()` cannot reach:
- *
- *  - the App Router ROUTE CACHE, holding rendered RSC payloads for visited
- *    segments. `router.refresh()` does not clear it — only Next's internal
- *    `invalidateEntirePrefetchCache` does, which no application code can call;
- *  - the SEGMENT CACHE of prefetched payloads, which `staleTimes` bounds but
- *    does not empty;
- *  - BFCACHE, whose restores bypass staleness entirely, so no `staleTimes`
- *    value can substitute.
- *
- * The sign-IN side adopted `window.location.assign` for the same reason
- * (`(auth)/auth/page.tsx`, `establishSessionAndRedirect`).
- *
- * The sequence itself, and what each failure is allowed to prevent, lives in
- * `sign-out-sequence.ts`.
- */
 /**
  * Expire this browser's Supabase auth cookie, chunks included.
  *
@@ -64,22 +37,30 @@ function expireSupabaseAuthCookie(): void {
 /**
  * The ONE sign-out in the product. Every logout control calls this.
  *
- * Re-entrant by refusal, not by queueing. The bounded sequence below can take
- * several seconds when the network is broken, which is long enough for a user
- * to press Log out again; a second pass would re-issue every request and race
- * the first one's navigation. The first call owns the exit.
+ * The navigation is a DOCUMENT LOAD, deliberately, and not `router.push` /
+ * `router.replace`. An identity change must not carry a single byte of the
+ * previous user's rendering across, and a soft navigation carries three caches
+ * that `resetClientState()` cannot reach:
+ *
+ *  - the App Router ROUTE CACHE, holding rendered RSC payloads for visited
+ *    segments. `router.refresh()` does not clear it — only Next's internal
+ *    `invalidateEntirePrefetchCache` does, which no application code can call;
+ *  - the SEGMENT CACHE of prefetched payloads, which `staleTimes` bounds but
+ *    does not empty;
+ *  - BFCACHE, whose restores bypass staleness entirely, so no `staleTimes`
+ *    value can substitute.
+ *
+ * The sign-IN side adopted `window.location.assign` for the same reason
+ * (`(auth)/auth/page.tsx`, `establishSessionAndRedirect`).
+ *
+ * Re-entry is refused by `runSignOut`, not here — a second press must never
+ * start a second sequence, but it must always still navigate. See `runSignOut`
+ * for why a user can genuinely press Log out twice.
+ *
+ * The sequence itself, and what each failure is allowed to prevent, lives in
+ * `sign-out-sequence.ts`.
  */
 export async function performSignOut(): Promise<void> {
-  if (isSigningOut()) return;
-
-  // Before the first await, and before anything that can throw. Signed-out
-  // route guards read `isSigningOut()` (see `useSignedOutRedirect`) so a
-  // `SIGNED_OUT` event cannot fire their soft `router.replace('/auth')` while
-  // this document load is still being set up — a soft navigation there would
-  // reach `/auth` with the App Router route cache intact, which is the exact
-  // defect this whole path exists to remove.
-  markSignOutStarted();
-
   let left = false;
   try {
     const supabase = createClient();
@@ -101,12 +82,15 @@ export async function performSignOut(): Promise<void> {
     // `runSignOut` cannot fail to leave, but everything BEFORE it can:
     // `createClient()` throws synchronously when the runtime env is
     // unparseable (`lib/supabase/client.ts`). Callers say `void
-    // performSignOut()`, so that throw would strand a user who has already
-    // tripped the in-flight latch, on a page whose guard now stands down for
-    // them. The invariant is "a sign-out always leaves", from any state of the
-    // world — so the exit is in a `finally`, taken only if the sequence did not
-    // already take it.
+    // performSignOut()`, so that throw would strand the user. The invariant is
+    // "a sign-out always leaves", from any state of the world.
+    //
+    // The cookie goes with it. This path never reached `runSignOut`, so
+    // `dropAuthCookie()` was never called — and landing on `/auth` with a live
+    // session is exactly the bounce-straight-back-in symptom the whole
+    // `dropAuthCookie` step exists to prevent.
     if (!left) {
+      expireSupabaseAuthCookie();
       window.location.assign(SIGN_OUT_DESTINATION);
     }
   }

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -5,6 +5,10 @@ import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
 // UI, so no auth path has to block on the backend to build this redirect.
 const DEFAULT_AUTH_RETURN_URL = PROJECT_LANDING_PATH;
 const LEGACY_AUTH_RETURN_PREFIXES = [
+  // Not legacy — but the same rule applies: a sign-in must never RETURN here.
+  // `?redirect=/logout` would undo the sign-in that just happened, so it is
+  // replaced with the landing door. See `app/logout/page.tsx`.
+  '/logout',
   '/dashboard',
   '/instances',
   '/sessions',

--- a/apps/web/src/lib/auth/return-url.ts
+++ b/apps/web/src/lib/auth/return-url.ts
@@ -137,6 +137,41 @@ export function resolveNewAccountReturnUrl(
 }
 
 /**
+ * Whether the visitor's return URL must be resolved through the new-account
+ * rule instead of replayed verbatim.
+ *
+ * Two cases, one answer:
+ *  - `isNewUser` — the account is seconds old and cannot own anything that
+ *    predates it. This is the rule that already shipped.
+ *  - an ATTRIBUTED bounce whose owner is not the user who just signed in. The
+ *    middleware wrote `/auth?redirect=<path>` for somebody else's session, and
+ *    replaying it drops this user on a stranger's "Request access" page. An
+ *    existing account is exactly the population the `isNewUser` rule excludes,
+ *    which is why a second account on the same browser kept landing there.
+ *
+ * An UNATTRIBUTED bounce (`bouncedOwnerId` empty) NEVER demotes. Middleware
+ * cannot always name an owner, and a pasted or bookmarked
+ * `/auth?redirect=<path>` link carries no bounce cookie at all — treating
+ * "unknown" as "foreign" would break both.
+ *
+ * A named owner with no known signer DOES demote: that is the fail-closed half.
+ */
+export function shouldDemoteReturnUrl({
+  bouncedOwnerId,
+  signedInUserId,
+  isNewUser,
+}: {
+  bouncedOwnerId?: string | null;
+  signedInUserId?: string | null;
+  isNewUser?: boolean | null;
+}): boolean {
+  if (isNewUser) return true;
+  const owner = typeof bouncedOwnerId === 'string' ? bouncedOwnerId : '';
+  if (owner.length === 0) return false;
+  return owner !== (typeof signedInUserId === 'string' ? signedInUserId : '');
+}
+
+/**
  * True when a (already-sanitized) return URL points at an invite acceptance
  * page. Invited users must land here verbatim after sign-up so they see the
  * accept/decline dialog — they must NOT be bounced to a freshly-provisioned

--- a/apps/web/src/lib/auth/sign-out-actions.ts
+++ b/apps/web/src/lib/auth/sign-out-actions.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import { AUTH_BOUNCE_COOKIE } from '@/lib/onboarding/landing-destination';
+import { getEnv } from '@/lib/env-config';
+import { createClient } from '@/lib/supabase/server';
+import { recordPlatformLogout } from '@kortix/sdk';
+import { cookies } from 'next/headers';
+
+/**
+ * Drop the middleware's bounce attribution.
+ *
+ * `AUTH_BOUNCE_COOKIE` is `httpOnly` (see the `redirectPreservingSession` branch
+ * in `middleware.ts`), so no client can clear it with `document.cookie` — a
+ * server round trip is the only route, and this action is it.
+ *
+ * Two callers, one reason each:
+ *
+ *  1. Authentication resolved a destination, so the bounce is SPENT. Leaving it
+ *     behind would let one sign-in's attribution demote the next one, and every
+ *     successful path needs it: password, OTP and signup all hand a destination
+ *     back to the client without ever touching `/auth/callback`, so the clear
+ *     beside that route's `ACTIVE_INSTANCE_COOKIE` reaches none of them.
+ *  2. A sign-out ends the identity the bounce names. Middleware writes the
+ *     cookie with a 300s life and only a successful sign-in clears it, so a
+ *     logout otherwise leaves it armed — and the next account to sign in on
+ *     this browser inside that window gets its return URL demoted by a bounce
+ *     that belonged to somebody who has already left.
+ *
+ * Deleting it is always SAFE: an absent cookie reads as UNATTRIBUTED, which
+ * never demotes (`shouldDemoteReturnUrl`). Clearing it too eagerly costs
+ * nothing; leaving it costs a wrong destination.
+ */
+export async function clearAuthBounceCookie(): Promise<void> {
+  (await cookies()).delete(AUTH_BOUNCE_COOKIE);
+}
+
+/**
+ * The SERVER half of a sign-out, run before the browser drops its session.
+ *
+ * `supabase.auth.signOut()` is a client-side act: it invalidates the refresh
+ * token at Supabase and clears the browser's cookies. It cannot revoke the
+ * ACCESS token that is already minted, and it emits no audit event. This does
+ * both, through `POST /v1/auth/logout`:
+ *
+ *  - marks every `account_session_activity` row for the session revoked, so the
+ *    API's session gate denies the rest of the current access-token window
+ *    instead of waiting for Supabase to refuse the next refresh;
+ *  - emits the `auth.logout` audit event with the actor and session id.
+ *
+ * It ran on exactly ONE of the six sign-out controls before this was unified
+ * (`auth/phone-verification`), so five of six logouts left the session usable
+ * server-side until the access token expired on its own. It runs on all six now.
+ *
+ * FIRST in the sequence, deliberately: it authenticates with the access token
+ * that `supabase.auth.signOut()` is about to throw away.
+ *
+ * Best effort by construction. A backend that is down or slow must never be
+ * able to keep a user signed in, so every failure is swallowed and the
+ * client-side sign-out — which is authoritative for this browser — proceeds.
+ * The 3s ceiling is the bound on how long that can delay the logout.
+ *
+ * It deliberately does NOT delete `kortix_last_project`. The old `signOut()`
+ * action did, and it was the only logout path that did. That cookie is
+ * owner-bound (`serializeLastProject`), so the next account cannot follow it,
+ * and the middleware reads its OWNER half to attribute a bounce once identity
+ * resolution has already returned `user: null` — which is exactly what happens
+ * after a logout and on the dominant session-expiry path. Deleting it here
+ * un-attributes every post-logout bounce.
+ */
+export async function finalizeServerSignOut(): Promise<void> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (session?.access_token) {
+      // `getEnv()`, not `getServerPublicEnv()` — the two resolve `BACKEND_URL`
+      // from the same variables in the same order, but `public-env-server`
+      // carries `import 'server-only'`. This module is reachable from the
+      // browser sign-out path (a client module has to import a server action to
+      // get a reference to it), and that guard throws the moment anything in
+      // that graph is loaded outside a React Server Component.
+      const backendUrl = getEnv().BACKEND_URL || 'http://localhost:8008/v1';
+      await recordPlatformLogout({
+        backendUrl,
+        accessToken: session.access_token,
+        signal: AbortSignal.timeout(3_000),
+      });
+    }
+  } catch {
+    /* swallow — the server-side revoke is best-effort; the client sign-out is
+       what actually ends this browser's session. */
+  }
+
+  await clearAuthBounceCookie();
+}

--- a/apps/web/src/lib/auth/sign-out-actions.ts
+++ b/apps/web/src/lib/auth/sign-out-actions.ts
@@ -29,6 +29,13 @@ import { cookies } from 'next/headers';
  * Deleting it is always SAFE: an absent cookie reads as UNATTRIBUTED, which
  * never demotes (`shouldDemoteReturnUrl`). Clearing it too eagerly costs
  * nothing; leaving it costs a wrong destination.
+ *
+ * On the sign-out path the clear is BEST EFFORT, not a guarantee. It arrives as
+ * a `Set-Cookie` on this action's response, and `runSignOut` bounds the call —
+ * so if the server is slow enough to blow the budget, `leave()` starts a
+ * document load that aborts the in-flight fetch and the deletion never applies.
+ * Acceptable precisely because the failure direction is benign: a surviving
+ * bounce cookie can only demote a return URL to the landing door.
  */
 export async function clearAuthBounceCookie(): Promise<void> {
   (await cookies()).delete(AUTH_BOUNCE_COOKIE);

--- a/apps/web/src/lib/auth/sign-out-actions.ts
+++ b/apps/web/src/lib/auth/sign-out-actions.ts
@@ -2,6 +2,7 @@
 
 import { AUTH_BOUNCE_COOKIE } from '@/lib/onboarding/landing-destination';
 import { getEnv } from '@/lib/env-config';
+import { MAINTENANCE_BYPASS_COOKIE } from '@/lib/maintenance-bypass';
 import { createClient } from '@/lib/supabase/server';
 import { recordPlatformLogout } from '@kortix/sdk';
 import { cookies } from 'next/headers';
@@ -39,6 +40,24 @@ import { cookies } from 'next/headers';
  */
 export async function clearAuthBounceCookie(): Promise<void> {
   (await cookies()).delete(AUTH_BOUNCE_COOKIE);
+}
+
+/**
+ * Drop the admin maintenance-lockdown bypass cookie (`maintenance-bypass.ts`).
+ *
+ * It is `httpOnly` (minted by `POST /api/maintenance/bypass`) — same reason
+ * as `clearAuthBounceCookie`, a server round trip is the only way to clear
+ * it. Task 5's client-state sweep cannot reach it either: cookies are outside
+ * `localStorage`/`sessionStorage` entirely, so without an explicit clear here
+ * the 8h bypass would keep working, on this browser, past the sign-out that
+ * ended the admin session it was minted for — for up to 8h, on a possibly
+ * shared machine, for whoever signs in next.
+ *
+ * Always safe to call: an absent cookie deletes to a no-op, and
+ * `verifyBypassToken` already fails closed on anything malformed.
+ */
+export async function clearMaintenanceBypassCookie(): Promise<void> {
+  (await cookies()).delete(MAINTENANCE_BYPASS_COOKIE);
 }
 
 /**
@@ -106,4 +125,5 @@ export async function finalizeServerSignOut(): Promise<void> {
   }
 
   await clearAuthBounceCookie();
+  await clearMaintenanceBypassCookie();
 }

--- a/apps/web/src/lib/auth/sign-out-actions.ts
+++ b/apps/web/src/lib/auth/sign-out-actions.ts
@@ -42,14 +42,19 @@ export async function clearAuthBounceCookie(): Promise<void> {
  * ACCESS token that is already minted, and it emits no audit event. This does
  * both, through `POST /v1/auth/logout`:
  *
- *  - marks every `account_session_activity` row for the session revoked, so the
- *    API's session gate denies the rest of the current access-token window
- *    instead of waiting for Supabase to refuse the next refresh;
- *  - emits the `auth.logout` audit event with the actor and session id.
+ *  - marks every `account_session_activity` row for the session revoked. Be
+ *    exact about the reach: `accountSessionGate()` is mounted on the ACCOUNTS
+ *    router only (`apps/api/src/accounts/index.ts`), so the `revokedAt` 401
+ *    covers `/v1/accounts/*` for the rest of the current access-token window.
+ *    It is not a whole-API kill switch. Without it that window is only closed
+ *    when Supabase refuses the next refresh;
+ *  - emits the `auth.logout` audit event with the actor and session id. This
+ *    half IS universal — the audit record is written regardless of which routes
+ *    the gate protects.
  *
  * It ran on exactly ONE of the six sign-out controls before this was unified
- * (`auth/phone-verification`), so five of six logouts left the session usable
- * server-side until the access token expired on its own. It runs on all six now.
+ * (`auth/phone-verification`), so five of six logouts emitted no audit event
+ * and revoked nothing. It runs on all six now.
  *
  * FIRST in the sequence, deliberately: it authenticates with the access token
  * that `supabase.auth.signOut()` is about to throw away.

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -17,8 +17,8 @@
 // this file names `router.push` / `router.replace` only inside string
 // constants — never in prose that a future slice could pick up.
 import { describe, expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 
 const WEB_SRC = resolve(import.meta.dir, '../..');
 
@@ -157,6 +157,90 @@ describe('the server half of the sign-out', () => {
   });
 });
 
+describe('nothing on an identity change can wait forever', () => {
+  // `packages/sdk/src/browser/cache/idb-sync-cache.ts` `openDB()` registers
+  // `onupgradeneeded`/`onsuccess`/`onerror` and NO `onblocked`, and the file has
+  // no `onversionchange` either. A version upgrade blocked by a tab still
+  // holding the old version settles neither `success` nor `error`, and
+  // `dbPromise` is memoized so every later caller parks behind it. That is not
+  // hypothetical: `DB_VERSION` has been bumped twice in this repo's history.
+  //
+  // Unbounded, that single promise could (a) stop a user signing out at all,
+  // and (b) park the whole app on its loading frame at SIGN-IN, because
+  // `adoptUser` awaits the same reset before `setIsLoading(false)`.
+
+  test('the sign-out bounds every step, not just guards it', () => {
+    const sequence = code('lib/auth/sign-out-sequence.ts');
+    expect(sequence).toContain("from '@/lib/utils/time-budget'");
+
+    // All FOUR pre-navigation awaits, enumerated: a new unbounded `await
+    // steps.` added beside them fails here.
+    const budgeted = sequence.match(/withTimeBudget\(steps\./g) ?? [];
+    expect(budgeted.length).toBe(4);
+    expect(sequence).not.toContain('await steps.');
+  });
+
+  test('resetClientState bounds its one async step, for EVERY caller', () => {
+    // In `runSignOut` and in `AuthProvider.adoptUser` alike — the sign-in side
+    // is where this widened, because an absent marker now runs the reset ahead
+    // of the first paint.
+    const reset = code('lib/utils/reset-client-state.ts');
+    expect(reset).toContain("from '@/lib/utils/time-budget'");
+    expect(reset).toContain('withTimeBudget(clearSessionIDBCache())');
+    expect(reset).not.toContain('await clearSessionIDBCache()');
+  });
+
+  test('the identity-critical clears stay SYNCHRONOUS, which is what makes the bound safe', () => {
+    // Outrunning the IDB purge is only safe while everything that could leak
+    // across identities has already completed. If any of these three grows an
+    // `await`, the bound above starts skipping real work.
+    const reset = code('lib/utils/reset-client-state.ts');
+    for (const call of [
+      'getSharedQueryClient()?.clear();',
+      'useCurrentAccountStore.getState().clear();',
+      'clearUserLocalStorage();',
+    ]) {
+      expect(reset).toContain(call);
+      expect(reset).not.toContain(`await ${call}`);
+    }
+  });
+});
+
+describe('the signed-out route guards do not race the exit', () => {
+  // `performSignOut` fires `SIGNED_OUT` before its document load starts, so a
+  // guard that only checks `!user` reaches `/auth` by SOFT navigation first —
+  // carrying the App Router route cache across the identity change, which is
+  // the exact defect the hard navigation exists to remove.
+  const GUARDED = [
+    'features/workspace/new/new-workspace-page.tsx',
+    'app/(app)/projects/start/page.tsx',
+  ];
+
+  test('every signed-out guard checks isSigningOut() FIRST', () => {
+    for (const file of GUARDED) {
+      const body = code(file);
+      expect(body).toContain("from '@/lib/auth/sign-out-sequence'");
+
+      const bail = body.indexOf('if (isSigningOut()) return;');
+      const guard = body.indexOf("if (!authLoading && !user) router.replace('/auth');");
+      expect(bail).toBeGreaterThan(-1);
+      expect(guard).toBeGreaterThan(bail);
+    }
+  });
+
+  test('the latch is set before performSignOut awaits anything', () => {
+    const body = slice(
+      code('lib/auth/perform-sign-out.ts'),
+      'export async function performSignOut()',
+      '\n}\n',
+    );
+    const mark = body.indexOf('markSignOutStarted();');
+    const firstAwait = body.indexOf('await ');
+    expect(mark).toBeGreaterThan(-1);
+    expect(firstAwait).toBeGreaterThan(mark);
+  });
+});
+
 describe('the sign-out path stays importable from the browser', () => {
   test('nothing in its graph pulls in `server-only`', async () => {
     // `AuthProvider` imports `performSignOut`, and `AuthProvider` is mounted by
@@ -169,6 +253,58 @@ describe('the sign-out path stays importable from the browser', () => {
   });
 });
 
+/** The local modules an import specifier can name, in resolution order. */
+function resolveLocal(specifier: string, fromFile: string): string | null {
+  const base = specifier.startsWith('@/')
+    ? resolve(WEB_SRC, specifier.slice(2))
+    : specifier.startsWith('.')
+      ? resolve(dirname(resolve(WEB_SRC, fromFile)), specifier)
+      : null;
+  if (!base) return null; // a package, not our source
+
+  for (const candidate of [
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+    base,
+  ]) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return relative(WEB_SRC, candidate);
+    }
+  }
+  return null;
+}
+
+/**
+ * Every first-party module reachable from `entries`, transitively.
+ *
+ * A fixed list of file paths is the wrong shape for this ban: it holds only for
+ * the exact files somebody thought of. `resetClientState()` already calls into
+ * `clear-local-storage.ts` and `current-account-store.ts`, and
+ * `clear-local-storage.ts` is arguably the MORE natural home for "forget this
+ * browser's user state" — so a fixed list would pass while the cookie died.
+ * Walking the graph means a module cannot slip in behind the check.
+ */
+function importGraph(entries: string[]): string[] {
+  const seen = new Set<string>();
+  const queue = [...entries];
+
+  while (queue.length) {
+    const file = queue.shift()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    const source = readFileSync(resolve(WEB_SRC, file), 'utf8');
+    for (const match of source.matchAll(/(?:from|import)\s*['"]([^'"]+)['"]/g)) {
+      const next = resolveLocal(match[1], file);
+      if (next && !seen.has(next)) queue.push(next);
+    }
+  }
+
+  return [...seen];
+}
+
 describe('the sign-out path leaves `kortix_last_project` alone', () => {
   // Load-bearing, not an oversight. The cookie is owner-bound
   // (`serializeLastProject`), so the next account cannot follow it, and the
@@ -177,19 +313,72 @@ describe('the sign-out path leaves `kortix_last_project` alone', () => {
   // a logout and on the dominant session-expiry path. Deleting it on sign-out
   // un-attributes every post-logout bounce and re-opens the hole the
   // return-URL gate closes.
-  test('neither the shared sign-out nor any control names the cookie', () => {
-    const files = [
+  // Two different bans, because they are two different mistakes.
+  //
+  // A module may NAME the cookie — `landing-destination.ts` declares the
+  // constant and parses it — as long as it has no way to WRITE one. That is
+  // checked as a capability, not as a hard-coded exemption, so the moment
+  // somebody gives that module `cookies()` or `document.cookie` the ban applies
+  // to it too.
+  const COOKIE_NAMES = ['LAST_PROJECT_COOKIE', 'kortix_last_project'];
+  // Task 5's symbol. A deleter by name — no module on this path may reach it,
+  // capability argument or not.
+  const DELETERS = ['clearLastProjectId'];
+
+  /** Whether a module has any means of writing or deleting a cookie at all. */
+  function canWriteCookies(file: string): boolean {
+    const body = code(file);
+    return (
+      body.includes('next/headers') ||
+      body.includes('document.cookie') ||
+      body.includes('cookies()') ||
+      body.includes('.cookies.set') ||
+      body.includes('.cookies.delete')
+    );
+  }
+
+  test('no module in the sign-out import GRAPH can delete the cookie', () => {
+    const graph = importGraph([
       'lib/auth/perform-sign-out.ts',
       'lib/auth/sign-out-sequence.ts',
       'lib/auth/sign-out-actions.ts',
       'lib/utils/reset-client-state.ts',
-    ].concat(CONTROLS.map((control) => control.file));
+    ]);
 
-    for (const file of files) {
-      const body = code(file);
-      expect(body).not.toContain('LAST_PROJECT_COOKIE');
-      expect(body).not.toContain('kortix_last_project');
-      expect(body).not.toContain('clearLastProjectId');
+    // The walk has to actually reach past the entry points, or this test is a
+    // fixed list wearing a graph's clothes. These two are the modules a future
+    // "forget this browser's user state" change would most naturally land in,
+    // and neither was covered by the path list this replaced.
+    expect(graph).toContain('lib/utils/clear-local-storage.ts');
+    expect(graph).toContain('stores/current-account-store.ts');
+    expect(graph.length).toBeGreaterThan(6);
+
+    for (const file of graph) {
+      for (const deleter of DELETERS) {
+        expect({ file, symbol: deleter, present: code(file).includes(deleter) }).toEqual({
+          file,
+          symbol: deleter,
+          present: false,
+        });
+      }
+
+      const named = COOKIE_NAMES.filter((name) => code(file).includes(name));
+      if (named.length === 0) continue;
+      expect({ file, named, writesCookies: canWriteCookies(file) }).toEqual({
+        file,
+        named,
+        writesCookies: false,
+      });
+    }
+  });
+
+  test('no logout control names the cookie either', () => {
+    // Direct, not transitive: these files import half the app, so their graphs
+    // reach modules that legitimately own the cookie (the middleware's helpers).
+    for (const control of CONTROLS) {
+      for (const banned of [...COOKIE_NAMES, ...DELETERS]) {
+        expect(code(control.file)).not.toContain(banned);
+      }
     }
   });
 });

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -155,6 +155,16 @@ describe('the server half of the sign-out', () => {
     expect(serverActions).toContain('AUTH_BOUNCE_COOKIE');
     expect(serverActions).toContain('await clearAuthBounceCookie();');
   });
+
+  // Task 5's client-state sweep (`reset-client-state.ts`) cannot reach this —
+  // it is an httpOnly cookie, outside `localStorage`/`sessionStorage`
+  // entirely. Without this call the 8h admin maintenance-lockdown bypass
+  // keeps working, on this browser, past the sign-out that ended the admin
+  // session it was minted for.
+  test('clears the httpOnly maintenance-bypass cookie, which no client can reach', () => {
+    expect(serverActions).toContain('MAINTENANCE_BYPASS_COOKIE');
+    expect(serverActions).toContain('await clearMaintenanceBypassCookie();');
+  });
 });
 
 describe('nothing on an identity change can wait forever', () => {

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -1,0 +1,195 @@
+// Every logout control leaves on a DOCUMENT load, and every one of them goes
+// through the single `performSignOut`.
+//
+// Why this is a correctness rule and not a preference: a soft navigation keeps
+// the App Router route cache, the segment cache, and — on a Back/Forward —
+// bfcache. `resetClientState()` reaches none of the three, `router.refresh()`
+// does not clear the route cache (only Next's internal
+// `invalidateEntirePrefetchCache` does, which no application code can call),
+// and bfcache restores bypass staleness entirely, so no `staleTimes` value
+// substitutes. Across an identity change that means the next account can be
+// shown the previous account's rendered segments.
+//
+// SOURCE assertions, and therefore subject to this repo's documented trap: a
+// source test that matches inside a COMMENT passes against text that never
+// runs. Task 3's first harness did exactly that. So: comments are stripped
+// before any match, every anchor is asserted to exist before it is used, and
+// this file names `router.push` / `router.replace` only inside string
+// constants — never in prose that a future slice could pick up.
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const WEB_SRC = resolve(import.meta.dir, '../..');
+
+/** Comments stripped; `//` spared when it is a URL scheme. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function code(relativePath: string): string {
+  return stripComments(readFileSync(resolve(WEB_SRC, relativePath), 'utf8'));
+}
+
+/**
+ * The executable text between two anchors. Both anchors are asserted, so a
+ * rename fails this test instead of silently reducing it to an empty slice
+ * that every `not.toContain` passes against.
+ */
+function slice(source: string, startAnchor: string, endAnchor: string): string {
+  const start = source.indexOf(startAnchor);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(endAnchor, start + startAnchor.length);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+/** Every navigation in a slice, as `[mechanism, argument]` pairs. */
+function navigations(text: string): string[][] {
+  const pattern =
+    /window\.location\.(assign|replace)\(([^)]*)\)|window\.location\.(href)\s*=\s*([^;]+);|router\.(push|replace|refresh|prefetch)\(([^)]*)\)/g;
+  return [...text.matchAll(pattern)].map((match) => [
+    match[1] ?? match[3] ?? match[5],
+    (match[2] ?? match[4] ?? match[6] ?? '').trim(),
+  ]);
+}
+
+/** The six sign-out controls, each sliced down to its own logout path. */
+const CONTROLS: { name: string; file: string; from: string; to: string }[] = [
+  {
+    name: 'the user menu / workspace switcher Log out',
+    file: 'features/layout/user-menu-shared.tsx',
+    from: 'export function useLogoutFlow(',
+    to: 'const dialog = (',
+  },
+  {
+    name: 'the command palette Log out',
+    file: 'features/workspace/command-palette.tsx',
+    from: 'const performLogout = useCallback(',
+    to: 'const handleSetTheme = useCallback(',
+  },
+  {
+    name: "/projects/start's stuck-state escape hatch",
+    file: 'app/(app)/projects/start/page.tsx',
+    from: 'function StartSignOutButton()',
+    to: 'function ProjectStartError(',
+  },
+  {
+    name: "/new's Log out",
+    file: 'features/workspace/new/new-workspace-page.tsx',
+    from: 'fallbackLabel={user?.email}',
+    to: 'Log out',
+  },
+  {
+    name: "phone verification's Sign out",
+    file: 'app/(auth)/auth/phone-verification/page.tsx',
+    from: 'const signOutMutation = useMutation(',
+    to: 'const handleSignOut',
+  },
+  {
+    name: "AuthProvider's signOut, which every useAuth() consumer gets",
+    file: 'features/providers/auth-provider.tsx',
+    from: 'const value = useMemo<AuthContextType>(',
+    to: 'return <AuthContext.Provider',
+  },
+];
+
+describe('all six sign-out controls run the one sign-out', () => {
+  for (const control of CONTROLS) {
+    test(`${control.name} calls performSignOut`, () => {
+      const body = slice(code(control.file), control.from, control.to);
+      expect(body).toContain('performSignOut');
+    });
+  }
+
+  for (const control of CONTROLS) {
+    test(`${control.name} performs NO client-side navigation of its own`, () => {
+      // Enumerated rather than spot-checked: a `router.push('/auth')` added
+      // beside the call fails here instead of slipping past a `toContain`.
+      // `router.prefetch` counts too — it only warms a segment cache that a
+      // document load never reads.
+      expect(navigations(slice(code(control.file), control.from, control.to))).toEqual([]);
+    });
+  }
+});
+
+describe('the one sign-out leaves on a document load', () => {
+  test('performSignOut hands `leave` a window.location.assign', () => {
+    const body = slice(
+      code('lib/auth/perform-sign-out.ts'),
+      'export async function performSignOut()',
+      '\n}\n',
+    );
+    expect(body).toContain('window.location.assign(destination)');
+  });
+
+  test('neither the wiring nor the sequence holds a router at all', () => {
+    for (const file of ['lib/auth/perform-sign-out.ts', 'lib/auth/sign-out-sequence.ts']) {
+      const body = code(file);
+      expect(body).not.toContain('router.');
+      expect(body).not.toContain('next/navigation');
+    }
+  });
+
+  test('it lands on /auth', () => {
+    expect(code('lib/auth/sign-out-sequence.ts')).toContain(
+      "export const SIGN_OUT_DESTINATION = '/auth';",
+    );
+  });
+});
+
+describe('the server half of the sign-out', () => {
+  const serverActions = code('lib/auth/sign-out-actions.ts');
+
+  test('revokes the session server-side and emits the audit event', () => {
+    // It ran on ONE of the six controls before this was unified, so five of six
+    // logouts left the session usable against the API until the access token
+    // expired on its own.
+    expect(serverActions).toContain('recordPlatformLogout(');
+    expect(code('lib/auth/perform-sign-out.ts')).toContain(
+      'finalizeServerSession: finalizeServerSignOut',
+    );
+  });
+
+  test('clears the httpOnly auth-bounce cookie, which no client can reach', () => {
+    expect(serverActions).toContain('AUTH_BOUNCE_COOKIE');
+    expect(serverActions).toContain('await clearAuthBounceCookie();');
+  });
+});
+
+describe('the sign-out path stays importable from the browser', () => {
+  test('nothing in its graph pulls in `server-only`', async () => {
+    // `AuthProvider` imports `performSignOut`, and `AuthProvider` is mounted by
+    // dozens of component tests. Reaching `server-only` from here — as an
+    // earlier revision did, through `@/lib/public-env-server` — turned 72 of
+    // them into load errors at once. A real import, not a source match: only
+    // evaluating the module proves the whole transitive graph is clean.
+    const signOutModule = await import('./perform-sign-out');
+    expect(typeof signOutModule.performSignOut).toBe('function');
+  });
+});
+
+describe('the sign-out path leaves `kortix_last_project` alone', () => {
+  // Load-bearing, not an oversight. The cookie is owner-bound
+  // (`serializeLastProject`), so the next account cannot follow it, and the
+  // middleware reads its OWNER half to attribute a bounce once identity
+  // resolution has already returned `user: null` — which is what happens after
+  // a logout and on the dominant session-expiry path. Deleting it on sign-out
+  // un-attributes every post-logout bounce and re-opens the hole the
+  // return-URL gate closes.
+  test('neither the shared sign-out nor any control names the cookie', () => {
+    const files = [
+      'lib/auth/perform-sign-out.ts',
+      'lib/auth/sign-out-sequence.ts',
+      'lib/auth/sign-out-actions.ts',
+      'lib/utils/reset-client-state.ts',
+    ].concat(CONTROLS.map((control) => control.file));
+
+    for (const file of files) {
+      const body = code(file);
+      expect(body).not.toContain('LAST_PROJECT_COOKIE');
+      expect(body).not.toContain('kortix_last_project');
+      expect(body).not.toContain('clearLastProjectId');
+    }
+  });
+});

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -513,7 +513,10 @@ function importGraph(entries: string[]): string[] {
     if (seen.has(file)) continue;
     seen.add(file);
 
-    const source = readFileSync(resolve(WEB_SRC, file), 'utf8');
+    // Comments stripped, same as `code()` above: an import specifier inside
+    // PROSE (a doc comment naming a module by example) is not an import
+    // statement and must not add a graph edge.
+    const source = stripComments(readFileSync(resolve(WEB_SRC, file), 'utf8'));
     for (const match of source.matchAll(/(?:from|import)\s*['"]([^'"]+)['"]/g)) {
       const next = resolveLocal(match[1], file);
       if (next && !seen.has(next)) queue.push(next);

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -17,7 +17,7 @@
 // this file names `router.push` / `router.replace` only inside string
 // constants — never in prose that a future slice could pick up.
 import { describe, expect, test } from 'bun:test';
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 
 const WEB_SRC = resolve(import.meta.dir, '../..');
@@ -186,7 +186,7 @@ describe('nothing on an identity change can wait forever', () => {
     // of the first paint.
     const reset = code('lib/utils/reset-client-state.ts');
     expect(reset).toContain("from '@/lib/utils/time-budget'");
-    expect(reset).toContain('withTimeBudget(clearSessionIDBCache())');
+    expect(reset).toContain('withTimeBudget(clearSessionIDBCache(), idbTimeoutMs)');
     expect(reset).not.toContain('await clearSessionIDBCache()');
   });
 
@@ -211,34 +211,174 @@ describe('the signed-out route guards do not race the exit', () => {
   // guard that only checks `!user` reaches `/auth` by SOFT navigation first —
   // carrying the App Router route cache across the identity change, which is
   // the exact defect the hard navigation exists to remove.
-  const GUARDED = [
-    'features/workspace/new/new-workspace-page.tsx',
-    'app/(app)/projects/start/page.tsx',
-  ];
+  //
+  // GREP-DERIVED, never a fixed list. An earlier version of this test named two
+  // files, which is the shape condemned three describes above: the guard existed
+  // at EIGHT sites, and the six that were missed included the two where the
+  // logout controls actually render (`project-shell.tsx`, and
+  // `accounts/layout.tsx`, which mounts `AppHeader`).
 
-  test('every signed-out guard checks isSigningOut() FIRST', () => {
-    for (const file of GUARDED) {
-      const body = code(file);
-      expect(body).toContain("from '@/lib/auth/sign-out-sequence'");
+  /** Every `.ts`/`.tsx` under `src`, excluding tests. */
+  function sourceFiles(dir = ''): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(resolve(WEB_SRC, dir), { withFileTypes: true })) {
+      const rel = dir ? `${dir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) out.push(...sourceFiles(rel));
+      else if (/\.tsx?$/.test(entry.name) && !/\.test\./.test(entry.name)) out.push(rel);
+    }
+    return out;
+  }
 
-      const bail = body.indexOf('if (isSigningOut()) return;');
-      const guard = body.indexOf("if (!authLoading && !user) router.replace('/auth');");
-      expect(bail).toBeGreaterThan(-1);
-      expect(guard).toBeGreaterThan(bail);
+  test('the guard exists in exactly ONE place', () => {
+    // The shape, spelled either way it was spelled across the eight copies.
+    const shape = /if \(!(?:authLoading|isLoading) && !user\) router\.replace\('\/auth'\)/;
+    const holders = sourceFiles().filter((file) => shape.test(code(file)));
+
+    expect(holders).toEqual(['lib/auth/use-signed-out-redirect.ts']);
+  });
+
+  test('the one guard stands down while a sign-out is in flight', () => {
+    const hook = code('lib/auth/use-signed-out-redirect.ts');
+    const bail = hook.indexOf('if (isSigningOut()) return;');
+    const guard = hook.search(/if \(!isLoading && !user\) router\.replace\('\/auth'\)/);
+
+    expect(bail).toBeGreaterThan(-1);
+    expect(guard).toBeGreaterThan(bail);
+  });
+
+  test('every surface that used to hand-roll it now calls the hook', () => {
+    // The six that were missed plus the two that were not. Named so a silent
+    // deletion of a guard reads as a failure rather than as a passing regex.
+    for (const file of [
+      'features/workspace/project-layout/project-shell.tsx',
+      'app/(app)/accounts/layout.tsx',
+      'app/(app)/accounts/page.tsx',
+      'app/(app)/accounts/[id]/page.tsx',
+      'app/(app)/accounts/[id]/scim-setup/page.tsx',
+      'app/(app)/accounts/[id]/sso-setup/page.tsx',
+      'app/(app)/projects/start/page.tsx',
+      'features/workspace/new/new-workspace-page.tsx',
+    ]) {
+      expect({ file, calls: code(file).includes('useSignedOutRedirect();') }).toEqual({
+        file,
+        calls: true,
+      });
     }
   });
 
-  test('the latch is set before performSignOut awaits anything', () => {
+  test('the latch is set before performSignOut can throw, and refuses re-entry', () => {
     const body = slice(
       code('lib/auth/perform-sign-out.ts'),
       'export async function performSignOut()',
       '\n}\n',
     );
+    const reentry = body.indexOf('if (isSigningOut()) return;');
     const mark = body.indexOf('markSignOutStarted();');
-    const firstAwait = body.indexOf('await ');
-    expect(mark).toBeGreaterThan(-1);
-    expect(firstAwait).toBeGreaterThan(mark);
+    const firstRisk = body.indexOf('createClient()');
+
+    expect(reentry).toBeGreaterThan(-1);
+    expect(mark).toBeGreaterThan(reentry);
+    expect(firstRisk).toBeGreaterThan(mark);
   });
+
+  test('a sign-out leaves even if the wiring throws before the sequence runs', () => {
+    // `createClient()` throws synchronously on unparseable env, and callers say
+    // `void performSignOut()` — so without the `finally` that throw strands a
+    // user who has already tripped the in-flight latch, on a page whose guard
+    // now stands down for them.
+    const body = slice(
+      code('lib/auth/perform-sign-out.ts'),
+      'export async function performSignOut()',
+      '\n}\n',
+    );
+    expect(body).toContain('} finally {');
+    expect(body).toContain('if (!left) {');
+    expect(body).toContain('window.location.assign(SIGN_OUT_DESTINATION);');
+  });
+});
+
+describe('a sign-out that the server refuses still signs the user out', () => {
+  // `@supabase/auth-js@2.110.0` `GoTrueClient._signOut()` POSTs to `/logout` for
+  // EVERY scope, `'local'` included, and returns before `_removeSession()` on
+  // any error that is not 404/401/403. Offline and 5xx defeat both attempts,
+  // and nothing else on this path touches the auth cookie.
+  const wiring = code('lib/auth/perform-sign-out.ts');
+
+  test('the sequence expires the cookie whenever the session is not PROVEN gone', () => {
+    const sequence = code('lib/auth/sign-out-sequence.ts');
+    expect(sequence).toContain('if (!sessionRemoved) {');
+    expect(sequence).toContain('steps.dropAuthCookie();');
+  });
+
+  test('the wiring expires the REAL cookie, chunk variants included', () => {
+    expect(wiring).toContain("from '@/lib/supabase/constants'");
+    expect(wiring).toContain('KORTIX_SUPABASE_AUTH_COOKIE');
+    // `@supabase/ssr` splits an oversized session across `<name>.0`, `<name>.1`,
+    // … so clearing only the base name leaves a signed-in browser whenever the
+    // JWT is large.
+    expect(wiring).toContain('`${KORTIX_SUPABASE_AUTH_COOKIE}.${index}`');
+    expect(wiring).toContain('Max-Age=0');
+    // Same path the client writes it with; a mismatched path expires nothing.
+    expect(wiring).toContain('path=/');
+    expect(wiring).toContain('dropAuthCookie: expireSupabaseAuthCookie');
+  });
+});
+
+describe('the three bare logout controls now say something is happening', () => {
+  // Five of six controls make a server round trip they never made before, and
+  // the sequence is bounded at four steps — long enough that a dialog closing
+  // onto an unchanged app reads as "nothing happened" and invites a second
+  // click. Uniform treatment: disable, the shared spinner, and a label change
+  // where the label is a literal.
+  //
+  // Every assertion here is SLICED to the control. `preventDefault` appears 3
+  // times in `user-menu-shared.tsx` and 7 in `command-palette.tsx`, so a
+  // whole-file `toContain` would pass on an unrelated dropdown handler — a
+  // false green of exactly the shape this file exists to avoid.
+  const PENDING = [
+    {
+      name: 'the user menu',
+      file: 'features/layout/user-menu-shared.tsx',
+      handler: ['const performLogout = (', 'const dialog = ('],
+      control: ['<AlertDialogAction', '</AlertDialogAction>'],
+      holdsDialog: true,
+    },
+    {
+      name: 'the command palette',
+      file: 'features/workspace/command-palette.tsx',
+      handler: ['const performLogout = useCallback(', 'const handleSetTheme = useCallback('],
+      control: ['<AlertDialogAction', '</AlertDialogAction>'],
+      holdsDialog: true,
+    },
+    {
+      name: "/new's Log out",
+      file: 'features/workspace/new/new-workspace-page.tsx',
+      handler: ['<AccountPicker', 'Log out'],
+      control: ['<AccountPicker', 'Log out'],
+      holdsDialog: false,
+    },
+  ];
+
+  for (const entry of PENDING) {
+    test(`${entry.name} disables its control and shows the shared spinner`, () => {
+      // Sliced to the ACTION element, not the dialog: `AlertDialogCancel` also
+      // takes `disabled`, so a dialog-wide match was satisfied by the Cancel
+      // button and passed with the action left enabled.
+      const control = slice(code(entry.file), entry.control[0], entry.control[1]);
+      expect(control).toContain('<Loading className="size-4 shrink-0" />');
+      expect(control).toMatch(/disabled=\{(?:pending|loggingOut|signingOut)\}/);
+    });
+  }
+
+  for (const entry of PENDING.filter((candidate) => candidate.holdsDialog)) {
+    test(`${entry.name} keeps its dialog up instead of closing onto nothing`, () => {
+      // Radix closes an `AlertDialogAction` on click. Without this the user sees
+      // the dialog vanish and the unchanged app sit there for the whole budget.
+      const handler = slice(code(entry.file), entry.handler[0], entry.handler[1]);
+      expect(handler).toContain('event.preventDefault();');
+      expect(handler).toContain('performSignOut()');
+    });
+  }
 });
 
 describe('the sign-out path stays importable from the browser', () => {

--- a/apps/web/src/lib/auth/sign-out-navigation.test.ts
+++ b/apps/web/src/lib/auth/sign-out-navigation.test.ts
@@ -174,10 +174,18 @@ describe('nothing on an identity change can wait forever', () => {
     expect(sequence).toContain("from '@/lib/utils/time-budget'");
 
     // All FOUR pre-navigation awaits, enumerated: a new unbounded `await
-    // steps.` added beside them fails here.
-    const budgeted = sequence.match(/withTimeBudget\(steps\./g) ?? [];
+    // steps.` added beside them fails here. Four, not three, because
+    // `endSession` appears twice — once for the attempt and once for the retry.
+    const budgeted = sequence.match(/withTimeBudget\(\s*steps\./g) ?? [];
     expect(budgeted.length).toBe(4);
     expect(sequence).not.toContain('await steps.');
+
+    // Each one spends its OWN budget, not a shared number: the server revoke
+    // must not be bounded tighter than its own `AbortSignal.timeout(3_000)`,
+    // and the reset needs far less than either.
+    for (const budget of ['budgets.finalizeServerSession', 'budgets.endSession', 'budgets.resetClientState']) {
+      expect(sequence).toContain(budget);
+    }
   });
 
   test('resetClientState bounds its one async step, for EVERY caller', () => {
@@ -266,19 +274,17 @@ describe('the signed-out route guards do not race the exit', () => {
     }
   });
 
-  test('the latch is set before performSignOut can throw, and refuses re-entry', () => {
-    const body = slice(
-      code('lib/auth/perform-sign-out.ts'),
-      'export async function performSignOut()',
-      '\n}\n',
-    );
-    const reentry = body.indexOf('if (isSigningOut()) return;');
-    const mark = body.indexOf('markSignOutStarted();');
-    const firstRisk = body.indexOf('createClient()');
+  test('the latch is set before anything can fire SIGNED_OUT', () => {
+    // It lives in `runSignOut` now, set before the first await, so that a
+    // `createClient()` throw cannot latch it and lock the user out — and so
+    // that the refusal branch and the latch cannot drift apart.
+    const sequence = code('lib/auth/sign-out-sequence.ts');
+    const latch = sequence.indexOf('signOutStarted = true;');
+    const firstStep = sequence.indexOf('steps.finalizeServerSession()');
 
-    expect(reentry).toBeGreaterThan(-1);
-    expect(mark).toBeGreaterThan(reentry);
-    expect(firstRisk).toBeGreaterThan(mark);
+    expect(latch).toBeGreaterThan(-1);
+    expect(firstStep).toBeGreaterThan(latch);
+    expect(code('lib/auth/perform-sign-out.ts')).not.toContain('markSignOutStarted');
   });
 
   test('a sign-out leaves even if the wiring throws before the sequence runs', () => {
@@ -306,21 +312,72 @@ describe('a sign-out that the server refuses still signs the user out', () => {
 
   test('the sequence expires the cookie whenever the session is not PROVEN gone', () => {
     const sequence = code('lib/auth/sign-out-sequence.ts');
+    // Twice: once as soon as it is known, and again immediately before leaving,
+    // because auth-js keeps refreshing an in-memory session it never removed.
+    const drops = sequence.match(/steps\.dropAuthCookie\(\);/g) ?? [];
+    expect(drops.length).toBe(2);
     expect(sequence).toContain('if (!sessionRemoved) {');
-    expect(sequence).toContain('steps.dropAuthCookie();');
   });
 
   test('the wiring expires the REAL cookie, chunk variants included', () => {
-    expect(wiring).toContain("from '@/lib/supabase/constants'");
-    expect(wiring).toContain('KORTIX_SUPABASE_AUTH_COOKIE');
+    // SLICED to the function. Asserting against the whole file made
+    // `KORTIX_SUPABASE_AUTH_COOKIE` satisfiable by the import line alone and
+    // `path=/` a generic substring with no anchor to the cookie write — the
+    // same false-green shape this file has already produced three times.
+    const expire = slice(wiring, 'function expireSupabaseAuthCookie', '\n}\n');
+
+    expect(expire).toContain('KORTIX_SUPABASE_AUTH_COOKIE');
     // `@supabase/ssr` splits an oversized session across `<name>.0`, `<name>.1`,
     // … so clearing only the base name leaves a signed-in browser whenever the
     // JWT is large.
-    expect(wiring).toContain('`${KORTIX_SUPABASE_AUTH_COOKIE}.${index}`');
-    expect(wiring).toContain('Max-Age=0');
+    expect(expire).toContain('`${KORTIX_SUPABASE_AUTH_COOKIE}.${index}`');
+    expect(expire).toContain('Max-Age=0');
     // Same path the client writes it with; a mismatched path expires nothing.
-    expect(wiring).toContain('path=/');
+    expect(expire).toContain('path=/');
+
+    expect(wiring).toContain("from '@/lib/supabase/constants'");
     expect(wiring).toContain('dropAuthCookie: expireSupabaseAuthCookie');
+  });
+
+  test('the fallback exit expires the cookie too', () => {
+    // The `createClient()`-throws path never reaches `runSignOut`, so
+    // `dropAuthCookie` was never called — landing on `/auth` with a live
+    // session is the exact bounce-back-in symptom the step exists to prevent.
+    const fallback = slice(wiring, '  } finally {', '\n}\n');
+    const expire = fallback.indexOf('expireSupabaseAuthCookie();');
+    const leave = fallback.indexOf('window.location.assign(SIGN_OUT_DESTINATION);');
+
+    expect(expire).toBeGreaterThan(-1);
+    expect(leave).toBeGreaterThan(expire);
+  });
+
+  test('a network-class failure skips the pointless retry', () => {
+    const sequence = code('lib/auth/sign-out-sequence.ts');
+    expect(sequence).toContain("outcome.value.error?.name === 'AuthRetryableFetchError'");
+    expect(sequence).toContain("if (outcome.status === 'timeout') return true;");
+    expect(sequence).toContain('!isNetworkClassFailure(ended)');
+  });
+});
+
+describe('a second press always leaves', () => {
+  // Pressing Log out with unsaved file edits open raises the `beforeunload`
+  // prompt (`file-viewer/file-content-renderer.tsx`); pressing Stay cancels the
+  // navigation and leaves the user inside the app with the latch set. Refusing
+  // silently made that permanent — the pending flags are never cleared, so the
+  // control stayed disabled, and the route guard had already stood down.
+  test('the refusal branch navigates instead of returning silently', () => {
+    const sequence = code('lib/auth/sign-out-sequence.ts');
+    const refusal = slice(sequence, 'if (signOutStarted) {', '\n  }');
+
+    expect(refusal).toContain('steps.leave(SIGN_OUT_DESTINATION);');
+    expect(refusal).toContain('return;');
+  });
+
+  test('the test-only latch reset is never called from product code', () => {
+    const callers = sourceFilesForBan().filter((file) =>
+      code(file).includes('__resetSignOutLatchForTests'),
+    );
+    expect(callers).toEqual(['lib/auth/sign-out-sequence.ts']);
   });
 });
 
@@ -392,6 +449,17 @@ describe('the sign-out path stays importable from the browser', () => {
     expect(typeof signOutModule.performSignOut).toBe('function');
   });
 });
+
+/** Every `.ts`/`.tsx` under `src`, excluding tests. */
+function sourceFilesForBan(dir = ''): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(resolve(WEB_SRC, dir), { withFileTypes: true })) {
+    const rel = dir ? `${dir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) out.push(...sourceFilesForBan(rel));
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\./.test(entry.name)) out.push(rel);
+  }
+  return out;
+}
 
 /** The local modules an import specifier can name, in resolution order. */
 function resolveLocal(specifier: string, fromFile: string): string | null {

--- a/apps/web/src/lib/auth/sign-out-sequence.test.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.test.ts
@@ -1,15 +1,23 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 
 import {
+  __resetSignOutLatchForTests,
   isSigningOut,
-  markSignOutStarted,
   runSignOut,
+  SIGN_OUT_BUDGETS_MS,
   SIGN_OUT_DESTINATION,
   type SignOutSteps,
 } from './sign-out-sequence';
 
 /** Small enough that a "this step hangs" test finishes instantly. */
-const FAST = { stepTimeoutMs: 5 };
+const FAST = {
+  budgets: { finalizeServerSession: 5, endSession: 5, resetClientState: 5 },
+};
+
+// The latch is module state that production never clears, because the only
+// thing that ends a sign-out is the document being replaced. Every test here
+// runs a fresh sign-out, so every test starts from a fresh latch.
+beforeEach(() => __resetSignOutLatchForTests());
 
 /**
  * The sign-out ORDER and its failure handling, on injected steps.
@@ -136,6 +144,10 @@ describe('runSignOut, the signOut ERROR path', () => {
       'endSession:local',
       'dropAuthCookie',
       'resetClientState',
+      // AGAIN, immediately before leaving: with the session never removed,
+      // auth-js still holds it in memory with `autoRefreshToken` ticking, and a
+      // refresh in the reset window writes it straight back into the cookie.
+      'dropAuthCookie',
       'leave',
     ]);
   });
@@ -279,20 +291,54 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
     expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
   });
 
-  test('a hung sign-out is retried locally, then resets and leaves', async () => {
-    const r = recorder({
-      endSession: (scope) => (scope === 'local' ? Promise.resolve({ error: null }) : hang()),
-    });
+  test('a hung sign-out is NOT retried — it expires the cookie instead', async () => {
+    // A timeout carries no error to classify and the request is still in
+    // flight; `scope: 'local'` posts to the same host and can only fail the
+    // same way, one budget later. Skipping it is what keeps the worst case at
+    // 6.0s instead of 8.0s, and the cookie is what makes skipping it safe.
+    const r = recorder({ endSession: hang });
 
     await runSignOut(r.steps, FAST);
 
     expect(r.calls).toEqual([
       'finalizeServerSession',
       'endSession',
-      'endSession:local',
+      'dropAuthCookie',
       'resetClientState',
+      'dropAuthCookie',
       'leave',
     ]);
+  });
+
+  test('a settled AuthRetryableFetchError is not retried either', async () => {
+    // auth-js's own tag for "the fetch did not complete" — offline, DNS. Same
+    // reasoning as the timeout above, but with an error object to read.
+    const r = recorder({
+      endSession: async () => ({ error: { name: 'AuthRetryableFetchError', message: 'offline' } }),
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).not.toContain('endSession:local');
+    expect(r.calls).toContain('dropAuthCookie');
+  });
+
+  test('a settled HTTP error IS retried — global and local are different writes', async () => {
+    // The paired positive. `scope: 'global'` revokes every refresh token for
+    // the user and is a heavier server write than `scope: 'local'`, so a global
+    // 500 beside a local 200 is a real outcome. Collapsing "any failure" into
+    // "never retry" would throw that away.
+    const r = recorder({
+      endSession: async (scope) =>
+        scope === 'local'
+          ? { error: null }
+          : { error: { name: 'AuthApiError', status: 500, message: 'boom' } },
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).toContain('endSession:local');
+    expect(r.calls).not.toContain('dropAuthCookie');
   });
 
   test('a hung reset — the real IndexedDB case — still leaves', async () => {
@@ -316,9 +362,9 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
     expect(r.calls).toEqual([
       'finalizeServerSession',
       'endSession',
-      'endSession:local',
       'dropAuthCookie',
       'resetClientState',
+      'dropAuthCookie',
       'leave',
     ]);
     expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
@@ -332,7 +378,7 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
     });
 
     const started = Date.now();
-    await runSignOut(r.steps, { stepTimeoutMs: 20 });
+    await runSignOut(r.steps, { budgets: { finalizeServerSession: 20, endSession: 20, resetClientState: 20 } });
     const elapsed = Date.now() - started;
 
     // Four bounded steps at 20ms. Generous ceiling so a loaded CI box does not
@@ -343,15 +389,74 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
 });
 
 /**
- * The in-flight latch. Placed LAST in this file on purpose: it is module state
- * that never resets, so marking it earlier would leak into the tests above.
- * Nothing before this point calls `markSignOutStarted` — only `performSignOut`
- * does, and that lives in the other module.
+ * The in-flight latch, and what a SECOND press does.
+ *
+ * The product path is real: press Log out with unsaved file edits open, and the
+ * `beforeunload` handler in `file-viewer/file-content-renderer.tsx` raises the
+ * browser's "Leave site?" prompt. Pressing Stay cancels the navigation and
+ * leaves the user inside the app — signed out, with the latch set.
+ *
+ * Refusing silently, as an earlier revision did, made that state PERMANENT:
+ * every later press was a no-op, the control stayed `disabled` (the pending
+ * flags are never cleared, by design), and `useSignedOutRedirect` had already
+ * stood down. The user had no working way to leave.
  */
-describe('the sign-out in-flight latch', () => {
-  test('is false until a sign-out starts, then latches', () => {
-    expect(isSigningOut()).toBe(false);
-    markSignOutStarted();
+describe('a second press never runs a second sequence, but always leaves', () => {
+  test('the first run latches; the second only navigates', async () => {
+    const first = recorder();
+    await runSignOut(first.steps, FAST);
     expect(isSigningOut()).toBe(true);
+
+    const second = recorder();
+    await runSignOut(second.steps, FAST);
+
+    // Nothing re-issued: no server revoke, no sign-out, no reset.
+    expect(second.calls).toEqual(['leave']);
+    expect(second.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('the latch is set before the first step can fire SIGNED_OUT', async () => {
+    // `useSignedOutRedirect` reads it. If `endSession` fires `SIGNED_OUT` before
+    // the latch is set, the guard's soft `router.replace('/auth')` wins the race
+    // and the route cache survives the identity change.
+    let latchedDuringFirstStep = false;
+    const r = recorder({
+      finalizeServerSession: async () => {
+        latchedDuringFirstStep = isSigningOut();
+      },
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(latchedDuringFirstStep).toBe(true);
+  });
+
+  test('it starts unlatched', () => {
+    // `beforeEach` resets it; this pins that the reset works, so every other
+    // test in this file is running a genuine first sign-out.
+    expect(isSigningOut()).toBe(false);
+  });
+});
+
+describe('the budgets', () => {
+  test('are 3s / 2s / 1s, summing to the 6.0s worst case', () => {
+    expect(SIGN_OUT_BUDGETS_MS).toEqual({
+      finalizeServerSession: 3_000,
+      endSession: 2_000,
+      resetClientState: 1_000,
+    });
+    const worstCase =
+      SIGN_OUT_BUDGETS_MS.finalizeServerSession +
+      SIGN_OUT_BUDGETS_MS.endSession +
+      SIGN_OUT_BUDGETS_MS.resetClientState;
+    expect(worstCase).toBe(6_000);
+  });
+
+  test('the server revoke is not tighter than its own AbortSignal', () => {
+    // `finalizeServerSignOut` uses `AbortSignal.timeout(3_000)`. A tighter outer
+    // bound would mean that abort could never fire while anyone waits, and the
+    // request would only land because later steps happen to keep the document
+    // alive — accidental coupling that every future latency cut would erode.
+    expect(SIGN_OUT_BUDGETS_MS.finalizeServerSession).toBeGreaterThanOrEqual(3_000);
   });
 });

--- a/apps/web/src/lib/auth/sign-out-sequence.test.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.test.ts
@@ -439,17 +439,12 @@ describe('a second press never runs a second sequence, but always leaves', () =>
 });
 
 describe('the budgets', () => {
-  test('are 3s / 2s / 1s, summing to the 6.0s worst case', () => {
+  test('are 3s / 2s / 1s', () => {
     expect(SIGN_OUT_BUDGETS_MS).toEqual({
       finalizeServerSession: 3_000,
       endSession: 2_000,
       resetClientState: 1_000,
     });
-    const worstCase =
-      SIGN_OUT_BUDGETS_MS.finalizeServerSession +
-      SIGN_OUT_BUDGETS_MS.endSession +
-      SIGN_OUT_BUDGETS_MS.resetClientState;
-    expect(worstCase).toBe(6_000);
   });
 
   test('the server revoke is not tighter than its own AbortSignal', () => {
@@ -458,5 +453,70 @@ describe('the budgets', () => {
     // request would only land because later steps happen to keep the document
     // alive — accidental coupling that every future latency cut would erode.
     expect(SIGN_OUT_BUDGETS_MS.finalizeServerSession).toBeGreaterThanOrEqual(3_000);
+  });
+});
+
+/**
+ * The REAL worst-case ceiling, proven by running `runSignOut` on a clock —
+ * not by summing constants and asserting the sum, which is what stood here
+ * before and which cannot fail no matter what `runSignOut` actually does.
+ *
+ * The scenario: a SETTLED, non-network HTTP error (a 500) that happens to
+ * resolve near the end of the first `endSession` budget.
+ * `isNetworkClassFailure` only skips the retry for `{status: 'timeout'}` or a
+ * settled `AuthRetryableFetchError` — a plain 500 is neither, so the retry
+ * fires and gets its OWN fresh `budgets.endSession`, not the leftover of the
+ * first. That makes `endSession` run TWICE, which is exactly what the false
+ * "sum of three" ceiling could not see.
+ */
+describe('the true sign-out ceiling is 8.0s (endSession can run twice), not 6.0s', () => {
+  test('a settled non-network endSession failure buys the retry a FRESH full budget', async () => {
+    // Scaled down from the real 3000/2000/1000 (same 3:2:1 ratio) so the test
+    // runs in milliseconds, not seconds.
+    const budgets = { finalizeServerSession: 10, endSession: 100, resetClientState: 10 };
+
+    // Settles just under its budget with a plain HTTP error — proven, not
+    // hung: `isNetworkClassFailure` reads `status === 'timeout'` only when
+    // `withTimeBudget` itself gives up, so this must SETTLE inside its
+    // budget to reach the "settled HTTP error" branch at all.
+    const settleNearBudgetEnd = () =>
+      new Promise<{ error: { status: number; message: string } }>((resolve) => {
+        setTimeout(
+          () => resolve({ error: { status: 500, message: 'boom' } }),
+          Math.round(budgets.endSession * 0.85),
+        );
+      });
+
+    const r = recorder({ endSession: settleNearBudgetEnd });
+
+    const started = Date.now();
+    await runSignOut(r.steps, { budgets });
+    const elapsed = Date.now() - started;
+
+    // Both attempts genuinely ran — the second `endSession` budget is real,
+    // not theoretical.
+    expect(r.calls.filter((c) => c === 'endSession' || c === 'endSession:local')).toEqual([
+      'endSession',
+      'endSession:local',
+    ]);
+
+    // The FALSE ceiling the old test pinned: the sum of the three DISTINCT
+    // budgets, counting `endSession` once.
+    const falseCeiling =
+      budgets.finalizeServerSession + budgets.endSession + budgets.resetClientState;
+    // The TRUE ceiling: `endSession` counted twice, matching the doc comment
+    // fixed alongside this test (`sign-out-sequence.ts`).
+    const trueCeiling = falseCeiling + budgets.endSession;
+
+    // Falsifies the "sum of three" claim: elapsed clears it, because the
+    // retry consumed a WHOLE second `endSession` budget rather than sharing
+    // what was left of the first. If the retry instead shared the first
+    // attempt's remaining budget (the change that would make 6.0s true),
+    // elapsed would land near `falseCeiling`, not clear it — see this
+    // test's mutation proof in the final-fix-wave report.
+    expect(elapsed).toBeGreaterThan(falseCeiling);
+    // Still bounded near the real (four-budget) ceiling — generous slack for
+    // scheduler jitter, not room for a fifth budget to appear from nowhere.
+    expect(elapsed).toBeLessThan(trueCeiling + 80);
   });
 });

--- a/apps/web/src/lib/auth/sign-out-sequence.test.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.test.ts
@@ -46,6 +46,9 @@ function recorder(
         calls.push('finalizeServerSession');
         if (overrides.finalizeServerSession) await overrides.finalizeServerSession();
       },
+      dropAuthCookie: () => {
+        calls.push('dropAuthCookie');
+      },
       endSession: async (scope) => {
         calls.push(scope ? `endSession:${scope}` : 'endSession');
         scopes.push(scope);
@@ -116,7 +119,13 @@ describe('runSignOut, the signOut ERROR path', () => {
     expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
   });
 
-  test('a local retry that ALSO fails still resets and still leaves', async () => {
+  test('a local retry that ALSO fails EXPIRES THE AUTH COOKIE, then resets and leaves', async () => {
+    // The security defect this closes. `scope: 'local'` is not local: in
+    // `@supabase/auth-js@2.110.0` it still POSTs to `/logout` and, on anything
+    // that is not 404/401/403, returns BEFORE `_removeSession()`. Offline and
+    // 5xx defeat both calls, and nothing else on this path touches the auth
+    // cookie — so without this step the user waits the full budget, lands on
+    // `/auth` with a live session, and is bounced straight back into the app.
     const r = recorder({ endSession: async () => ({ error: { message: 'nope' } }) });
 
     await runSignOut(r.steps, FAST);
@@ -125,9 +134,42 @@ describe('runSignOut, the signOut ERROR path', () => {
       'finalizeServerSession',
       'endSession',
       'endSession:local',
+      'dropAuthCookie',
       'resetClientState',
       'leave',
     ]);
+  });
+
+  test('the cookie is expired BEFORE the navigation, not after', async () => {
+    // After `leave()` the document is being replaced; a write racing a document
+    // load is not a guarantee of anything.
+    const r = recorder({ endSession: async () => ({ error: { message: 'nope' } }) });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls.indexOf('dropAuthCookie')).toBeLessThan(r.calls.indexOf('leave'));
+  });
+
+  test('a clean sign-out does NOT touch the cookie', async () => {
+    // The paired negative. Without it, an unconditional `dropAuthCookie()`
+    // passes every assertion above while doing work on the happy path that
+    // Supabase has already done correctly.
+    const r = recorder();
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).not.toContain('dropAuthCookie');
+  });
+
+  test('a retry that SUCCEEDS does not touch the cookie either', async () => {
+    const r = recorder({
+      endSession: async (scope) =>
+        scope === 'local' ? { error: null } : { error: { message: 'network down' } },
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).not.toContain('dropAuthCookie');
   });
 
   test('a THROWN sign-out is retried locally too', async () => {
@@ -190,6 +232,7 @@ describe('runSignOut, nothing can strand a signed-out user', () => {
     const steps: SignOutSteps = {
       finalizeServerSession: async () => {},
       endSession: async () => ({ error: null }),
+      dropAuthCookie: () => {},
       resetClientState: () =>
         new Promise<void>((resolve) => {
           resolveReset = () => {
@@ -261,7 +304,7 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
     expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
   });
 
-  test('EVERY step hanging at once still leaves', async () => {
+  test('EVERY step hanging at once still expires the cookie and still leaves', async () => {
     const r = recorder({
       finalizeServerSession: hang,
       endSession: hang,
@@ -274,6 +317,7 @@ describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
       'finalizeServerSession',
       'endSession',
       'endSession:local',
+      'dropAuthCookie',
       'resetClientState',
       'leave',
     ]);

--- a/apps/web/src/lib/auth/sign-out-sequence.test.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from 'bun:test';
 
-import { SIGN_OUT_DESTINATION, runSignOut, type SignOutSteps } from './sign-out-sequence';
+import {
+  isSigningOut,
+  markSignOutStarted,
+  runSignOut,
+  SIGN_OUT_DESTINATION,
+  type SignOutSteps,
+} from './sign-out-sequence';
+
+/** Small enough that a "this step hangs" test finishes instantly. */
+const FAST = { stepTimeoutMs: 5 };
 
 /**
  * The sign-out ORDER and its failure handling, on injected steps.
@@ -57,7 +66,7 @@ function recorder(
 describe('runSignOut, happy path', () => {
   test('ends the session once, clears the bounce, resets, then leaves', async () => {
     const r = recorder();
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
     expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
     expect(r.scopes).toEqual([undefined]);
@@ -73,7 +82,7 @@ describe('runSignOut, happy path', () => {
     // access token that `supabase.auth.signOut()` is about to throw away, so
     // running it second would silently stop revoking anything.
     const r = recorder();
-    return runSignOut(r.steps).then(() => {
+    return runSignOut(r.steps, FAST).then(() => {
       expect(r.calls.indexOf('finalizeServerSession')).toBeLessThan(
         r.calls.indexOf('endSession'),
       );
@@ -94,7 +103,7 @@ describe('runSignOut, the signOut ERROR path', () => {
       },
     });
 
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
     expect(attempt).toBe(2);
     expect(r.calls).toEqual([
@@ -110,7 +119,7 @@ describe('runSignOut, the signOut ERROR path', () => {
   test('a local retry that ALSO fails still resets and still leaves', async () => {
     const r = recorder({ endSession: async () => ({ error: { message: 'nope' } }) });
 
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
     expect(r.calls).toEqual([
       'finalizeServerSession',
@@ -121,16 +130,26 @@ describe('runSignOut, the signOut ERROR path', () => {
     ]);
   });
 
-  test('a THROWN sign-out is not retried, but still resets and still leaves', async () => {
+  test('a THROWN sign-out is retried locally too', async () => {
+    // A thrown fetch is the archetypal "the server was unreachable", which is
+    // exactly when a local sign-out is the right answer. Treating a throw as
+    // terminal left the session in the browser.
     const r = recorder({
-      endSession: async () => {
+      endSession: async (scope) => {
+        if (scope === 'local') return { error: null };
         throw new Error('boom');
       },
     });
 
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
-    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+    expect(r.calls).toEqual([
+      'finalizeServerSession',
+      'endSession',
+      'endSession:local',
+      'resetClientState',
+      'leave',
+    ]);
   });
 });
 
@@ -144,7 +163,7 @@ describe('runSignOut, nothing can strand a signed-out user', () => {
       },
     });
 
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
     expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
   });
@@ -156,7 +175,7 @@ describe('runSignOut, nothing can strand a signed-out user', () => {
       },
     });
 
-    await runSignOut(r.steps);
+    await runSignOut(r.steps, FAST);
 
     expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
     expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
@@ -181,7 +200,7 @@ describe('runSignOut, nothing can strand a signed-out user', () => {
       leave: () => order.push('left'),
     };
 
-    const running = runSignOut(steps);
+    const running = runSignOut(steps, FAST);
     // Drain the microtasks the two awaited steps ahead of the reset queue, so
     // the assertion below is about the reset gate and not about scheduling.
     for (let i = 0; i < 20; i += 1) await Promise.resolve();
@@ -191,5 +210,104 @@ describe('runSignOut, nothing can strand a signed-out user', () => {
     await running;
 
     expect(order).toEqual(['reset-finished', 'left']);
+  });
+});
+
+/**
+ * The blocker this round fixed. Each of these steps could hang FOREVER, and one
+ * of them demonstrably can: `resetClientState()` awaits `clearSessionIDBCache()`,
+ * whose `openDB()` registers no `onblocked` handler, so an upgrade blocked by a
+ * stale tab settles neither `success` nor `error`. Unbounded, `leave()` was
+ * never reached — the user could not sign out and saw no error.
+ *
+ * A `try`/`catch` cannot catch a promise that never settles. Only a clock can,
+ * which is why every one of these uses a hanging promise rather than a
+ * rejecting one.
+ */
+describe('runSignOut, a step that NEVER settles cannot trap the user', () => {
+  const hang = () => new Promise<never>(() => {});
+
+  test('a hung server half still ends the session, resets and leaves', async () => {
+    const r = recorder({ finalizeServerSession: hang });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('a hung sign-out is retried locally, then resets and leaves', async () => {
+    const r = recorder({
+      endSession: (scope) => (scope === 'local' ? Promise.resolve({ error: null }) : hang()),
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).toEqual([
+      'finalizeServerSession',
+      'endSession',
+      'endSession:local',
+      'resetClientState',
+      'leave',
+    ]);
+  });
+
+  test('a hung reset — the real IndexedDB case — still leaves', async () => {
+    const r = recorder({ resetClientState: hang });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('EVERY step hanging at once still leaves', async () => {
+    const r = recorder({
+      finalizeServerSession: hang,
+      endSession: hang,
+      resetClientState: hang,
+    });
+
+    await runSignOut(r.steps, FAST);
+
+    expect(r.calls).toEqual([
+      'finalizeServerSession',
+      'endSession',
+      'endSession:local',
+      'resetClientState',
+      'leave',
+    ]);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('the whole sequence finishes in roughly the sum of its budgets', async () => {
+    const r = recorder({
+      finalizeServerSession: hang,
+      endSession: hang,
+      resetClientState: hang,
+    });
+
+    const started = Date.now();
+    await runSignOut(r.steps, { stepTimeoutMs: 20 });
+    const elapsed = Date.now() - started;
+
+    // Four bounded steps at 20ms. Generous ceiling so a loaded CI box does not
+    // flake; the point is that it is BOUNDED, not that it is exact.
+    expect(elapsed).toBeGreaterThanOrEqual(60);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});
+
+/**
+ * The in-flight latch. Placed LAST in this file on purpose: it is module state
+ * that never resets, so marking it earlier would leak into the tests above.
+ * Nothing before this point calls `markSignOutStarted` — only `performSignOut`
+ * does, and that lives in the other module.
+ */
+describe('the sign-out in-flight latch', () => {
+  test('is false until a sign-out starts, then latches', () => {
+    expect(isSigningOut()).toBe(false);
+    markSignOutStarted();
+    expect(isSigningOut()).toBe(true);
   });
 });

--- a/apps/web/src/lib/auth/sign-out-sequence.test.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'bun:test';
+
+import { SIGN_OUT_DESTINATION, runSignOut, type SignOutSteps } from './sign-out-sequence';
+
+/**
+ * The sign-out ORDER and its failure handling, on injected steps.
+ *
+ * Dependency injection rather than `mock.module`: a module mock in this repo is
+ * process-wide, and these assertions are about the sequence `runSignOut` runs,
+ * not about who supplies each step.
+ */
+
+type Recorder = {
+  calls: string[];
+  steps: SignOutSteps;
+  scopes: (string | undefined)[];
+  destinations: string[];
+};
+
+function recorder(
+  overrides: Partial<{
+    endSession: (scope?: 'local') => Promise<{ error: { message?: string } | null }>;
+    finalizeServerSession: () => Promise<void>;
+    resetClientState: () => Promise<void>;
+  }> = {},
+): Recorder {
+  const calls: string[] = [];
+  const scopes: (string | undefined)[] = [];
+  const destinations: string[] = [];
+
+  return {
+    calls,
+    scopes,
+    destinations,
+    steps: {
+      finalizeServerSession: async () => {
+        calls.push('finalizeServerSession');
+        if (overrides.finalizeServerSession) await overrides.finalizeServerSession();
+      },
+      endSession: async (scope) => {
+        calls.push(scope ? `endSession:${scope}` : 'endSession');
+        scopes.push(scope);
+        return overrides.endSession ? overrides.endSession(scope) : { error: null };
+      },
+      resetClientState: async () => {
+        calls.push('resetClientState');
+        if (overrides.resetClientState) await overrides.resetClientState();
+      },
+      leave: (destination) => {
+        calls.push('leave');
+        destinations.push(destination);
+      },
+    },
+  };
+}
+
+describe('runSignOut, happy path', () => {
+  test('ends the session once, clears the bounce, resets, then leaves', async () => {
+    const r = recorder();
+    await runSignOut(r.steps);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+    expect(r.scopes).toEqual([undefined]);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('the destination is /auth', () => {
+    expect(SIGN_OUT_DESTINATION).toBe('/auth');
+  });
+
+  test('the SERVER-side sign-out runs before the browser drops its session', () => {
+    // Order, not decoration: `finalizeServerSignOut` authenticates with the
+    // access token that `supabase.auth.signOut()` is about to throw away, so
+    // running it second would silently stop revoking anything.
+    const r = recorder();
+    return runSignOut(r.steps).then(() => {
+      expect(r.calls.indexOf('finalizeServerSession')).toBeLessThan(
+        r.calls.indexOf('endSession'),
+      );
+    });
+  });
+});
+
+describe('runSignOut, the signOut ERROR path', () => {
+  test('retries locally, still resets, and still leaves', async () => {
+    // The defect this pins: every previous control discarded `{ error }`. On
+    // that path Supabase removed no session and fired no `SIGNED_OUT`, so
+    // nothing was cleared — and the user was navigated away regardless.
+    let attempt = 0;
+    const r = recorder({
+      endSession: async (scope) => {
+        attempt += 1;
+        return scope === 'local' ? { error: null } : { error: { message: 'network down' } };
+      },
+    });
+
+    await runSignOut(r.steps);
+
+    expect(attempt).toBe(2);
+    expect(r.calls).toEqual([
+      'finalizeServerSession',
+      'endSession',
+      'endSession:local',
+      'resetClientState',
+      'leave',
+    ]);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('a local retry that ALSO fails still resets and still leaves', async () => {
+    const r = recorder({ endSession: async () => ({ error: { message: 'nope' } }) });
+
+    await runSignOut(r.steps);
+
+    expect(r.calls).toEqual([
+      'finalizeServerSession',
+      'endSession',
+      'endSession:local',
+      'resetClientState',
+      'leave',
+    ]);
+  });
+
+  test('a THROWN sign-out is not retried, but still resets and still leaves', async () => {
+    const r = recorder({
+      endSession: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    await runSignOut(r.steps);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+  });
+});
+
+describe('runSignOut, nothing can strand a signed-out user', () => {
+  test('a failed SERVER-side sign-out does not skip the client sign-out', async () => {
+    // The API revoke and the audit are best effort. A backend that is down must
+    // never be able to keep a user signed in on this browser.
+    const r = recorder({
+      finalizeServerSession: async () => {
+        throw new Error('server action unreachable');
+      },
+    });
+
+    await runSignOut(r.steps);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+  });
+
+  test('a failed reset does not skip the navigation', async () => {
+    const r = recorder({
+      resetClientState: async () => {
+        throw new Error('indexedDB blocked');
+      },
+    });
+
+    await runSignOut(r.steps);
+
+    expect(r.calls).toEqual(['finalizeServerSession', 'endSession', 'resetClientState', 'leave']);
+    expect(r.destinations).toEqual([SIGN_OUT_DESTINATION]);
+  });
+
+  test('the reset always completes BEFORE the navigation starts', async () => {
+    // Reversing these would hand the next document a cache the previous user
+    // owned, because the reset would still be in flight when the load begins.
+    const order: string[] = [];
+    let resolveReset: (() => void) | null = null;
+
+    const steps: SignOutSteps = {
+      finalizeServerSession: async () => {},
+      endSession: async () => ({ error: null }),
+      resetClientState: () =>
+        new Promise<void>((resolve) => {
+          resolveReset = () => {
+            order.push('reset-finished');
+            resolve();
+          };
+        }),
+      leave: () => order.push('left'),
+    };
+
+    const running = runSignOut(steps);
+    // Drain the microtasks the two awaited steps ahead of the reset queue, so
+    // the assertion below is about the reset gate and not about scheduling.
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    expect(order).toEqual([]);
+
+    resolveReset!();
+    await running;
+
+    expect(order).toEqual(['reset-finished', 'left']);
+  });
+});

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TIME_BUDGET_MS, withTimeBudget } from '@/lib/utils/time-budget';
+import { type BudgetOutcome, withTimeBudget } from '@/lib/utils/time-budget';
 
 /**
  * The sign-out SEQUENCE: what happens, in what order, what a failure at each
@@ -16,8 +16,45 @@ import { DEFAULT_TIME_BUDGET_MS, withTimeBudget } from '@/lib/utils/time-budget'
  */
 export const SIGN_OUT_DESTINATION = '/auth';
 
-/** The result shape `supabase.auth.signOut()` returns. */
-type SignOutResult = { error: { message?: string } | null };
+/**
+ * How long each step may hold up the exit, in milliseconds. Worst case is their
+ * SUM — 6.0s — because the local retry is skipped in the only case that could
+ * make all three run long (see `runSignOut`).
+ *
+ * They are not the same number, and the differences are load-bearing:
+ *
+ *  - **3000 for the server revoke**, matching `finalizeServerSignOut`'s own
+ *    `AbortSignal.timeout(3_000)`. A tighter outer bound would mean that inner
+ *    abort could never fire while anyone waits, and — because `withTimeBudget`
+ *    does not CANCEL anything — the request would only land at all because the
+ *    remaining steps happen to keep the document alive long enough. That is
+ *    accidental coupling: every second cut from the tail would silently remove
+ *    grace from an in-flight revoke. Equal budgets make the guarantee explicit.
+ *  - **2000 for the sign-out**, the one step whose success is the whole point.
+ *  - **1000 for the reset**, which is generous rather than tight:
+ *    `clearSessionIDBCache` issues `tx.objectStore(STORE_NAME).clear()` and
+ *    returns WITHOUT awaiting the transaction, so the only awaited work is
+ *    `openDB()`. Cache size is irrelevant — a 10-entry and a 10,000-entry cache
+ *    settle identically, and the only thing 1000ms is really waiting out is the
+ *    blocked-upgrade hang that has no upper bound at all.
+ */
+export const SIGN_OUT_BUDGETS_MS = {
+  finalizeServerSession: 3_000,
+  endSession: 2_000,
+  resetClientState: 1_000,
+} as const;
+
+export type SignOutBudgets = { -readonly [K in keyof typeof SIGN_OUT_BUDGETS_MS]: number };
+
+/**
+ * The result shape `supabase.auth.signOut()` returns.
+ *
+ * `name` is read, not decoration: it is how a NETWORK-class failure is told
+ * apart from an HTTP one. `@supabase/auth-js` tags the former
+ * `AuthRetryableFetchError` (`lib/errors.js`), and only that distinction makes
+ * the retry decision below correct rather than superstitious.
+ */
+type SignOutResult = { error: { message?: string; name?: string; status?: number } | null };
 
 /** The four things a sign-out does, injected so the order and the failure handling can be tested. */
 export type SignOutSteps = {
@@ -63,20 +100,25 @@ export type SignOutSteps = {
 /**
  * Whether a sign-out has begun in this document.
  *
- * Latched, never cleared: the sign-out ends on a document load, so "we are
- * leaving" is true until this document is gone. Signed-out route guards read it
- * so they do not race the exit — see `NewWorkspacePage` and `ProjectStartPage`.
+ * Latched, and never cleared in production: the sign-out ends on a document
+ * load, so "we are leaving" stays true until this document is gone. The signed-
+ * out route guard reads it so it does not race the exit — see
+ * `useSignedOutRedirect`.
  */
 let signOutStarted = false;
-
-/** Called by `performSignOut` the instant a user asks to leave. */
-export function markSignOutStarted(): void {
-  signOutStarted = true;
-}
 
 /** True once a sign-out is in flight in this document. */
 export function isSigningOut(): boolean {
   return signOutStarted;
+}
+
+/**
+ * TEST ONLY. Production never clears the latch, so a test file that runs more
+ * than one sign-out has to. Named to be unmistakable in a diff; a source
+ * assertion pins that nothing outside a test calls it.
+ */
+export function __resetSignOutLatchForTests(): void {
+  signOutStarted = false;
 }
 
 /**
@@ -91,13 +133,21 @@ export function isSigningOut(): boolean {
  *     `/auth` as though it had worked, where the still live session sent them
  *     straight back into the app.
  *
- *     Reading the error buys a retry with `scope: 'local'`, and that retry is
+    Reading the error buys a retry with `scope: 'local'`, and that retry is
  *     worth taking — but it is NOT the guarantee it looks like. `scope: 'local'`
  *     still posts to `/logout` and still bails before removing the session on a
  *     non-404/401/403 error, so offline and 5xx defeat both calls. The
  *     guarantee comes from `dropAuthCookie()`, which runs whenever the session
  *     is not PROVEN gone: a returned error, a thrown fetch, or a timeout, on
  *     either attempt.
+ *
+ *     The retry is SKIPPED when the first attempt already proved the network is
+ *     the problem — a timeout, or a settled `AuthRetryableFetchError` — because
+ *     `scope: 'local'` makes the same request to the same host and can only
+ *     fail the same way, one budget later. It is KEPT for any settled HTTP
+ *     error: `scope: 'global'` revokes every refresh token for the user, which
+ *     is a heavier server write than `scope: 'local'`, so a global 500 beside a
+ *     local 200 is not hypothetical.
  *  2. **The cleanup runs REGARDLESS.** `resetClientState()` is not conditional
  *     on the sign-out succeeding. The `SIGNED_OUT` listener in `AuthProvider`
  *     also resets, but it only fires when Supabase actually removed a session —
@@ -116,35 +166,55 @@ export function isSigningOut(): boolean {
  *     the IndexedDB purge can be outrun, and those entries are keyed
  *     `user:<id>` (`buildSessionCacheKey`), so the next account cannot read
  *     them.
- *  4. **Nothing is stranded.** `/new`'s button neither awaited nor navigated,
- *     so it signed the user out and left them on the create form.
+ *  4. **Nothing is stranded, and a SECOND press still leaves.** `/new`'s button
+ *     neither awaited nor navigated, so it signed the user out and left them on
+ *     the create form. The re-entry branch below is the other half of that: it
+ *     refuses to run a second sequence but still navigates, because a user can
+ *     genuinely end up back here — press Log out with unsaved file edits open
+ *     and the `beforeunload` prompt lets them press "Stay"
+ *     (`file-viewer/file-content-renderer.tsx`). Returning silently left them
+ *     signed out, inside the app, with a permanently disabled button and a
+ *     route guard that had already stood down.
  *
- * Worst case before `leave()` is FOUR full budgets — 8.0s at the default. No
- * step is cheap on a broken network: `scope: 'local'` posts to `/logout` like
- * every other scope, so the retry re-issues the request that just timed out and
- * burns its whole budget doing it. That is the price of never hanging forever,
- * and it is why the three bare controls grew a pending state.
+ * Worst case before `leave()` is 6.0s: the sum of the three budgets, since the
+ * only case that makes all of them run long — everything hanging — is exactly
+ * the case that skips the retry.
  */
 export async function runSignOut(
   steps: SignOutSteps,
-  { stepTimeoutMs = DEFAULT_TIME_BUDGET_MS }: { stepTimeoutMs?: number } = {},
+  { budgets = SIGN_OUT_BUDGETS_MS }: { budgets?: SignOutBudgets } = {},
 ): Promise<void> {
-  const server = await withTimeBudget(steps.finalizeServerSession(), stepTimeoutMs);
+  if (signOutStarted) {
+    // Never a second sequence; ALWAYS a navigation.
+    steps.leave(SIGN_OUT_DESTINATION);
+    return;
+  }
+  // Before the first await, so a `SIGNED_OUT` fired inside `endSession` cannot
+  // beat the guard's stand-down.
+  signOutStarted = true;
+
+  const server = await withTimeBudget(
+    steps.finalizeServerSession(),
+    budgets.finalizeServerSession,
+  );
   if (server.status !== 'settled') {
     // Best effort. A backend that is down — or merely slow — must never be able
     // to keep a user signed in.
     console.error('[signOut] server-side sign-out did not complete:', server);
   }
 
-  const ended = await withTimeBudget(steps.endSession(), stepTimeoutMs);
+  const ended = await withTimeBudget(steps.endSession(), budgets.endSession);
   let sessionRemoved = ended.status === 'settled' && !ended.value.error;
-  if (!sessionRemoved) {
+
+  if (!sessionRemoved && !isNetworkClassFailure(ended)) {
     console.error('[signOut] server sign-out failed, retrying locally:', ended);
-    const local = await withTimeBudget(steps.endSession('local'), stepTimeoutMs);
+    const local = await withTimeBudget(steps.endSession('local'), budgets.endSession);
     sessionRemoved = local.status === 'settled' && !local.value.error;
     if (!sessionRemoved) {
       console.error('[signOut] local sign-out also failed:', local);
     }
+  } else if (!sessionRemoved) {
+    console.error('[signOut] sign-out failed at the network; not retrying:', ended);
   }
 
   // PROVEN gone, or take it away ourselves. Nothing below this line can tell
@@ -155,10 +225,39 @@ export async function runSignOut(
     steps.dropAuthCookie();
   }
 
-  const reset = await withTimeBudget(steps.resetClientState(), stepTimeoutMs);
+  const reset = await withTimeBudget(steps.resetClientState(), budgets.resetClientState);
   if (reset.status !== 'settled') {
     console.error('[signOut] client-state reset did not complete:', reset);
   }
 
+  // Again, immediately before leaving. When the session was never removed,
+  // auth-js still holds it in memory with `autoRefreshToken` ticking, and a
+  // refresh — or a visibility-change `_recoverAndRefresh` — writes it straight
+  // back into the cookie through `storage.setItem`. The window is small (~1s
+  // against a 30s tick) and the fix is one line.
+  if (!sessionRemoved) {
+    steps.dropAuthCookie();
+  }
+
   steps.leave(SIGN_OUT_DESTINATION);
+}
+
+/**
+ * Whether the first sign-out attempt already proved the NETWORK is the problem,
+ * which makes a second identical request to the same host pointless.
+ *
+ * Two shapes count. A `timeout` carries no error to classify — the request is
+ * still in flight, and re-issuing it only buys another full budget of waiting.
+ * A settled `AuthRetryableFetchError` is auth-js's own tag for "the fetch did
+ * not complete" (`@supabase/auth-js/dist/main/lib/errors.js`), which is what
+ * offline and DNS failures produce.
+ *
+ * Everything else — any settled HTTP error, and a throw — falls through to the
+ * retry on purpose. `scope: 'global'` revokes every refresh token for the user
+ * and is a heavier server write than `scope: 'local'`, so a global failure
+ * beside a local success is a real outcome, not a theoretical one.
+ */
+function isNetworkClassFailure(outcome: BudgetOutcome<SignOutResult>): boolean {
+  if (outcome.status === 'timeout') return true;
+  return outcome.status === 'settled' && outcome.value.error?.name === 'AuthRetryableFetchError';
 }

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -27,8 +27,33 @@ export type SignOutSteps = {
    * authenticates with the access token the next step throws away.
    */
   finalizeServerSession: () => Promise<void>;
-  /** `supabase.auth.signOut()`. `scope: 'local'` skips the server entirely. */
+  /**
+   * `supabase.auth.signOut()`.
+   *
+   * `scope: 'local'` is NOT a local-only operation, despite the name — see
+   * `dropAuthCookie` for what that costs and how it is covered.
+   */
   endSession: (scope?: 'local') => Promise<SignOutResult>;
+  /**
+   * Expire this browser's Supabase auth cookie by hand.
+   *
+   * The last line of defence, and it exists because BOTH `endSession()` calls
+   * can leave the session in place. In `@supabase/auth-js@2.110.0`,
+   * `GoTrueClient._signOut()` posts to `/logout` for EVERY scope — `'local'`
+   * included — and on an error that is not 404/401/403 it returns BEFORE
+   * `_removeSession()`. Offline and 5xx produce `AuthRetryableFetchError` and
+   * `AuthApiError(500)`, neither of which is in that list, so the session
+   * survives, no `SIGNED_OUT` fires, and `resetClientState()` does not touch it
+   * either (`clearUserLocalStorage` clears only enumerated app keys).
+   *
+   * `leave('/auth')` then loads `/auth`, where `AuthContent` reads the still
+   * valid session, computes `trustedUser`, and redirects straight back into the
+   * app. The user waited the full budget and is NOT signed out, with no error
+   * shown. This is the one step that makes "signed out on this browser" true
+   * regardless of what any server said: the cookie is not `httpOnly`, so the
+   * document can expire it itself.
+   */
+  dropAuthCookie: () => void;
   /** React Query, the account store, per-user localStorage, the IDB cache. */
   resetClientState: () => Promise<void>;
   /** A DOCUMENT navigation. Never `router.push` — see `performSignOut`. */
@@ -59,15 +84,20 @@ export function isSigningOut(): boolean {
  *
  * Four properties this holds that no previous logout path did:
  *
- *  1. **The error is READ.** `signOut()` returns `{ error }` rather than
- *     throwing, and every previous caller dropped it. On that path Supabase
- *     removed no session, fired no `SIGNED_OUT`, and cleared nothing — and the
- *     user was navigated to `/auth` as though it had worked, where the still
- *     live session sent them straight back into the app. The retry with
- *     `scope: 'local'` is what actually fixes it: every non-clean outcome —
- *     a returned error, a thrown fetch, or a timeout — means "the server would
- *     not revoke it", and a local sign-out drops the session from this browser
- *     without asking the server for permission.
+ *  1. **The error is READ, and the session is ENDED even when reading it is not
+ *     enough.** `signOut()` returns `{ error }` rather than throwing, and every
+ *     previous caller dropped it. On that path Supabase removed no session,
+ *     fired no `SIGNED_OUT`, and cleared nothing — and the user was navigated to
+ *     `/auth` as though it had worked, where the still live session sent them
+ *     straight back into the app.
+ *
+ *     Reading the error buys a retry with `scope: 'local'`, and that retry is
+ *     worth taking — but it is NOT the guarantee it looks like. `scope: 'local'`
+ *     still posts to `/logout` and still bails before removing the session on a
+ *     non-404/401/403 error, so offline and 5xx defeat both calls. The
+ *     guarantee comes from `dropAuthCookie()`, which runs whenever the session
+ *     is not PROVEN gone: a returned error, a thrown fetch, or a timeout, on
+ *     either attempt.
  *  2. **The cleanup runs REGARDLESS.** `resetClientState()` is not conditional
  *     on the sign-out succeeding. The `SIGNED_OUT` listener in `AuthProvider`
  *     also resets, but it only fires when Supabase actually removed a session —
@@ -89,9 +119,11 @@ export function isSigningOut(): boolean {
  *  4. **Nothing is stranded.** `/new`'s button neither awaited nor navigated,
  *     so it signed the user out and left them on the create form.
  *
- * Worst case before `leave()` is four budgets. In practice the local retry is
- * pure storage and returns in ~0ms even when every network call is dead, so a
- * fully broken environment exits in about three.
+ * Worst case before `leave()` is FOUR full budgets — 8.0s at the default. No
+ * step is cheap on a broken network: `scope: 'local'` posts to `/logout` like
+ * every other scope, so the retry re-issues the request that just timed out and
+ * burns its whole budget doing it. That is the price of never hanging forever,
+ * and it is why the three bare controls grew a pending state.
  */
 export async function runSignOut(
   steps: SignOutSteps,
@@ -105,13 +137,22 @@ export async function runSignOut(
   }
 
   const ended = await withTimeBudget(steps.endSession(), stepTimeoutMs);
-  const cleanlyEnded = ended.status === 'settled' && !ended.value.error;
-  if (!cleanlyEnded) {
+  let sessionRemoved = ended.status === 'settled' && !ended.value.error;
+  if (!sessionRemoved) {
     console.error('[signOut] server sign-out failed, retrying locally:', ended);
     const local = await withTimeBudget(steps.endSession('local'), stepTimeoutMs);
-    if (local.status !== 'settled' || local.value.error) {
+    sessionRemoved = local.status === 'settled' && !local.value.error;
+    if (!sessionRemoved) {
       console.error('[signOut] local sign-out also failed:', local);
     }
+  }
+
+  // PROVEN gone, or take it away ourselves. Nothing below this line can tell
+  // the difference between "Supabase removed the session" and "Supabase
+  // returned early and left it there", so the only safe reading of anything
+  // other than a clean result is that the session is still live.
+  if (!sessionRemoved) {
+    steps.dropAuthCookie();
   }
 
   const reset = await withTimeBudget(steps.resetClientState(), stepTimeoutMs);

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -17,9 +17,12 @@ import { type BudgetOutcome, withTimeBudget } from '@/lib/utils/time-budget';
 export const SIGN_OUT_DESTINATION = '/auth';
 
 /**
- * How long each step may hold up the exit, in milliseconds. Worst case is their
- * SUM — 6.0s — because the local retry is skipped in the only case that could
- * make all three run long (see `runSignOut`).
+ * How long each step may hold up the exit, in milliseconds. Worst case is
+ * 8.0s, not the sum of these three: `runSignOut` gives the local RETRY its
+ * own fresh `endSession` budget, and the retry fires on any settled non-
+ * network HTTP error (a 500), not only on a hang — so `endSession` can
+ * genuinely run twice. `finalizeServerSession + endSession + endSession +
+ * resetClientState` = 3.0 + 2.0 + 2.0 + 1.0 = 8.0s. See `runSignOut`.
  *
  * They are not the same number, and the differences are load-bearing:
  *
@@ -134,7 +137,7 @@ export function __resetSignOutLatchForTests(): void {
  *     `/auth` as though it had worked, where the still live session sent them
  *     straight back into the app.
  *
-    Reading the error buys a retry with `scope: 'local'`, and that retry is
+ *     Reading the error buys a retry with `scope: 'local'`, and that retry is
  *     worth taking — but it is NOT the guarantee it looks like. `scope: 'local'`
  *     still posts to `/logout` and still bails before removing the session on a
  *     non-404/401/403 error, so offline and 5xx defeat both calls. The
@@ -177,9 +180,17 @@ export function __resetSignOutLatchForTests(): void {
  *     signed out, inside the app, with a permanently disabled button and a
  *     route guard that had already stood down.
  *
- * Worst case before `leave()` is 6.0s: the sum of the three budgets, since the
- * only case that makes all of them run long — everything hanging — is exactly
- * the case that skips the retry.
+ * Worst case before `leave()` is 8.0s, not the 6.0s sum of the three DISTINCT
+ * budgets. The case that makes every step run long is NOT the same case that
+ * skips the retry: a hang produces `{status: 'timeout'}`, which
+ * `isNetworkClassFailure` does treat as network-class and skips the retry for
+ * — but a SETTLED plain HTTP error (a 500) that happens to resolve near the
+ * end of the first `endSession` budget is neither a timeout nor a settled
+ * `AuthRetryableFetchError`, so it falls through to the retry, which gets its
+ * OWN fresh `budgets.endSession` rather than whatever was left of the first.
+ * That is `endSession` counted twice: `finalizeServerSession` (3.0) +
+ * `endSession` (2.0) + the retry's `endSession` (2.0) + `resetClientState`
+ * (1.0) = 8.0s.
  */
 export async function runSignOut(
   steps: SignOutSteps,

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -1,0 +1,86 @@
+/**
+ * The sign-out SEQUENCE: what happens, in what order, and what a failure at
+ * each step is allowed to prevent.
+ *
+ * Split from `perform-sign-out.ts` — which supplies the real steps — because
+ * the wiring reaches a `'use server'` module and the browser Supabase client,
+ * and neither belongs in the module that states the rule.
+ */
+
+/**
+ * Where a sign-out lands. Not configurable on purpose: every logout control in
+ * the product ends on the same screen, and a caller-supplied destination is how
+ * six controls grew four different behaviours in the first place.
+ */
+export const SIGN_OUT_DESTINATION = '/auth';
+
+/** The result shape `supabase.auth.signOut()` returns. */
+type SignOutResult = { error: { message?: string } | null };
+
+/** The four things a sign-out does, injected so the order and the failure handling can be tested. */
+export type SignOutSteps = {
+  /**
+   * The server half: revoke the session in the API's activity table, emit the
+   * audit event, and clear the httpOnly auth-bounce cookie. FIRST, because it
+   * authenticates with the access token the next step throws away.
+   */
+  finalizeServerSession: () => Promise<void>;
+  /** `supabase.auth.signOut()`. `scope: 'local'` skips the server entirely. */
+  endSession: (scope?: 'local') => Promise<SignOutResult>;
+  /** React Query, the account store, per-user localStorage, the IDB cache. */
+  resetClientState: () => Promise<void>;
+  /** A DOCUMENT navigation. Never `router.push` — see `performSignOut`. */
+  leave: (destination: string) => void;
+};
+
+/**
+ * Run one sign-out.
+ *
+ * Three properties this holds that no previous logout path did:
+ *
+ *  1. **The error is READ.** `signOut()` returns `{ error }` rather than
+ *     throwing, and every previous caller dropped it. On that path Supabase
+ *     removed no session, fired no `SIGNED_OUT`, and cleared nothing — and the
+ *     user was navigated to `/auth` as though it had worked, where the still
+ *     live session sent them straight back into the app. The retry with
+ *     `scope: 'local'` is what actually fixes it: the common failures are "the
+ *     server could not revoke it" (offline, 5xx, an already-rotated refresh
+ *     token), and a local sign-out drops the session from this browser without
+ *     asking the server for permission.
+ *  2. **The cleanup runs REGARDLESS.** `resetClientState()` is not conditional
+ *     on the sign-out succeeding. The `SIGNED_OUT` listener in `AuthProvider`
+ *     also resets, but it only fires when Supabase actually removed a session —
+ *     which is exactly the case that already worked.
+ *  3. **Leaving ALWAYS happens.** Every step is guarded, so a thrown cleanup
+ *     cannot strand a signed-out user on an authenticated screen — which is
+ *     what `/new`'s button did, since it neither awaited nor navigated.
+ */
+export async function runSignOut(steps: SignOutSteps): Promise<void> {
+  try {
+    await steps.finalizeServerSession();
+  } catch (error) {
+    // Best effort. A backend that is down must never keep a user signed in.
+    console.error('[signOut] server-side sign-out failed:', error);
+  }
+
+  try {
+    const { error } = await steps.endSession();
+    if (error) {
+      console.error('[signOut] server sign-out failed, retrying locally:', error.message);
+      const local = await steps.endSession('local');
+      if (local.error) {
+        console.error('[signOut] local sign-out also failed:', local.error.message);
+      }
+    }
+  } catch (error) {
+    console.error('[signOut] sign-out threw:', error);
+  }
+
+  try {
+    await steps.resetClientState();
+  } catch (error) {
+    console.error('[signOut] failed to reset client state:', error);
+  }
+
+  steps.leave(SIGN_OUT_DESTINATION);
+}

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -81,7 +81,8 @@ export type SignOutSteps = {
    * `_removeSession()`. Offline and 5xx produce `AuthRetryableFetchError` and
    * `AuthApiError(500)`, neither of which is in that list, so the session
    * survives, no `SIGNED_OUT` fires, and `resetClientState()` does not touch it
-   * either (`clearUserLocalStorage` clears only enumerated app keys).
+   * either (`clearUserLocalStorage` only sweeps this app's own storage-key
+   * prefixes, never a cookie).
    *
    * `leave('/auth')` then loads `/auth`, where `AuthContent` reads the still
    * valid session, computes `trustedUser`, and redirects straight back into the

--- a/apps/web/src/lib/auth/sign-out-sequence.ts
+++ b/apps/web/src/lib/auth/sign-out-sequence.ts
@@ -1,6 +1,8 @@
+import { DEFAULT_TIME_BUDGET_MS, withTimeBudget } from '@/lib/utils/time-budget';
+
 /**
- * The sign-out SEQUENCE: what happens, in what order, and what a failure at
- * each step is allowed to prevent.
+ * The sign-out SEQUENCE: what happens, in what order, what a failure at each
+ * step is allowed to prevent, and how long any step may hold up the exit.
  *
  * Split from `perform-sign-out.ts` — which supplies the real steps — because
  * the wiring reaches a `'use server'` module and the browser Supabase client,
@@ -34,52 +36,87 @@ export type SignOutSteps = {
 };
 
 /**
+ * Whether a sign-out has begun in this document.
+ *
+ * Latched, never cleared: the sign-out ends on a document load, so "we are
+ * leaving" is true until this document is gone. Signed-out route guards read it
+ * so they do not race the exit — see `NewWorkspacePage` and `ProjectStartPage`.
+ */
+let signOutStarted = false;
+
+/** Called by `performSignOut` the instant a user asks to leave. */
+export function markSignOutStarted(): void {
+  signOutStarted = true;
+}
+
+/** True once a sign-out is in flight in this document. */
+export function isSigningOut(): boolean {
+  return signOutStarted;
+}
+
+/**
  * Run one sign-out.
  *
- * Three properties this holds that no previous logout path did:
+ * Four properties this holds that no previous logout path did:
  *
  *  1. **The error is READ.** `signOut()` returns `{ error }` rather than
  *     throwing, and every previous caller dropped it. On that path Supabase
  *     removed no session, fired no `SIGNED_OUT`, and cleared nothing — and the
  *     user was navigated to `/auth` as though it had worked, where the still
  *     live session sent them straight back into the app. The retry with
- *     `scope: 'local'` is what actually fixes it: the common failures are "the
- *     server could not revoke it" (offline, 5xx, an already-rotated refresh
- *     token), and a local sign-out drops the session from this browser without
- *     asking the server for permission.
+ *     `scope: 'local'` is what actually fixes it: every non-clean outcome —
+ *     a returned error, a thrown fetch, or a timeout — means "the server would
+ *     not revoke it", and a local sign-out drops the session from this browser
+ *     without asking the server for permission.
  *  2. **The cleanup runs REGARDLESS.** `resetClientState()` is not conditional
  *     on the sign-out succeeding. The `SIGNED_OUT` listener in `AuthProvider`
  *     also resets, but it only fires when Supabase actually removed a session —
  *     which is exactly the case that already worked.
- *  3. **Leaving ALWAYS happens.** Every step is guarded, so a thrown cleanup
- *     cannot strand a signed-out user on an authenticated screen — which is
- *     what `/new`'s button did, since it neither awaited nor navigated.
+ *  3. **Leaving ALWAYS happens, on a WALL CLOCK.** Every step is bounded, not
+ *     just guarded. A `try`/`catch` cannot rescue a promise that never settles,
+ *     and one of these steps can genuinely hang forever: `resetClientState()`
+ *     awaits `clearSessionIDBCache()`, whose `openDB()` has no `onblocked`
+ *     handler, so a version upgrade blocked by a stale tab never resolves.
+ *     Unbounded, the user could not sign out at all and saw no error.
+ *
+ *     Bounding is safe for a reason specific to this sequence: everything
+ *     identity-critical in `resetClientState()` is SYNCHRONOUS and complete
+ *     before its one awaited call — the React Query cache, the persisted
+ *     account selection and the per-user localStorage are already gone. Only
+ *     the IndexedDB purge can be outrun, and those entries are keyed
+ *     `user:<id>` (`buildSessionCacheKey`), so the next account cannot read
+ *     them.
+ *  4. **Nothing is stranded.** `/new`'s button neither awaited nor navigated,
+ *     so it signed the user out and left them on the create form.
+ *
+ * Worst case before `leave()` is four budgets. In practice the local retry is
+ * pure storage and returns in ~0ms even when every network call is dead, so a
+ * fully broken environment exits in about three.
  */
-export async function runSignOut(steps: SignOutSteps): Promise<void> {
-  try {
-    await steps.finalizeServerSession();
-  } catch (error) {
-    // Best effort. A backend that is down must never keep a user signed in.
-    console.error('[signOut] server-side sign-out failed:', error);
+export async function runSignOut(
+  steps: SignOutSteps,
+  { stepTimeoutMs = DEFAULT_TIME_BUDGET_MS }: { stepTimeoutMs?: number } = {},
+): Promise<void> {
+  const server = await withTimeBudget(steps.finalizeServerSession(), stepTimeoutMs);
+  if (server.status !== 'settled') {
+    // Best effort. A backend that is down — or merely slow — must never be able
+    // to keep a user signed in.
+    console.error('[signOut] server-side sign-out did not complete:', server);
   }
 
-  try {
-    const { error } = await steps.endSession();
-    if (error) {
-      console.error('[signOut] server sign-out failed, retrying locally:', error.message);
-      const local = await steps.endSession('local');
-      if (local.error) {
-        console.error('[signOut] local sign-out also failed:', local.error.message);
-      }
+  const ended = await withTimeBudget(steps.endSession(), stepTimeoutMs);
+  const cleanlyEnded = ended.status === 'settled' && !ended.value.error;
+  if (!cleanlyEnded) {
+    console.error('[signOut] server sign-out failed, retrying locally:', ended);
+    const local = await withTimeBudget(steps.endSession('local'), stepTimeoutMs);
+    if (local.status !== 'settled' || local.value.error) {
+      console.error('[signOut] local sign-out also failed:', local);
     }
-  } catch (error) {
-    console.error('[signOut] sign-out threw:', error);
   }
 
-  try {
-    await steps.resetClientState();
-  } catch (error) {
-    console.error('[signOut] failed to reset client state:', error);
+  const reset = await withTimeBudget(steps.resetClientState(), stepTimeoutMs);
+  if (reset.status !== 'settled') {
+    console.error('[signOut] client-state reset did not complete:', reset);
   }
 
   steps.leave(SIGN_OUT_DESTINATION);

--- a/apps/web/src/lib/auth/use-signed-out-redirect.ts
+++ b/apps/web/src/lib/auth/use-signed-out-redirect.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useAuth } from '@/features/providers/auth-provider';
+import { isSigningOut } from '@/lib/auth/sign-out-sequence';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+/**
+ * Leave for `/auth` once the session is gone — the ONE signed-out guard.
+ *
+ * Every authenticated surface needs this because the middleware only gates the
+ * REQUEST. A session that dies while a page is already mounted — an expired
+ * token, a sign-out in another tab, a revoked refresh token — leaves a
+ * signed-out user looking at a live screen whose every call can only 401.
+ *
+ * It was written out by hand at EIGHT sites. That is not a style problem: the
+ * copies drifted apart the moment one of them needed the `isSigningOut()` check
+ * below, and the two that got it first were the two where logging out is a rare
+ * escape hatch, not the two where the logout controls actually render
+ * (`project-shell.tsx` and `accounts/layout.tsx`, which mounts `AppHeader`).
+ *
+ * `isSigningOut()` FIRST, and this is the whole reason the guard is shared.
+ * `performSignOut` fires `SIGNED_OUT` before its document load begins, so a
+ * guard that only checks `!user` wins that race and reaches `/auth` by SOFT
+ * navigation — carrying the App Router route cache across an identity change,
+ * which is the exact defect the hard navigation exists to remove.
+ *
+ * A soft `replace` is right for every OTHER way a session ends: there is no
+ * identity to flush that this document ever published, only a dead screen to
+ * leave.
+ */
+export function useSignedOutRedirect(): void {
+  const router = useRouter();
+  const { user, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isSigningOut()) return;
+    if (!isLoading && !user) router.replace('/auth');
+  }, [isLoading, user, router]);
+}

--- a/apps/web/src/lib/maintenance-bypass.test.ts
+++ b/apps/web/src/lib/maintenance-bypass.test.ts
@@ -6,14 +6,16 @@ import {
 } from './maintenance-bypass';
 
 const NOW = 1_800_000_000; // fixed reference time (seconds)
+const ADMIN_A = '11111111-1111-4111-8111-111111111111';
+const ADMIN_B = '22222222-2222-4222-8222-222222222222';
 
 test('a freshly minted token verifies', async () => {
-  const token = await createBypassToken(NOW);
+  const token = await createBypassToken(ADMIN_A, NOW);
   expect(await verifyBypassToken(token, NOW)).toBe(true);
 });
 
 test('a token is valid right up to its expiry and invalid after', async () => {
-  const token = await createBypassToken(NOW);
+  const token = await createBypassToken(ADMIN_A, NOW);
   const justBeforeExp = NOW + MAINTENANCE_BYPASS_TTL_SECONDS - 1;
   const afterExp = NOW + MAINTENANCE_BYPASS_TTL_SECONDS + 1;
   expect(await verifyBypassToken(token, justBeforeExp)).toBe(true);
@@ -29,15 +31,51 @@ test('empty / malformed tokens are rejected', async () => {
 });
 
 test('a tampered signature is rejected', async () => {
-  const token = await createBypassToken(NOW);
-  const [exp, sig] = token.split('.');
+  const token = await createBypassToken(ADMIN_A, NOW);
+  const parts = token.split('.');
+  const sig = parts[parts.length - 1];
   const flipped = sig.slice(0, -1) + (sig.endsWith('0') ? '1' : '0');
-  expect(await verifyBypassToken(`${exp}.${flipped}`, NOW)).toBe(false);
+  parts[parts.length - 1] = flipped;
+  expect(await verifyBypassToken(parts.join('.'), NOW)).toBe(false);
 });
 
 test('a forged expiry (kept far in the future, unsigned) is rejected', async () => {
-  const token = await createBypassToken(NOW);
-  const sig = token.split('.')[1];
+  const token = await createBypassToken(ADMIN_A, NOW);
+  const [, userId, sig] = token.split('.');
   // Attacker extends expiry but cannot resign it with the server secret.
-  expect(await verifyBypassToken(`9999999999.${sig}`, NOW)).toBe(false);
+  expect(await verifyBypassToken(`9999999999.${userId}.${sig}`, NOW)).toBe(false);
+});
+
+/**
+ * JAY: the token used to be a bare `${exp}.${sig}` capability — anyone who
+ * held a valid copy could use it, with no way to tell whose lockdown-era
+ * access it represented. `userId` is now part of the SIGNED payload.
+ */
+test('the bound user id is part of the signed payload: relabeling it invalidates the token', async () => {
+  const token = await createBypassToken(ADMIN_A, NOW);
+  const [exp, userId, sig] = token.split('.');
+  expect(userId).toBe(ADMIN_A);
+
+  // Swap in a different admin's id without re-signing — exactly what an
+  // attacker who can read (but not forge-sign) the cookie would try.
+  const relabeled = `${exp}.${ADMIN_B}.${sig}`;
+  expect(await verifyBypassToken(relabeled, NOW)).toBe(false);
+
+  // The original, correctly-signed token for its real owner still works.
+  expect(await verifyBypassToken(token, NOW)).toBe(true);
+});
+
+/**
+ * A pre-binding token (the old two-part `${exp}.${sig}` shape a previous
+ * deploy could still have set as a cookie) must fail closed, not be silently
+ * accepted as "no user bound". Uses a real signature computed against the
+ * CURRENT token's own hash — a two-part slice of a real, validly-signed
+ * three-part token — so this proves the SHAPE is rejected, not just an
+ * arbitrary bad signature.
+ */
+test('a pre-binding token (old two-part exp.sig shape) is rejected', async () => {
+  const token = await createBypassToken(ADMIN_A, NOW);
+  const [exp, , sig] = token.split('.');
+  const legacyShaped = `${exp}.${sig}`; // one dot, not two
+  expect(await verifyBypassToken(legacyShaped, NOW)).toBe(false);
 });

--- a/apps/web/src/lib/maintenance-bypass.ts
+++ b/apps/web/src/lib/maintenance-bypass.ts
@@ -5,8 +5,25 @@
  * When maintenance is at the `blocking` (Full Lockdown) level, middleware
  * redirects everyone to `/maintenance`. A platform admin can mint a short-lived
  * bypass token from that page; middleware honors it so admins keep access even
- * during a full lockdown. The token is an HMAC-signed `${exp}.${sig}` string set
- * as an httpOnly cookie, so it can't be forged client-side or read by scripts.
+ * during a full lockdown. The token is an HMAC-signed `${exp}.${userId}.${sig}`
+ * string set as an httpOnly cookie, so it can't be forged client-side or read by
+ * scripts.
+ *
+ * BOUND TO THE MINTING ADMIN. The token used to be `${exp}.${sig}` — a bare
+ * capability with no identity in it at all: any valid, unexpired copy worked
+ * for anyone who held it, for the full 8h TTL, with no way to tell whose
+ * lockdown-era access it represented. `userId` is now part of the SIGNED
+ * payload, so tampering with it (swapping in a different admin's id without
+ * the server secret) invalidates the signature — this is real cryptographic
+ * binding, not an unchecked label. `middleware.ts`'s verify call stays a
+ * single unauthenticated boolean check (no live cross-reference against the
+ * CURRENT request's signed-in user): the maintenance gate runs before this
+ * middleware resolves `user` at all, and reordering that resolution to enable
+ * a live comparison is exactly the "restructure the security-critical
+ * middleware" this task was told not to do. What the binding buys instead:
+ * the cookie's own contents now say who it was minted for (useful for
+ * clearing on THAT user's sign-out and for future per-admin revocation), and
+ * a stolen/replayed token can no longer be silently relabeled.
  *
  * The lockdown is a traffic-shedding / UX gate, not a security boundary — the
  * backend still enforces real auth on every request — but signing the cookie
@@ -72,28 +89,48 @@ function safeEqual(a: string, b: string): boolean {
   return diff === 0;
 }
 
-/** Mint a bypass token valid until `nowSeconds + ttlSeconds`. */
+/**
+ * Mint a bypass token valid until `nowSeconds + ttlSeconds`, bound to
+ * `userId` — the admin who requested it (`POST /api/maintenance/bypass`
+ * already resolves this via `supabase.auth.getUser()` before calling in).
+ */
 export async function createBypassToken(
+  userId: string,
   nowSeconds: number = Math.floor(Date.now() / 1000),
   ttlSeconds: number = MAINTENANCE_BYPASS_TTL_SECONDS,
 ): Promise<string> {
   const exp = nowSeconds + ttlSeconds;
-  const sig = await sign(String(exp));
-  return `${exp}.${sig}`;
+  const payload = `${exp}.${userId}`;
+  const sig = await sign(payload);
+  return `${payload}.${sig}`;
 }
 
-/** Verify a bypass token: valid signature AND not expired. */
+/**
+ * Verify a bypass token: valid signature AND not expired.
+ *
+ * The signature covers `${exp}.${userId}` together, so an attacker who edits
+ * EITHER field — extends the expiry, or relabels the token as a different
+ * admin's — invalidates it without the server secret. A pre-binding token
+ * (the old two-part `${exp}.${sig}` shape) has no second `.` and is rejected
+ * by the same `lastDot <= firstDot` check that rejects every other malformed
+ * shape — a lockdown-era cookie minted by the previous version simply stops
+ * verifying after this deploys, which is the correct fail-closed behavior for
+ * a format change on a privileged token.
+ */
 export async function verifyBypassToken(
   token: string | undefined | null,
   nowSeconds: number = Math.floor(Date.now() / 1000),
 ): Promise<boolean> {
   if (!token) return false;
-  const dot = token.indexOf('.');
-  if (dot <= 0) return false;
-  const expPart = token.slice(0, dot);
-  const sigPart = token.slice(dot + 1);
+  const firstDot = token.indexOf('.');
+  const lastDot = token.lastIndexOf('.');
+  if (firstDot <= 0 || lastDot <= firstDot) return false;
+  const expPart = token.slice(0, firstDot);
+  const userIdPart = token.slice(firstDot + 1, lastDot);
+  const sigPart = token.slice(lastDot + 1);
+  if (!userIdPart || !sigPart) return false;
   const exp = Number(expPart);
   if (!Number.isFinite(exp) || exp <= nowSeconds) return false;
-  const expected = await sign(expPart);
+  const expected = await sign(`${expPart}.${userIdPart}`);
   return safeEqual(sigPart, expected);
 }

--- a/apps/web/src/lib/onboarding/ensure-first-project.test.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
-import { pickLandingProject, shouldAutoCreateFirstProject } from './ensure-first-project';
+import {
+  clearAutoProjectSuppression,
+  isAutoProjectSuppressed,
+  pickLandingProject,
+  shouldAutoCreateFirstProject,
+  suppressAutoProjectAfterDelete,
+} from './ensure-first-project';
 
 type State = Parameters<typeof shouldAutoCreateFirstProject>[0];
 
@@ -99,5 +105,103 @@ describe('pickLandingProject', () => {
       project_id: A.project_id,
     });
     expect(pickLandingProject(projects, null)).toMatchObject({ project_id: A.project_id });
+  });
+});
+
+/**
+ * JAY: symptom 5. `kortix:suppress-auto-project` used to be a bare `'1'` with
+ * no owner, so a flag set by account A's archive survived a sign-out that
+ * skipped the client-state sweep and suppressed provisioning for whichever
+ * DIFFERENT account signed in next on the same tab. It is now bound to the
+ * account that set it.
+ */
+describe('isAutoProjectSuppressed / suppressAutoProjectAfterDelete', () => {
+  const ACCOUNT_A = '11111111-1111-4111-8111-111111111111';
+  const ACCOUNT_B = '22222222-2222-4222-8222-222222222222';
+
+  class FakeSessionStorage implements Storage {
+    private store = new Map<string, string>();
+    get length(): number {
+      return this.store.size;
+    }
+    clear(): void {
+      this.store.clear();
+    }
+    getItem(key: string): string | null {
+      return this.store.has(key) ? (this.store.get(key) as string) : null;
+    }
+    key(index: number): string | null {
+      return Array.from(this.store.keys())[index] ?? null;
+    }
+    removeItem(key: string): void {
+      this.store.delete(key);
+    }
+    setItem(key: string, value: string): void {
+      this.store.set(key, value);
+    }
+  }
+
+  type MutableGlobals = { window?: unknown };
+  const g = globalThis as MutableGlobals;
+  const originalWindow = g.window;
+  let fakeSessionStorage: FakeSessionStorage;
+
+  function stubWindow(): void {
+    fakeSessionStorage = new FakeSessionStorage();
+    Object.defineProperty(globalThis, 'window', {
+      value: { sessionStorage: fakeSessionStorage },
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: originalWindow,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  test('suppression set by account A does not suppress for account B', () => {
+    stubWindow();
+    suppressAutoProjectAfterDelete(ACCOUNT_A);
+
+    expect(isAutoProjectSuppressed(ACCOUNT_A)).toBe(true);
+    expect(isAutoProjectSuppressed(ACCOUNT_B)).toBe(false);
+  });
+
+  test('an unset flag suppresses nobody', () => {
+    stubWindow();
+    expect(isAutoProjectSuppressed(ACCOUNT_A)).toBe(false);
+  });
+
+  test('a caller with no account id is never suppressed, even if a flag is set', () => {
+    stubWindow();
+    suppressAutoProjectAfterDelete(ACCOUNT_A);
+    expect(isAutoProjectSuppressed(null)).toBe(false);
+    expect(isAutoProjectSuppressed(undefined)).toBe(false);
+  });
+
+  test('the legacy bare "1" value (pre-binding format) is treated as unsuppressed', () => {
+    stubWindow();
+    fakeSessionStorage.setItem('kortix:suppress-auto-project', '1');
+    expect(isAutoProjectSuppressed(ACCOUNT_A)).toBe(false);
+  });
+
+  test('clearAutoProjectSuppression removes the flag for every account', () => {
+    stubWindow();
+    suppressAutoProjectAfterDelete(ACCOUNT_A);
+    expect(isAutoProjectSuppressed(ACCOUNT_A)).toBe(true);
+
+    clearAutoProjectSuppression();
+
+    expect(isAutoProjectSuppressed(ACCOUNT_A)).toBe(false);
+  });
+
+  test('suppressAutoProjectAfterDelete with no account id writes nothing', () => {
+    stubWindow();
+    suppressAutoProjectAfterDelete(null);
+    expect(fakeSessionStorage.getItem('kortix:suppress-auto-project')).toBeNull();
   });
 });

--- a/apps/web/src/lib/onboarding/ensure-first-project.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.ts
@@ -2,6 +2,7 @@ import { type KortixProject, listProjectsForAccount, provisionProject } from '@k
 
 import { isValidProjectId } from '@/lib/onboarding/landing-destination';
 import { hasPostAuthIntent } from '@/lib/onboarding/post-auth-intent';
+import { useCurrentAccountStore } from '@/stores/current-account-store';
 
 export type FirstProjectAutoCreateState = {
   activeAccountId: string | null;
@@ -30,8 +31,25 @@ export const FIRST_PROJECT_TEMPLATE = 'general-knowledge-worker';
  * immediately recreate it — the app undoing the action the user just took.
  * Tab-scoped on purpose: the suppression is about *this* deliberate delete, so a
  * later sign-in or a fresh tab provisions again like any other empty account.
+ *
+ * BOUND TO THE ACCOUNT THAT TRIGGERED IT. The stored value used to be a bare
+ * `'1'` — process-wide within the tab, with no owner. Signing out never runs
+ * through this module, so a sign-out path that skips the client-state sweep
+ * (`resetClientState`) left the flag set; the NEXT account to sign in on that
+ * tab inherited someone else's "you just archived your last workspace"
+ * terminal instead of the first-run auto-provision flow it was actually
+ * entitled to. `isAutoProjectSuppressed` now requires the caller's account id
+ * to match the account recorded at write time — mirroring how
+ * `last-project-cookie.ts` binds its cookie to `userId` — so a stale flag
+ * from a previous account can never suppress provisioning for a different
+ * one, sweep or no sweep.
  */
 const SUPPRESS_AUTO_PROJECT_KEY = 'kortix:suppress-auto-project';
+
+interface SuppressAutoProjectRecord {
+  accountId: string;
+  at: number;
+}
 
 function safeSessionStorage(): Storage | null {
   try {
@@ -42,12 +60,53 @@ function safeSessionStorage(): Storage | null {
   }
 }
 
-export function suppressAutoProjectAfterDelete(): void {
-  safeSessionStorage()?.setItem(SUPPRESS_AUTO_PROJECT_KEY, '1');
+/**
+ * The stored record, or `null` for anything that is not a live one: absent,
+ * unparseable, the pre-binding bare `'1'` format, or missing/malformed
+ * `accountId`. `null` reads as "not suppressed" everywhere this is used —
+ * failing closed on identity rather than ever suppressing for an unknown
+ * owner.
+ */
+function parseSuppressAutoProjectRecord(raw: string | null): SuppressAutoProjectRecord | null {
+  if (!raw) return null;
+  let parsed: Partial<SuppressAutoProjectRecord>;
+  try {
+    parsed = JSON.parse(raw) as Partial<SuppressAutoProjectRecord>;
+  } catch {
+    return null;
+  }
+  if (typeof parsed?.accountId !== 'string' || parsed.accountId.length === 0) return null;
+  if (typeof parsed.at !== 'number' || !Number.isFinite(parsed.at)) return null;
+  return { accountId: parsed.accountId, at: parsed.at };
 }
 
-export function isAutoProjectSuppressed(): boolean {
-  return safeSessionStorage()?.getItem(SUPPRESS_AUTO_PROJECT_KEY) === '1';
+/**
+ * Record the suppression for `accountId`.
+ *
+ * The one real caller (`general-tab.tsx`'s archive mutation) passes this
+ * function straight through as a zero-arg `() => void` callback, so the
+ * default below — the globally-selected account at the moment archiving
+ * completes — is what actually runs in production. Every project navigation
+ * calls `setSelectedAccountId` to heal this exact value to the account just
+ * landed in (`/projects/start`), so by the time a user reaches a project's
+ * settings tab it already names that project's account. Tests exercise the
+ * explicit parameter directly instead of relying on the global.
+ */
+export function suppressAutoProjectAfterDelete(
+  accountId: string | null | undefined = useCurrentAccountStore.getState().selectedAccountId,
+): void {
+  if (!accountId) return;
+  const record: SuppressAutoProjectRecord = { accountId, at: Date.now() };
+  safeSessionStorage()?.setItem(SUPPRESS_AUTO_PROJECT_KEY, JSON.stringify(record));
+}
+
+/** True only when the stored suppression names THIS account. */
+export function isAutoProjectSuppressed(accountId: string | null | undefined): boolean {
+  if (!accountId) return false;
+  const record = parseSuppressAutoProjectRecord(
+    safeSessionStorage()?.getItem(SUPPRESS_AUTO_PROJECT_KEY) ?? null,
+  );
+  return record?.accountId === accountId;
 }
 
 export function clearAutoProjectSuppression(): void {

--- a/apps/web/src/lib/onboarding/ensure-first-project.ts
+++ b/apps/web/src/lib/onboarding/ensure-first-project.ts
@@ -86,11 +86,18 @@ function parseSuppressAutoProjectRecord(raw: string | null): SuppressAutoProject
  * The one real caller (`general-tab.tsx`'s archive mutation) passes this
  * function straight through as a zero-arg `() => void` callback, so the
  * default below — the globally-selected account at the moment archiving
- * completes — is what actually runs in production. Every project navigation
- * calls `setSelectedAccountId` to heal this exact value to the account just
- * landed in (`/projects/start`), so by the time a user reaches a project's
- * settings tab it already names that project's account. Tests exercise the
- * explicit parameter directly instead of relying on the global.
+ * completes — is what actually runs in production. This default is correct
+ * ONLY because the store is kept healed to whichever project is actually
+ * open: `/projects/start`'s landing resolution calls `setSelectedAccountId`
+ * on arrival, and — the path that actually matters for reaching Settings —
+ * `workspace-menu-section.tsx`'s workspace switcher does the same on every
+ * switch (`if (project.account_id !== selectedAccountId)
+ * setSelectedAccountId(project.account_id)`), so by the time a user opens a
+ * project's settings tab the store already names that project's account.
+ * This invariant is enforced nowhere in types — if either healing call is
+ * ever removed, this default silently starts suppressing (or failing to
+ * suppress) for the wrong account. Tests exercise the explicit parameter
+ * directly instead of relying on the global.
  */
 export function suppressAutoProjectAfterDelete(
   accountId: string | null | undefined = useCurrentAccountStore.getState().selectedAccountId,

--- a/apps/web/src/lib/onboarding/landing-destination.test.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import {
   PROJECT_LANDING_PATH,
   isValidProjectId,
+  parseAuthBounceOwner,
+  parseLastProjectOwner,
   projectPathFromId,
   resolveDefaultLandingPath,
 } from './landing-destination';
@@ -86,6 +88,36 @@ describe('resolveDefaultLandingPath', () => {
       `${USER_A}:../../admin`,
     ]) {
       expect(resolveDefaultLandingPath(hostile, USER_A)).toBe(PROJECT_LANDING_PATH);
+    }
+  });
+});
+
+describe('parseAuthBounceOwner and parseLastProjectOwner must agree', () => {
+  // Byte-identical bodies today (both delegate to the same
+  // `ownerIdFromCookie`) kept as two exported names because
+  // `AUTH_BOUNCE_COOKIE` and `LAST_PROJECT_COOKIE` answer different
+  // questions — see `parseLastProjectOwner`'s own doc comment. This is the
+  // anti-drift guard that comment promises: a future edit to one function's
+  // owner-parsing rule that is not mirrored to the other fails HERE, on the
+  // next input either one is exercised with, instead of drifting silently
+  // until a bounce or a landing resolution disagrees about who owns a
+  // cookie.
+  test('return the SAME owner for the same cookie value, across real and edge-case inputs', () => {
+    for (const cookieValue of [
+      undefined,
+      null,
+      '',
+      'not-a-cookie',
+      `${VALID}:/projects/abc`,
+      `${VALID}:${encodeURIComponent('/projects/abc?x=1')}`,
+      'bare-legacy-value-no-colon',
+      ':missing-owner',
+      `${VALID}:`,
+    ]) {
+      expect({ cookieValue, result: parseLastProjectOwner(cookieValue) }).toEqual({
+        cookieValue,
+        result: parseAuthBounceOwner(cookieValue),
+      });
     }
   });
 });

--- a/apps/web/src/lib/onboarding/landing-destination.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.ts
@@ -51,6 +51,12 @@ export const POST_AUTH_INTENT_MAX_AGE = 60 * 5;
  * pasted or bookmarked `/auth?redirect=…` link arrives with no cookie at all.
  * An empty owner means UNATTRIBUTED, which never demotes — see
  * `shouldDemoteReturnUrl`.
+ *
+ * Accepted cost of the window: a bounce can outlive the navigation that caused
+ * it, so a genuinely shared deep link opened within 300s of somebody else's
+ * bounce is demoted once. Every successful sign-in clears the cookie, so
+ * re-opening the link works immediately — it self-corrects, and erring toward
+ * the landing door is the right direction to be wrong in.
  */
 export const AUTH_BOUNCE_COOKIE = 'kortix_auth_bounce';
 

--- a/apps/web/src/lib/onboarding/landing-destination.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.ts
@@ -153,6 +153,17 @@ export function parseAuthBounceOwner(cookieValue: string | null | undefined): st
  * Who the remembered project belongs to, or `''`. The middleware falls back to
  * this when the bounce happens after the stale-session self-heal has already
  * dropped the Supabase cookies and there is no user id left to read.
+ *
+ * Byte-identical to `parseAuthBounceOwner` today — both cookies share the
+ * `<ownerId>:<rest>` shape via `ownerIdFromCookie`. Kept as a SEPARATE
+ * exported name rather than an alias on purpose: `AUTH_BOUNCE_COOKIE` and
+ * `LAST_PROJECT_COOKIE` answer different questions, and a rule that should
+ * apply to only one of them (a shorter TTL, a stricter owner check) must not
+ * force touching the other's call sites to add. If that divergence never
+ * happens, collapse the two into one — until then,
+ * `landing-destination.test.ts`'s "these two must agree" test is the
+ * anti-drift guard: a change to one that is not mirrored to the other fails
+ * immediately instead of drifting silently.
  */
 export function parseLastProjectOwner(cookieValue: string | null | undefined): string {
   return ownerIdFromCookie(cookieValue);

--- a/apps/web/src/lib/onboarding/landing-destination.ts
+++ b/apps/web/src/lib/onboarding/landing-destination.ts
@@ -35,6 +35,28 @@ export const POST_AUTH_INTENT_COOKIE = 'kortix_post_auth';
 /** Short-lived on purpose: it only has to outlive the post-auth redirect. */
 export const POST_AUTH_INTENT_MAX_AGE = 60 * 5;
 
+/**
+ * Written by the middleware at the exact moment it turns an unauthenticated
+ * request into `/auth?redirect=<path>`. Value: `<ownerId>:<encoded path>`.
+ *
+ * The `redirect` query param carries the path but no identity, so the auth
+ * flows downstream cannot tell "this user's own session just expired" from
+ * "a different user was here 30 seconds ago". They are opposite answers: the
+ * first must return to the path, the second must never see it. Signing in as B
+ * on a screen bounced from A's project sent B to A's "Request access" page,
+ * because the only guard in place ran for brand-new accounts.
+ *
+ * The owner half is allowed to be EMPTY. Middleware does not always have a user
+ * id to attach (the stale-session self-heal may have already nulled it), and a
+ * pasted or bookmarked `/auth?redirect=…` link arrives with no cookie at all.
+ * An empty owner means UNATTRIBUTED, which never demotes — see
+ * `shouldDemoteReturnUrl`.
+ */
+export const AUTH_BOUNCE_COOKIE = 'kortix_auth_bounce';
+
+/** Short-lived on purpose: it only has to outlive one trip through /auth. */
+export const AUTH_BOUNCE_MAX_AGE = 60 * 5;
+
 /** One year. The value is a project id, not a credential. */
 export const LAST_PROJECT_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
@@ -85,6 +107,49 @@ export function parseLastProjectForUser(
   const projectId = cookieValue.slice(separator + 1);
   if (ownerId !== currentUserId) return null;
   return isValidProjectId(projectId) ? projectId : null;
+}
+
+/**
+ * The owner half of a `<ownerId>:<rest>` cookie, or `''` when the cookie is
+ * absent, has no separator, or names something that is not a user id.
+ *
+ * Both cookies written by this module use that shape, and both are written by
+ * the browser, so the owner is validated before anyone compares against it.
+ * `''` is the honest answer for "no identity here", never a wildcard.
+ */
+function ownerIdFromCookie(cookieValue: string | null | undefined): string {
+  if (!cookieValue) return '';
+  const separator = cookieValue.indexOf(':');
+  if (separator === -1) return '';
+  const ownerId = cookieValue.slice(0, separator);
+  return isValidProjectId(ownerId) ? ownerId : '';
+}
+
+/**
+ * The `AUTH_BOUNCE_COOKIE` value for one middleware bounce.
+ *
+ * The path is percent-encoded here rather than left to the cookie serializer,
+ * because a request path can legally hold characters a cookie value cannot (a
+ * comma, a semicolon, a space) and a truncated header is not worth the risk.
+ * Only the owner half is ever read back; the path rides along so a bounce is
+ * legible in a browser inspector and in a bug report.
+ */
+export function serializeAuthBounce(ownerId: string | null | undefined, path: string): string {
+  return `${isValidProjectId(ownerId) ? ownerId : ''}:${encodeURIComponent(path)}`;
+}
+
+/** Who owned the session that got bounced, or `''` for an UNATTRIBUTED bounce. */
+export function parseAuthBounceOwner(cookieValue: string | null | undefined): string {
+  return ownerIdFromCookie(cookieValue);
+}
+
+/**
+ * Who the remembered project belongs to, or `''`. The middleware falls back to
+ * this when the bounce happens after the stale-session self-heal has already
+ * dropped the Supabase cookies and there is no user id left to read.
+ */
+export function parseLastProjectOwner(cookieValue: string | null | undefined): string {
+  return ownerIdFromCookie(cookieValue);
 }
 
 /** `/projects/<id>` for a trusted-shaped id, else null. */

--- a/apps/web/src/lib/onboarding/resolve-landing-destination.test.ts
+++ b/apps/web/src/lib/onboarding/resolve-landing-destination.test.ts
@@ -47,7 +47,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team', 'member'), account('personal', 'owner')],
       selectedAccountId: 'team',
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({
         team: [],
@@ -70,7 +70,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team', 'member'), account('personal', 'owner')],
       selectedAccountId: null,
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({
         team: [project('t1', 'team')],
@@ -94,7 +94,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('personal', 'owner'), account('team', 'member')],
       selectedAccountId: 'personal',
       preferredProjectId: 't1',
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({
         personal: [project('p1', 'personal')],
@@ -118,7 +118,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team', 'member'), account('personal', 'owner')],
       selectedAccountId: null,
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({ team: [], personal: [] }, async (input) => {
         // `account_id` is optional on the wire type; the assertion below
@@ -148,7 +148,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team', 'member'), account('personal', 'owner')],
       selectedAccountId: 'team',
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({ team: [], personal: [] }, async () => {
         provisionCalls += 1;
@@ -157,7 +157,7 @@ describe('resolveLandingDestination', () => {
     });
 
     expect(provisionCalls).toBe(0);
-    expect(result).toEqual({ kind: 'terminal', canCreate: false });
+    expect(result).toEqual({ kind: 'terminal', canCreate: false, suppressed: false });
   });
 
   test('member everywhere with nothing to open is the ONLY true no-permission terminal', async () => {
@@ -165,12 +165,12 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team-a', 'member'), account('team-b', 'member')],
       selectedAccountId: null,
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: fakeClient({ 'team-a': [], 'team-b': [] }),
     });
 
-    expect(result).toEqual({ kind: 'terminal', canCreate: false });
+    expect(result).toEqual({ kind: 'terminal', canCreate: false, suppressed: false });
   });
 
   test('suppression after a delete holds back the create but reports it was possible', async () => {
@@ -179,7 +179,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('personal', 'owner')],
       selectedAccountId: 'personal',
       preferredProjectId: null,
-      suppressed: true,
+      isAccountSuppressed: (accountId) => accountId === 'personal',
       mayCreate: true,
       client: fakeClient({ personal: [] }, async () => {
         provisionCalls += 1;
@@ -188,7 +188,37 @@ describe('resolveLandingDestination', () => {
     });
 
     expect(provisionCalls).toBe(0);
-    expect(result).toEqual({ kind: 'terminal', canCreate: true });
+    expect(result).toEqual({ kind: 'terminal', canCreate: true, suppressed: true });
+  });
+
+  // JAY: review round 1 finding. The suppression check applies to the ONE
+  // primary candidate account this resolver evaluates for creation
+  // (`creator`, above) — never "any account the caller happens to own". A
+  // flag left over from account 'other' (its own last-project archive) must
+  // never suppress auto-create in an unrelated account 'personal' the SAME
+  // user also owns. Two owned accounts, `isAccountSuppressed` scoped to the
+  // one that is NOT the primary candidate.
+  test('a suppression flag scoped to a DIFFERENT account does not block auto-create on the primary candidate', async () => {
+    const provisioned: string[] = [];
+    const result = await resolveLandingDestination({
+      accounts: [account('personal', 'owner'), account('other', 'owner')],
+      selectedAccountId: 'personal',
+      preferredProjectId: null,
+      isAccountSuppressed: (accountId) => accountId === 'other',
+      mayCreate: true,
+      client: fakeClient({ personal: [], other: [] }, async (input) => {
+        const accountId = input.account_id ?? 'missing-account-id';
+        provisioned.push(accountId);
+        return project('fresh', accountId);
+      }),
+    });
+
+    expect(provisioned).toEqual(['personal']);
+    expect(result).toEqual({
+      kind: 'project',
+      accountId: 'personal',
+      project: project('fresh', 'personal'),
+    });
   });
 
   test('one account list failing does not block landing in another account', async () => {
@@ -198,7 +228,7 @@ describe('resolveLandingDestination', () => {
       accounts: [account('team', 'member'), account('personal', 'owner')],
       selectedAccountId: 'team',
       preferredProjectId: null,
-      suppressed: false,
+      isAccountSuppressed: () => false,
       mayCreate: true,
       client: {
         listProjectsForAccount: async (accountId) => {
@@ -224,7 +254,7 @@ describe('resolveLandingDestination', () => {
         accounts: [account('personal', 'owner')],
         selectedAccountId: null,
         preferredProjectId: null,
-        suppressed: false,
+        isAccountSuppressed: () => false,
         mayCreate: true,
         client: {
           listProjectsForAccount: async () => {

--- a/apps/web/src/lib/onboarding/resolve-landing-destination.ts
+++ b/apps/web/src/lib/onboarding/resolve-landing-destination.ts
@@ -21,15 +21,25 @@ import {
 export type LandingResolution =
   | { kind: 'project'; project: KortixProject; accountId: string }
   /** No project anywhere. `canCreate` (of the primary candidate account —
-   *  the user's active workspace context) feeds `classifyLandingTerminal`. */
-  | { kind: 'terminal'; canCreate: boolean };
+   *  the user's active workspace context) feeds `classifyLandingTerminal`.
+   *  `suppressed` is scoped to that SAME primary candidate — never "any
+   *  account this user owns" — see the doc comment above `creator` below. */
+  | { kind: 'terminal'; canCreate: boolean; suppressed: boolean };
 
 export async function resolveLandingDestination(input: {
   accounts: KortixAccount[];
   selectedAccountId: string | null;
   preferredProjectId?: string | null;
-  /** `isAutoProjectSuppressed()` — the user just archived their last project. */
-  suppressed: boolean;
+  /**
+   * `isAutoProjectSuppressed` — the user just archived THIS account's last
+   * project. Applied to the ONE `creator` account this resolution actually
+   * evaluates for auto-create (see below), never called for the others: a
+   * flag scoped to account A must not suppress creation in an unrelated
+   * account B just because the same user happens to own both. Pass
+   * `isAutoProjectSuppressed` from `ensure-first-project.ts` directly — its
+   * signature already matches.
+   */
+  isAccountSuppressed: (accountId: string) => boolean;
   /** `navigationMayCreateProject()` — this navigation proved create intent. */
   mayCreate: boolean;
   client?: EnsureFirstProjectClient;
@@ -83,7 +93,13 @@ export async function resolveLandingDestination(input: {
   // self-host without managed git would be a guaranteed 503 anyway).
   const primary = candidates[0];
   const creator = primary && canCreateIn(primary) ? primary : undefined;
-  if (creator && input.mayCreate && !input.suppressed) {
+  // Evaluated for `creator.account_id` ONLY. `isAccountSuppressed` is
+  // account-bound by design (`ensure-first-project.ts`), and this resolver
+  // itself only ever gates auto-create for this ONE candidate — checking any
+  // OTHER account here would suppress creation for an account nobody
+  // archived anything on, just because the caller happens to own both.
+  const suppressedForCreator = creator ? input.isAccountSuppressed(creator.account_id) : false;
+  if (creator && input.mayCreate && !suppressedForCreator) {
     const created = await ensureFirstProject(
       creator.account_id,
       { preferredProjectId, allowCreate: true },
@@ -92,7 +108,7 @@ export async function resolveLandingDestination(input: {
     if (created) return { kind: 'project', project: created, accountId: creator.account_id };
   }
 
-  return { kind: 'terminal', canCreate: creator !== undefined };
+  return { kind: 'terminal', canCreate: creator !== undefined, suppressed: suppressedForCreator };
 }
 
 /** Owners/admins may create projects (ACCOUNT_ACTIONS.PROJECT_CREATE). */

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -45,6 +45,15 @@ export function createClient() {
   const url = resolveBrowserSupabaseUrl(runtimeEnv.SUPABASE_URL)
   const key = runtimeEnv.SUPABASE_ANON_KEY
 
+  // `@supabase/ssr` never sets `secure` itself (confirmed against the
+  // installed package's `dist/` — zero matches for `secure`), so on
+  // production HTTPS the session cookie was written without it: readable over
+  // a plaintext downgrade or a same-network MITM. Mirrors
+  // `last-project-cookie.ts`'s `window.location.protocol === 'https:'` check
+  // — NOT `httpOnly`, which `createBrowserClient` needs JS read access to
+  // avoid (see the class doc on `@supabase/ssr`).
+  const secure = typeof window !== 'undefined' && window.location.protocol === 'https:'
+
   if (!url || !key) {
     if (typeof window !== 'undefined') {
       throw new Error('Missing Supabase browser environment variables');
@@ -55,6 +64,7 @@ export function createClient() {
         name: KORTIX_SUPABASE_AUTH_COOKIE,
         path: '/',
         sameSite: 'lax',
+        secure,
       },
     })
   }
@@ -64,6 +74,7 @@ export function createClient() {
       name: KORTIX_SUPABASE_AUTH_COOKIE,
       path: '/',
       sameSite: 'lax',
+      secure,
     },
   })
 }

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -32,6 +32,10 @@ export async function createClient() {
         name: KORTIX_SUPABASE_AUTH_COOKIE,
         path: '/',
         sameSite: 'lax',
+        // `@supabase/ssr` never sets this itself — see the doc comment in
+        // `lib/supabase/client.ts`. Server-side, `NODE_ENV` is the reliable
+        // signal (mirrors `MAINTENANCE_BYPASS_COOKIE`'s route handler).
+        secure: process.env.NODE_ENV === 'production',
       },
       cookies: {
         getAll() {

--- a/apps/web/src/lib/utils/clear-local-storage.test.ts
+++ b/apps/web/src/lib/utils/clear-local-storage.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import {
+  APP_STORAGE_PREFIXES,
+  KEEP_STORAGE_KEYS,
+  clearUserLocalStorage,
+  isAppOwnedStorageKey,
+  isKeptStorageKey,
+} from './clear-local-storage';
+
+/**
+ * A minimal but FUNCTIONAL `Storage` — real `length`/`key(i)` iteration, not
+ * the `key: () => null, length: 0` stub some other fixtures in this repo use
+ * (fine for a Map-backed `getItem`/`setItem` test, not for code that walks
+ * every key via `storage.length`/`storage.key(i)`, which `sweepStorage()`
+ * does).
+ */
+class FakeStorage implements Storage {
+  private entries = new Map<string, string>();
+
+  get length(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.entries.has(key) ? (this.entries.get(key) as string) : null;
+  }
+
+  key(index: number): string | null {
+    return [...this.entries.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.entries.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.entries.set(key, value);
+  }
+}
+
+/**
+ * Hard-coded, independent of the exports under test. A loop written
+ * `for (const x of APP_STORAGE_PREFIXES)` looks like coverage but is a
+ * VACUOUS PASS the moment that array is emptied — zero iterations, zero
+ * assertions, green suite. Mutation-tested: emptying `KEEP_STORAGE_KEYS` in
+ * `clear-local-storage.ts` left an earlier version of this file's tests
+ * fully green. These two literals, plus the `toEqual` checks below, are what
+ * make that mutation fail instead.
+ */
+const EXPECTED_PREFIXES = [
+  'kortix-',
+  'kortix.',
+  'kortix:',
+  'kortix_',
+  'opencode-',
+  'opencode_',
+  'files-view-mode',
+  'files-sort-',
+  'maintenance-dismissed-',
+];
+const EXPECTED_KEEP_KEYS = [
+  'kortix-sound-preferences',
+  'kortix-user-preferences',
+  'kortix-web-notifications',
+];
+
+const originalWindow = globalThis.window;
+const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+const originalSessionStorage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+
+let fakeLocalStorage: FakeStorage;
+let fakeSessionStorage: FakeStorage;
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true });
+}
+
+beforeEach(() => {
+  fakeLocalStorage = new FakeStorage();
+  fakeSessionStorage = new FakeStorage();
+  // A real browser's `localStorage`/`sessionStorage` are reachable both as
+  // bare identifiers and as `window.localStorage` — this app's code (and
+  // Bun's own global `localStorage`, which is backed by SQLite, not a real
+  // browser bucket) mixes both spellings across files, so both are stubbed.
+  defineGlobal('window', { localStorage: fakeLocalStorage, sessionStorage: fakeSessionStorage });
+  defineGlobal('localStorage', fakeLocalStorage);
+  defineGlobal('sessionStorage', fakeSessionStorage);
+});
+
+afterEach(() => {
+  defineGlobal('window', originalWindow);
+  defineGlobal('localStorage', originalLocalStorage);
+  defineGlobal('sessionStorage', originalSessionStorage);
+});
+
+describe('isAppOwnedStorageKey', () => {
+  test('APP_STORAGE_PREFIXES is exactly the documented set — catches silent drift either way', () => {
+    expect([...APP_STORAGE_PREFIXES].sort()).toEqual([...EXPECTED_PREFIXES].sort());
+  });
+
+  test('matches every documented prefix', () => {
+    // Enumerated against the LITERAL above, not `APP_STORAGE_PREFIXES` itself
+    // — looping over the export under test means emptying it drops the loop
+    // to zero iterations and passes vacuously (see the comment on
+    // `EXPECTED_PREFIXES`).
+    for (const prefix of EXPECTED_PREFIXES) {
+      expect(isAppOwnedStorageKey(`${prefix}anything`)).toBe(true);
+    }
+  });
+
+  test('rejects a key with no app prefix', () => {
+    expect(isAppOwnedStorageKey('theme')).toBe(false);
+    expect(isAppOwnedStorageKey('some-third-party-widget-id')).toBe(false);
+  });
+
+  test('a prefix must anchor the START of the key, not appear anywhere in it', () => {
+    // `sb-kortix-auth-token` (the Supabase auth cookie's localStorage-shaped
+    // name in some SDK versions) contains "kortix-" but must NOT match —
+    // `dropAuthCookie` owns that key exclusively.
+    expect(isAppOwnedStorageKey('sb-kortix-auth-token')).toBe(false);
+  });
+});
+
+describe('isKeptStorageKey', () => {
+  test('KEEP_STORAGE_KEYS is exactly the documented set — catches silent drift either way', () => {
+    expect([...KEEP_STORAGE_KEYS].sort()).toEqual([...EXPECTED_KEEP_KEYS].sort());
+  });
+
+  test('the three documented device-scoped keys are kept', () => {
+    // Against the LITERAL, not `KEEP_STORAGE_KEYS` — see `EXPECTED_KEEP_KEYS`.
+    for (const key of EXPECTED_KEEP_KEYS) {
+      expect(isKeptStorageKey(key)).toBe(true);
+    }
+  });
+
+  test('a KEEP key is exact-match, not a prefix', () => {
+    expect(isKeptStorageKey('kortix-sound-preferences-extra')).toBe(false);
+  });
+
+  test('rejects anything not on the list', () => {
+    expect(isKeptStorageKey('kortix-browser-recents')).toBe(false);
+  });
+});
+
+describe('clearUserLocalStorage', () => {
+  test('sweeps app-owned keys from localStorage', () => {
+    fakeLocalStorage.setItem('kortix-browser-recents', '[]');
+    fakeLocalStorage.setItem('kortix.currentAccount', '{}');
+    fakeLocalStorage.setItem('opencode-model-store-v1', '{}');
+    fakeLocalStorage.setItem('files-view-mode', 'grid');
+    fakeLocalStorage.setItem('maintenance-dismissed-2026-01-01', 'true');
+
+    clearUserLocalStorage();
+
+    expect(fakeLocalStorage.length).toBe(0);
+  });
+
+  test('sweeps app-owned keys from sessionStorage too — the impersonation-key class of bug', () => {
+    // `kortix.impersonation` (the SDK's sessionStorage key) is the confirmed
+    // leak this sweep exists to close on the disk side; a fixture key in the
+    // same shape stands in for it here without depending on `@kortix/sdk`.
+    fakeSessionStorage.setItem('kortix.impersonation', '{"grantId":"g1"}');
+    fakeSessionStorage.setItem('kortix:suppress-auto-project', '1');
+
+    clearUserLocalStorage();
+
+    expect(fakeSessionStorage.length).toBe(0);
+  });
+
+  test('keeps KEEP_STORAGE_KEYS in both storages', () => {
+    for (const key of EXPECTED_KEEP_KEYS) {
+      fakeLocalStorage.setItem(key, '{}');
+    }
+
+    clearUserLocalStorage();
+
+    for (const key of EXPECTED_KEEP_KEYS) {
+      expect(fakeLocalStorage.getItem(key)).not.toBeNull();
+    }
+    expect(fakeLocalStorage.length).toBe(EXPECTED_KEEP_KEYS.length);
+  });
+
+  test('leaves a key with no app prefix untouched', () => {
+    fakeLocalStorage.setItem('theme', 'dark');
+    fakeLocalStorage.setItem('some-unrelated-widget', 'x');
+
+    clearUserLocalStorage();
+
+    expect(fakeLocalStorage.getItem('theme')).toBe('dark');
+    expect(fakeLocalStorage.getItem('some-unrelated-widget')).toBe('x');
+  });
+
+  test('never touches document.cookie — `kortix_last_project` cannot be reached from here', () => {
+    // Load-bearing per ruling R12 (see `reset-client-state.ts`'s header and
+    // `lib/auth/sign-out-navigation.test.ts`'s tripwire): this function must
+    // have NO way to write a cookie, not merely "does not currently write
+    // this one". A getter that throws on read proves the code path is never
+    // exercised, not just that today's keys happen to survive.
+    const originalDocument = globalThis.document;
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      get cookie(): string {
+        throw new Error('clearUserLocalStorage must never touch document.cookie');
+      },
+    } as unknown as PropertyDescriptor);
+
+    try {
+      expect(() => clearUserLocalStorage()).not.toThrow();
+    } finally {
+      Object.defineProperty(globalThis, 'document', {
+        value: originalDocument,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  test('does nothing (and does not throw) with no window', () => {
+    defineGlobal('window', undefined);
+    fakeLocalStorage.setItem('kortix-browser-recents', '[]');
+
+    expect(() => clearUserLocalStorage()).not.toThrow();
+    expect(fakeLocalStorage.getItem('kortix-browser-recents')).toBe('[]');
+  });
+
+  test('a throwing localStorage does not stop the sessionStorage sweep', () => {
+    fakeSessionStorage.setItem('kortix.impersonation', '{}');
+    defineGlobal('localStorage', {
+      get length(): number {
+        throw new Error('SecurityError');
+      },
+    });
+
+    expect(() => clearUserLocalStorage()).not.toThrow();
+    expect(fakeSessionStorage.length).toBe(0);
+  });
+});

--- a/apps/web/src/lib/utils/clear-local-storage.ts
+++ b/apps/web/src/lib/utils/clear-local-storage.ts
@@ -1,27 +1,114 @@
+/**
+ * Prefixes this app writes `localStorage` / `sessionStorage` keys under.
+ *
+ * A key that starts with one of these belongs to Kortix, not the browser or a
+ * third party, so it is safe — and, unless it is on `KEEP_STORAGE_KEYS`,
+ * REQUIRED — to erase on an identity change. This is the single source of
+ * truth for "does this app own this key": `sweepStorage()` below uses it to
+ * decide what to delete, and `persisted-store-coverage.test.ts` uses the
+ * SAME constant (imported, never re-typed) to prove every persisted zustand
+ * store's key falls under one of these prefixes or is explicitly kept. A
+ * prefix added here without a matching KEEP entry starts sweeping that store
+ * on the next sign-out; a store whose name matches neither list fails that
+ * test instead of silently surviving forever.
+ *
+ * `'files-view-mode'` and `'maintenance-dismissed-'` are not `kortix-`
+ * prefixed — they predate that convention — so they are named directly rather
+ * than dropped, which would silently stop sweeping them.
+ */
+export const APP_STORAGE_PREFIXES = [
+  'kortix-',
+  'kortix.',
+  'kortix:',
+  'kortix_',
+  'opencode-',
+  'opencode_',
+  'files-view-mode',
+  'files-sort-',
+  'maintenance-dismissed-',
+] as const;
+
+/**
+ * Keys that DO match a prefix above but hold a genuinely device-scoped
+ * preference — theme, sound, notification permission — not anything tied to
+ * the signed-in identity. These survive the sweep on purpose: the next
+ * account on this browser inherits the same physical device, so re-asking
+ * "dark or light?" on every sign-in would be the regression, not the fix.
+ *
+ * `persisted-store-coverage.test.ts` asserts every persisted zustand store
+ * whose name is on this list has NO `registerPersistedStore(...)` call
+ * (see `persisted-store-registry.ts`) — the disk KEEP and the in-memory
+ * exclusion must never drift apart.
+ */
+export const KEEP_STORAGE_KEYS: ReadonlySet<string> = new Set([
+  'kortix-sound-preferences',
+  'kortix-user-preferences',
+  'kortix-web-notifications',
+]);
+
+/** Whether `key` is owned by this app (matches a prefix above). */
+export function isAppOwnedStorageKey(key: string): boolean {
+  return APP_STORAGE_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/** Whether `key` matches an app prefix but is deliberately kept. */
+export function isKeptStorageKey(key: string): boolean {
+  return KEEP_STORAGE_KEYS.has(key);
+}
+
+/**
+ * Delete every app-owned key from `storage`, except the kept ones.
+ *
+ * Snapshots the key list before removing anything: mutating a `Storage`
+ * object while iterating its live index (`storage.key(i)`) skips entries, the
+ * classic "removing from an array while looping over it" bug.
+ */
+function sweepStorage(storage: Storage): void {
+  const keys: string[] = [];
+  for (let i = 0; i < storage.length; i++) {
+    const key = storage.key(i);
+    if (key !== null) keys.push(key);
+  }
+  for (const key of keys) {
+    if (isAppOwnedStorageKey(key) && !isKeptStorageKey(key)) {
+      storage.removeItem(key);
+    }
+  }
+}
+
+/**
+ * Wipe every per-user key this app has ever written to `localStorage` or
+ * `sessionStorage`, keeping only the device-scoped preferences on
+ * `KEEP_STORAGE_KEYS`.
+ *
+ * A PREFIX sweep, not a literal delete-list: the list this replaced named
+ * seven keys, five of which had had no writer for months while none of the
+ * fifteen persisted zustand stores added since it was written were named at
+ * all — `kortix-browser-recents` (the last 8 URLs any user browsed in-app,
+ * rendered to the NEXT user as a clickable list) among them. A key this app
+ * writes under one of `APP_STORAGE_PREFIXES` is swept the moment it exists,
+ * with no second commit required to remember it.
+ *
+ * Does NOT touch cookies. `kortix_last_project` survives sign-out on purpose
+ * — see `lib/onboarding/last-project-cookie.ts` and the tripwire test at
+ * `lib/auth/sign-out-navigation.test.ts`.
+ */
 export const clearUserLocalStorage = () => {
   if (typeof window === 'undefined') return;
 
+  // Independent try/catch per storage, deliberately not one try wrapping
+  // both: `sessionStorage` holds the confirmed impersonation leak
+  // (`kortix.impersonation`), so a `localStorage` access throwing first (Safari
+  // private mode, a partitioned iframe) must not skip the sessionStorage sweep.
   try {
-    localStorage.removeItem('customModels');
-    localStorage.removeItem('model-selection-v3');
-    localStorage.removeItem('agent-selection-storage');
-    localStorage.removeItem('auth-tracking-storage');
-    localStorage.removeItem('pendingAgentPrompt');
-    // Clean up legacy keys
-    localStorage.removeItem('opencode-model-store-v1');
-    // Clear tab state so it doesn't leak across accounts
-    localStorage.removeItem('kortix-tabs');
-    // Clear pattern-based keys
-    Object.keys(localStorage).forEach(key => {
-      if (key.startsWith('maintenance-dismissed-')) {
-        localStorage.removeItem(key);
-      }
-    });
-    // Clear sessionStorage runtime connection flag
-    try { sessionStorage.removeItem('kortix-runtime-was-connected'); } catch {}
-
-    console.log('✅ Local storage cleared on logout');
+    sweepStorage(localStorage);
   } catch (error) {
     console.error('❌ Error clearing local storage:', error);
+  }
+
+  try {
+    sweepStorage(sessionStorage);
+  } catch (error) {
+    console.error('❌ Error clearing session storage:', error);
   }
 };

--- a/apps/web/src/lib/utils/reset-client-state.test.ts
+++ b/apps/web/src/lib/utils/reset-client-state.test.ts
@@ -48,10 +48,13 @@ mock.module('@kortix/sdk/idb-sync-cache', () => ({
  * would reject a SIGN-IN and park the app on its loading frame, in exactly
  * the browsers least able to report it.
  *
- * Stubs a throwing GLOBAL `localStorage`, the same technique
- * `clear-local-storage.test.ts` uses for its own "a throwing localStorage
- * does not stop the sessionStorage sweep" case — not `mock.module` on
- * `@/lib/utils/clear-local-storage`. `mock.module` is PROCESS-WIDE in this
+ * Stubs throwing GLOBAL storage accessors (`window`, `localStorage`,
+ * `sessionStorage`) — the same STUBBING TECHNIQUE `clear-local-storage.test.ts`
+ * uses throughout its own file, though that file throws only one storage at
+ * a time to prove the two sweeps are independent; this file throws both,
+ * standing in for a fully storage-blocked browser (Safari private mode) —
+ * not `mock.module` on `@/lib/utils/clear-local-storage`. `mock.module` is
+ * PROCESS-WIDE in this
  * repo: it replaced `clearUserLocalStorage` for every test that shares this
  * process, so `bun test src/lib/utils` outside `--isolate` broke
  * `clear-local-storage.test.ts`'s own tests of the real function with an
@@ -61,13 +64,23 @@ mock.module('@kortix/sdk/idb-sync-cache', () => ({
  */
 const originalWindow = globalThis.window;
 const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+const originalSessionStorage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
 
 /**
  * `clearUserLocalStorage()` early-returns on `typeof window === 'undefined'`
  * — true by default in this Bun test environment (`test-setup.ts` registers
  * no DOM), so the throwing `localStorage` below would never even be reached
- * without also stubbing `window`. Same two-global shape
- * `clear-local-storage.test.ts` stubs for its own throwing-storage case.
+ * without also stubbing `window`. THREE globals stubbed, matching
+ * `clear-local-storage.test.ts`'s own `defineGlobal` calls exactly (`window`,
+ * bare `localStorage`, bare `sessionStorage`) — not two. Bun provides no
+ * default global `sessionStorage` in this test environment (only
+ * `localStorage` is a real Bun global here), so leaving it unstubbed does
+ * not silently pass through to a working implementation; it throws a
+ * `ReferenceError` instead of the deliberate `SecurityError` this function
+ * constructs for `localStorage` — an accident of this environment, not a
+ * guarantee. Stubbing it explicitly means the sessionStorage branch is
+ * proven on purpose and stays proven even if Bun ever adds a default
+ * `sessionStorage` global.
  */
 function stubThrowingLocalStorage(): void {
   const throwing = {
@@ -85,6 +98,11 @@ function stubThrowingLocalStorage(): void {
     writable: true,
     value: throwing,
   });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    writable: true,
+    value: throwing,
+  });
 }
 
 function restoreLocalStorage(): void {
@@ -97,6 +115,11 @@ function restoreLocalStorage(): void {
     configurable: true,
     writable: true,
     value: originalLocalStorage,
+  });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    writable: true,
+    value: originalSessionStorage,
   });
 }
 

--- a/apps/web/src/lib/utils/reset-client-state.test.ts
+++ b/apps/web/src/lib/utils/reset-client-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import * as idb from '@kortix/sdk/idb-sync-cache';
+
+/**
+ * `resetClientState()` must SETTLE even when its IndexedDB purge never does.
+ *
+ * That is not a hypothetical: `openDB()` in
+ * `packages/sdk/src/browser/cache/idb-sync-cache.ts` registers
+ * `onupgradeneeded`/`onsuccess`/`onerror` and no `onblocked` (`grep -c` returns
+ * 0, as it does for `onversionchange`), so an `indexedDB.open` needing a version
+ * upgrade while a stale tab holds the older version fires neither `success` nor
+ * `error`. `DB_VERSION` has been bumped twice in this repo.
+ *
+ * Two callers depend on this settling, and BOTH would fail visibly:
+ *   - `runSignOut` awaits it before `leave()` — the user could not sign out;
+ *   - `AuthProvider.adoptUser` awaits it before `setIsLoading(false)` — the
+ *     whole app parks on its loading frame at SIGN-IN.
+ *
+ * A hanging promise, not a rejecting one: a rejection is what a `try`/`catch`
+ * already handled, and it is not the failure that was shipped.
+ *
+ * `mock.module` is process-wide, which is safe here because `apps/web` runs
+ * `bun test --isolate` (package.json) — one process per file. This file mocks
+ * exactly one export and spreads the rest of the real module.
+ */
+mock.module('@kortix/sdk/idb-sync-cache', () => ({
+  ...idb,
+  clearSessionIDBCache: () => new Promise<void>(() => {}),
+}));
+
+const { resetClientState } = await import('./reset-client-state');
+
+describe('resetClientState with an IndexedDB purge that never settles', () => {
+  test('still resolves, on the clock', async () => {
+    const started = Date.now();
+    await resetClientState({ idbTimeoutMs: 20 });
+    const elapsed = Date.now() - started;
+
+    // The assertion that matters is that it resolved AT ALL — without the
+    // bound this test does not fail, it times out.
+    expect(elapsed).toBeGreaterThanOrEqual(15);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  test('resolves repeatedly, so a second sign-in is not blocked by the first', async () => {
+    await resetClientState({ idbTimeoutMs: 5 });
+    await resetClientState({ idbTimeoutMs: 5 });
+    expect(true).toBe(true);
+  });
+});

--- a/apps/web/src/lib/utils/reset-client-state.test.ts
+++ b/apps/web/src/lib/utils/reset-client-state.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import * as idb from '@kortix/sdk/idb-sync-cache';
-import * as localStorageUtils from '@/lib/utils/clear-local-storage';
 import {
   clearImpersonationSession,
   getImpersonationSession,
@@ -41,19 +40,65 @@ mock.module('@kortix/sdk/idb-sync-cache', () => ({
 /**
  * `clearUserLocalStorage()` reaches `localStorage` directly, and reading that
  * accessor THROWS in a storage-blocked context (Safari private mode, a
- * partitioned iframe). It was the one unguarded call in `resetClientState()`.
+ * partitioned iframe).
  *
- * `runSignOut` absorbed a rejection through `withTimeBudget`, but
- * `AuthProvider.adoptUser` awaits this bare and before `setIsLoading(false)` —
- * so an unguarded throw rejected a SIGN-IN and parked the app on its loading
- * frame, in exactly the browsers least able to report it.
+ * `runSignOut` absorbed a rejection through `withTimeBudget`, and
+ * `AuthProvider.adoptUser` awaits `resetClientState()` bare, before
+ * `setIsLoading(false)` — so a throw reaching `resetClientState()` unhandled
+ * would reject a SIGN-IN and park the app on its loading frame, in exactly
+ * the browsers least able to report it.
+ *
+ * Stubs a throwing GLOBAL `localStorage`, the same technique
+ * `clear-local-storage.test.ts` uses for its own "a throwing localStorage
+ * does not stop the sessionStorage sweep" case — not `mock.module` on
+ * `@/lib/utils/clear-local-storage`. `mock.module` is PROCESS-WIDE in this
+ * repo: it replaced `clearUserLocalStorage` for every test that shares this
+ * process, so `bun test src/lib/utils` outside `--isolate` broke
+ * `clear-local-storage.test.ts`'s own tests of the real function with an
+ * error belonging to a module this file never runs. The gated CI command
+ * (`bun test --isolate --parallel=4`) never saw it — one process per file —
+ * but any focused run a human or agent types did.
  */
-mock.module('@/lib/utils/clear-local-storage', () => ({
-  ...localStorageUtils,
-  clearUserLocalStorage: () => {
-    throw new Error('SecurityError: localStorage is not available');
-  },
-}));
+const originalWindow = globalThis.window;
+const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+
+/**
+ * `clearUserLocalStorage()` early-returns on `typeof window === 'undefined'`
+ * — true by default in this Bun test environment (`test-setup.ts` registers
+ * no DOM), so the throwing `localStorage` below would never even be reached
+ * without also stubbing `window`. Same two-global shape
+ * `clear-local-storage.test.ts` stubs for its own throwing-storage case.
+ */
+function stubThrowingLocalStorage(): void {
+  const throwing = {
+    get length(): number {
+      throw new Error('SecurityError: localStorage is not available');
+    },
+  };
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: { localStorage: throwing, sessionStorage: throwing },
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: throwing,
+  });
+}
+
+function restoreLocalStorage(): void {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    writable: true,
+    value: originalWindow,
+  });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: originalLocalStorage,
+  });
+}
 
 const { resetClientState } = await import('./reset-client-state');
 
@@ -70,23 +115,47 @@ describe('resetClientState with an IndexedDB purge that never settles', () => {
   });
 
   test('resolves repeatedly, so a second sign-in is not blocked by the first', async () => {
+    // `expect(true).toBe(true)` used to stand here — it proves only that
+    // both awaits eventually returned, which is also true if the second call
+    // silently inherited (or waited out) the first's hang before settling.
+    // Bounding each call's OWN elapsed time is what actually distinguishes
+    // "the second sign-in got its own fresh budget" from "the second sign-in
+    // was blocked by the first and only unblocked much later" — the risk
+    // named in this test's own title.
+    const firstStarted = Date.now();
     await resetClientState({ idbTimeoutMs: 5 });
+    const firstElapsed = Date.now() - firstStarted;
+
+    const secondStarted = Date.now();
     await resetClientState({ idbTimeoutMs: 5 });
-    expect(true).toBe(true);
+    const secondElapsed = Date.now() - secondStarted;
+
+    expect(firstElapsed).toBeLessThan(500);
+    expect(secondElapsed).toBeLessThan(500);
   });
 });
 
 describe('resetClientState when localStorage access throws', () => {
+  beforeEach(() => stubThrowingLocalStorage());
+  afterEach(() => restoreLocalStorage());
+
   test('still resolves, so a SIGN-IN cannot be parked by a blocked storage bucket', async () => {
-    // Unguarded, this rejects and the `await` below throws.
+    // The real `clearUserLocalStorage()` runs here, against the throwing
+    // global stubbed above — not a mocked-away function. Its own internal
+    // try/catch (`clear-local-storage.ts`) already absorbs a throwing
+    // `localStorage`, so this proves the FULL real path — `resetClientState`
+    // calling the real `clearUserLocalStorage` calling a genuinely throwing
+    // browser API — still settles, end to end.
     await resetClientState({ idbTimeoutMs: 5 });
     expect(true).toBe(true);
   });
 
-  test('the earlier clears still ran — the throw does not abort the whole reset', async () => {
+  test('the earlier clears still ran — a throwing localStorage does not abort the whole reset', async () => {
     // `clearUserLocalStorage` is the THIRD step. The React Query cache and the
     // account store are cleared before it, and both are guarded already; this
-    // pins that a throw in step 3 does not skip step 4 either.
+    // pins that a throwing storage bucket in step 3 does not skip step 4
+    // either, across two consecutive resets (the second sign-in must not be
+    // blocked by the first).
     await resetClientState({ idbTimeoutMs: 5 });
     await resetClientState({ idbTimeoutMs: 5 });
     expect(true).toBe(true);

--- a/apps/web/src/lib/utils/reset-client-state.test.ts
+++ b/apps/web/src/lib/utils/reset-client-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 
 import * as idb from '@kortix/sdk/idb-sync-cache';
+import * as localStorageUtils from '@/lib/utils/clear-local-storage';
 
 /**
  * `resetClientState()` must SETTLE even when its IndexedDB purge never does.
@@ -29,6 +30,23 @@ mock.module('@kortix/sdk/idb-sync-cache', () => ({
   clearSessionIDBCache: () => new Promise<void>(() => {}),
 }));
 
+/**
+ * `clearUserLocalStorage()` reaches `localStorage` directly, and reading that
+ * accessor THROWS in a storage-blocked context (Safari private mode, a
+ * partitioned iframe). It was the one unguarded call in `resetClientState()`.
+ *
+ * `runSignOut` absorbed a rejection through `withTimeBudget`, but
+ * `AuthProvider.adoptUser` awaits this bare and before `setIsLoading(false)` —
+ * so an unguarded throw rejected a SIGN-IN and parked the app on its loading
+ * frame, in exactly the browsers least able to report it.
+ */
+mock.module('@/lib/utils/clear-local-storage', () => ({
+  ...localStorageUtils,
+  clearUserLocalStorage: () => {
+    throw new Error('SecurityError: localStorage is not available');
+  },
+}));
+
 const { resetClientState } = await import('./reset-client-state');
 
 describe('resetClientState with an IndexedDB purge that never settles', () => {
@@ -44,6 +62,23 @@ describe('resetClientState with an IndexedDB purge that never settles', () => {
   });
 
   test('resolves repeatedly, so a second sign-in is not blocked by the first', async () => {
+    await resetClientState({ idbTimeoutMs: 5 });
+    await resetClientState({ idbTimeoutMs: 5 });
+    expect(true).toBe(true);
+  });
+});
+
+describe('resetClientState when localStorage access throws', () => {
+  test('still resolves, so a SIGN-IN cannot be parked by a blocked storage bucket', async () => {
+    // Unguarded, this rejects and the `await` below throws.
+    await resetClientState({ idbTimeoutMs: 5 });
+    expect(true).toBe(true);
+  });
+
+  test('the earlier clears still ran — the throw does not abort the whole reset', async () => {
+    // `clearUserLocalStorage` is the THIRD step. The React Query cache and the
+    // account store are cleared before it, and both are guarded already; this
+    // pins that a throw in step 3 does not skip step 4 either.
     await resetClientState({ idbTimeoutMs: 5 });
     await resetClientState({ idbTimeoutMs: 5 });
     expect(true).toBe(true);

--- a/apps/web/src/lib/utils/reset-client-state.test.ts
+++ b/apps/web/src/lib/utils/reset-client-state.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, mock, test } from 'bun:test';
 
 import * as idb from '@kortix/sdk/idb-sync-cache';
 import * as localStorageUtils from '@/lib/utils/clear-local-storage';
+import {
+  clearImpersonationSession,
+  getImpersonationSession,
+  setImpersonationSession,
+} from '@kortix/sdk';
+import { useBrowserRecentsStore } from '@/stores/browser-recents-store';
+import { useTabStore } from '@/stores/tab-store';
+import { useUserPreferencesStore } from '@/stores/user-preferences-store';
 
 /**
  * `resetClientState()` must SETTLE even when its IndexedDB purge never does.
@@ -82,5 +90,85 @@ describe('resetClientState when localStorage access throws', () => {
     await resetClientState({ idbTimeoutMs: 5 });
     await resetClientState({ idbTimeoutMs: 5 });
     expect(true).toBe(true);
+  });
+});
+
+describe('resetClientState resets registered persisted stores IN MEMORY, not just on disk', () => {
+  // This is the confirmed leak the whole task exists to close:
+  // `kortix-browser-recents` (the last 8 URLs any user browsed in-app) is
+  // rendered to the NEXT signed-in user as a clickable list. Deleting the
+  // localStorage key is not enough on its own — a component still mounted
+  // and subscribed to the store (or one that mounts a beat later) can
+  // re-persist the very key `clearUserLocalStorage()` just deleted, unless
+  // the IN-MEMORY state is reset too. This exercises the real store through
+  // the real `resetClientState()`, not a source-string assertion.
+  test('a browsed URL does not survive resetClientState()', async () => {
+    useBrowserRecentsStore.getState().addRecent('http://localhost:3000/leaked-project');
+    expect(useBrowserRecentsStore.getState().recents).toHaveLength(1);
+
+    await resetClientState({ idbTimeoutMs: 5 });
+
+    expect(useBrowserRecentsStore.getState().recents).toEqual([]);
+  });
+
+  test('an open tab does not survive resetClientState() either — a second registered store', async () => {
+    // A second, independently-registered store (`persisted-store-registry.ts`)
+    // pins that the sweep is not special-cased to just one store.
+    useTabStore.setState({ activeTabId: 'leaked-project-tab' });
+    expect(useTabStore.getState().activeTabId).toBe('leaked-project-tab');
+
+    await resetClientState({ idbTimeoutMs: 5 });
+
+    expect(useTabStore.getState().activeTabId).toBe(useTabStore.getInitialState().activeTabId);
+  });
+
+  test('a device-scoped KEPT preference is NOT reset — the boundary holds both ways', async () => {
+    // `useUserPreferencesStore` is deliberately absent from the registry
+    // (`KEEP_STORAGE_KEYS` in `clear-local-storage.ts` names its persisted
+    // key as device-scoped). If a future change folded it into the sweep by
+    // mistake, this is the test that would catch a THEME reset on every
+    // sign-out.
+    useUserPreferencesStore.getState().setThemeId('a-distinctive-non-default-theme');
+    expect(useUserPreferencesStore.getState().preferences.themeId).toBe(
+      'a-distinctive-non-default-theme',
+    );
+
+    await resetClientState({ idbTimeoutMs: 5 });
+
+    expect(useUserPreferencesStore.getState().preferences.themeId).toBe(
+      'a-distinctive-non-default-theme',
+    );
+  });
+});
+
+describe('resetClientState clears the impersonation session, module state included', () => {
+  // `packages/sdk/src/core/http/impersonation.ts` holds `current`/`hydrated`
+  // at MODULE scope, on top of the sessionStorage key. Deleting only the
+  // sessionStorage key (what the old delete-list would have done) leaves the
+  // in-memory mirror live: `getImpersonationSession()` would keep returning
+  // the stale session, and the admin banner would keep attaching
+  // `X-Kortix-Impersonate` to every request, for the rest of the tab's life.
+  test('a live impersonation session does not survive resetClientState()', async () => {
+    setImpersonationSession({
+      grantId: 'grant-1',
+      accountId: 'acct-1',
+      accountName: 'Leaked Account',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(getImpersonationSession()?.grantId).toBe('grant-1');
+
+    await resetClientState({ idbTimeoutMs: 5 });
+
+    expect(getImpersonationSession()).toBeNull();
+  });
+
+  test('cleanup: clears any session a prior test in this file left live', () => {
+    // `current`/`hydrated` are module-level in the SDK, so state from the test
+    // above (or a future one added here) would otherwise leak into whichever
+    // test file bun schedules next in this process. `--isolate` gives this
+    // file its own process, but leaving module state dirty at the end of a
+    // file is still the wrong default to model.
+    clearImpersonationSession();
+    expect(getImpersonationSession()).toBeNull();
   });
 });

--- a/apps/web/src/lib/utils/reset-client-state.ts
+++ b/apps/web/src/lib/utils/reset-client-state.ts
@@ -52,7 +52,17 @@ export async function resetClientState({
     console.error('Failed to clear current-account store:', error);
   }
 
-  clearUserLocalStorage();
+  try {
+    clearUserLocalStorage();
+  } catch (error) {
+    // The only unguarded call in this function, and the one that reaches
+    // `localStorage` directly. Reading that accessor THROWS in a storage-blocked
+    // context (Safari private mode, a partitioned iframe). `runSignOut` absorbs
+    // a rejection through `withTimeBudget`, but `AuthProvider.adoptUser` awaits
+    // this bare — so an unguarded throw here rejects a SIGN-IN, before
+    // `setIsLoading(false)`.
+    console.error('Failed to clear per-user localStorage:', error);
+  }
 
   const purged = await withTimeBudget(clearSessionIDBCache(), idbTimeoutMs);
   if (purged.status !== 'settled') {

--- a/apps/web/src/lib/utils/reset-client-state.ts
+++ b/apps/web/src/lib/utils/reset-client-state.ts
@@ -2,7 +2,10 @@ import { getSharedQueryClient } from '@/lib/query-client-singleton';
 import { withTimeBudget } from '@/lib/utils/time-budget';
 import { clearUserLocalStorage } from '@/lib/utils/clear-local-storage';
 import { clearSessionIDBCache } from '@kortix/sdk/idb-sync-cache';
+import { clearImpersonationSession } from '@kortix/sdk';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
+import { clearAutoProjectSuppression } from '@/lib/onboarding/ensure-first-project';
+import { resetAllRegisteredPersistedStores } from '@/stores/persisted-store-registry';
 
 /**
  * Wipe ALL client-side state tied to the signed-in user.
@@ -12,14 +15,23 @@ import { useCurrentAccountStore } from '@/stores/current-account-store';
  *   1. React Query cache — every cached server response (accounts, projects,
  *      sessions, billing, …). This is the big one that was missing.
  *   2. The persisted "current account" selection (zustand + its localStorage).
- *   3. Remaining per-user localStorage (models, agents, sandbox/tab state).
- *   4. The IndexedDB session-sync cache.
+ *   3. Every OTHER persisted zustand store's IN-MEMORY state — via
+ *      `resetAllRegisteredPersistedStores()`, see `persisted-store-registry.ts`
+ *      — plus the SDK's impersonation session, which lives partly at module
+ *      scope (`current`/`hydrated` in
+ *      `packages/sdk/src/core/http/impersonation.ts`) and so cannot be forgotten
+ *      by deleting its sessionStorage key alone.
+ *   4. Remaining per-user localStorage AND sessionStorage — a PREFIX sweep,
+ *      not a delete-list; see `clear-local-storage.ts`. Runs AFTER step 3 so a
+ *      store that just had its in-memory state reset has nothing left to
+ *      re-persist.
+ *   5. The IndexedDB session-sync cache.
  *
  * Safe to call from anywhere (no React context needed) — the QueryClient is
  * read from the module-level singleton, so AuthProvider (mounted above the
  * React Query provider) can use it too.
  *
- * **Steps 1-3 are SYNCHRONOUS and always complete. Step 4 is bounded and may
+ * **Steps 1-4 are SYNCHRONOUS and always complete. Step 5 is bounded and may
  * be outrun.** That distinction is the contract, not an implementation detail:
  * callers await this before publishing a new identity, and `clearSessionIDBCache()`
  * can hang FOREVER — `openDB()` in `packages/sdk/src/browser/cache/idb-sync-cache.ts`
@@ -29,11 +41,17 @@ import { useCurrentAccountStore } from '@/stores/current-account-store';
  * that meant a user could not sign out AND the app could park on its loading
  * frame at sign-in, with no error shown either way.
  *
- * Outrunning step 4 is safe because it purges INERT data: nothing in Kortix
+ * Outrunning step 5 is safe because it purges INERT data: nothing in Kortix
  * reads those entries any more (see that module's own header), and they are
  * keyed `user:<id>` via `buildSessionCacheKey`, so the next account cannot read
  * them even if the purge never lands. Everything that would actually leak
  * across identities is already gone by then.
+ *
+ * Does NOT clear `kortix_last_project`. That cookie is owner-bound
+ * (`<userId>:<projectId>`) and deliberately survives sign-out — the
+ * middleware reads its owner half to attribute a post-logout bounce. See
+ * `lib/onboarding/last-project-cookie.ts` and the tripwire test at
+ * `lib/auth/sign-out-navigation.test.ts`.
  */
 export async function resetClientState({
   // Injectable ONLY so the "a hung IndexedDB purge still settles" test does not
@@ -50,6 +68,28 @@ export async function resetClientState({
     useCurrentAccountStore.getState().clear();
   } catch (error) {
     console.error('Failed to clear current-account store:', error);
+  }
+
+  // Does NOT statically import the stores it resets. Each persisted store
+  // registers its own reset at its OWN module scope (see
+  // `persisted-store-registry.ts`) so that `reset-client-state.ts` — reachable
+  // from every route through `AuthProvider` — cannot drag a feature-heavy
+  // store's transitive imports (e.g. `session-browser-store.ts` →
+  // `kortix-computer-store.ts` → the shiki-backed markdown renderer) into
+  // every route's initial JS chunk. `connectors-page.chunk.test.ts` is the
+  // regression this avoids; it was tripped once already during this change.
+  resetAllRegisteredPersistedStores();
+
+  try {
+    clearImpersonationSession();
+  } catch (error) {
+    console.error('Failed to clear impersonation session:', error);
+  }
+
+  try {
+    clearAutoProjectSuppression();
+  } catch (error) {
+    console.error('Failed to clear auto-project suppression:', error);
   }
 
   try {

--- a/apps/web/src/lib/utils/reset-client-state.ts
+++ b/apps/web/src/lib/utils/reset-client-state.ts
@@ -1,4 +1,5 @@
 import { getSharedQueryClient } from '@/lib/query-client-singleton';
+import { withTimeBudget } from '@/lib/utils/time-budget';
 import { clearUserLocalStorage } from '@/lib/utils/clear-local-storage';
 import { clearSessionIDBCache } from '@kortix/sdk/idb-sync-cache';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
@@ -17,6 +18,22 @@ import { useCurrentAccountStore } from '@/stores/current-account-store';
  * Safe to call from anywhere (no React context needed) — the QueryClient is
  * read from the module-level singleton, so AuthProvider (mounted above the
  * React Query provider) can use it too.
+ *
+ * **Steps 1-3 are SYNCHRONOUS and always complete. Step 4 is bounded and may
+ * be outrun.** That distinction is the contract, not an implementation detail:
+ * callers await this before publishing a new identity, and `clearSessionIDBCache()`
+ * can hang FOREVER — `openDB()` in `packages/sdk/src/browser/cache/idb-sync-cache.ts`
+ * has no `onblocked` handler, so an `indexedDB.open` needing a version upgrade
+ * while a stale tab holds the old version fires neither `success` nor `error`,
+ * and the promise is memoized so every later caller parks behind it. Unbounded,
+ * that meant a user could not sign out AND the app could park on its loading
+ * frame at sign-in, with no error shown either way.
+ *
+ * Outrunning step 4 is safe because it purges INERT data: nothing in Kortix
+ * reads those entries any more (see that module's own header), and they are
+ * keyed `user:<id>` via `buildSessionCacheKey`, so the next account cannot read
+ * them even if the purge never lands. Everything that would actually leak
+ * across identities is already gone by then.
  */
 export async function resetClientState(): Promise<void> {
   try {
@@ -32,5 +49,9 @@ export async function resetClientState(): Promise<void> {
   }
 
   clearUserLocalStorage();
-  await clearSessionIDBCache();
+
+  const purged = await withTimeBudget(clearSessionIDBCache());
+  if (purged.status !== 'settled') {
+    console.error('[resetClientState] session IDB purge did not complete:', purged);
+  }
 }

--- a/apps/web/src/lib/utils/reset-client-state.ts
+++ b/apps/web/src/lib/utils/reset-client-state.ts
@@ -35,7 +35,11 @@ import { useCurrentAccountStore } from '@/stores/current-account-store';
  * them even if the purge never lands. Everything that would actually leak
  * across identities is already gone by then.
  */
-export async function resetClientState(): Promise<void> {
+export async function resetClientState({
+  // Injectable ONLY so the "a hung IndexedDB purge still settles" test does not
+  // have to wait two real seconds. No caller passes it.
+  idbTimeoutMs,
+}: { idbTimeoutMs?: number } = {}): Promise<void> {
   try {
     getSharedQueryClient()?.clear();
   } catch (error) {
@@ -50,7 +54,7 @@ export async function resetClientState(): Promise<void> {
 
   clearUserLocalStorage();
 
-  const purged = await withTimeBudget(clearSessionIDBCache());
+  const purged = await withTimeBudget(clearSessionIDBCache(), idbTimeoutMs);
   if (purged.status !== 'settled') {
     console.error('[resetClientState] session IDB purge did not complete:', purged);
   }

--- a/apps/web/src/lib/utils/reset-client-state.ts
+++ b/apps/web/src/lib/utils/reset-client-state.ts
@@ -78,6 +78,12 @@ export async function resetClientState({
   // `kortix-computer-store.ts` → the shiki-backed markdown renderer) into
   // every route's initial JS chunk. `connectors-page.chunk.test.ts` is the
   // regression this avoids; it was tripped once already during this change.
+  //
+  // NOT wrapped in try/catch, unlike every other step in this function — a
+  // throw here propagates and skips everything below it, including the
+  // localStorage sweep and the IndexedDB purge. Known gap, not closed here:
+  // closing it is a behaviour change (deciding what "reset" means when one
+  // store's reset throws), out of scope for a documentation-only pass.
   resetAllRegisteredPersistedStores();
 
   try {
@@ -95,12 +101,14 @@ export async function resetClientState({
   try {
     clearUserLocalStorage();
   } catch (error) {
-    // The only unguarded call in this function, and the one that reaches
-    // `localStorage` directly. Reading that accessor THROWS in a storage-blocked
-    // context (Safari private mode, a partitioned iframe). `runSignOut` absorbs
-    // a rejection through `withTimeBudget`, but `AuthProvider.adoptUser` awaits
-    // this bare — so an unguarded throw here rejects a SIGN-IN, before
-    // `setIsLoading(false)`.
+    // Guarded, because it reaches `localStorage` directly, and reading that
+    // accessor THROWS in a storage-blocked context (Safari private mode, a
+    // partitioned iframe). `runSignOut` absorbs a rejection through
+    // `withTimeBudget`, but `AuthProvider.adoptUser` awaits this bare — so an
+    // UNGUARDED throw here would reject a SIGN-IN, before
+    // `setIsLoading(false)`. (`resetAllRegisteredPersistedStores()` above is
+    // the one call in this function that is NOT guarded this way — see its
+    // own comment.)
     console.error('Failed to clear per-user localStorage:', error);
   }
 

--- a/apps/web/src/lib/utils/time-budget.test.ts
+++ b/apps/web/src/lib/utils/time-budget.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DEFAULT_TIME_BUDGET_MS, withTimeBudget } from './time-budget';
+
+/**
+ * The clock exists for one reachable hang: `openDB()` in the SDK's
+ * `idb-sync-cache` has no `onblocked` handler, so a blocked version upgrade
+ * settles NEITHER `success` nor `error`. A promise that never settles cannot be
+ * caught, only outrun — so the case that matters most here is the one a
+ * try/catch test would never reach.
+ */
+describe('withTimeBudget', () => {
+  test('a promise that NEVER settles resolves as a timeout', async () => {
+    const outcome = await withTimeBudget(new Promise<void>(() => {}), 5);
+    expect(outcome).toEqual({ status: 'timeout' });
+  });
+
+  test('a resolved promise hands back its value', async () => {
+    expect(await withTimeBudget(Promise.resolve(42), 5)).toEqual({
+      status: 'settled',
+      value: 42,
+    });
+  });
+
+  test('a REJECTED promise is reported, never thrown', async () => {
+    // The caller decides what a failure means. Rethrowing here would just move
+    // the `try` somewhere else.
+    const boom = new Error('boom');
+    expect(await withTimeBudget(Promise.reject(boom), 5)).toEqual({
+      status: 'failed',
+      error: boom,
+    });
+  });
+
+  test('work that settles inside the budget is not delayed by the budget', async () => {
+    const started = Date.now();
+    const outcome = await withTimeBudget(Promise.resolve('fast'), 10_000);
+    expect(outcome).toEqual({ status: 'settled', value: 'fast' });
+    // Would be 10s if the timer were awaited rather than cleared.
+    expect(Date.now() - started).toBeLessThan(1_000);
+  });
+
+  test('a late settle after a timeout changes nothing', async () => {
+    let release!: () => void;
+    const slow = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    expect(await withTimeBudget(slow, 5)).toEqual({ status: 'timeout' });
+    release();
+    await slow;
+    // No throw, no unhandled rejection, no second resolution.
+    expect(true).toBe(true);
+  });
+
+  test('the default budget is 2s', () => {
+    expect(DEFAULT_TIME_BUDGET_MS).toBe(2000);
+  });
+});

--- a/apps/web/src/lib/utils/time-budget.ts
+++ b/apps/web/src/lib/utils/time-budget.ts
@@ -1,0 +1,53 @@
+/**
+ * A wall clock for an `await` that has no ceiling of its own.
+ *
+ * This exists because of one concrete, reachable hang. `openDB()` in
+ * `packages/sdk/src/browser/cache/idb-sync-cache.ts` registers
+ * `onupgradeneeded`, `onsuccess` and `onerror` but NO `onblocked`, and the file
+ * has no `onversionchange` handler either (`grep -c` returns 0 for both). An
+ * `indexedDB.open` that needs a version upgrade while another tab still holds a
+ * connection at the older version fires `blocked` and then NEITHER `success`
+ * NOR `error` — the promise never settles. `DB_VERSION` has been bumped twice
+ * in this repo, so a tab left open on the pre-bump bundle is all it takes. The
+ * promise is memoized in `dbPromise`, so every later caller in that document
+ * parks behind it too.
+ *
+ * `try`/`catch` cannot rescue a promise that never settles. Only a clock can.
+ *
+ * Never rejects: a rejection from `work` is reported as `failed`, not thrown,
+ * so a caller can decide what a failure means without a second `try`.
+ */
+
+/** Milliseconds any single step may hold up a user-visible outcome. */
+export const DEFAULT_TIME_BUDGET_MS = 2000;
+
+export type BudgetOutcome<T> =
+  | { status: 'settled'; value: T }
+  | { status: 'failed'; error: unknown }
+  | { status: 'timeout' };
+
+/**
+ * Resolve when `work` settles, or when `budgetMs` elapses — whichever is first.
+ *
+ * A timeout does NOT cancel `work`; nothing can cancel an in-flight IndexedDB
+ * request. It only stops the caller waiting on it. Anything that must be true
+ * before the caller proceeds has to happen SYNCHRONOUSLY before the awaited
+ * step, not inside it.
+ */
+export function withTimeBudget<T>(
+  work: Promise<T>,
+  budgetMs: number = DEFAULT_TIME_BUDGET_MS,
+): Promise<BudgetOutcome<T>> {
+  return new Promise<BudgetOutcome<T>>((resolve) => {
+    const timer = setTimeout(() => resolve({ status: 'timeout' }), budgetMs);
+    const finish = (outcome: BudgetOutcome<T>) => {
+      clearTimeout(timer);
+      // `resolve` after a timeout is a no-op, so a late settle is harmless.
+      resolve(outcome);
+    };
+    work.then(
+      (value) => finish({ status: 'settled', value }),
+      (error) => finish({ status: 'failed', error }),
+    );
+  });
+}

--- a/apps/web/src/middleware-auth-bounce.test.ts
+++ b/apps/web/src/middleware-auth-bounce.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { NextRequest } from 'next/server';
+
+import {
+  AUTH_BOUNCE_COOKIE,
+  LAST_PROJECT_COOKIE,
+  parseAuthBounceOwner,
+} from '@/lib/onboarding/landing-destination';
+import { middleware } from './middleware';
+
+/**
+ * The middleware bounce has to say WHO it bounced.
+ *
+ * `/auth?redirect=<path>` on its own is an anonymous instruction to replay a
+ * path. Everything downstream then has to guess whether the person now signing
+ * in is the person the path belonged to. Signing in as B on a screen bounced
+ * from A's project sent B to A's "Request access" page, because the only guard
+ * in place ran for brand-new accounts and B is an existing one.
+ *
+ * This drives the REAL middleware — no Supabase mock — because the value that
+ * matters is the one actually written to `Set-Cookie`.
+ */
+
+const FOREIGN_PROJECT = '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c';
+const USER_A = '11111111-1111-1111-1111-111111111111';
+
+/** A logged-out browser asking for a private path. */
+function bounceRequest(path: string, cookie?: string): NextRequest {
+  const request = new NextRequest(new Request(`https://dev.kortix.com${path}`));
+  if (cookie) request.cookies.set(LAST_PROJECT_COOKIE, cookie);
+  return request;
+}
+
+function setCookieFor(response: Response, name: string): string | undefined {
+  return response.headers.getSetCookie().find((value) => value.startsWith(`${name}=`));
+}
+
+/** The cookie value as the next request will read it back (one decode hop). */
+function bounceCookieValue(response: Response): string | undefined {
+  const header = setCookieFor(response, AUTH_BOUNCE_COOKIE);
+  if (!header) return undefined;
+  return decodeURIComponent(header.slice(`${AUTH_BOUNCE_COOKIE}=`.length).split(';')[0]);
+}
+
+describe('middleware bounce attribution', () => {
+  test('still bounces an unauthenticated request to /auth with its path', async () => {
+    const response = await middleware(bounceRequest(FOREIGN_PROJECT));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      `https://dev.kortix.com/auth?redirect=${encodeURIComponent(FOREIGN_PROJECT)}`,
+    );
+  });
+
+  test('attributes the bounce to the owner of the remembered project', async () => {
+    // The session is already gone by the time the bounce is built — that is the
+    // whole shape of the bug (a rotated refresh token, or the self-heal that
+    // nulls `user` on the way past). The remembered project outlives the token
+    // and is the only identity left to attach.
+    const response = await middleware(
+      bounceRequest(FOREIGN_PROJECT, `${USER_A}:319395c1-9c3f-41b4-ac6c-9539a12dbb7c`),
+    );
+
+    expect(parseAuthBounceOwner(bounceCookieValue(response))).toBe(USER_A);
+  });
+
+  test('an unattributed bounce is written as such, not skipped', async () => {
+    // No session, no remembered project. The cookie must still be written with
+    // an EMPTY owner: that is what tells the next sign-in "this bounce names
+    // nobody", which is different from "no bounce happened" only in that both
+    // must keep the return URL. Writing nothing at all would be fine today and
+    // wrong the moment anyone reads absence as attribution.
+    const value = bounceCookieValue(await middleware(bounceRequest(FOREIGN_PROJECT)));
+
+    expect(value).toBeDefined();
+    expect(parseAuthBounceOwner(value)).toBe('');
+  });
+
+  test('a legacy bare-project-id cookie attributes nobody', async () => {
+    // Written before ownership binding existed, so it names a project and no
+    // user. Guessing an owner from it would demote real sign-ins.
+    const response = await middleware(
+      bounceRequest(FOREIGN_PROJECT, '319395c1-9c3f-41b4-ac6c-9539a12dbb7c'),
+    );
+
+    expect(parseAuthBounceOwner(bounceCookieValue(response))).toBe('');
+  });
+
+  test('the bounced path rides along, cookie-safe', async () => {
+    // A path can legally hold characters a cookie value cannot. The header must
+    // survive one, and the owner half must still parse out of it.
+    const response = await middleware(
+      bounceRequest(
+        '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c?tab=a,b',
+        `${USER_A}:319395c1-9c3f-41b4-ac6c-9539a12dbb7c`,
+      ),
+    );
+    const value = bounceCookieValue(response) as string;
+
+    expect(value.includes(',')).toBe(false);
+    expect(value.includes(';')).toBe(false);
+    expect(parseAuthBounceOwner(value)).toBe(USER_A);
+    expect(decodeURIComponent(value.slice(value.indexOf(':') + 1))).toBe(
+      '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c?tab=a,b',
+    );
+  });
+
+  test('a public route is not a bounce and gets no cookie', async () => {
+    const response = await middleware(bounceRequest('/pricing'));
+
+    expect(setCookieFor(response, AUTH_BOUNCE_COOKIE)).toBeUndefined();
+  });
+});

--- a/apps/web/src/middleware-cookie-hardening.test.ts
+++ b/apps/web/src/middleware-cookie-hardening.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { NextRequest } from 'next/server';
+import { resolve } from 'node:path';
+
+import { AUTH_BOUNCE_COOKIE } from '@/lib/onboarding/landing-destination';
+import { ENVIRONMENT_ACCESS_COOKIE, ENVIRONMENT_PROTECTION_USERNAME } from '@/lib/environment-protection';
+import { middleware } from './middleware';
+
+/**
+ * JAY: Task 8. Three independent cookie-hardening fixes on the auth surface:
+ *
+ *  1. The Supabase session cookie, and the auth-bounce cookie, were written
+ *     WITHOUT `Secure` on production HTTPS — `@supabase/ssr` never adds it
+ *     itself (grepped its installed `dist/`: zero matches for `secure`).
+ *  2. `__Secure-kortix_test_access` was the only `Domain`-scoped cookie in
+ *     the repo (`.kortix.com`), so dev's middleware wrote a cookie that was
+ *     also sent to staging, prod, and api.kortix.com.
+ *
+ * `kortix_auth_bounce` and `__Secure-kortix_test_access` are both set
+ * unconditionally by middleware's own code (no Supabase network call in the
+ * path that sets them), so both are driven through the REAL middleware —
+ * same pattern as `middleware-auth-bounce.test.ts` ("no Supabase mock"). The
+ * three `@supabase/ssr` `cookieOptions.secure` sites cannot be driven this
+ * way: the actual `Set-Cookie` only happens deep inside that SDK's own
+ * refresh-cookie logic, reachable only against a live Supabase session — so
+ * those are covered by a source assertion instead (this file's last
+ * `describe`), matching this repo's documented preference (behavioral where
+ * possible, source assertion — comments stripped first — where it is not).
+ */
+
+const FOREIGN_PROJECT = '/projects/319395c1-9c3f-41b4-ac6c-9539a12dbb7c';
+
+function setCookieFor(response: Response, name: string): string | undefined {
+  return response.headers.getSetCookie().find((value) => value.startsWith(`${name}=`));
+}
+
+// Next's bundled types declare `NODE_ENV` readonly on `ProcessEnv`. It is
+// still an ordinary, writable string at runtime — the same escape hatch
+// `middleware.ts` itself uses (`Reflect.get(process.env, ...)`) for other
+// dynamically-read vars.
+const env = process.env as Record<string, string | undefined>;
+const originalNodeEnv = env.NODE_ENV;
+
+afterEach(() => {
+  // `process.env` is a single shared object across every file bun test runs
+  // in this process (no `--isolate` at HEAD — see the repo's own test
+  // isolation notes). Every mutated var is restored exactly, every test,
+  // regardless of pass/fail.
+  if (originalNodeEnv === undefined) delete env.NODE_ENV;
+  else env.NODE_ENV = originalNodeEnv;
+  delete env.WEB_PROTECTION_ENABLED;
+  delete env.WEB_PROTECTION_PASSWORD;
+});
+
+describe('kortix_auth_bounce: Secure on production HTTPS', () => {
+  test('carries Secure when NODE_ENV=production', async () => {
+    env.NODE_ENV = 'production';
+    const request = new NextRequest(new Request(`https://dev.kortix.com${FOREIGN_PROJECT}`));
+
+    const response = await middleware(request);
+
+    const cookie = setCookieFor(response, AUTH_BOUNCE_COOKIE);
+    expect(cookie).toBeDefined();
+    expect(cookie).toContain('Secure');
+  });
+
+  test('control: omits Secure outside production (matches bun test\'s own NODE_ENV=test)', async () => {
+    env.NODE_ENV = 'test';
+    const request = new NextRequest(new Request(`https://dev.kortix.com${FOREIGN_PROJECT}`));
+
+    const response = await middleware(request);
+
+    const cookie = setCookieFor(response, AUTH_BOUNCE_COOKIE);
+    expect(cookie).toBeDefined();
+    expect(cookie).not.toContain('Secure');
+  });
+});
+
+describe('__Secure-kortix_test_access: host-only, no Domain', () => {
+  function basicAuthRequest(path: string): NextRequest {
+    const credentials = Buffer.from(`${ENVIRONMENT_PROTECTION_USERNAME}:test-protection-pw`).toString(
+      'base64',
+    );
+    return new NextRequest(
+      new Request(`https://dev.kortix.com${path}`, {
+        headers: { authorization: `Basic ${credentials}` },
+      }),
+    );
+  }
+
+  test('a valid Basic-auth request mints the cookie WITHOUT a Domain attribute', async () => {
+    process.env.WEB_PROTECTION_ENABLED = 'true';
+    process.env.WEB_PROTECTION_PASSWORD = 'test-protection-pw';
+
+    const response = await middleware(basicAuthRequest('/help'));
+
+    const cookie = setCookieFor(response, ENVIRONMENT_ACCESS_COOKIE);
+    expect(cookie).toBeDefined();
+    // Host-only: no Domain attribute at all — not even the origin's own host,
+    // since RFC 6265 host-only cookies simply omit the attribute.
+    expect(cookie?.toLowerCase()).not.toContain('domain=');
+    // Every other attribute this cookie is supposed to carry stays intact —
+    // this proves the fix removed exactly `Domain`, not the whole options
+    // object.
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Secure');
+    expect(cookie?.toLowerCase()).toContain('samesite=lax');
+  });
+});
+
+describe('the three @supabase/ssr cookieOptions sites set `secure`', () => {
+  // Cannot be driven behaviorally (see file doc comment) — `@supabase/ssr`
+  // only writes this cookie from inside its own token-refresh logic, which
+  // needs a live Supabase session. Source assertion instead, comments
+  // stripped first (this repo's documented trap: a match inside a comment
+  // passes against text that never runs).
+  // Line comments FIRST, then block comments — the reverse of the pattern
+  // this repo otherwise uses (e.g. `sign-out-navigation.test.ts`). Reversed
+  // deliberately: `middleware.ts` has plain `//` comments mentioning path
+  // globs like `/auth/*` and `/settings/*` — read as `/* */`-first, THAT
+  // literal `/*` is misread as a block-comment open with no close on the
+  // same line, so the non-greedy `[\s\S]*?\*\/` swallows everything up to
+  // the FAR-AWAY next real `*/` (the matcher config's JSDoc block),
+  // including `cookieOptions:` in between. A block comment's interior is
+  // discarded either way, so stripping line comments first changes nothing
+  // about what a real block comment's content resolves to.
+  function stripComments(source: string): string {
+    return source.replace(/(^|[^:])\/\/.*$/gm, '$1').replace(/\/\*[\s\S]*?\*\//g, '');
+  }
+
+  function cookieOptionsBlocks(file: string): string[] {
+    const source = stripComments(readFileSync(resolve(import.meta.dir, file), 'utf8'));
+    const blocks: string[] = [];
+    let from = 0;
+    for (;;) {
+      const start = source.indexOf('cookieOptions:', from);
+      if (start < 0) break;
+      const end = source.indexOf('}', source.indexOf('{', start));
+      expect(end).toBeGreaterThan(start);
+      blocks.push(source.slice(start, end + 1));
+      from = end + 1;
+    }
+    return blocks;
+  }
+
+  test('lib/supabase/client.ts: both createBrowserClient() cookieOptions blocks set secure', () => {
+    const blocks = cookieOptionsBlocks('lib/supabase/client.ts');
+    expect(blocks.length).toBe(2);
+    for (const block of blocks) {
+      expect(block).toContain('secure');
+    }
+  });
+
+  test('lib/supabase/server.ts: the createServerClient() cookieOptions block sets secure', () => {
+    const blocks = cookieOptionsBlocks('lib/supabase/server.ts');
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]).toContain('secure');
+  });
+
+  test('middleware.ts: the createServerClient() cookieOptions block sets secure', () => {
+    const blocks = cookieOptionsBlocks('middleware.ts');
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]).toContain('secure');
+  });
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -236,7 +236,12 @@ export async function middleware(request: NextRequest) {
       expectedAccessCookie
     ) {
       response.cookies.set(ENVIRONMENT_ACCESS_COOKIE, expectedAccessCookie, {
-        domain: '.kortix.com',
+        // No `domain` — this is the only Domain-scoped cookie in the repo,
+        // and `.kortix.com` sent it to EVERY subdomain: dev's middleware set
+        // a cookie that staging, prod, and api.kortix.com all received on
+        // every request too, regardless of which environment actually
+        // authorized it. Omitting `domain` makes it host-only (RFC 6265
+        // §5.3): scoped to whichever exact host issued it.
         httpOnly: true,
         maxAge: 60 * 60 * 24 * 7,
         path: '/',
@@ -458,6 +463,9 @@ export async function middleware(request: NextRequest) {
       name: KORTIX_SUPABASE_AUTH_COOKIE,
       path: '/',
       sameSite: 'lax',
+      // `@supabase/ssr` never sets this itself — see the doc comment in
+      // `lib/supabase/client.ts`.
+      secure: process.env.NODE_ENV === 'production',
     },
     cookies: {
       getAll() {
@@ -630,6 +638,7 @@ export async function middleware(request: NextRequest) {
           maxAge: AUTH_BOUNCE_MAX_AGE,
           path: '/',
           sameSite: 'lax',
+          secure: process.env.NODE_ENV === 'production',
         },
       );
       return finalizeEnvironmentAccess(bounceResponse);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -60,6 +60,7 @@ const PUBLIC_ROUTES = [
   '/', // Homepage should be public!
   '/auth',
   '/auth/callback',
+  '/logout', // Signing OUT must never require signing IN — a protected /logout would be bounced to /auth?redirect=/logout, and the sign-in would land right back here
   '/auth/signup',
   '/auth/forgot-password',
   '/auth/reset-password',

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,9 +8,13 @@ import { legalTermsRedirectUrl } from '@/lib/legal-terms-redirect';
 import { getMaintenanceConfig } from '@/lib/maintenance-store';
 import { MAINTENANCE_BYPASS_COOKIE, verifyBypassToken } from '@/lib/maintenance-bypass';
 import {
+  AUTH_BOUNCE_COOKIE,
+  AUTH_BOUNCE_MAX_AGE,
   LAST_PROJECT_COOKIE,
   PROJECT_LANDING_PATH,
+  parseLastProjectOwner,
   resolveDefaultLandingPath,
+  serializeAuthBounce,
 } from '@/lib/onboarding/landing-destination';
 import { KORTIX_SUPABASE_AUTH_COOKIE } from '@/lib/supabase/constants';
 import {
@@ -499,6 +503,22 @@ export async function middleware(request: NextRequest) {
     authError = identity.authError;
   }
 
+  // Who is being bounced. Captured HERE, before the self-heal below can null
+  // `user`: `getUser()` is allowed to hand back a user AND an error together,
+  // and the self-heal drops that user on the floor a few lines down. Reading
+  // after it would throw away the one identity the request still had.
+  //
+  // The remembered project's owner is the fallback, and it is what actually
+  // carries attribution in the common failure: a rotated refresh token already
+  // resolves to `user: null` before the self-heal runs, so there is no session
+  // id left to read. That cookie outlives the token, and it is the same
+  // browser-written value `resolveDefaultLandingPath` already trusts.
+  //
+  // Empty is an allowed answer. It means UNATTRIBUTED, which never demotes a
+  // return URL — see `shouldDemoteReturnUrl`.
+  const bounceOwnerId =
+    user?.id || parseLastProjectOwner(request.cookies.get(LAST_PROJECT_COOKIE)?.value);
+
   // Self-heal a stale/rotated session. A refresh token that's invalid or
   // "already used" (e.g. after a redeploy or a two-tab refresh race) keeps
   // erroring on every request and dead-ends the user on /auth. Drop the Supabase
@@ -598,7 +618,21 @@ export async function middleware(request: NextRequest) {
       // browser bounces to /auth still carrying the poisoned cookie, and the
       // auth page's own client-side session check has to rediscover the same
       // invalidity from scratch before it can show a usable form.
-      return finalizeEnvironmentAccess(redirectPreservingSession(url));
+      const bounceResponse = redirectPreservingSession(url);
+      // Attach WHO was bounced. `redirect` alone says where, and the auth flows
+      // downstream cannot tell an expired session returning to its own project
+      // from a different account picking up the previous one's path.
+      bounceResponse.cookies.set(
+        AUTH_BOUNCE_COOKIE,
+        serializeAuthBounce(bounceOwnerId, redirectTarget),
+        {
+          httpOnly: true,
+          maxAge: AUTH_BOUNCE_MAX_AGE,
+          path: '/',
+          sameSite: 'lax',
+        },
+      );
+      return finalizeEnvironmentAccess(bounceResponse);
     }
 
     return finalizeEnvironmentAccess(supabaseResponse);

--- a/apps/web/src/stores/announcement-store.ts
+++ b/apps/web/src/stores/announcement-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 export interface AnnouncementData {
   component: string;
@@ -68,9 +69,18 @@ export const useAnnouncementStore = create<AnnouncementStore>()(
       },
     }),
     {
-      name: 'announcement-store-v2',
+      // `kortix.` prefixed (not the historical `announcement-store-v2`) so the
+      // sign-out sweep's prefix match covers it structurally — see
+      // `APP_STORAGE_PREFIXES` in `lib/utils/clear-local-storage.ts`. Which
+      // announcements a browser has dismissed is per-account state; the old
+      // unprefixed name meant it silently outlived a sign-out.
+      name: 'kortix.announcements-v2',
       storage: createSafeJSONStorage(),
       partialize: (state) => ({ dismissedAnnouncements: state.dismissedAnnouncements }),
     }
   )
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore('kortix.announcements-v2', () => resetPersistedStore(useAnnouncementStore));

--- a/apps/web/src/stores/browser-recents-store.ts
+++ b/apps/web/src/stores/browser-recents-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 export interface BrowserRecent {
   /** Canonical visited URL, e.g. http://localhost:3000/debug/tools */
@@ -63,3 +64,7 @@ export const useBrowserRecentsStore = create<BrowserRecentsState>()(
     },
   ),
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore('kortix-browser-recents', () => resetPersistedStore(useBrowserRecentsStore));

--- a/apps/web/src/stores/diagnostics-store.ts
+++ b/apps/web/src/stores/diagnostics-store.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 // ============================================================================
 // Types
@@ -415,6 +416,10 @@ export const useDiagnosticsStore = create<DiagnosticsState>()(
     partialize: (state) => ({ byFile: state.byFile }) as unknown as DiagnosticsState,
   },
 ));
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore('kortix-diagnostics', () => resetPersistedStore(useDiagnosticsStore));
 
 // Expose on window for console debugging
 if (typeof window !== 'undefined') {

--- a/apps/web/src/stores/persisted-store-coverage.test.ts
+++ b/apps/web/src/stores/persisted-store-coverage.test.ts
@@ -1,0 +1,271 @@
+// The point of this file, not a supporting cast member: walk every persisted
+// zustand store under this directory and prove two things a future store
+// cannot silently skip —
+//   1. its disk key is either swept by `clearUserLocalStorage()`'s prefix
+//      match or explicitly kept as device-scoped (`clear-local-storage.ts`);
+//   2. unless it IS kept, its in-memory state is reset at sign-out — via its
+//      OWN `registerPersistedStore(...)` call into `persisted-store-registry.ts`
+//      (see that file's header for why `reset-client-state.ts` does not
+//      import stores directly: a static import of `session-browser-store.ts`
+//      once dragged a 3.8MB markdown renderer into every route's initial JS
+//      chunk, caught by `connectors-page.chunk.test.ts`).
+//
+// Both checks are driven by extracting real names from real source files —
+// this directory's listing, each file's `persist(..., { name: … })`, and each
+// file's own `registerPersistedStore(...)` call — not by a hand-maintained
+// mirror list that could drift from what actually exists. Adding a store here
+// with an uncovered name, or one that never registers itself, fails a
+// generated test by name.
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  isAppOwnedStorageKey,
+  isKeptStorageKey,
+} from '@/lib/utils/clear-local-storage';
+
+const STORES_DIR = resolve(import.meta.dir);
+
+/**
+ * Every name a call matching `pattern` resolves to in `source`. `pattern`
+ * must capture three groups: [1] the opening quote of a string literal (a
+ * backreference anchor, discarded), [2] the literal's own text, [3] a bare
+ * identifier — exactly one of [2] / [3] is set per match. A bare identifier
+ * resolves against a `const <identifier> = '...'` declared in the SAME file.
+ *
+ * Shared by the `persist(` and `registerPersistedStore(` walks below — both
+ * name a store the same two ways in this codebase (an inline literal, or a
+ * `STORAGE_KEY` const).
+ *
+ * Throws rather than skipping when an identifier cannot be resolved: a call
+ * this walker cannot read is a hole in the coverage guarantee, not something
+ * to silently pass over.
+ */
+function extractNames(
+  source: string,
+  file: string,
+  pattern: RegExp,
+  callDescription: string,
+): string[] {
+  const names: string[] = [];
+  for (const match of source.matchAll(pattern)) {
+    if (match[2] !== undefined) {
+      names.push(match[2]);
+      continue;
+    }
+    const identifier = match[3];
+    const constMatch = source.match(
+      new RegExp(`const\\s+${identifier}\\s*=\\s*(['"])((?:(?!\\1).)*)\\1`),
+    );
+    if (!constMatch) {
+      throw new Error(
+        `${file}: ${callDescription} names '${identifier}' but no matching ` +
+          `'const ${identifier} = "..."' was found in the same file`,
+      );
+    }
+    names.push(constMatch[2]);
+  }
+  return names;
+}
+
+/**
+ * Every `persist(..., { name: <literal-or-const> })` name declared in
+ * `source`. Two current stores write `name: STORAGE_KEY` — a module-level
+ * `const` — rather than an inline literal; both forms resolve to the real
+ * string value a `persist` `StateStorage` actually reads and writes.
+ */
+function extractPersistNames(source: string, file: string): string[] {
+  if (!/\bpersist\(/.test(source)) return [];
+  const names = extractNames(
+    source,
+    file,
+    /\bname:\s*(?:(['"])((?:(?!\1).)*)\1|([A-Za-z_$][\w$]*))/g,
+    'persist()',
+  );
+  if (names.length === 0) {
+    throw new Error(`${file}: calls persist() but no 'name:' could be extracted`);
+  }
+  return names;
+}
+
+/**
+ * Every `registerPersistedStore(<literal-or-const>, ...)` name declared in
+ * `source`. Mirrors `extractPersistNames`'s two spellings.
+ */
+function extractRegisteredNames(source: string, file: string): string[] {
+  return extractNames(
+    source,
+    file,
+    /\bregisterPersistedStore\(\s*(?:(['"])((?:(?!\1).)*)\1|([A-Za-z_$][\w$]*))\s*,/g,
+    'registerPersistedStore()',
+  );
+}
+
+/** `export const useXStore = create<...>(` → `'useXStore'`, else null. */
+function extractExportedHookName(source: string): string | null {
+  const match = source.match(/export const (use[A-Za-z0-9_]*Store)\s*=\s*create[<(]/);
+  return match ? match[1] : null;
+}
+
+function storeSourceFiles(): string[] {
+  return readdirSync(STORES_DIR, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() && /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name),
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+
+interface DiscoveredStore {
+  file: string;
+  source: string;
+  hookName: string | null;
+  names: string[];
+}
+
+function discoverPersistedStores(): DiscoveredStore[] {
+  const discovered: DiscoveredStore[] = [];
+  for (const file of storeSourceFiles()) {
+    const source = readFileSync(resolve(STORES_DIR, file), 'utf8');
+    const names = extractPersistNames(source, file);
+    if (names.length === 0) continue;
+    discovered.push({ file, source, hookName: extractExportedHookName(source), names });
+  }
+  return discovered;
+}
+
+describe('every persisted zustand store is covered by the sign-out disk sweep', () => {
+  const discovered = discoverPersistedStores();
+
+  test('the walk actually finds persisted stores — an empty walk would pass everything', () => {
+    // A floor on the CURRENT, real count (12 as of this test's writing) minus
+    // slack, not an exact pin — an exact count would churn on every unrelated
+    // store addition. The floor exists so a walker broken by a directory
+    // rename or a changed `persist(` call shape fails loud instead of
+    // quietly checking zero stores.
+    expect(discovered.length).toBeGreaterThanOrEqual(11);
+  });
+
+  for (const store of discovered) {
+    for (const name of store.names) {
+      test(`${store.file} → '${name}' matches a swept prefix or is on KEEP_STORAGE_KEYS`, () => {
+        expect(isAppOwnedStorageKey(name) || isKeptStorageKey(name)).toBe(true);
+      });
+    }
+  }
+});
+
+describe('extractPersistNames resolves both spellings a persist() config uses here', () => {
+  test('an inline string literal', () => {
+    expect(
+      extractPersistNames(`persist((set) => ({}), { name: 'literal-key' })`, 'fixture.ts'),
+    ).toEqual(['literal-key']);
+  });
+
+  test('a module-level const reference', () => {
+    const source = `const STORAGE_KEY = 'const-key';\npersist((set) => ({}), { name: STORAGE_KEY })`;
+    expect(extractPersistNames(source, 'fixture.ts')).toEqual(['const-key']);
+  });
+
+  test('a file with no persist() call yields no names, instead of throwing', () => {
+    expect(
+      extractPersistNames(`export const useFoo = create(() => ({ x: 1 }));`, 'fixture.ts'),
+    ).toEqual([]);
+  });
+
+  test('an unresolvable identifier throws, rather than silently reporting no names', () => {
+    expect(() =>
+      extractPersistNames(`persist((set) => ({}), { name: NEVER_DEFINED })`, 'fixture.ts'),
+    ).toThrow(/NEVER_DEFINED/);
+  });
+});
+
+describe('extractRegisteredNames resolves both spellings a registerPersistedStore() call uses here', () => {
+  test('an inline string literal', () => {
+    expect(
+      extractRegisteredNames(
+        `registerPersistedStore('literal-key', () => resetPersistedStore(useFooStore));`,
+        'fixture.ts',
+      ),
+    ).toEqual(['literal-key']);
+  });
+
+  test('a module-level const reference', () => {
+    const source =
+      `const STORAGE_KEY = 'const-key';\n` +
+      `registerPersistedStore(STORAGE_KEY, () => resetPersistedStore(useFooStore));`;
+    expect(extractRegisteredNames(source, 'fixture.ts')).toEqual(['const-key']);
+  });
+
+  test('a file with no registerPersistedStore() call yields no names', () => {
+    expect(extractRegisteredNames(`export const useFoo = create(() => ({}));`, 'fixture.ts')).toEqual(
+      [],
+    );
+  });
+});
+
+describe('the coverage predicate genuinely fails closed — mutation proof', () => {
+  // Pins the exact failure mode the brief's "FAIL when one is neither
+  // covered" requirement describes, using a name no real store will ever
+  // have — proof the check above can actually go red, not only that it
+  // happens to be green today.
+  test('a name matching no prefix and absent from KEEP is reported as NOT covered', () => {
+    const name = 'totally-unprefixed-store-key';
+    expect(isAppOwnedStorageKey(name)).toBe(false);
+    expect(isKeptStorageKey(name)).toBe(false);
+    expect(isAppOwnedStorageKey(name) || isKeptStorageKey(name)).toBe(false);
+  });
+
+  test('a name that matches a prefix but is not on KEEP is still covered (swept)', () => {
+    expect(isAppOwnedStorageKey('kortix-not-actually-a-real-store')).toBe(true);
+    expect(isKeptStorageKey('kortix-not-actually-a-real-store')).toBe(false);
+  });
+
+  test('a KEEP_STORAGE_KEYS entry is covered even though it matches no prefix logic on its own', () => {
+    expect(isKeptStorageKey('kortix-sound-preferences')).toBe(true);
+  });
+});
+
+describe('every SWEPT persisted store also registers its own in-memory reset', () => {
+  // The disk sweep alone is not enough: `resetClientState()`'s own header
+  // explains why — a component still subscribed to a persisted store can
+  // re-persist the very key the sweep just deleted unless that store's
+  // in-memory state is reset FIRST. Each store does that via its OWN
+  // `registerPersistedStore(...)` call (see `persisted-store-registry.ts`),
+  // checked here against that SAME file's `persist()` name — so a future
+  // store cannot opt out of the in-memory half of the sweep either, and a
+  // registration under the WRONG name (a copy-paste from another store) is
+  // caught too.
+  const discovered = discoverPersistedStores();
+
+  for (const store of discovered) {
+    const isKeptStore = store.names.every((name) => isKeptStorageKey(name));
+    // Handled by a named, literal, SYNCHRONOUS call in `resetClientState()`
+    // itself — the sign-out source tripwire (`sign-out-navigation.test.ts`)
+    // pins that exact line, so it deliberately does not use the registry.
+    if (store.hookName === 'useCurrentAccountStore') continue;
+
+    if (isKeptStore) {
+      // KEEP-listed stores (theme, sound, notification permission) must NOT
+      // register — the disk KEEP and the in-memory exclusion are two
+      // independent lists, and a store accidentally registered on BOTH
+      // (matching `KEEP_STORAGE_KEYS` yet still resetting in memory) would
+      // silently wipe a device-scoped preference on every sign-out, exactly
+      // the regression `reset-client-state.test.ts`'s "a device-scoped KEPT
+      // preference is NOT reset" behavioral test catches from the other side.
+      test(`${store.file} is KEPT and correctly does NOT register itself`, () => {
+        expect(extractRegisteredNames(store.source, store.file)).toEqual([]);
+      });
+      continue;
+    }
+
+    test(`${store.file} registers itself for every one of its persist() names`, () => {
+      const registered = extractRegisteredNames(store.source, store.file);
+      for (const name of store.names) {
+        expect(registered).toContain(name);
+      }
+    });
+  }
+});

--- a/apps/web/src/stores/persisted-store-registry.ts
+++ b/apps/web/src/stores/persisted-store-registry.ts
@@ -1,0 +1,74 @@
+/**
+ * Lets a persisted zustand store register its OWN sign-out reset, so
+ * `reset-client-state.ts` — imported by `AuthProvider`, which mounts on
+ * EVERY route — never has to statically `import` the store module itself.
+ *
+ * That indirection exists because of a real, measured regression: a store's
+ * own file often imports feature code far heavier than its persisted state
+ * needs (`session-browser-store.ts` → `kortix-computer-store.ts` →
+ * `features/files` → … → the shiki-backed markdown code renderer, ~3.8MB).
+ * `connectors-page.chunk.test.ts` walks the connectors route's real static
+ * import graph and asserts that renderer is NOT in its initial chunk — a
+ * static `import { useSessionBrowserStore } from '@/stores/session-browser-store'`
+ * inside `reset-client-state.ts` put it there, because an ES module is
+ * all-or-nothing to the bundler and `reset-client-state.ts` sits on every
+ * route's critical path through `AuthProvider`.
+ *
+ * This module has NO imports of its own and MUST stay that way — the whole
+ * point is a leaf `reset-client-state.ts` can depend on regardless of which
+ * heavy stores exist.
+ *
+ * A store that registers itself only when its own module is evaluated has a
+ * useful property for free: a route that never loads a given store's module
+ * never has it in this registry at sign-out — but it also never accumulated
+ * any in-memory state on that store to leak, since the module never ran.
+ * "Not registered" and "nothing to reset" are the same fact.
+ */
+
+const registry = new Map<string, () => void>();
+
+/**
+ * A persisted zustand store's public surface, generic over its state shape.
+ * `getInitialState()` returns the exact object the store's creator function
+ * produced, BEFORE `persist` hydrated it from disk — see zustand's own
+ * `persistImpl` (`api.getInitialState = () => configResult`) — so it is
+ * always the pristine, identity-neutral default. Resetting to it can never
+ * drift from the real shape the way a hand-copied `initialState` duplicate
+ * could, because it comes from the store itself.
+ */
+interface ResettablePersistedStore<T> {
+  getInitialState: () => T;
+  setState: (state: T, replace: true) => void;
+}
+
+export function resetPersistedStore<T>(store: ResettablePersistedStore<T>): void {
+  store.setState(store.getInitialState(), true);
+}
+
+/**
+ * Call once per persisted store, at the store's own module scope, right
+ * after `create()` — e.g. in `stores/browser-recents-store.ts`:
+ *
+ *   registerPersistedStore('kortix-browser-recents', () =>
+ *     resetPersistedStore(useBrowserRecentsStore),
+ *   );
+ *
+ * `name` must be the store's OWN `persist` `name:` — it is checked against
+ * that value by `persisted-store-coverage.test.ts`, which also fails closed
+ * if a persisted store under `src/stores/` has no matching registration at
+ * all.
+ */
+export function registerPersistedStore(name: string, reset: () => void): void {
+  registry.set(name, reset);
+}
+
+/** Reset every registered store's in-memory state, synchronously. */
+export function resetAllRegisteredPersistedStores(): void {
+  for (const [name, reset] of registry) {
+    try {
+      reset();
+    } catch (error) {
+      console.error(`Failed to reset persisted store '${name}':`, error);
+    }
+  }
+}

--- a/apps/web/src/stores/project-session-tabs-store.ts
+++ b/apps/web/src/stores/project-session-tabs-store.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 /**
  * Per-project open-session tabs.
@@ -177,3 +178,7 @@ export const useProjectSessionTabsStore = create<State & Actions>()(
     },
   ),
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore(STORAGE_KEY, () => resetPersistedStore(useProjectSessionTabsStore));

--- a/apps/web/src/stores/projects-view-store.ts
+++ b/apps/web/src/stores/projects-view-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 /**
  * How the Projects page groups its grid:
@@ -34,3 +35,7 @@ export const useProjectsViewStore = create<ProjectsViewState>()(
     },
   ),
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore('kortix.projectsView', () => resetPersistedStore(useProjectsViewStore));

--- a/apps/web/src/stores/session-browser-store.ts
+++ b/apps/web/src/stores/session-browser-store.ts
@@ -3,6 +3,7 @@
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
 import { useKortixComputerStore } from '@/stores/kortix-computer-store';
 import { useUserPreferencesStore } from '@/stores/user-preferences-store';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
@@ -159,6 +160,15 @@ export const useSessionBrowserStore = create<SessionBrowserState>()(
     },
   ),
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+// This is THE store that motivated the registry: a static import here from
+// `reset-client-state.ts` (reachable from every route via `AuthProvider`) drags
+// in `kortix-computer-store.ts` → `@/features/files` → … → the shiki-backed
+// markdown code renderer, which `connectors-page.chunk.test.ts` asserts is NOT
+// in that route's initial chunk.
+registerPersistedStore('kortix-session-browser', () => resetPersistedStore(useSessionBrowserStore));
 
 /** Canonical tab id for a session's internal-browser tab in `useTabStore`. */
 export function sessionPreviewTabId(sessionId: string): string {

--- a/apps/web/src/stores/session-filter-store.ts
+++ b/apps/web/src/stores/session-filter-store.ts
@@ -10,6 +10,7 @@ import {
   type SessionOrderMode,
 } from '@/features/workspace/project-sidebar/session-grouping';
 import { createSafeJSONStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 /**
  * Per-project session-list VIEW state — grouping, ordering, the two filter
@@ -283,3 +284,7 @@ export const useSessionFilterStore = create<State & Actions>()(
     },
   ),
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore(STORAGE_KEY, () => resetPersistedStore(useSessionFilterStore));

--- a/apps/web/src/stores/tab-store.ts
+++ b/apps/web/src/stores/tab-store.ts
@@ -4,6 +4,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { getCurrentInstanceIdFromWindow, toInstanceAwarePath } from '@kortix/sdk/instance-routes';
 import { safeLocalStorage } from '@/lib/storage/managed-storage';
+import { registerPersistedStore, resetPersistedStore } from '@/stores/persisted-store-registry';
 
 // ============================================================================
 // Types
@@ -476,6 +477,10 @@ export const useTabStore = create<TabState>()(
     }
   )
 );
+
+// Registers this store for `resetClientState()`'s sign-out sweep without
+// `reset-client-state.ts` importing this file — see `persisted-store-registry.ts`.
+registerPersistedStore('kortix-tabs', () => resetPersistedStore(useTabStore));
 
 // ============================================================================
 // Utility: open + navigate in one shot

--- a/docs/superpowers/plans/2026-08-30-identity-boundary-plan.md
+++ b/docs/superpowers/plans/2026-08-30-identity-boundary-plan.md
@@ -1,0 +1,373 @@
+# Plan — close the cross-account identity boundary in apps/web
+
+Branch: `identity-boundary` (one worktree, one branch — everything lands together).
+Source audit: 61 findings, 14 agents, find → adversarial verify. Artifact:
+https://claude.ai/code/artifact/f5596f07-649b-45f4-b279-14632e235194
+
+## The problem (not the solution)
+
+Logging out of Kortix account A and into account B on the same browser leaves A's
+identity reachable. Five reported symptoms:
+
+1. B is redirected into A's workspace.
+2. `/new` displays A's email address to B. (customer-visible disclosure)
+3. B cannot create a project — "you need access to this project".
+4. Both happen for one human with two paid accounts.
+5. A genuinely-new user does not get the first-run flow.
+
+The owner-bound `kortix_last_project` cookie (`<userId>:<projectId>`,
+`landing-destination.ts`) is CORRECT and is deployed (`b2e10a152b`, `v0.13.2`, on
+`origin/prod`). It is not the bug. The leak is in the layers above it.
+
+## Global Constraints
+
+- **G1 — No behaviour change for the single-account happy path.** A user who signs
+  in, works, and signs out on their own machine must see zero difference apart from
+  logout becoming a full document load.
+- **G2 — Fail closed on identity.** Wherever identity cannot be established, the
+  code must choose the safe branch (the landing door, a blocked submit, a reset) —
+  never "assume same user".
+- **G3 — An absent marker means UNKNOWN, not SAME.** Every guard of the form
+  `if (prev && prev !== next)` is wrong. Absent must trigger the reset.
+- **G4 — Structure over cleanup.** Prefer making a leak unrepresentable (identity in
+  the key, ownership in the value) over adding another entry to a delete-list.
+- **G5 — `packages/sdk` rules apply in full** to any task touching it: failing test
+  first, run it, watch it fail, then implement; every turn ends with gates run and
+  real output pasted; exported names including types are a public API contract;
+  never hand-bump `version`.
+- **G6 — Do not weaken existing tests to pass.** `signup-destination.test.ts` and
+  `landing-destination.test.ts` encode real contracts. If a change breaks one,
+  the change is wrong until proven otherwise in the report.
+- **G7 — Verify line numbers before editing.** Every `file:line` below was read at
+  plan time and WILL drift as earlier tasks land. Locate by symbol, not by line.
+- **G8 — No `pnpm dev` / no browser.** Verify by `bun test`, `tsc --noEmit`,
+  `npx eslint <files>`. Per standing instruction, do not boot a stack or drive a
+  browser.
+- **G9 — Commit per task on `identity-boundary`.** Never push, never open a PR,
+  never merge.
+
+---
+
+> Task order is load-bearing: it resolves the file conflicts recorded in the
+> pre-flight scan (see the ledger). Do not reorder.
+
+---
+
+## Task 1 — Stop manufacturing an email address in the identity slot
+
+**Why:** symptom 2, and it reproduces on a completely clean browser with no stale
+cache. The API stores every personal account as `"a@x.com's Account"`
+(`apps/api/src/accounts/core/app.ts` `defaultAccountName`, written by
+`bootstrap-personal-account.ts`). `filterCreatableAccounts` strips the possessive
+with `.replaceAll("'s Account", '')`, producing the bare string `a@x.com`, and
+`AccountPicker` paints that in the slot whose only other value is `user.email`. An
+invited admin therefore sees the account owner's address labelled as their own
+identity. This is a customer-visible disclosure of one user's email to another.
+
+**Files:** `apps/web/src/features/workspace/new/new-workspace-form.ts`,
+`apps/web/src/features/workspace/new/account-picker.tsx`,
+`apps/web/src/features/workspace/new/new-workspace-page.tsx`.
+
+**Changes:**
+1. In `filterCreatableAccounts`, remove the `.replaceAll("'s Account", '')`. The
+   possessive is exactly what tells a reader the account belongs to someone else.
+2. In `AccountPicker`, the identity slot must render `fallbackLabel` (the
+   authenticated `user.email`) and NEVER an account name. Render the account name
+   only as a separate, labelled "Create in" value. Below two creatable accounts,
+   show the identity line plus a muted account line — do not collapse them into one
+   string.
+3. `new-workspace-page.tsx` keeps passing `fallbackLabel={user?.email}`.
+
+**Tests** (`bun test`, colocated):
+- `filterCreatableAccounts` given `[{ name: "a@x.com's Account" }]` returns a name
+  that still contains `'s Account` — i.e. never the bare email.
+- `AccountPicker` label resolution: with `accounts.length < 2` and a non-null
+  `fallbackLabel`, the identity line equals `fallbackLabel` and never
+  `accounts[0].name`. Assert on the resolution function, not on rendered DOM.
+
+---
+
+## Task 2 — Make `/new`'s account resolver identity-aware
+
+**Why:** symptom 3. `resolveDefaultCreatableAccountId` is documented as
+"email match → primary owner → first creatable", but BOTH email branches are dead
+code against the real `GET /v1/accounts` shape: it compares `account.name` to a bare
+email (the API returns `"…'s Account"`) and `account.slug` to an email (the API
+returns `accountId.slice(0, 8)`). The `email` argument is inert, so the function
+returns "the first owned account in whatever list it was handed", and `/new` POSTs
+that `account_id` with the signed-in user's JWT.
+
+**Files:** `apps/web/src/features/workspace/new/new-workspace-form.ts`,
+`apps/web/src/features/workspace/new/use-create-workspace.ts`,
+`apps/web/src/features/workspace/new/new-workspace-page.tsx`.
+
+**Changes:**
+1. Replace the dead name/slug matching in `resolveDefaultCreatableAccountId` with an
+   identity match on `account_id === userId`. Personal accounts use
+   `accountId === userId` by construction — VERIFY this in
+   `apps/api/src/accounts/core/bootstrap-personal-account.ts` before relying on it
+   and state what you found in the report. Change the parameter from `email` to
+   `userId`; update every caller.
+2. In `new-workspace-page.tsx`: when `creatableAccounts` is non-empty AND `user.id`
+   is not present as an `account_id` in it, treat the list as FOREIGN — render no
+   account name and block submit (G2, fail closed).
+3. In `use-create-workspace.ts`, `resolveTargetAccountId` must assert the resolved
+   id is present in the current user's `creatableAccounts` before the POST; throw
+   rather than send if not.
+
+**Tests:** the foreign-list case blocks submit; the identity match picks the personal
+account; a member-only user with no owned account resolves to `undefined` rather
+than a stranger's account.
+
+---
+
+## Task 3 — Make the middleware bounce attributable   (CRITICAL)
+
+**Why:** symptoms 1, 3 and 4 — the only CONFIRMED critical. Middleware writes
+`/auth?redirect=<path>` with no identity attached. The guard that would drop a
+foreign path runs for signups ONLY: every consumer reads
+`isNewUser ? resolveNewAccountReturnUrl(x) : x`. An existing user — which is exactly
+what a second paid account is — keeps the raw path and lands in the previous user's
+project. It also escapes the browser: `sendEmailCode` bakes that path into the
+emailed sign-in link, so it survives to a device that never held the first session.
+
+**Files:** `apps/web/src/middleware.ts`,
+`apps/web/src/lib/onboarding/landing-destination.ts` (constants),
+`apps/web/src/lib/auth/return-url.ts`,
+`apps/web/src/app/(auth)/auth/actions.ts`,
+`apps/web/src/app/(auth)/auth/callback/route.ts`.
+
+**Changes:**
+1. Add `AUTH_BOUNCE_COOKIE = 'kortix_auth_bounce'` and a 300s max-age beside
+   `POST_AUTH_INTENT_COOKIE`.
+2. In the middleware branch that redirects an unauthenticated request to `/auth`,
+   also set `kortix_auth_bounce=<userId>:<path>`. Take the user id from
+   `resolveMiddlewareIdentity` BEFORE the refresh-token self-heal nulls it; if
+   unavailable, fall back to the owner half of `kortix_last_project`; if that is
+   absent too, write `:<path>` — an empty owner means UNATTRIBUTED.
+3. Add `shouldDemoteReturnUrl({ bouncedOwnerId, signedInUserId, isNewUser })` to
+   `return-url.ts`. True when `isNewUser`, OR when `bouncedOwnerId` is non-empty and
+   differs from `signedInUserId`. An UNATTRIBUTED bounce does NOT demote — that keeps
+   a pasted or bookmarked link working, and keeps `signup-destination.test.ts` green
+   (G6).
+4. Apply at all four consumers: both `isNewUser ? … : …` sites in `actions.ts`, the
+   `flowMode === 'signup'` site in `sendEmailCode` (this is the LINK-MINT gate —
+   without it the poisoned path still escapes into email), and `callback/route.ts`.
+5. Clear the bounce cookie on EVERY successful post-auth redirect — both redirect
+   sites in `actions.ts` and the one in `callback/route.ts`. Clearing it only beside
+   the existing `ACTIVE_INSTANCE_COOKIE` clear is NOT sufficient: that clear lives
+   in `callback/route.ts`, which password and OTP sign-in never touch.
+
+**Tests:** bounced-as-A / signs-in-as-B demotes to `PROJECT_LANDING_PATH`;
+bounced-as-A / signs-in-as-A keeps the path; unattributed bounce keeps the path;
+`signup-destination.test.ts` and `return-url.test.ts` pass UNMODIFIED.
+
+---
+
+## Task 4 — One `performSignOut()`: hard navigation, error handling, guard repair
+
+**Why:** three defects that all live on the sign-out path, and fixing them
+separately would mean rewriting the same three files twice.
+(a) All three logout controls are SOFT navigations, so Next's route cache, segment
+cache and bfcache survive the identity change — `router.refresh()` does not clear the
+route cache, and bfcache reads bypass staleness entirely, so shortening `staleTimes`
+cannot substitute. (b) Six sign-out controls have four different cleanups and every
+one DISCARDS `signOut()`'s error — on the error path no session is removed, no
+`SIGNED_OUT` fires, and nothing is cleared. (c) `SIGNED_OUT` deletes
+`kortix-last-user-id`, the exact marker the later `SIGNED_IN` comparison needs, so
+the second-chance reset can never fire after an explicit logout.
+
+**Files:** new `apps/web/src/lib/auth/perform-sign-out.ts`;
+`apps/web/src/features/layout/user-menu-shared.tsx`,
+`apps/web/src/features/workspace/command-palette.tsx`,
+`apps/web/src/app/(app)/projects/start/page.tsx`,
+`apps/web/src/features/workspace/new/new-workspace-page.tsx`,
+`apps/web/src/app/(auth)/auth/phone-verification/page.tsx`,
+`apps/web/src/features/providers/auth-provider.tsx`.
+
+**Changes:**
+1. `performSignOut()`: call `supabase.auth.signOut()`, READ the `{ error }`, and on
+   error retry with `{ scope: 'local' }`; run `await resetClientState()` regardless;
+   then `window.location.assign('/auth')`. The hard navigation is what discards
+   every Next client cache — do not use `router.push`/`router.replace`.
+2. Wire ALL SIX controls to it, including `/new`'s Log out button, which today
+   neither awaits nor navigates and strands a signed-out user on the page.
+3. `auth-provider.tsx`: delete `safeRemoveItem('kortix-last-user-id')` from the
+   `SIGNED_OUT` branch. Change BOTH guards so an ABSENT marker triggers the reset
+   (G3). Additionally hold the marker in a `useRef` — the cache it guards is
+   per-document, and one origin-wide localStorage key cannot describe several tabs.
+   Add an `INITIAL_SESSION` case so a cross-user cold load does not publish the new
+   user before the reset lands.
+4. Give `/new` the `if (!authLoading && !user) router.replace('/auth')` guard the
+   other surfaces have.
+
+**Tests:** the signOut-error path still resets and still navigates; an absent marker
+triggers the reset; a source assertion that no logout path uses
+`router.push`/`router.replace`. Update the existing nav-contract assertions in
+`landing-loop-contract.test.ts` and `new-workspace-page.test.ts` to assert the hard
+navigation — update them, do not delete them (G6).
+
+---
+
+## Task 5 — Extend `resetClientState()` to everything identity-bearing
+
+**Why:** `clearUserLocalStorage()` names seven keys; five have had no writer for
+months, and it names none of the fifteen persisted stores added since it was
+written. `resetClientState()` deletes from disk but resets only ONE in-memory zustand
+store — and because sign-out used to be a soft navigation, a surviving module
+re-persisted the key that was just deleted. Confirmed leaks include
+`kortix-browser-recents` (the last 8 URLs any user browsed in-app, rendered to the
+next user as a clickable list) and `kortix.impersonation`.
+
+**Files:** `apps/web/src/lib/utils/clear-local-storage.ts`,
+`apps/web/src/lib/utils/reset-client-state.ts`, plus a new test.
+
+**Changes:**
+1. Replace the literal delete-list with a PREFIX SWEEP over both `localStorage` and
+   `sessionStorage`: remove everything matching the app's own prefixes (`kortix-`,
+   `kortix.`, `kortix:`, `kortix_`, `opencode-`, `opencode_`, `files-view-mode`,
+   `files-sort-`) behind an explicit KEEP list for genuinely device-scoped values
+   (theme, sound preferences, notification permission). Delete the five dead entries.
+2. In `resetClientState()`, reset the IN-MEMORY state of every persisted zustand
+   store BEFORE the disk sweep, via one `PERSISTED_STORES` array of
+   `{ store, initialState }`, so a surviving module cannot re-persist.
+3. Add `clearImpersonationSession()` (already exported from `@kortix/sdk` — removing
+   the sessionStorage key alone is NOT enough, because `impersonation.ts` holds
+   `current`/`hydrated` at module scope), plus `clearAutoProjectSuppression()` and
+   `clearLastProjectId()`.
+4. `await` the IndexedDB clear properly so a navigation immediately after cannot
+   abort it.
+
+**Tests — this test is the point of the task:** walk `apps/web/src/stores/*.ts`,
+extract every `persist` `name:`, and FAIL when one is neither covered by the sweep
+nor on the KEEP list. A future store must not be able to opt out silently.
+
+---
+
+## Task 6 — Bind `kortix:suppress-auto-project` to its owner
+
+**Why:** symptom 5. Archiving your last workspace writes a bare `'1'` into
+sessionStorage. Nothing clears it on sign-out and the flag is process-wide, so the
+next user in that tab is told "Your last workspace is archived" instead of being
+auto-provisioned a first project.
+
+**Files:** `apps/web/src/lib/onboarding/ensure-first-project.ts`,
+`apps/web/src/app/(app)/projects/start/page.tsx`.
+
+**Changes:** store `{ accountId, at }` instead of `'1'`, and make
+`isAutoProjectSuppressed(accountId)` require a match — mirroring how the last-project
+cookie is bound to its owner. Task 5's sweep is the belt; this is the braces, and it
+holds even on a sign-out path that never runs the sweep (G4).
+
+**Tests:** suppression set by account A does not suppress for account B.
+
+---
+
+## Task 7 — Guard the auth-token cache against a stale write-back
+
+**Why:** `getSupabaseAccessToken()` commits `cachedToken = token` after an await with
+no generation check, and `setCachedAuthToken(null)` neither bumps a generation nor
+clears `inflight`. The audit verdict was PLAUSIBLE, not CONFIRMED — auth-js closes
+two of the three orderings that reach it — but it is a missing invariant on the
+token path and cheap to close.
+
+**Files:** `apps/web/src/lib/auth-token.ts`.
+
+**Changes:** add a monotonic `authEpoch`; bump it in `setCachedAuthToken` and
+`setBootstrapAuthToken`; capture it immediately before `inflight = fetchToken()`;
+discard the commit when the epoch changed. Null `inflight` on
+`setCachedAuthToken(null)` so piggybacking callers do not inherit a dead fetch.
+
+**Tests:** resolve a deferred `fetchToken` AFTER `setCachedAuthToken(null)` and
+assert the result is discarded and `null` returned.
+
+---
+
+## Task 8 — Cookie hardening
+
+**Why:** three independent cookie defects on the auth surface. The Supabase session
+cookie is written WITHOUT `Secure` and with a 400-day max-age on production HTTPS —
+`@supabase/ssr` never adds it (confirmed by grepping the installed package's
+`dist/`), and no `Strict-Transport-Security` header exists anywhere in `apps/web` to
+close the cleartext window.
+
+**Files:** `apps/web/src/lib/supabase/client.ts`, `apps/web/src/middleware.ts`,
+`apps/web/src/lib/supabase/server.ts`, `apps/web/next.config.ts`, plus the two
+privileged cookies.
+
+**Changes:**
+1. Add `secure` to all three `cookieOptions` sites:
+   `process.env.NODE_ENV === 'production'` server-side and
+   `window.location.protocol === 'https:'` client-side, mirroring
+   `last-project-cookie.ts`. Do NOT attempt `httpOnly` — `createBrowserClient`
+   requires JS read access.
+2. Add a `Strict-Transport-Security` header in `next.config.ts`.
+3. `kortix-maint-bypass` — an 8-hour privileged capability cookie with no user
+   binding and no clear path. Bind it to a user id and clear it in
+   `performSignOut()` (Task 4). NOTE: Task 5's storage sweep cannot reach cookies,
+   so this must be explicit.
+4. `__Secure-kortix_test_access` — the only `Domain`-scoped cookie in the repo, set
+   on `.kortix.com`, so dev's middleware writes a cookie that is sent to staging,
+   prod and `api.kortix.com`. Scope it to the host that sets it.
+
+NOTE: this task edits `middleware.ts`, which Task 3 also edits — different regions,
+but land Task 3 first.
+
+---
+
+## Task 9 — Server: decide the invited-user contract
+
+**Why:** symptoms 1 and 5, reachable with a perfectly clean browser and no
+client-state bug at all. `GET /v1/accounts` claims pending invites BEFORE deciding
+whether to bootstrap, and the bootstrap is skipped the moment any membership exists —
+so an invited user never receives a personal account, and the landing door resolves
+straight into the inviter's workspace. Meanwhile
+`apps/api/src/shared/resolve-account.ts` DOES bootstrap for a caller with no
+membership, so which behaviour you get depends purely on which route reaches the
+database first.
+
+**Files:** `apps/api/src/accounts/core/accounts.ts`.
+
+**Change (controller ruling R3):** bootstrap the personal account BEFORE claiming
+pending invites, so an invited user ends with both their own account and the org.
+Chosen over the alternative (keep today's behaviour, make the landing honest)
+because `resolve-account.ts` already bootstraps unconditionally for account-agnostic
+callers — bootstrapping first makes the two paths agree instead of introducing a
+third behaviour.
+
+**Tests:** an invite-first signup ends with two memberships — their own personal
+account and the inviter's org — and the landing door resolves into the personal one.
+
+---
+
+## Task 10 — SDK: put the user id in the query key   (`packages/sdk` — G5 applies IN FULL)
+
+**Why:** the structural cause behind symptoms 2 and 3. No identity-bearing query key
+carries the authenticated user: `['accounts']` is a bare literal in 19 call sites,
+and `qk` scopes by account, never by user. A stale entry is therefore merely
+UNLIKELY rather than UNREACHABLE, and the whole design depends on an imperative
+`queryClient.clear()` firing on every path, finishing before anything refetches, and
+never being undone. `queryClient.clear()` also leaves mounted observers attached,
+which immediately refetch.
+
+**RUNS LAST** — it touches call sites that Tasks 1, 2 and 4 rewrite.
+
+**Files:** `packages/sdk/src/react/query-keys.ts` and its exports; then the 19
+`['accounts']` call sites in `apps/web`.
+
+**Changes:**
+1. Thread `userId` through `qk.projects.scope()`, `qk.project.scope()` and every
+   member. `use-kortix-master.ts` already ships this shape — follow it exactly.
+2. Add `qk.accounts.list(userId)` and retire the bare `['accounts']` literal
+   everywhere, including the `invalidateQueries` call sites.
+3. Add `enabled: !!user` to the readers that lack it — at least `user-menu`,
+   `account-switcher`, `use-ensure-selected-account`, `account-memberships`,
+   `new-workspace-page`, `use-create-workspace`, `workspace-menu-section`, and
+   `accounts/settings/general-tab`.
+
+**This is the highest-risk task.** TDD is mandatory and non-negotiable. Adding an
+export requires three synchronized edits. Renaming an exported name INCLUDING A TYPE
+is a breaking change. Never hand-bump `version`. If the blast radius proves larger
+than this plan assumes, STOP and report rather than half-migrating — a partial key
+migration is worse than none, because two keyspaces for one resource is a cache
+correctness bug in its own right.

--- a/packages/sdk/src/react/query-keys.test.ts
+++ b/packages/sdk/src/react/query-keys.test.ts
@@ -1,3 +1,4 @@
+import { QueryClient } from '@tanstack/react-query';
 import { describe, expect, test } from 'bun:test';
 import { qk } from './query-keys';
 import { kortixKeys } from './use-kortix-master';
@@ -327,5 +328,124 @@ describe('qk.projects.scope', () => {
     expect(qk.projects.list().length).toBeGreaterThan(scope.length);
     expect(qk.projects.list()).not.toEqual(scope as never);
     expect(qk.projects.list('acct_1')).not.toEqual(scope as never);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════
+// qk.accounts — the ONE key family that is scoped by the signed-in USER
+// ═════════════════════════════════════════════════════════════════════════
+//
+// Every other family here partitions by ACCOUNT or by PROJECT. The account
+// LIST cannot: it is the answer to "which accounts does the caller belong
+// to", so the caller is the only thing that partitions it. Before this
+// family existed, 13 `apps/web` readers and 7 writers/invalidators shared
+// one bare `['accounts']` literal with no user segment, so a list fetched
+// for user A stayed readable, byte-for-byte, by user B on the same document
+// — and `/new` would then resolve a create target out of A's accounts and
+// POST it under B's JWT, which the API answers 403.
+//
+// The list CONTENTS cannot distinguish the two cases: a legitimate invited
+// admin (a user with no personal account who administers someone else's org)
+// produces a single `KortixAccount` whose `account_id !== user.id` — exactly
+// what a stale single-account list from another user produces. Only the KEY
+// the list was cached under carries the answer. Hence this family.
+describe('qk.accounts', () => {
+  test('the account list partitions by USER', () => {
+    expect(qk.accounts.list('user_a')).not.toEqual(qk.accounts.list('user_b') as never);
+  });
+
+  test("carries the user id as a segment — not merely a length that happens to differ", () => {
+    expect(qk.accounts.list('user_a')).toContain('user_a');
+    expect(qk.accounts.list('user_b')).not.toContain('user_a');
+  });
+
+  // Fail closed (G2): a reader whose user id is not known yet must not land
+  // on ANY signed-in user's entry. It gets its own dead slot instead, which
+  // nothing ever writes because every reader is `enabled: !!user`.
+  test('an unknown user gets its own slot, never a signed-in user\'s', () => {
+    const anon = qk.accounts.list(undefined);
+    expect(anon).not.toEqual(qk.accounts.list('user_a') as never);
+    expect(anon).not.toEqual(qk.accounts.list('user_b') as never);
+    expect(startsWith(qk.accounts.list('user_a'), anon)).toBe(false);
+    expect(startsWith(anon, qk.accounts.list('user_a'))).toBe(false);
+  });
+
+  // `scope()` is the invalidation prefix. Every invalidator ("this account
+  // changed") uses it, so it must reach every user's slot — a mutation
+  // callback has no reliable user id in hand, and picking the wrong one
+  // would leave the live reader stale.
+  test('scope() is a strict prefix of every user list', () => {
+    const scope = qk.accounts.scope();
+    expect(startsWith(qk.accounts.list('user_a'), scope)).toBe(true);
+    expect(startsWith(qk.accounts.list('user_b'), scope)).toBe(true);
+    expect(startsWith(qk.accounts.list(undefined), scope)).toBe(true);
+  });
+
+  test('scope() is a strict prefix, never a key itself', () => {
+    const scope = qk.accounts.scope();
+    expect(qk.accounts.list('user_a').length).toBeGreaterThan(scope.length);
+    expect(qk.accounts.list('user_a')).not.toEqual(scope as never);
+  });
+
+  // The account family must not prefix-match, or be prefix-matched by, the
+  // project families — `invalidateQueries({ queryKey: qk.projects.scope() })`
+  // fires on every account create and must not blow away the account list,
+  // and `qk.accounts.scope()` must not reach a project key.
+  test('is disjoint from the project families and from kortixKeys', () => {
+    const accountKeys = [
+      qk.accounts.scope(),
+      qk.accounts.list('user_a'),
+      qk.accounts.list(undefined),
+    ];
+    const others = [
+      qk.projects.scope(),
+      qk.projects.list(),
+      qk.projects.list('user_a'),
+      qk.project.scope('user_a'),
+      kortixKeys.projects(),
+      kortixKeys.project('user_a'),
+    ];
+    for (const a of accountKeys) {
+      for (const o of others) {
+        expect(startsWith(a, o)).toBe(false);
+        expect(startsWith(o, a)).toBe(false);
+      }
+    }
+  });
+});
+
+// The defect this family closes, asserted against a REAL QueryClient rather
+// than against the key arrays alone: key equality is React Query's, not
+// ours, so the proof has to go through its cache.
+describe('qk.accounts — a real cache cannot serve one user another user\'s list', () => {
+  const listA = [{ account_id: 'acct_owned_by_a', name: "a's Account" }];
+
+  test("user B reads undefined from an entry written for user A", () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(qk.accounts.list('user_a'), listA);
+
+    expect(client.getQueryData<typeof listA>(qk.accounts.list('user_a'))).toEqual(listA);
+    expect(client.getQueryData(qk.accounts.list('user_b'))).toBeUndefined();
+    // ...and neither does a reader whose identity has not resolved yet.
+    expect(client.getQueryData(qk.accounts.list(undefined))).toBeUndefined();
+  });
+
+  test("invalidating scope() reaches the entry written for a specific user", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(qk.accounts.list('user_a'), listA);
+    expect(client.getQueryState(qk.accounts.list('user_a'))?.isInvalidated).toBe(false);
+
+    await client.invalidateQueries({ queryKey: qk.accounts.scope() });
+
+    expect(client.getQueryState(qk.accounts.list('user_a'))?.isInvalidated).toBe(true);
+  });
+
+  test("invalidating the PROJECT scope does not touch the account list", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    client.setQueryData(qk.accounts.list('user_a'), listA);
+
+    await client.invalidateQueries({ queryKey: qk.projects.scope() });
+
+    expect(client.getQueryState(qk.accounts.list('user_a'))?.isInvalidated).toBe(false);
   });
 });

--- a/packages/sdk/src/react/query-keys.ts
+++ b/packages/sdk/src/react/query-keys.ts
@@ -52,6 +52,76 @@
  * can ever prefix-match the other. Do not "tidy" this back to `'kortix'`.
  */
 export const qk = {
+  /**
+   * The account LIST — `listAccounts()`, `GET /accounts`, `KortixAccount[]`.
+   *
+   * The ONLY family here keyed by the signed-in USER rather than by an
+   * account or a project, and the only one that could not be keyed any other
+   * way: this list is the answer to "which accounts does the CALLER belong
+   * to", so the caller is the only thing that partitions it.
+   *
+   * ## Why the user segment is load-bearing, not tidiness
+   *
+   * Before this family existed, 13 `apps/web` readers and 7 writers /
+   * invalidators shared one bare `['accounts']` array literal with no user
+   * segment. One document that saw two users in its lifetime therefore held
+   * ONE cache entry for both, and nothing but an imperative
+   * `queryClient.clear()` on the sign-out path stood between user B and user
+   * A's list. `clear()` is the wrong shape for that job — it has to fire on
+   * every exit path, finish before anything refetches, and never be undone,
+   * and it leaves mounted observers attached, which immediately refetch.
+   *
+   * The failure that escaped through that gap: `/new` resolves its create
+   * target out of this list, so a leftover single-account list belonging to
+   * user A made `POST /projects/provision` go out with A's `account_id`
+   * under B's JWT — a 403 the user cannot act on.
+   *
+   * That instance could not be closed by inspecting the list CONTENTS. A
+   * legitimate invited admin — a user with no personal account who
+   * administers someone else's org — has a byte-identical input: one
+   * `KortixAccount` whose `account_id !== user.id`, whose `name` is
+   * `"<owner-email>'s Account"`, and whose `is_primary_owner` is merely
+   * `accountRole === 'owner'`. No field on the response answers "which user
+   * was this fetched FOR". Rejecting that shape would permanently lock that
+   * population out of creating any workspace. Only the KEY carries the
+   * answer — which is why it is here, and why `list` takes the user id as a
+   * REQUIRED argument (see below).
+   */
+  accounts: {
+    /**
+     * Invalidation prefix covering EVERY user's list. Never pass this as a
+     * `queryKey`.
+     *
+     * This is the correct target for every "an account changed" invalidation
+     * (rename, create, leave, branding write): those all run inside a
+     * mutation callback, which has no reliable signed-in user id in hand,
+     * and guessing the wrong one would leave the live reader stale while
+     * appearing to work. `list(userId)` nests directly under this, so one
+     * prefix call provably reaches the only slot that can be live.
+     */
+    scope: () => ['kx', 'accounts'] as const,
+
+    /**
+     * One user's account list.
+     *
+     * `userId` is REQUIRED — deliberately not optional. Omitting it is the
+     * exact bug this family exists to make unrepresentable, so it has to be
+     * a type error rather than a silently shared slot. `null`/`undefined`
+     * are still accepted, because a reader legitimately renders for one
+     * paint before `useAuth()` resolves; they route to a dedicated
+     * `'anonymous'` slot that is not, and cannot prefix-match, any signed-in
+     * user's entry. Nothing ever writes that slot: every reader is gated
+     * `enabled: !!user`, so an identity-less reader fails CLOSED (it sees
+     * `undefined`) instead of falling back to whoever was here last.
+     *
+     * `'anonymous'` matches `use-kortix-master.ts`'s existing convention for
+     * the same situation (`identity.userId ?? 'anonymous'`), so the two
+     * identity-bearing key families in this package spell it one way.
+     */
+    list: (userId: string | null | undefined) =>
+      [...qk.accounts.scope(), userId ?? 'anonymous'] as const,
+  },
+
   projects: {
     /** Invalidation prefix covering every account's list AND the accountless
      *  slot. Never pass this as a `queryKey` — `list(accountId)` and


### PR DESCRIPTION
Logging out of one Kortix account and into another on the same browser left the
first user's identity reachable. This closes it, plus four adjacent defects the
audit turned up on the same surface.

## The reported symptoms, and what closes each

| Symptom | Closed by |
| --- | --- |
| Signing in as B lands in A's workspace | `middleware.ts` now attributes its `?redirect=` bounce with an owner (`kortix_auth_bounce`), and `shouldDemoteReturnUrl` drops a foreign path at **all five** sign-in exits — password, email code, magic link, OAuth/SSO, and the sign-up form. `/auth` leaves by hard navigation so the raw query param can no longer supersede the gated destination. |
| `/new` shows the previous user's email | The identity slot renders the authenticated `user.email` unconditionally. `filterCreatableAccounts` no longer strips `'s Account` from an account name, which is what turned `"a@x.com's Account"` into a bare address in the slot reserved for "you are signed in as". |
| "You need access to this project" when creating | `/new` resolves its create-target by identity (`account_id === user.id`) instead of two dead string comparisons that could never match the real API shape. A foreign account list blocks submit and now says why. |
| Two paid accounts collide | Every guard on the return-URL path was spelled `isNewUser ? guard : raw`. A second account you already own is an *existing* user — exactly the population the guard excluded. |
| A genuinely-new user misses the first-run flow | `kortix:suppress-auto-project` is bound to `{accountId, at}` and checked against the account resolution actually evaluates, so one account's archived workspace can no longer suppress another's first run. |

## Also fixed on the same surface

- **Sign-out could silently not sign you out.** `supabase.auth.signOut()` issues a network POST for every scope, including `'local'`, and returns before `_removeSession()` on any error that is not 404/401/403. Offline or a 5xx left the session alive, and `/auth` then bounced the user back into the app. Sign-out now expires the auth cookie directly.
- **Five of six logout controls never revoked server-side.** The API verifies the Supabase JWT locally via JWKS, so `signOut()` revokes only the refresh token; the access token stayed valid until expiry. All six controls now call the revoke endpoint.
- **Sign-out could hang forever.** `openDB()` has no `onblocked` handler and `DB_VERSION` has been bumped twice, so a tab on an older bundle could block a resume indefinitely and `leave()` was never reached. Every pre-navigation await is now bounded; worst case is 8.0s and the three bare controls show a pending state.
- **One customer's in-app browsing history was shown to the next.** `clearUserLocalStorage()` named seven keys, five of them dead, and none of the fifteen persisted stores added since. It is a prefix sweep with an explicit keep-list, and a test walks the stores directory so a new store cannot opt out silently.
- **The Supabase session cookie shipped without `Secure`** on production HTTPS with a 400-day lifetime. Added at all four cookie sites, plus HSTS.
- **Server:** `GET /v1/accounts` and `/v1/accounts/me` bootstrap the personal account *before* claiming pending invites, so an invite-first signup no longer lands in a stranger's workspace on first login.

## Structural change

`['accounts']` was a bare literal across 20 call sites and the SDK's `qk` factory scoped by account, never by user — so a stale entry was merely unlikely, not unreachable. It is now `qk.accounts.list(userId)`, with an eslint rule and a default-deny test that walks `apps/web/src`. Threading the same user id through `qk.project*` measured 661 call sites across 145 files and is deliberately left for its own change; a partial key migration is worse than none.

## Test plan

Verified on the branch tip, each with the package's own command:

- `apps/web` — `bun test --isolate --parallel=4` -> **9010 pass / 1 fail**. The one failure is the pre-existing `content timestamp manifest` check, also failing on `main`.
- `packages/sdk` — `bun run test` (one file per process) -> **2769 pass / 0 fail**.
- `apps/api` — `bun run test` -> **8579 pass / 79 skip / 0 fail**.
- `npx tsc --noEmit` on `apps/web` -> the 17 documented baseline errors, no new ones.
- `npx eslint` on all changed files -> 0 errors.

Every assertion added or rewritten was mutation-proven: the guarded behaviour was broken, the test watched to fail, and the failure recorded. This was not optional — **eight assertions on this branch turned out to be unable to fail**, and every one was caught by breaking the code rather than by a green suite. One of them was guarding this branch's own stated latency ceiling by adding three constants together.

## Not verified

No browser or `next build` run. The cookie expiry, the `beforeunload` interaction and a real blocked IndexedDB upgrade are argued from source and pinned against injected steps. Worth one manual pass: sign in as a single-account user, sign out, sign in as a second user, open `/new`, and confirm you see your own email and a successful create.

## Known follow-ups

- `isForeignAccountList`'s only remaining trigger is a legitimate user with no personal account who administers two or more orgs. It now explains itself rather than presenting a dead form, but the predicate should probably relax now that the key is user-scoped.
- SAML JIT provisioning and direct invite acceptance still bypass the bootstrap gate; this change closed two of the four routes.
- The SDK's `openDB()` still needs `onblocked`/`onversionchange`. The app survives a blocked upgrade; the underlying defect remains.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790771558&installation_model_id=434224&pr_number=7065&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7065&signature=e2e379e959640569bd44f6f6922e7e22f3ecd39f7ea9046b46bfc6612e71dea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->