### PR TITLE
Throw confetti only for a chosen icon, never for the initial

### DIFF
--- a/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
+++ b/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
@@ -5,6 +5,7 @@ import { useState, type ReactNode } from 'react';
 
 import { IdentityConfetti } from '@/components/ui/identity-confetti';
 import { SessionWelcome } from '@/features/session/session-welcome';
+import { resolveConfettiFace } from '@/lib/confetti-identity';
 import { useProjectIcon, useProjectName } from '@kortix/sdk/react';
 import { ProjectHomeSections } from './project-home-sections';
 import { StarterPromptBand } from './starter-prompt-band';
@@ -58,6 +59,12 @@ import { StarterPromptBand } from './starter-prompt-band';
  * of the word itself. It is the one playful thing on this screen, and it is
  * deliberately silent at rest — see the button's own comment for why it carries
  * no hover treatment.
+ *
+ * ONLY when the workspace wears an icon someone picked — an emoji or a glyph.
+ * With neither, `resolveConfettiFace` degrades to the chalk initial tile, and
+ * throwing thirty-eight copies of the letter already sitting in the heading is
+ * not a celebration. Those workspaces render the name as plain text, so there
+ * is no pointer and no tooltip offering a payoff that would fall flat.
  */
 export function ProjectHomeWelcomeBody({
   projectId,
@@ -77,6 +84,16 @@ export function ProjectHomeWelcomeBody({
   // the name in this heading and the icon thrown out of it cannot come from
   // two caches that have diverged — and it costs no extra request.
   const icon = useProjectIcon(projectId);
+  // Only an icon someone CHOSE is worth throwing. `resolveConfettiFace` falls
+  // through to the chalk initial tile when a project has neither emoji nor
+  // glyph, and a burst of the same letter the heading is already showing reads
+  // as noise, not as a celebration. Those projects get plain text instead — no
+  // pointer, no tooltip promising a payoff that would not land. Gated on the
+  // resolver rather than on `icon?.icon` so this can never disagree with the
+  // face `EntityAvatar` draws, including the unknown-glyph fall-through.
+  const wearsChosenIcon =
+    resolveConfettiFace({ glyph: icon?.icon_glyph, emoji: icon?.icon, label: name }).kind !==
+    'initial';
   // `id` is the remount key: `IdentityConfetti` fires on mount, so a second
   // press needs a second mount. `origin` is captured per press rather than
   // fixed, because the word moves — the heading rewraps with the viewport and
@@ -154,27 +171,33 @@ export function ProjectHomeWelcomeBody({
               noise on every load for a control nobody needs to find. The
               pointer cursor and the tooltip are the whole invitation.
             */}
-            <button
-              type="button"
-              title="Throw some confetti"
-              onClick={(event) => {
-                const rect = event.currentTarget.getBoundingClientRect();
-                setBurst((current) => ({
-                  id: (current?.id ?? 0) + 1,
-                  // Canvas fractions, measured against the viewport, because
-                  // the confetti canvas is portalled to <body> at `fixed
-                  // inset-0`. Centre of the word, so the burst comes out of the
-                  // name rather than from somewhere near it.
-                  origin: {
-                    x: (rect.left + rect.width / 2) / window.innerWidth,
-                    y: (rect.top + rect.height / 2) / window.innerHeight,
-                  },
-                }));
-              }}
-              className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
-            >
-              {displayName}
-            </button>{' '}
+            {wearsChosenIcon ? (
+              <button
+                type="button"
+                title="Throw some confetti"
+                onClick={(event) => {
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  setBurst((current) => ({
+                    id: (current?.id ?? 0) + 1,
+                    // Canvas fractions, measured against the viewport, because
+                    // the confetti canvas is portalled to <body> at `fixed
+                    // inset-0`. Centre of the word, so the burst comes out of
+                    // the name rather than from somewhere near it.
+                    origin: {
+                      x: (rect.left + rect.width / 2) / window.innerWidth,
+                      y: (rect.top + rect.height / 2) / window.innerHeight,
+                    },
+                  }));
+                }}
+                className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+              >
+                {displayName}
+              </button>
+            ) : (
+              // Same colour, no affordance: the name still carries the
+              // sentence's one highlight, it just is not pressable.
+              <span className="text-foreground">{displayName}</span>
+            )}{' '}
             {tI18nHardcoded.raw(
               'autoFeaturesCoWorkerProjectLayoutProjectHomeJsxTextSomething18ab9904',
             )}


### PR DESCRIPTION
## Summary

The workspace name in the project-home heading is a button that throws confetti made of that workspace's own icon. When a workspace has neither an emoji nor a glyph, `resolveConfettiFace` falls through to the chalk initial tile, so pressing it threw 38 copies of the same letter already sitting in the heading.

- Gate the button on `resolveConfettiFace({ glyph, emoji, label }).kind !== 'initial'`. Emoji and glyph workspaces are unchanged; letter-only workspaces no longer burst.
- Render the name as a plain `<span className="text-foreground">` in that case, so there is no pointer cursor and no "Throw some confetti" tooltip promising a payoff that would not land. The sentence and its one highlight are byte-identical.
- Gating on the resolver rather than on `icon?.icon` keeps this in step with the face `EntityAvatar` draws, including the unknown-glyph fall-through.

One file: `apps/web/src/features/workspace/project-layout/home/welcome-body.tsx`.

## Test plan

- `npx tsc --noEmit -p tsconfig.json` in `apps/web` — clean.
- `npx eslint src/features/workspace/project-layout/home/welcome-body.tsx` — clean.
- `npx prettier --check` on the file — passes.
- Manual: open a project whose icon is an emoji, press the name, confetti of that emoji. Open a project with no icon set, press the name — nothing happens and there is no pointer cursor on the name.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790880482&installation_model_id=434224&pr_number=7079&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7079&signature=80370ee281a67dd409317990288398b841c41f580c89df1c73d143e799e0a145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->