### PR TITLE
revert(gateway): restore gpt-5.6-sol to the codex lineup

### DIFF
--- a/apps/api/src/llm-gateway/models/catalog-models.test.ts
+++ b/apps/api/src/llm-gateway/models/catalog-models.test.ts
@@ -101,15 +101,13 @@ describe('gatewayModelCatalog — served catalog', () => {
   });
 
   test('project catalog advertises the GPT-5.6 Codex family', () => {
-    expect(full['codex/gpt-5.6-luna']).toMatchObject({
-      name: 'GPT-5.6 Luna (ChatGPT)',
+    expect(full['codex/gpt-5.6-sol']).toMatchObject({
+      name: 'GPT-5.6 Sol (ChatGPT)',
       reasoning: true,
       tool_call: true,
     });
     expect(full['codex/gpt-5.6-terra']).toBeDefined();
-    // gpt-5.6-sol is not a ChatGPT-account model (upstream 400), so it must not
-    // be advertised under the codex subscription route.
-    expect(full['codex/gpt-5.6-sol']).toBeUndefined();
+    expect(full['codex/gpt-5.6-luna']).toBeDefined();
   });
 
   test('native OpenCode Zen free models are not served by the gateway catalog', () => {
@@ -142,7 +140,7 @@ describe('gatewayModelCatalog — served catalog', () => {
     expect(full['glm-5.3-flash']?.provider).toBe('kortix');
     // Codex (ChatGPT subscription) models brand as their own `codex` provider,
     // distinct from the raw `openai` BYOK provider.
-    expect(full['codex/gpt-5.6-luna']?.provider).toBe('codex');
+    expect(full['codex/gpt-5.6-sol']?.provider).toBe('codex');
 
     const missingProvider = Object.entries(full)
       .filter(([, m]) => typeof m.provider !== 'string' || m.provider.length === 0)
@@ -164,7 +162,7 @@ describe('gatewayModelCatalog — served catalog', () => {
 
     // Codex models carry the same enriched field set (previously hand-built
     // without reasoning_options/cost/modalities/structured_output/knowledge).
-    const codexModel = full['codex/gpt-5.6-luna'];
+    const codexModel = full['codex/gpt-5.6-sol'];
     expect(codexModel?.reasoning_options?.[0]?.values).toContain('xhigh');
   });
 
@@ -230,7 +228,7 @@ describe('catalogModelForWireModel — generation-controls capability lookup', (
   });
 
   test('resolves a codex/<id> wire model via the underlying openai/<id> catalog entry', () => {
-    const model = catalogModelForWireModel('codex/gpt-5.6-luna');
+    const model = catalogModelForWireModel('codex/gpt-5.6-sol');
     expect(model?.reasoning).toBe(true);
     expect(model?.temperature).toBe(false);
   });

--- a/apps/api/src/llm-gateway/models/codex-models.ts
+++ b/apps/api/src/llm-gateway/models/codex-models.ts
@@ -1,12 +1,7 @@
 export const CODEX_AUTH_SECRET_NAME = 'CODEX_AUTH_JSON';
 
-// Note: `gpt-5.6-sol` is intentionally NOT served here. The ChatGPT Codex
-// subscription rejects it with `400: "The 'gpt-5.6-sol' model is not supported
-// when using Codex with a ChatGPT account"` (it is an OpenAI-API-only variant,
-// not a ChatGPT-account model). Advertising it under `codex/<id>` caused every
-// request for it to fail (14/32 errors over 7d, 0 tokens served) and broke the
-// cron triggers pinned to it.
 const DEFAULT_CODEX_MODEL_IDS = [
+  'gpt-5.6-sol',
   'gpt-5.6-terra',
   'gpt-5.6-luna',
   'gpt-5.5',


### PR DESCRIPTION
## Demo
Non-visual change — gateway model catalog revert; no screen recording applies.

## Why
PR #7071 removed `gpt-5.6-sol` from the ChatGPT codex lineup on the assumption it was unsupported. That was wrong: the 502/400 was only because the single ChatGPT-subscription account being used didn't have access to `gpt-5.6-sol`. Other codex accounts DO have access, so the model must stay in the lineup.

## What changed
Reverts #7071 (merge `f8279998f`) — restores `gpt-5.6-sol` to `DEFAULT_CODEX_MODEL_IDS` and reverts the test assertions.

## Verification
`git revert -m 1 f8279998f` — `gpt-5.6-sol` is back in `DEFAULT_CODEX_MODEL_IDS`; catalog tests restored to assert `codex/gpt-5.6-sol`.

## Risk / rollback
None — pure revert to the pre-#7071 state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858766&installation_model_id=434224&pr_number=7075&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7075&signature=9bb6c5839f03244da982c18c5bd2152ca971fa57d2135c65cfb888801102bb3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->