### PR TITLE
web: flatten the composer and project-home band onto the base surface

### DIFF
--- a/apps/web/src/features/session/composer/composer.tsx
+++ b/apps/web/src/features/session/composer/composer.tsx
@@ -1446,7 +1446,7 @@ function ComposerImpl({
           // `globals.css` and `shadow-xl` was dead — twMerge dropped it for the
           // arbitrary `shadow-[…oklch…]` that followed, which was the only
           // raw colour left in the composer.
-          'bg-secondary/30 border-border relative isolate z-10 w-full rounded-xl border',
+          'bg-background border-border relative isolate z-10 w-full rounded-xl border',
           'pt-3',
           // The drag border swaps colour AND gains a ring. Without this it
           // snapped: a hard flash the moment a file crossed the card.

--- a/apps/web/src/features/workspace/project-layout/home/band.ts
+++ b/apps/web/src/features/workspace/project-layout/home/band.ts
@@ -23,7 +23,7 @@
  * over the animated wallpaper (`ProjectHomeWallpaper`) and legibility outranks
  * flatness.
  */
-export const BAND_PANEL_CLASS = 'bg-background/70 w-full rounded-md pb-2 backdrop-blur-sm';
+export const BAND_PANEL_CLASS = 'w-full rounded-md pb-2';
 
 /** The band's header line: title on the left, anything else trailing. */
 export const BAND_HEADER_CLASS = 'flex items-center gap-2 py-2 pr-2 pl-4';

--- a/apps/web/src/lib/seo/content-timestamps.json
+++ b/apps/web/src/lib/seo/content-timestamps.json
@@ -48,7 +48,7 @@
   "docs:project/agents": "2026-08-19T07:16:09.000Z",
   "docs:project": "2026-08-26T23:48:11.000Z",
   "docs:project/legacy-toml": "2026-07-30T12:52:42.000Z",
-  "docs:project/manifest": "2026-08-23T00:12:23.000Z",
+  "docs:project/manifest": "2026-09-01T14:42:59.000Z",
   "docs:project/models": "2026-08-25T21:11:32.000Z",
   "docs:project/secrets": "2026-08-22T20:28:33.000Z",
   "docs:quickstart": "2026-08-26T23:48:11.000Z",
@@ -60,7 +60,7 @@
   "docs:sdk/reference": "2026-08-26T23:05:53.000Z",
   "docs:sdk/sessions": "2026-08-26T13:06:00.000Z",
   "docs:sdk/sign-in": "2026-08-27T12:52:55.000Z",
-  "docs:work/change-requests": "2026-07-22T02:58:51.000Z",
+  "docs:work/change-requests": "2026-09-01T14:42:59.000Z",
   "docs:work": "2026-08-26T23:48:11.000Z",
   "docs:work/runtime": "2026-08-26T00:19:20.000Z",
   "docs:work/sessions": "2026-08-19T16:27:13.000Z"


### PR DESCRIPTION
## Summary

Two surfaces in `apps/web` were tinted panels floating over the page. This makes them part of the page.

- **Composer** (`composer.tsx`): `bg-secondary/30` -> `bg-background`. The card now shares the page surface; the existing `border-border` carries the edge on its own.
- **Project-home band** (`band.ts`): drop `bg-background/70` and `backdrop-blur-sm` from `BAND_PANEL_CLASS`. The band no longer frosts the animated wallpaper behind it. The constant is now layout only: `w-full rounded-md pb-2`.
- **`content-timestamps.json`**: regenerated. `docs:project/manifest` and `docs:work/change-requests` move to `2026-09-01T14:42:59.000Z`.

Both class changes are token-driven. No raw colour, no arbitrary value, no behaviour change.

## Test plan

- [ ] `/projects/<id>` — the home band sits flat on the wallpaper, no frosted rectangle behind the section headers.
- [ ] Session composer — card background matches the page; the border is the only edge. Drag a file over it and confirm the drag border/ring transition still runs.
- [ ] Light and dark both read correctly on each surface.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790889850&installation_model_id=434224&pr_number=7087&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7087&signature=1bfaf1f3f4e23986c83d900c198eeaf09c8d8f96e4d6e52e69dc1a7d639707e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->