### PR TITLE
triggers: settle reuse-mode fire runtime status on delivery/dead-letter

### DIFF
--- a/apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts
+++ b/apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts
@@ -15,10 +15,11 @@
 // process-global in bun:test, so run this file in its own `bun test <file>`
 // invocation (as CI does), same caveat as ../../sandbox-reaper.test.ts.
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { projectSessions, sessionLifecycleCommands } from '@kortix/db';
+import { projectSessions, projectTriggerRuntime, sessionLifecycleCommands } from '@kortix/db';
 
 let commandRow: Record<string, unknown> | null = null;
 let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+let insertCalls: Array<{ table: unknown; values: Record<string, unknown> }> = [];
 let errorLogs: Array<{ message: string; context?: Record<string, unknown> }> = [];
 
 mock.module('../../../lib/logger', () => ({
@@ -53,6 +54,18 @@ mock.module('../../../shared/db', () => ({
         },
       }),
     }),
+    // Awaitable insert + `.onConflictDoUpdate()` — used by
+    // markTriggerRuntimeDeliveryFailed to flip projectTriggerRuntime to 'failed'.
+    insert: (table: unknown) => ({
+      values: (values: Record<string, unknown>) => ({
+        onConflictDoUpdate: () => ({
+          then: (resolve: (v: unknown) => void) => {
+            insertCalls.push({ table, values });
+            resolve(undefined);
+          },
+        }),
+      }),
+    }),
   },
 }));
 
@@ -75,6 +88,7 @@ const baseCommandRow = (overrides: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   commandRow = null;
   updateCalls = [];
+  insertCalls = [];
   errorLogs = [];
 });
 
