### PR TITLE
chore(secrets): report file-only exceptions that excuse nothing, and drop four

### DIFF
--- a/scripts/secrets-file-only.allowlist
+++ b/scripts/secrets-file-only.allowlist
@@ -20,13 +20,9 @@ CLOUDFLARE_ZONE_NAME           terraform / preview-edge scripts
 TF_VAR_cloudflare_api_token    terraform input
 TF_VAR_cloudflare_zone_id      terraform input
 PORT                           local listen port
-KORTIX_PREVIEW_BASE_DOMAIN     dev file only; deployed dev gets it from the task definition — verify with secrets-sm-parity.py check --ecs
 BETTERSTACK_API_TOKEN          prod file only: owner record, terraform input
 BETTERSTACK_CLICKHOUSE_HOST    prod file only: owner record, terraform input
 BETTERSTACK_CLICKHOUSE_USERNAME prod file only: owner record, terraform input
 BETTERSTACK_CLICKHOUSE_PASSWORD prod file only: owner record, terraform input
 BETTERSTACK_MCP_URL            prod file only: owner record, terraform input
 BETTERSTACK_TELEMETRY_API_TOKEN prod file only: owner record, terraform input
-JUSTAVPS_API_KEY               prod file only: owner record, terraform input
-JUSTAVPS_API_URL               prod file only: owner record, terraform input
-JUSTAVPS_PROXY_DOMAIN          prod file only: owner record, terraform input

--- a/scripts/secrets-sm-parity.py
+++ b/scripts/secrets-sm-parity.py
@@ -105,6 +105,7 @@ def compare(env: str):
 
 def check(envs) -> int:
     allow = file_only_allow()
+    used: set[str] = set()
     failed = False
     quar = {**quarantined(), **excluded()}
     for env in envs:
@@ -118,6 +119,16 @@ def check(envs) -> int:
         for k in missing: print(f"    missing in file : {k}")
         for k in differ:  print(f"    differs         : {k}")
         for k in unlisted_extra: print(f"    file-only, not in scripts/secrets-file-only.allowlist : {k}")
+        used.update(k for k in extra if k in allow)
+
+    # An entry that excused nothing is stale — the key now mirrors normally, or
+    # it is gone. Report it rather than let the exception list quietly grow into
+    # a place where a genuine drift can hide. Informational: a stale line is
+    # untidy, not unsafe, and failing on it would block work for no gain.
+    stale = sorted(set(allow) - used)
+    if stale:
+        print(f"\n  note: {len(stale)} file-only entries excused nothing this run — remove them "
+              f"if the key now mirrors into Secrets Manager: {', '.join(stale)}")
     return 1 if failed else 0
 
 


### PR DESCRIPTION
Full audit of the four profiles against the three Secrets Manager blobs, prompted by "make sure they are on par entirely".

## The answer: they already are

```
dev      missing-in-file=0 differ=0 file-only=17 (unlisted 0) quarantined=6 leaked=0
staging  missing-in-file=0 differ=0 file-only=16 (unlisted 0) quarantined=6 leaked=0
prod     missing-in-file=0 differ=0 file-only=23 (unlisted 0) quarantined=0 leaked=0
```

I also checked the thing the gate cannot check for itself: whether each **quarantined** key is *still* prod-identical, since that equality is the only reason to hold one out of a shared profile. All six still are — none has quietly become safe to mirror.

## What was actually wrong: the exception list

Four keys were excused as file-only while being compared anyway:

| key | reality |
|---|---|
| `JUSTAVPS_API_KEY`, `_API_URL`, `_PROXY_DOMAIN` | in the prod profile **and** the prod blob — they mirror normally |
| `KORTIX_PREVIEW_BASE_DOMAIN` | supplied by the API task definition, which the checker already merges in |

Harmless individually. The reason to care is that an exception list nobody prunes is exactly where a real drift later gets waved through.

So `check` now reports entries that excused nothing on a run. It **reports rather than fails** — a leftover line is sloppy, not unsafe, and failing on it would block work for no gain. Removing the three JUSTAVPS lines ran straight into that new report, which is how `KORTIX_PREVIEW_BASE_DOMAIN` surfaced.

## Verified
`pnpm test:envs --sm` → all three green, separation `0 unallowed`, no stale exceptions remaining.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790874003&installation_model_id=434224&pr_number=7078&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7078&signature=0b005ba1f9b153c7acfba443193bd822433b085bc4e804d101915af396f6e151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->