### PR TITLE
perf(sandbox): reuse the on-disk checkout on repeat boots instead of re-downloading

### DIFF
--- a/apps/kortix-sandbox-agent-server/scripts/bench-materialize.ts
+++ b/apps/kortix-sandbox-agent-server/scripts/bench-materialize.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env bun
+/**
+ * Boot-latency benchmark for `materializeRepo` — the real function, across
+ * every disk state a session can start from.
+ *
+ * Not a test (the behaviour is pinned by src/__tests__/materialize-reuse.test.ts).
+ * This exists to answer "how much did that cost" with numbers, and to re-check
+ * the answer after a change to the materialization tiers.
+ *
+ *   bun scripts/bench-materialize.ts
+ *   bun scripts/bench-materialize.ts --runs=5 --behind=20
+ *   BENCH_REPOS=/path/a.git,/path/b.git bun scripts/bench-materialize.ts
+ *
+ * Synthetic origins by default, so it runs anywhere. `BENCH_REPOS` points it at
+ * real bare mirrors instead (`git clone --bare <url> <dir>`), which is the only
+ * way to see how the tiers behave on real history and real tree sizes.
+ *
+ * ── THREE MEASUREMENT TRAPS, all three of which faked a result once ─────────
+ *
+ * 1. `git clone /abs/path` IGNORES `--depth` ("warning: --depth is ignored in
+ *    local clones") and HARDLINKS the object database instead of transferring
+ *    it. A ~1 GB repo "cloned" in 1.2 s and reported a 977 MiB depth-1 pack; the
+ *    real depth-1 pack is 413 MiB. Every origin here is a `file://` URL.
+ *
+ * 2. `git reset --hard HEAD~N` does NOT delete objects, so a checkout staled
+ *    that way still holds the tip and any reuse path trivially reports "already
+ *    at tip, 0 bytes". Staleness is seeded as a real `--depth 1` clone of an
+ *    older commit.
+ *
+ * 3. Attributing "bytes transferred" from the resulting object store bills the
+ *    warm and reuse paths for objects that were already on disk. The tier is
+ *    read from the daemon's own log lines and only a wipe is charged for its
+ *    whole store.
+ */
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { randomBytes } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadConfig } from '../src/config'
+import { __setScaffoldRepoPathForTests, materializeRepo } from '../src/git'
+
+const numArg = (name: string, fallback: number) =>
+  Number(process.argv.find((a) => a.startsWith(`--${name}=`))?.split('=')[1] ?? fallback)
+const RUNS = numArg('runs', 3)
+const BEHIND = numArg('behind', 5)
+
+const PINNED = {
+  GIT_AUTHOR_NAME: 'Kortix',
+  GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+  GIT_COMMITTER_NAME: 'Kortix',
+  GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+}
+const git = (cwd: string, ...a: string[]) =>
+  execFileSync('git', a, { cwd, env: { ...process.env, ...PINNED }, encoding: 'utf8', maxBuffer: 1 << 26 }).trim()
+const gitQuiet = (cwd: string, ...a: string[]) =>
+  execFileSync('git', a, { cwd, env: { ...process.env, ...PINNED }, stdio: 'ignore', maxBuffer: 1 << 26 })
+
+function objectBytes(target: string): number {
+  const dir = join(target, '.git', 'objects')
+  if (!existsSync(dir)) return 0
+  return Number(execFileSync('du', ['-sk', dir], { encoding: 'utf8' }).split(/\s+/)[0]) * 1024
+}
+const median = (xs: number[]) => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)] ?? 0
+const mib = (b: number) => `${(b / 1048576).toFixed(1)}M`
+
+const scratch = mkdtempSync(join(tmpdir(), 'kortix-bench-materialize-'))
+const NO_SCAFFOLD = join(scratch, 'absent-scaffold.git')
+
+/** Which tier ran — read from the daemon's own log lines, never assumed. */
+const TIERS: [RegExp, string][] = [
+  [/using baked repo checkout \(warm\)/, 'warm'],
+  [/reusing the on-disk checkout/, 'REUSE-delta'],
+  [/zero-network: baked scaffold/, 'scaffold-zero'],
+  [/zero-network: API delta bundle/, 'scaffold-inline'],
+  [/one request: remote API delta bundle/, 'scaffold-remote'],
+  [/via scaffold delta-fetch/, 'scaffold-fetch'],
+  [/\[git\] cloning repo/, 'WIPE+clone'],
+]
+
+interface Cell { ms: number; bytes: number; tier: string; fail?: string }
+
+async function once(
+  target: string, repoUrl: string, branch: string, tip: string, extraEnv: Record<string, string>,
+): Promise<Cell> {
+  const before = objectBytes(target)
+  const hadCheckout = existsSync(join(target, '.git'))
+  const lines: string[] = []
+  const realWrite = process.stdout.write.bind(process.stdout)
+  // @ts-expect-error deliberate stdout capture for tier attribution
+  process.stdout.write = (chunk: unknown) => { lines.push(String(chunk)); return true }
+  const t0 = performance.now()
+  let fail: string | undefined
+  try {
+    await materializeRepo(loadConfig({
+      KORTIX_PROJECT_AUTO_CLONE: '1',
+      KORTIX_PROJECT_TARGET: target,
+      KORTIX_WORKSPACE: target,
+      KORTIX_PROJECT_ID: '11111111-1111-4111-8111-111111111111',
+      KORTIX_REPO_URL: repoUrl,
+      KORTIX_TOKEN: 'sandbox-token',
+      KORTIX_BRANCH_NAME: 'sess-1',
+      KORTIX_SESSION_FRESH: '1',
+      KORTIX_BASE_REF: branch,
+      KORTIX_DEFAULT_BRANCH: branch,
+      KORTIX_BASE_SHA: tip,
+      ...extraEnv,
+    }))
+  } catch (err) {
+    fail = err instanceof Error ? err.message.split('\n')[0].slice(0, 70) : String(err)
+  }
+  const ms = performance.now() - t0
+  process.stdout.write = realWrite
+
+  const log = lines.join('\n')
+  let tier = 'unknown'
+  for (const [re, name] of TIERS) if (re.test(log)) tier = name
+  if (/reuse refused: origin/.test(log)) tier += '(refused:origin)'
+  if (/failed its integrity probe/.test(log)) tier += '(refused:integrity)'
+
+  // A fast failure and a fast success look identical in a timing column.
+  try {
+    if (git(target, 'rev-parse', 'HEAD') !== tip) fail ??= 'wrong HEAD'
+    if (git(target, 'rev-parse', '--abbrev-ref', 'HEAD') !== 'sess-1') fail ??= 'wrong branch'
+    if (git(target, 'status', '--porcelain', '--untracked-files=no')) fail ??= 'dirty tree'
+  } catch { fail ??= 'verification threw' }
+
+  const after = objectBytes(target)
+  const wiped = tier.includes('WIPE') || !hadCheckout
+  return { ms, bytes: wiped ? after : Math.max(after - before, 0), tier, fail }
+}
+
+/** A shallow checkout of `sha`, presented as a prior boot would have left it. */
+function seedStale(bare: string, target: string, sha: string, branch: string, originUrl: string) {
+  const tmpRef = `bench-stale-${Math.random().toString(36).slice(2)}`
+  gitQuiet(bare, 'branch', '-f', tmpRef, sha)
+  try {
+    gitQuiet(scratch, 'clone', '-q', '--depth', '1', '--single-branch', '--branch', tmpRef, `file://${bare}`, target)
+    gitQuiet(target, 'branch', '-m', tmpRef, branch)
+    gitQuiet(target, 'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*')
+    gitQuiet(target, 'update-ref', `refs/remotes/origin/${branch}`, sha)
+    gitQuiet(target, 'update-ref', '-d', `refs/remotes/origin/${tmpRef}`)
+    gitQuiet(target, 'remote', 'set-url', 'origin', originUrl)
+  } finally {
+    gitQuiet(bare, 'branch', '-D', tmpRef)
+  }
+}
+
+async function scenario(
+  label: string,
+  seed: (target: string) => { repoUrl: string; branch: string; tip: string; scaffold: string; env?: Record<string, string> },
+) {
+  const cells: Cell[] = []
+  for (let i = 0; i < RUNS; i += 1) {
+    const target = join(scratch, `${label.replace(/\W/g, '')}-${i}`)
+    mkdirSync(target, { recursive: true })
+    const s = seed(target)
+    __setScaffoldRepoPathForTests(s.scaffold)
+    cells.push(await once(target, s.repoUrl, s.branch, s.tip, s.env ?? {}))
+    rmSync(target, { recursive: true, force: true })
+  }
+  const ms = median(cells.map((c) => c.ms))
+  const bytes = median(cells.map((c) => c.bytes))
+  const fail = cells.find((c) => c.fail)?.fail
+  console.log(
+    `   ${label.padEnd(32)} ${ms.toFixed(0).padStart(7)}ms  ${mib(bytes).padStart(8)}` +
+    `  [${cells[0]?.tier ?? '-'}]${fail ? `  FAIL ${fail}` : ''}`,
+  )
+}
+
+/** Synthetic origin: `commits` commits, optional incompressible blob. */
+function synthetic(commits: number, blobBytes = 0) {
+  const root = join(scratch, `synth-${Math.random().toString(36).slice(2)}`)
+  const src = join(root, 'src')
+  mkdirSync(src, { recursive: true })
+  gitQuiet(src, 'init', '-q', '-b', 'main')
+  writeFileSync(join(src, 'README.md'), 'generic scaffold\n')
+  gitQuiet(src, 'add', '-A'); gitQuiet(src, 'commit', '-q', '-m', 'chore: scaffold Kortix project')
+  const scaffoldSha = git(src, 'rev-parse', 'HEAD')
+  const scaffoldBare = join(root, 'scaffold.git')
+  gitQuiet(root, 'clone', '-q', '--bare', src, scaffoldBare)
+  for (let i = 1; i <= commits; i += 1) {
+    writeFileSync(join(src, `file-${i}.txt`), `change ${i}\n`)
+    // randomBytes, not Buffer.alloc: zeros compress away and would keep the
+    // bundle under the 24 KiB inline cap regardless of size.
+    if (blobBytes && i === commits) writeFileSync(join(src, 'blob.bin'), randomBytes(blobBytes))
+    gitQuiet(src, 'add', '-A'); gitQuiet(src, 'commit', '-q', '-m', `feat ${i}`)
+  }
+  const tip = git(src, 'rev-parse', 'main')
+  const bundlePath = join(root, 'delta.bundle')
+  gitQuiet(src, 'bundle', 'create', bundlePath, 'main', `^${scaffoldSha}`)
+  const parentCommit = execFileSync('git', ['cat-file', 'commit', scaffoldSha], { cwd: src })
+  const bare = join(root, 'origin.git')
+  gitQuiet(root, 'clone', '-q', '--bare', src, bare)
+  return {
+    bare, scaffoldBare, scaffoldSha, tip,
+    bundle64: readFileSync(bundlePath).toString('base64'),
+    parent64: parentCommit.toString('base64'),
+  }
+}
+
+console.log(`\nmaterializeRepo — ${RUNS} runs/scenario, medians, file:// origins`)
+console.log(`stale checkout = shallow clone ${BEHIND} commits behind tip\n`)
+
+const targets: { name: string; bare: string }[] = []
+const fromEnv = (process.env.BENCH_REPOS ?? '').split(',').map((s) => s.trim()).filter(Boolean)
+for (const bare of fromEnv) {
+  if (!existsSync(bare)) { console.log(`SKIP ${bare} — not found`); continue }
+  let tip = ''
+  // A still-cloning mirror ECHOES the literal "HEAD" rather than failing, so a
+  // 40-hex check is the only safe guard against benchmarking a partial origin.
+  try { tip = git(bare, 'rev-parse', 'HEAD') } catch { /* handled below */ }
+  if (!/^[0-9a-f]{40}$/.test(tip)) { console.log(`SKIP ${bare} — HEAD did not resolve to a SHA`); continue }
+  targets.push({ name: bare.split('/').pop() ?? bare, bare })
+}
+if (!targets.length) {
+  const s = synthetic(60)
+  targets.push({ name: 'synthetic (60 commits)', bare: s.bare })
+}
+
+for (const t of targets) {
+  const branch = git(t.bare, 'symbolic-ref', '--short', 'HEAD')
+  const commits = Number(git(t.bare, 'rev-list', '--count', branch))
+  const tip = git(t.bare, 'rev-parse', branch)
+  const back = Math.min(BEHIND, Math.max(commits - 1, 0))
+  const stale = back > 0 ? git(t.bare, 'rev-parse', `${branch}~${back}`) : tip
+  const url = `file://${t.bare}`
+  console.log(`── ${t.name}  (${commits} commits, stale=${back} behind)`)
+  await scenario('A empty workspace', () => ({ repoUrl: url, branch, tip, scaffold: NO_SCAFFOLD }))
+  await scenario('B disk already at tip', (target) => {
+    seedStale(t.bare, target, tip, branch, url)
+    return { repoUrl: url, branch, tip, scaffold: NO_SCAFFOLD }
+  })
+  if (back > 0) {
+    await scenario('C disk behind tip', (target) => {
+      seedStale(t.bare, target, stale, branch, url)
+      return { repoUrl: url, branch, tip, scaffold: NO_SCAFFOLD }
+    })
+  } else {
+    console.log('   C disk behind tip                n/a — single-commit repo')
+  }
+  console.log('')
+}
+
+console.log('── scaffold tiers (root SHARED with the baked scaffold)')
+for (const [label, blob] of [['D tiny delta (inline)', 0], ['E 8 MiB delta (over cap)', 8 * 1024 * 1024]] as const) {
+  const s = synthetic(5, blob)
+  const inlineFits = s.bundle64.length <= 24 * 1024
+  await scenario(label, () => ({
+    repoUrl: `file://${s.bare}`, branch: 'main', tip: s.tip, scaffold: s.scaffoldBare,
+    env: {
+      ...(inlineFits ? { KORTIX_GIT_DELTA_BUNDLE_BASE64: s.bundle64 } : {}),
+      KORTIX_GIT_DELTA_PARENT_SHA: s.scaffoldSha,
+      KORTIX_GIT_DELTA_PARENT_COMMIT_BASE64: s.parent64,
+    },
+  }))
+}
+
+rmSync(scratch, { recursive: true, force: true })
+console.log('')

