### PR TITLE
fix(gateway): drop gpt-5.6-sol from the ChatGPT codex lineup

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -101,13 +101,15 @@ describe('gatewayModelCatalog — served catalog', () => {
   });
 
   test('project catalog advertises the GPT-5.6 Codex family', () => {
-    expect(full['codex/gpt-5.6-sol']).toMatchObject({
-      name: 'GPT-5.6 Sol (ChatGPT)',
+    expect(full['codex/gpt-5.6-luna']).toMatchObject({
+      name: 'GPT-5.6 Luna (ChatGPT)',
       reasoning: true,
       tool_call: true,
     });
     expect(full['codex/gpt-5.6-terra']).toBeDefined();
-    expect(full['codex/gpt-5.6-luna']).toBeDefined();
+    // gpt-5.6-sol is not a ChatGPT-account model (upstream 400), so it must not
+    // be advertised under the codex subscription route.
+    expect(full['codex/gpt-5.6-sol']).toBeUndefined();
   });
 
   test('native OpenCode Zen free models are not served by the gateway catalog', () => {
@@ -140,7 +142,7 @@ describe('gatewayModelCatalog — served catalog', () => {
     expect(full['glm-5.3-flash']?.provider).toBe('kortix');
     // Codex (ChatGPT subscription) models brand as their own `codex` provider,
     // distinct from the raw `openai` BYOK provider.
-    expect(full['codex/gpt-5.6-sol']?.provider).toBe('codex');
+    expect(full['codex/gpt-5.6-luna']?.provider).toBe('codex');
 
     const missingProvider = Object.entries(full)
       .filter(([, m]) => typeof m.provider !== 'string' || m.provider.length === 0)
@@ -162,7 +164,7 @@ describe('gatewayModelCatalog — served catalog', () => {
 
     // Codex models carry the same enriched field set (previously hand-built
     // without reasoning_options/cost/modalities/structured_output/knowledge).
-    const codexModel = full['codex/gpt-5.6-sol'];
+    const codexModel = full['codex/gpt-5.6-luna'];
     expect(codexModel?.reasoning_options?.[0]?.values).toContain('xhigh');
   });
 
@@ -228,7 +230,7 @@ describe('catalogModelForWireModel — generation-controls capability lookup', (
   });
 
   test('resolves a codex/<id> wire model via the underlying openai/<id> catalog entry', () => {
-    const model = catalogModelForWireModel('codex/gpt-5.6-sol');
+    const model = catalogModelForWireModel('codex/gpt-5.6-luna');
     expect(model?.reasoning).toBe(true);
     expect(model?.temperature).toBe(false);
   });

--- a/apps/api/src/llm-gateway/models/codex-models.ts
+++ b/apps/api/src/llm-gateway/models/codex-models.ts
@@ -1,7 +1,12 @@
 export const CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON';
 
+// Note: `gpt-5.6-sol` is intentionally NOT served here. The ChatGPT Codex
+// subscription rejects it with `400: "The 'gpt-5.6-sol' model is not supported
+// when using Codex with a ChatGPT account"` (it is an OpenAI-API-only variant,
+// not a ChatGPT-account model). Advertising it under `codex/<id>` caused every
+// request for it to fail (14/32 errors over 7d, 0 tokens served) and broke the
+// cron triggers pinned to it.
 const DEFAULT_CODEX_MODEL_IDS = [
-  'gpt-5.6-sol',
   'gpt-5.6-terra',
   'gpt-5.6-luna',
   'gpt-5.5',


### PR DESCRIPTION
## Why

The ChatGPT Codex subscription account does not serve `gpt-5.6-sol` — it returns
`400: "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account"`.
Yet it was advertised under `codex/gpt-5.6-sol` and pinned by the `error-sweep`,
`drata-compliance-sweep`, and `competitor-intelligence-digest` cron triggers.

Evidence from the 2026-08-31 Luna heartbeat incident + gateway usage:
- `codex/gpt-5.6-sol`: 32 requests / 14 errors / **0 tokens served** over 7 days.
- `codex/gpt-5.6-luna` and `codex/gpt-5.6-terra`: 0 errors, tokens served normally.

## What changed

- Remove `gpt-5.6-sol` from `DEFAULT_CODEX_MODEL_IDS` (ChatGPT codex route). `gpt-5.6-luna`,
  `gpt-5.6-terra`, `gpt-5.5`, `gpt-5.4` remain.
- Update the catalog test to assert `codex/gpt-5.6-sol` is no longer served, and
  use `codex/gpt-5.6-luna` as the representative codex model in the other assertions.

## Verification

- `bun test --env-file=scripts/test.env src/llm-gateway/models/catalog-models.test.ts` → 24 pass, 0 fail.
- `bun test --env-file=scripts/test.env src/llm-gateway/models/picker.test.ts` → 13 pass, 0 fail.

## Risk / rollback

Low. Removes only a model that was already failing 100% of requests. Cron triggers
that were pinned to `codex/gpt-5.6-sol` are re-pinned to a supported model in the
company repo `kortix.yaml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790813150&installation_model_id=434224&pr_number=7071&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7071&signature=9901fbaec1ae2cc63311882c40b4305360494a38ea4abf340da35c123ba5b4b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->