@@ -104,6 +118,30 @@ describe('markCommandFailed — dead-letter is loud and parks the session', () =
     expect(sessionUpdates).toHaveLength(1);
     expect(sessionUpdates[0].updates.status).toBe('failed');
     expect(String(sessionUpdates[0].updates.error)).toContain('dead-lettered');
+
+    // The dead-letter now also surfaces on the trigger runtime row (last_status
+    // 'failed' + error) so the triggers API/UI stops showing a frozen 'queued'.
+    const runtimeInserts = insertCalls.filter((c) => c.table === projectTriggerRuntime);
+    expect(runtimeInserts).toHaveLength(1);
+    expect(runtimeInserts[0].values).toMatchObject({
+      projectId: 'proj-1',
+      slug: 'daily',
+      lastStatus: 'failed',
+    });
+    expect(String(runtimeInserts[0].values.lastError)).toContain('delivery outcome: pending');
+  });
+
+  test('a dead-letter without a trigger slug parks the session but does not touch the runtime row', async () => {
+    commandRow = baseCommandRow({ payload: { text: 'run the report' } });
+
+    await markCommandFailed('cmd-1', 'delivery outcome: no-session', {
+      retryable: false,
+      attempts: 1,
+      sessionId: 'sess-1',
+    });
+
+    expect(updateCalls.filter((u) => u.table === projectSessions)).toHaveLength(1);
+    expect(insertCalls.filter((c) => c.table === projectTriggerRuntime)).toHaveLength(0);
   });
 
   test('non-retryable failure dead-letters on the first attempt', async () => {

--- a/apps/api/src/projects/session-lifecycle/engine.ts
+++ b/apps/api/src/projects/session-lifecycle/engine.ts
@@ -32,6 +32,7 @@ import {
 } from '../instance-scope';
 import { loadSandboxMetadataForSessions, releaseCommandToOwningInstance } from './instance-release';
 import { db } from '../../shared/db';
+import { markTriggerRuntimeDelivered } from '../trigger-execution-store';
 import { connectorBindingPayloadConflicts } from '../lib/session-connector-bindings';
 import { secretsAllowlistPayloadConflicts } from '../secrets';
 import {
@@ -1720,6 +1721,18 @@ export async function executeQueuedContinue(
         await markCommandSucceeded(row.commandId, { status: 'delivered' }, row.sessionId);
       }
       tl.mark('marked');
+      // The prompt is now on the wire for its target session. If it came from a
+      // trigger, flip that trigger's runtime row from the transient "queued" to
+      // "fired" so monitoring can tell a delivered reuse fire from a wedged one
+      // (see markTriggerRuntimeDelivered). Failure to write back must never break
+      // delivery, hence the swallow.
+      if (typeof payload.triggerSlug === 'string') {
+        await markTriggerRuntimeDelivered({
+          projectId: row.projectId,
+          slug: payload.triggerSlug,
+          when: new Date(),
+        }).catch(() => {});
+      }
       if (!placedIntoLiveTurn || !wireMessageId) break;
       // PROOF. One tip read after the insert answers exactly whether the box
       // created a newer assistant BEFORE this prompt landed (the strand

--- a/apps/api/src/projects/session-lifecycle/store.ts
+++ b/apps/api/src/projects/session-lifecycle/store.ts
@@ -2,6 +2,7 @@ import { projectSessions, sessionLifecycleCommands } from '@kortix/db';
 import { type SQL, and, asc, eq, isNull, lte, ne, or, sql } from 'drizzle-orm';
 import { logger } from '../../lib/logger';
 import { db } from '../../shared/db';
+import { markTriggerRuntimeDeliveryFailed } from '../trigger-execution-store';
 import type {
   CreateSessionCommand,
   QueuedCreateSessionPayload,
@@ -647,6 +648,20 @@ export async function markCommandFailed(
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  // Surface the failure on the trigger runtime row too. markCommandFailed parks
+  // the session (above) so the next reuse fire self-heals, but until now it left
+  // `projectTriggerRuntime.last_status` frozen at "queued" — the triggers API/UI
+  // never showed the dead-letter, so the operator's queue-age alarm was the only
+  // (and a misleading) signal. Flip it to "failed" with the error.
+  if (typeof payload.triggerSlug === 'string') {
+    await markTriggerRuntimeDeliveryFailed({
+      projectId: row.projectId,
+      slug: payload.triggerSlug,
+      when: new Date(),
+      error,
+    }).catch(() => {});
   }
 }
 

--- a/apps/api/src/projects/trigger-execution-store.ts
+++ b/apps/api/src/projects/trigger-execution-store.ts
@@ -349,6 +349,76 @@ export async function markTriggerExecutionFailed(input: {
   return terminal ? 'dead_lettered' : 'queued';
 }
 
+/**
+ * Reflect a DELIVERED trigger prompt back onto the trigger runtime row.
+ *
+ * A `session_mode = "reuse" | "pinned" | "keyed"` fire enqueues a durable
+ * `continue_session` command and immediately records `last_status = "queued"`
+ * (`markGitTriggerFired(..., 'queued')`). The command is delivered later, on
+ * the scheduler's drain tick — and that settlement never wrote back to the
+ * runtime row, so `last_status` stayed `queued` forever and monitoring could
+ * not tell a healthy reuse fire from a wedged one. Flipping to `fired` on
+ * delivery makes `queued` strictly the transient in-flight state, so a queue-age
+ * alarm only fires on a real stall. Does NOT advance `last_fired_at` (already
+ * advanced at fire time).
+ */
+export async function markTriggerRuntimeDelivered(input: {
+  projectId: string;
+  slug: string;
+  when: Date;
+}): Promise<void> {
+  await db
+    .insert(projectTriggerRuntime)
+    .values({
+      projectId: input.projectId,
+      slug: input.slug,
+      lastStatus: 'fired',
+      lastError: null,
+      lastAttemptAt: input.when,
+      updatedAt: input.when,
+    })
+    .onConflictDoUpdate({
+      target: [projectTriggerRuntime.projectId, projectTriggerRuntime.slug],
+      set: {
+        lastStatus: 'fired',
+        lastError: null,
+        lastAttemptAt: input.when,
+        updatedAt: input.when,
+      },
+    });
+}
+
+/**
+ * Reflect a DEAD-LETTERED trigger prompt back onto the trigger runtime row.
+ *
+ * `markCommandFailed` already parks the target session `failed` (so the next
+ * `reuse` fire self-heals to a fresh session); this makes the failure VISIBLE in
+ * the triggers API (`last_status: "failed"`, `last_error`) instead of leaving
+ * `last_status` frozen at `queued` — the "monitoring blind" gap this closes.
+ */
+export async function markTriggerRuntimeDeliveryFailed(input: {
+  projectId: string;
+  slug: string;
+  when: Date;
+  error: string;
+}): Promise<void> {
+  const lastError = input.error.slice(0, 1000);
+  await db
+    .insert(projectTriggerRuntime)
+    .values({
+      projectId: input.projectId,
+      slug: input.slug,
+      lastStatus: 'failed',
+      lastError,
+      lastAttemptAt: input.when,
+      updatedAt: input.when,
+    })
+    .onConflictDoUpdate({
+      target: [projectTriggerRuntime.projectId, projectTriggerRuntime.slug],
+      set: { lastStatus: 'failed', lastError, lastAttemptAt: input.when, updatedAt: input.when },
+    });
+}
+
 export async function countUncatalogedTriggerProjects(): Promise<number> {
   const rows = await db
     .select({ count: sql<number>`count(distinct ${projectTriggerRuntime.projectId})` })


### PR DESCRIPTION
## Demo
Non-visual change — backend trigger-runtime observability fix; no screen recording applies.

Proof: `bun test apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts` → 5 pass (2 new assertions pin the runtime-row write), and `apps/api` `tsc --noEmit` is clean.

## Why
`incident-20260902T124900Z-hbqueue` — the hourly heartbeat trigger stalled with `last_status: queued` (>43m, `QUEUED_OVER_15M`) and zero KX-HOURLY results for ~19h. Root cause in `apps/api/src/projects/lib/triggers.ts`: a `session_mode=reuse|pinned|keyed` fire enqueues a durable `continue_session` command and `executeTriggerExecution` treats the enqueue as terminal success, freezing `projectTriggerRuntime.last_status='queued'` forever. The command's real settlement (delivery via `markCommandForwarded`/`markCommandSucceeded`, or dead-letter via `markCommandFailed`) runs later on the drain tick and never wrote back to the runtime row.

Consequences: (1) healthy reuse fires show `queued` forever, so a queue-age alarm fires spuriously; (2) a wedged session's dead-letter — which parks the session `failed` so the next fire self-heals — is invisible (`last_status` stays `queued`, `last_error` null), leaving monitoring blind.

## What changed
- `apps/api/src/projects/trigger-execution-store.ts`: add `markTriggerRuntimeDelivered` (flip `queued → fired`, no `last_fired_at` advance) and `markTriggerRuntimeDeliveryFailed` (`queued → failed` + `lastError`).
- `apps/api/src/projects/session-lifecycle/engine.ts`: on prompt delivery, write back `fired` when the command carries a `triggerSlug`.
- `apps/api/src/projects/session-lifecycle/store.ts`: on dead-letter, write back `failed` + error when the command carries a `triggerSlug`.
- Both write-backs are best-effort (swallowed) so a write failure can never break prompt delivery.

## Verification
- `bun test apps/api/src/projects/session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts` → 5 pass.
- `bun test apps/api/src/projects/session-lifecycle/__tests__/{queued-continue-inbox-delivery,runtime-unreachable-park,continue-session-deleted-guard}.test.ts` → 13 / 10 / 2 pass.
- `apps/api` `NODE_OPTIONS=--max-old-space-size=8192 bunx tsc --noEmit` → clean.

## Risk / rollback
Low. The two new writes are idempotent upserts on `projectTriggerRuntime` (same insert/onConflict pattern as the existing `markGitTriggerFired`/`markGitTriggerAttemptFailed`) and are `.catch(() => {})`-swallowed, so they cannot fail prompt delivery. No schema/migration change. Out of scope (follow-up): the deeper "delivered but the reused session strands an empty assistant message (completed: null)" session-runtime wedge — this PR makes that state *observable* (`fired` = delivered) but does not fail the session over on its own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953981&installation_model_id=434224&pr_number=7094&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7094&signature=ea4ba7adebd06e7ea01e0bfb7b9412755209b5d29ea4cc5cae8a8185c927c319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->