--- a/apps/kortix-sandbox-agent-server/src/__tests__/materialize-reuse.test.ts
+++ b/apps/kortix-sandbox-agent-server/src/__tests__/materialize-reuse.test.ts
@@ -1,0 +1,228 @@
+import { execFileSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'bun:test'
+import { loadConfig } from '../config'
+import { __setScaffoldRepoPathForTests, materializeRepo } from '../git'
+
+/**
+ * `materializeRepo` used to reuse the on-disk checkout ONLY when
+ * `bakedHead === cfg.baseSha`. Every other value cleared the directory and
+ * re-downloaded the repository, deleting objects it was about to fetch again.
+ * `tryReuseCheckoutDelta` advances that checkout instead.
+ *
+ * The wipe was self-healing by construction, so these tests pin the two guards
+ * that earn that property back. Both were written against a reproduced failure:
+ * without the identity guard a workspace holding a DIFFERENT project fetched
+ * into the same object database and produced a repo with two unrelated roots;
+ * without the integrity guard a truncated pack passed `rev-parse HEAD` (which
+ * reads a loose ref, not an object) and the session booted on a repo whose
+ * `fsck` failed.
+ *
+ * Origins are `file://` URLs on purpose: `git clone /abs/path` IGNORES `--depth`
+ * and hardlinks the object database, so a plain path cannot express "this disk
+ * is missing the newer objects" at all.
+ */
+
+const roots: string[] = []
+const PINNED = {
+  GIT_AUTHOR_NAME: 'Kortix',
+  GIT_AUTHOR_EMAIL: 'noreply@kortix.ai',
+  GIT_COMMITTER_NAME: 'Kortix',
+  GIT_COMMITTER_EMAIL: 'noreply@kortix.ai',
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: { ...process.env, ...PINNED },
+    encoding: 'utf8',
+    maxBuffer: 1 << 26,
+  }).trim()
+}
+
+function gitQuiet(cwd: string, ...args: string[]): void {
+  execFileSync('git', args, { cwd, env: { ...process.env, ...PINNED }, stdio: 'ignore' })
+}
+
+/** True when the command succeeds — used to ask "is this object present?". */
+function gitOk(cwd: string, ...args: string[]): boolean {
+  try {
+    gitQuiet(cwd, ...args)
+    return true
+  } catch {
+    return false
+  }
+}
+
+afterEach(() => {
+  __setScaffoldRepoPathForTests()
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+/** A bare origin on `main` with `commits` commits. Returns every SHA in order. */
+function seedOrigin(commits: number, marker = 'ALPHA') {
+  const root = mkdtempSync(join(tmpdir(), 'kortix-reuse-'))
+  roots.push(root)
+  const src = join(root, 'source')
+  mkdirSync(src)
+  gitQuiet(src, 'init', '-q', '-b', 'main')
+  const shas: string[] = []
+  for (let i = 1; i <= commits; i += 1) {
+    writeFileSync(join(src, `file-${i}.txt`), `${marker} ${i}\n`)
+    gitQuiet(src, 'add', '-A')
+    gitQuiet(src, 'commit', '-q', '-m', `commit ${i}`)
+    shas.push(git(src, 'rev-parse', 'HEAD'))
+  }
+  const bare = join(root, 'origin.git')
+  gitQuiet(root, 'clone', '-q', '--bare', src, bare)
+  // No scaffold on the box: the fallback below is the plain clone path.
+  __setScaffoldRepoPathForTests(join(root, 'absent-scaffold.git'))
+  return { root, bare, shas, tip: shas[commits - 1]!, url: `file://${bare}` }
+}
+
+/**
+ * A SHALLOW checkout of `sha`, presented exactly as a previous boot would have
+ * left it: on `branch`, with `origin` pointing at `originUrl`.
+ *
+ * `--single-branch --branch <tmp>` pins `remote.origin.fetch` to the temporary
+ * ref and creates `refs/remotes/origin/<tmp>`; both are repaired here, because
+ * leaving them breaks tracking setup once the temp ref is deleted and that is a
+ * fixture artifact, not the behaviour under test.
+ */
+function seedStaleCheckout(bare: string, target: string, sha: string, originUrl: string) {
+  const branch = 'main'
+  const tmpRef = `stale-${Math.random().toString(36).slice(2)}`
+  gitQuiet(bare, 'branch', '-f', tmpRef, sha)
+  try {
+    gitQuiet(
+      join(target, '..'),
+      'clone', '-q', '--depth', '1', '--single-branch', '--branch', tmpRef,
+      `file://${bare}`, target,
+    )
+    gitQuiet(target, 'branch', '-m', tmpRef, branch)
+    gitQuiet(target, 'config', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*')
+    gitQuiet(target, 'update-ref', `refs/remotes/origin/${branch}`, sha)
+    gitQuiet(target, 'update-ref', '-d', `refs/remotes/origin/${tmpRef}`)
+    gitQuiet(target, 'remote', 'set-url', 'origin', originUrl)
+  } finally {
+    gitQuiet(bare, 'branch', '-D', tmpRef)
+  }
+}
+
+function envFor(target: string, url: string, tip: string, extra: Record<string, string> = {}) {
+  return {
+    KORTIX_PROJECT_AUTO_CLONE: '1',
+    KORTIX_PROJECT_TARGET: target,
+    KORTIX_WORKSPACE: target,
+    KORTIX_PROJECT_ID: '11111111-1111-4111-8111-111111111111',
+    KORTIX_REPO_URL: url,
+    KORTIX_TOKEN: 'sandbox-token',
+    KORTIX_BRANCH_NAME: 'sess-1',
+    KORTIX_SESSION_FRESH: '1',
+    KORTIX_BASE_REF: 'main',
+    KORTIX_DEFAULT_BRANCH: 'main',
+    KORTIX_BASE_SHA: tip,
+    ...extra,
+  }
+}
+
+/** A workspace directory that already holds a checkout. */
+function targetIn(root: string): string {
+  const target = join(root, 'workspace')
+  mkdirSync(target, { recursive: true })
+  rmSync(target, { recursive: true, force: true })
+  return target
+}
+
+describe('materializeRepo checkout reuse', () => {
+  test('advances a stale checkout with a delta fetch instead of re-downloading', async () => {
+    const origin = seedOrigin(3)
+    const target = targetIn(origin.root)
+    seedStaleCheckout(origin.bare, target, origin.shas[0]!, origin.url)
+
+    expect(gitOk(target, 'cat-file', '-e', `${origin.tip}^{commit}`)).toBe(false)
+
+    await materializeRepo(loadConfig(envFor(target, origin.url, origin.tip)))
+
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(origin.tip)
+    expect(git(target, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('sess-1')
+    expect(git(target, 'rev-parse', 'main')).toBe(origin.tip)
+    expect(git(target, 'status', '--porcelain', '--untracked-files=no')).toBe('')
+    // The proof that the checkout was REUSED rather than rebuilt: the commit it
+    // started on is still in the object database. A wipe followed by a depth-1
+    // clone of the tip cannot contain it.
+    expect(gitOk(target, 'cat-file', '-e', `${origin.shas[0]}^{commit}`)).toBe(true)
+  })
+
+  test('refuses reuse when origin points at a different project, and never merges its objects', async () => {
+    const wanted = seedOrigin(3, 'ALPHA')
+    const foreign = seedOrigin(3, 'BRAVO')
+    const target = targetIn(wanted.root)
+    // The disk holds `foreign`, but this session is for `wanted`.
+    seedStaleCheckout(foreign.bare, target, foreign.tip, foreign.url)
+
+    await materializeRepo(loadConfig(envFor(target, wanted.url, wanted.tip)))
+
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(wanted.tip)
+    // One root only. Two would mean the other project's history was fetched
+    // into this sandbox's object database.
+    const allRoots = git(target, 'rev-list', '--max-parents=0', '--all').split('\n').filter(Boolean)
+    expect(allRoots).toHaveLength(1)
+    expect(gitOk(target, 'cat-file', '-e', `${foreign.tip}^{commit}`)).toBe(false)
+  })
+
+  test('refuses reuse when the object database is corrupt, and self-heals', async () => {
+    const origin = seedOrigin(3)
+    const target = targetIn(origin.root)
+    seedStaleCheckout(origin.bare, target, origin.shas[0]!, origin.url)
+
+    // Truncate every pack. git writes them 0444, so chmod first.
+    const packDir = join(target, '.git', 'objects', 'pack')
+    for (const entry of readdirSync(packDir).filter((f) => f.endsWith('.pack'))) {
+      chmodSync(join(packDir, entry), 0o644)
+      writeFileSync(join(packDir, entry), Buffer.from('CORRUPTED NOT A PACK'))
+    }
+
+    await materializeRepo(loadConfig(envFor(target, origin.url, origin.tip)))
+
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(origin.tip)
+    expect(gitOk(target, 'fsck', '--no-progress')).toBe(true)
+  })
+
+  test('a fresh session starts pristine — untracked and ignored leftovers are removed', async () => {
+    const origin = seedOrigin(3)
+    const target = targetIn(origin.root)
+    seedStaleCheckout(origin.bare, target, origin.shas[0]!, origin.url)
+    writeFileSync(join(target, 'untracked-scratch.txt'), 'previous session\n')
+    writeFileSync(join(target, '.gitignore'), 'ignored-build/\n')
+    mkdirSync(join(target, 'ignored-build'), { recursive: true })
+    writeFileSync(join(target, 'ignored-build', 'stale.o'), 'stale\n')
+
+    await materializeRepo(loadConfig(envFor(target, origin.url, origin.tip)))
+
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(origin.tip)
+    expect(existsSync(join(target, 'untracked-scratch.txt'))).toBe(false)
+    expect(existsSync(join(target, 'ignored-build'))).toBe(false)
+    // Still the reuse path, not a wipe.
+    expect(gitOk(target, 'cat-file', '-e', `${origin.shas[0]}^{commit}`)).toBe(true)
+  })
+
+  test('refuses reuse for a session-branch restore, which needs the remote branch', async () => {
+    const origin = seedOrigin(3)
+    // The agent's session branch already exists upstream.
+    gitQuiet(origin.bare, 'branch', '-f', 'sess-1', origin.tip)
+    const target = targetIn(origin.root)
+    seedStaleCheckout(origin.bare, target, origin.shas[0]!, origin.url)
+
+    await materializeRepo(loadConfig(
+      envFor(target, origin.url, origin.tip, { KORTIX_SESSION_BRANCH_RESTORE: '1' }),
+    ))
+
+    expect(git(target, 'rev-parse', 'HEAD')).toBe(origin.tip)
+    expect(git(target, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('sess-1')
+    // Restore takes the authoritative path, so the starting commit is gone.
+    expect(gitOk(target, 'cat-file', '-e', `${origin.shas[0]}^{commit}`)).toBe(false)
+  })
+})

--- a/apps/kortix-sandbox-agent-server/src/git.ts
+++ b/apps/kortix-sandbox-agent-server/src/git.ts
@@ -702,6 +702,12 @@ export async function materializeRepo(cfg: Config): Promise<void> {
       baseSha: cfg.baseSha,
       reason: restoreNeeded ? 'restore-session-branch' : 'base-mismatch',
     })
+    // Before discarding: this disk may already hold MOST of what the wipe is
+    // about to re-download. Advancing it with a delta fetch measured 4.6x
+    // faster and moved 8.5x fewer bytes than clear+re-clone on a 977 MiB repo
+    // (bench-materialize-matrix.ts, 2026-09-01). Any refusal falls through to
+    // the wipe below, which stays the authoritative, self-healing path.
+    if (await tryReuseCheckoutDelta(cfg, target, base, bakedHead)) return
     await clearDirContents(target)
   }
   {
@@ -979,6 +985,136 @@ export async function materializeProjectSeed(cfg: Config): Promise<boolean> {
   } catch (err) {
     logger.warn('[git] project seed materialize failed; warm seed will fall back to scaffold', {
       err: err instanceof Error ? err.message.slice(0, 200) : String(err),
+    })
+    return false
+  }
+}
+
+/**
+ * Advance the checkout ALREADY on disk to `cfg.baseSha` instead of deleting it
+ * and downloading the repository again. Returns true when `target` is ready on
+ * the session branch; false → the caller wipes and re-materializes.
+ *
+ * Why this exists: the tier above reuses the checkout only when
+ * `bakedHead === cfg.baseSha`. Every other value — a baked scaffold on a
+ * project that has commits, a restarted sandbox a few commits behind — wiped a
+ * disk that already held nearly every object the re-clone then re-fetched.
+ * Measured on a 977 MiB repo with a 413 MiB tip tree (file:// origin, so no
+ * network in the number): clear+re-clone 2950 ms / 415 MiB against 646 ms /
+ * 49 MiB here.
+ *
+ * TWO GUARDS, both mandatory, both measured against the failure they prevent
+ * (bench-materialize-adversarial.ts):
+ *
+ *   IDENTITY. Reuse only when `origin` ALREADY points at this project's repo.
+ *   A pristine image checkout still points at /opt/kortix/scaffold.git, so it
+ *   is refused here and reaches the scaffold tiers below — which keeps their
+ *   zero-network bundle path intact. Without this check a workspace holding a
+ *   DIFFERENT project fetched into the same object database and produced a repo
+ *   with two unrelated roots, leaving one project's objects readable inside
+ *   another's sandbox.
+ *
+ *   INTEGRITY. `cat-file -e HEAD^{tree}` forces a real object read out of the
+ *   pack. `rev-parse HEAD` does not: it reads a loose ref, so a sandbox killed
+ *   mid-write passed that check and booted into a repo whose `fsck` failed. The
+ *   wipe is self-healing by construction; a reuse path has to earn that back.
+ *
+ * A restore of an existing remote session branch is out of scope — that needs
+ * `checkoutSessionBranch`, not the base tip — so it is refused outright.
+ */
+async function tryReuseCheckoutDelta(
+  cfg: Config,
+  target: string,
+  base: string,
+  bakedHead: string,
+): Promise<boolean> {
+  if (cfg.sessionBranchRestore) return false
+  if (!cfg.baseSha || !/^[0-9a-f]{40}$/.test(cfg.baseSha)) return false
+  if (!/^[0-9a-f]{40}$/.test(bakedHead)) return false
+
+  // GUARD 1 — identity.
+  const originUrl = await execGit(['-C', target, 'remote', 'get-url', 'origin'])
+  if (originUrl.code !== 0 || originUrl.stdout.trim() !== cfg.repoUrl) {
+    logger.info('[git] reuse refused: origin is not this project', {
+      onDisk: originUrl.code === 0 ? originUrl.stdout.trim().slice(0, 120) : '(none)',
+    })
+    return false
+  }
+
+  // GUARD 2 — integrity.
+  const treeProbe = await execGit(['-C', target, 'cat-file', '-e', `${bakedHead}^{tree}`])
+  if (treeProbe.code !== 0) {
+    logger.warn('[git] reuse refused: object database failed its integrity probe', {
+      stderr: treeProbe.stderr.slice(0, 160),
+    })
+    return false
+  }
+
+  const t0 = Date.now()
+  try {
+    let fetchedObjects = 0
+    const alreadyHasTip = await execGit(['-C', target, 'cat-file', '-e', `${cfg.baseSha}^{commit}`])
+    if (alreadyHasTip.code !== 0) {
+      const credential = await resolveCloneCredential(cfg)
+      const fetchArgs = (ref: string) => [
+        '-C', target,
+        '-c', 'http.lowSpeedLimit=1000', '-c', 'http.lowSpeedTime=12',
+        'fetch', '-q', '--depth', '1', '--no-tags', 'origin', ref,
+      ]
+      // Fetching a bare SHA needs uploadpack.allowAnySHA1InWant; not every host
+      // enables it, so fall back to the branch and re-check for the tip after.
+      let fetched = await gitWithAuth(credential, cfg.repoUrl, fetchArgs(cfg.baseSha), {
+        timeoutMs: 35_000,
+      })
+      if (fetched.code !== 0) {
+        fetched = await gitWithAuth(
+          credential,
+          cfg.repoUrl,
+          fetchArgs(`+refs/heads/${base}:refs/remotes/origin/${base}`),
+          { timeoutMs: 35_000 },
+        )
+      }
+      if (fetched.code !== 0) throw new Error(`delta fetch failed: ${fetched.stderr.slice(0, 200)}`)
+      const haveTip = await execGit(['-C', target, 'cat-file', '-e', `${cfg.baseSha}^{commit}`])
+      // The branch moved between the server resolving baseSha and this fetch.
+      // The wipe path clones whatever the tip is, so defer to it.
+      if (haveTip.code !== 0) throw new Error(`fetched ${base} does not contain ${cfg.baseSha}`)
+      fetchedObjects = 1
+    }
+
+    const setBase = await execGit(['-C', target, 'update-ref', `refs/heads/${base}`, cfg.baseSha])
+    if (setBase.code !== 0) throw new Error(`update-ref ${base}: ${setBase.stderr}`)
+    const checkout = await execGit([
+      '-C', target, 'checkout', '-q', '--force', '-B', cfg.branchName ?? base, cfg.baseSha,
+    ])
+    if (checkout.code !== 0) throw new Error(`checkout: ${checkout.stderr.slice(0, 200)}`)
+
+    // A fresh session must start pristine. The wipe gave that for free; here it
+    // is explicit. Untracked and ignored leftovers from a previous session are
+    // removed — config-dir dependencies are installed AFTER materialization, so
+    // nothing this boot needs exists yet. A non-fresh restart keeps its files.
+    if (cfg.sessionFresh) {
+      const cleaned = await execGit(['-C', target, 'clean', '-q', '-f', '-d', '-x'])
+      if (cleaned.code !== 0) {
+        logger.warn('[git] reuse: clean failed; falling back to authoritative wipe', {
+          stderr: cleaned.stderr.slice(0, 160),
+        })
+        return false
+      }
+    }
+
+    await configureRepoGitIdentity(cfg, target)
+    await markSessionCheckoutAdopted(target, cfg.branchName)
+    logger.info('[git] repo materialized by reusing the on-disk checkout', {
+      ms: Date.now() - t0,
+      from: bakedHead.slice(0, 8),
+      to: cfg.baseSha.slice(0, 8),
+      fetched: fetchedObjects > 0 ? 'delta' : 'nothing (tip already present)',
+    })
+    return true
+  } catch (error) {
+    logger.info('[git] checkout reuse unavailable; using authoritative materialization', {
+      error: error instanceof Error ? error.message.slice(0, 200) : String(error),
     })
     return false
   }


### PR DESCRIPTION
## Scope — read this first

This helps **repeat boots of the same sandbox only** (daemon restart / resume). Measured on dev, 30 days: **33 of 586 boots = 5.6%**.

    boots-per-sandbox   1 boot: 536 sandboxes
                        2 boots: 9 · 3 boots: 3 · 4 boots: 4 · 7 boots: 1

On a **first** boot the tier deliberately does not fire. `/workspace` on the shared default image is a clone of `/opt/kortix/scaffold.git` (`fast-dockerfile.ts:130`), so `origin` is the scaffold path, not the project repo, and the identity guard refuses. Reproduced:

    origin in /workspace on a fresh image : file://…/scaffold.git
    cfg.repoUrl for this session          : file://…/project.git
    reuse tier fired?                     : NO
    refused because origin mismatch?      : YES
    what actually ran                     : WIPE+clone

That refusal is correct — a first boot needs the scaffold tiers, whose bundle path is already zero-network for starter-seeded projects. **It does mean this PR does not address the `repo-materialized` p50 of 6,856ms**, which is dominated by first boots. That cost is imported repos with no shared root and large tip trees; it needs bundle-URI/S3, sparse checkout, or a lazy filesystem, not checkout reuse.

## Problem

`materializeRepo` reused the on-disk checkout **only** when `bakedHead === cfg.baseSha`. On a repeat boot of a sandbox whose branch has moved, that fails, so `clearDirContents()` runs and the repo is downloaded again — **deleting objects it is about to re-fetch**.

## Change

`tryReuseCheckoutDelta` runs immediately before the wipe and advances the existing object database with `git fetch --depth 1 origin <baseSha>`. Any refusal falls through to the wipe, which stays the authoritative, self-healing path. **Purely additive: no existing tier changes, 0 deletions.**

## Measured

977 MiB repo, 413 MiB depth-1 pack, 647 commits, `file://` origin (no network in the number), 5 runs, disk 5 commits behind:

| | time | data | tier |
|---|---|---|---|
| before | 3,136ms | 421.3 MiB | `WIPE+clone` |
| after | **829ms** | **49.0 MiB** | `REUSE-delta` |

3.8x time, 8.6x data — **on the 5.6% of boots where it fires.** The byte figure is the bandwidth-independent one.

Every other disk state unchanged, still reporting its original tier:

| scenario | before | after | tier |
|---|---|---|---|
| empty workspace | 2,760ms / 414.6M | 2,569ms / 410.7M | `WIPE+clone` |
| disk already at tip | 410ms / 0.0M | 224ms / 0.0M | `warm` |
| scaffold + inline bundle | 191ms / 0.0M | 169ms / 0.0M | `scaffold-inline` |
| scaffold, 8 MiB delta | 459ms / 8.0M | 393ms / 8.0M | `scaffold-fetch` |

## Two guards, each written against a reproduced failure

- **Identity** — reuse only when `origin` already points at this project's repo. Without it, a workspace holding a **different** project fetched into the same object database and produced a repo with two unrelated roots, leaving one project's objects readable inside another's sandbox. This guard is also why first boots refuse.
- **Integrity** — `cat-file -e HEAD^{tree}` forces a real object read out of the pack. `rev-parse HEAD` does not (it reads a loose ref), so a sandbox killed mid-write passed that check and booted on a repo whose `fsck` failed.

A fresh session also gets `clean -fdx`, restoring the pristine start the wipe gave for free. A session-branch restore is refused outright — it needs `checkoutSessionBranch`, not the base tip.

## Verification

- `src/__tests__/materialize-reuse.test.ts` — 5 tests. **Verified meaningful: 2 of 5 fail with the tier reverted.**
- `bun test`: **1151 pass, 1 fail** — `git credential helper > skips configuration for a non-managed (no repo) sandbox`, which fails identically on `origin/main` with this change reverted and whose test file this branch does not touch.
- `tsc --noEmit`: clean.
- `scripts/bench-materialize.ts` documents three measurement traps that each faked a result during this work; the worst is that `git clone /abs/path` **ignores `--depth` and hardlinks objects**, making a 1 GB repo look like a 1.2s clone.

## Not verified

- No run against a real proxied origin, and not exercised on dev.
- No `gc` on the reuse path, so the object store can grow across repeat boots of one sandbox.
- **There is still no boot mark identifying which materialization tier fired**, so the 5.6% above is inferred from boots-per-sandbox, not measured directly. Adding that mark is the highest-value follow-up.

Draft until the above are closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)