### PR TITLE
session errors: unwrap serialized bodies in the SDK, rebuild the banner on Item

### DIFF
--- a/apps/web/src/features/session/session-error-banner.test.tsx
+++ b/apps/web/src/features/session/session-error-banner.test.tsx
@@ -88,3 +88,17 @@ describe('SessionRetryDisplay', () => {
     expect(html).toContain('context_length_exceeded');
   });
 });
+
+// Persisted on a local stack as OpenCode `UnknownError.data.message`:
+// `{"message":"The usage limit has been reached","code":429}`. Once the SDK
+// unwraps that to the sentence, it is a usage stop the user can lift, so it
+// must reach the upgrade card and not the generic failure row.
+describe('TurnErrorDisplay routes a usage-limit sentence to the upgrade card', () => {
+  test('"The usage limit has been reached" renders Upgrade plan', () => {
+    const html = renderToStaticMarkup(
+      <TurnErrorDisplay errorText="The usage limit has been reached" />,
+    );
+    expect(html).toContain('Upgrade plan');
+    expect(html).toContain('The usage limit has been reached');
+  });
+});

--- a/apps/web/src/features/session/session-error-banner.tsx
+++ b/apps/web/src/features/session/session-error-banner.tsx
@@ -2,21 +2,106 @@
 
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
+import type { ComponentProps, ReactNode } from 'react';
 
+import { Button } from '@/components/ui/button';
 import {
-  Checkpoint,
-  CheckpointIcon,
-  CheckpointLabel,
-  CheckpointTrigger,
-} from '@/components/ai-elements/checkpoint';
-import { Item, ItemContent, ItemDescription, ItemMedia, ItemTitle } from '@/components/ui/item';
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from '@/components/ui/item';
 import Loading from '@/components/ui/loading';
 import { cn } from '@/lib/utils';
 import { buildAccountSettingsHref } from '@/stores/account-settings-modal-store';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
 import { isAbortError, type GatewayErrorDetails } from '@kortix/sdk';
 import type { KortixSendError } from '@kortix/sdk/react';
-import { CreditCardIcon, LightningIcon, WarningCircleIcon } from '@phosphor-icons/react';
+import {
+  CaretRightIcon,
+  CreditCardIcon,
+  LightningIcon,
+  WarningCircleIcon,
+  type Icon,
+} from '@phosphor-icons/react';
+
+// ============================================================================
+// Shared row anatomy
+//
+// Every card in this file is one `Item`: a tinted status tile on the left, a
+// title / description / meta stack, and (for billing) the remedy as buttons
+// beneath the text. One shell means a retry row that becomes a terminal error
+// keeps its tile, its border and its rhythm — only the tone and the copy change.
+//
+// The tile tone is the only hue in the row. `error` is a failure, `warning` is
+// a billing stop the user can lift. An in-flight retry has no tile at all — it
+// is a spinner beside text, not a verdict.
+// ============================================================================
+
+type Tone = 'error' | 'warning';
+
+const TONE_TILE: Record<Tone, string> = {
+  error: 'bg-kortix-red/15 text-kortix-red',
+  warning: 'bg-kortix-orange/15 text-kortix-orange',
+};
+
+function StatusTile({
+  tone,
+  className,
+  children,
+}: {
+  tone: Tone;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <ItemMedia className={cn('size-8 rounded-sm', TONE_TILE[tone], className)}>
+      {children}
+    </ItemMedia>
+  );
+}
+
+/**
+ * `ItemMedia` top-aligns itself the moment a description exists — right for a
+ * paragraph of error text, wrong for a tile beside two short lines, where it
+ * reads as a tile that slipped upward. Written WITH the same variant prefix so
+ * `tailwind-merge` replaces the rule instead of losing the cascade.
+ */
+const TILE_CENTERED = cn(
+  'group-has-[[data-slot=item-description]]/item:translate-y-0',
+  'group-has-[[data-slot=item-description]]/item:self-center',
+);
+
+/**
+ * Remedy buttons on the far right of the row at `sm` and up; on a phone they
+ * wrap onto their own full-width line, right-aligned, so a two-button remedy
+ * never squeezes the sentence.
+ */
+const ROW_ACTIONS = 'basis-full flex-wrap justify-end sm:ml-auto sm:basis-auto';
+
+function StatusGlyph({ icon: Glyph }: { icon: Icon }) {
+  return <Glyph weight="fill" className="size-4 shrink-0" />;
+}
+
+/**
+ * The bordered row every card sits in. `Item` already wraps, so the content
+ * column shrinks below its intrinsic width (`min-w-0`) and long single tokens
+ * (request ids, model routes, URLs) break instead of pushing the row wide.
+ */
+function ErrorRow({ className, children, ...props }: ComponentProps<typeof Item>) {
+  return (
+    <Item
+      variant="muted"
+      size="sm"
+      className={cn('border-border border py-2.5', className)}
+      {...props}
+    >
+      {children}
+    </Item>
+  );
+}
 
 // ============================================================================
 // Insufficient-credits detection — upstream 402 from /v1/router/chat/completions
@@ -46,6 +131,7 @@ function isUsageLimitError(text: string): boolean {
   return (
     lower.includes('free usage') ||
     lower.includes('usage exceeded') ||
+    lower.includes('usage limit') ||
     lower.includes('subscription required') ||
     lower.includes('subscription_required') ||
     lower.includes('budget exceeded') ||
@@ -60,18 +146,24 @@ function UsageLimitCard({ errorText, className }: { errorText: string; className
   const billingHref = buildAccountSettingsHref({ tab: 'billing', accountId });
 
   return (
-    <Checkpoint className={className}>
-      <CheckpointIcon>
-        <LightningIcon className="size-4 shrink-0" />
-      </CheckpointIcon>
-      <CheckpointLabel className="overflow-visible whitespace-normal">{errorText}</CheckpointLabel>
-      <CheckpointTrigger asChild>
-        <Link href={billingHref} prefetch>
-          <LightningIcon className="size-3" />
-          Upgrade plan
-        </Link>
-      </CheckpointTrigger>
-    </Checkpoint>
+    <ErrorRow role="status" className={className}>
+      <StatusTile tone="warning" className={TILE_CENTERED}>
+        <StatusGlyph icon={LightningIcon} />
+      </StatusTile>
+      <ItemContent className="min-w-0">
+        {/* The server sentence ("Free usage exceeded, subscribe to Go") is
+            already the headline — no second line restating it. */}
+        <ItemTitle className="w-full text-pretty wrap-anywhere">{errorText}</ItemTitle>
+      </ItemContent>
+      <ItemActions className={ROW_ACTIONS}>
+        <Button asChild size="sm" className="active:scale-[0.96]">
+          <Link href={billingHref} prefetch>
+            <LightningIcon className="size-3.5 shrink-0" />
+            Upgrade plan
+          </Link>
+        </Button>
+      </ItemActions>
+    </ErrorRow>
   );
 }
 
@@ -101,31 +193,39 @@ function InsufficientCreditsCard({
   const title = tHardcodedUi.raw(
     'componentsSessionSessionErrorBanner.line58JsxAttrTitleYouRanOutOfCredits',
   );
-  const label = balance ? `${title} (${balance})` : title;
 
   return (
-    <Checkpoint className={className}>
-      <CheckpointIcon>
-        <CreditCardIcon className="size-4 shrink-0" />
-      </CheckpointIcon>
-      <CheckpointLabel className="overflow-visible whitespace-normal">{label}</CheckpointLabel>
-      <CheckpointTrigger asChild>
-        <Link href={billingHref} prefetch>
-          <LightningIcon className="size-3" />
-          {tHardcodedUi.raw('componentsSessionSessionErrorBanner.line74JsxTextEnableAutoTopUp')}
-        </Link>
-      </CheckpointTrigger>
-      <CheckpointTrigger variant="outline" asChild>
-        <Link href={billingHref} prefetch>
-          {tHardcodedUi.raw('componentsSessionSessionErrorBanner.line82JsxTextBuyCredits')}
-        </Link>
-      </CheckpointTrigger>
-    </Checkpoint>
+    <ErrorRow role="status" className={className}>
+      <StatusTile tone="warning" className={TILE_CENTERED}>
+        <StatusGlyph icon={CreditCardIcon} />
+      </StatusTile>
+      <ItemContent className="min-w-0 gap-0.5">
+        <ItemTitle className="w-full text-pretty wrap-anywhere">{title}</ItemTitle>
+        {/* The balance is the one number the user needs; when the message has
+            none, show the raw server text so nothing is dropped on the floor. */}
+        <ItemDescription className="line-clamp-none text-xs text-pretty wrap-anywhere tabular-nums">
+          {balance ? `Balance ${balance}` : errorText}
+        </ItemDescription>
+      </ItemContent>
+      <ItemActions className={ROW_ACTIONS}>
+        <Button asChild size="sm" className="active:scale-[0.96]">
+          <Link href={billingHref} prefetch>
+            <LightningIcon className="size-3.5 shrink-0" />
+            {tHardcodedUi.raw('componentsSessionSessionErrorBanner.line74JsxTextEnableAutoTopUp')}
+          </Link>
+        </Button>
+        <Button asChild variant="outline" size="sm" className="active:scale-[0.96]">
+          <Link href={billingHref} prefetch>
+            {tHardcodedUi.raw('componentsSessionSessionErrorBanner.line82JsxTextBuyCredits')}
+          </Link>
+        </Button>
+      </ItemActions>
+    </ErrorRow>
   );
 }
 
 // ============================================================================
-// TurnErrorDisplay — simple inline error card (matches SolidJS reference)
+// TurnErrorDisplay — inline failure row
 // ============================================================================
 
 type TurnErrorGatewayDetails = Pick<
@@ -139,19 +239,59 @@ function failureTarget(failure: NonNullable<GatewayErrorDetails['attemptFailures
   return `${failure.provider}/${failure.resolvedModel}${route}`;
 }
 
+/**
+ * `provider · code · requestId` — the "which upstream, which class, which
+ * request" line that support asks for. Rendered once, in meta type, beneath
+ * the human sentence rather than glued into it. `leading` prepends a caller
+ * fact that belongs in the same register (the retry attempt number).
+ */
+function GatewayMetaLine({
+  leading,
+  details,
+}: {
+  leading?: string;
+  details?: TurnErrorGatewayDetails;
+}) {
+  const metadata = [leading, details?.provider, details?.code, details?.requestId]
+    .filter(Boolean)
+    .join(' · ');
+  if (!metadata) return null;
+  return <p className="text-muted-foreground text-xs wrap-anywhere">{metadata}</p>;
+}
+
+/**
+ * The per-candidate failure chain, collapsed. It is the diagnostic, not the
+ * message: a reader who wants to know WHY every route failed opens it; everyone
+ * else sees one line saying how many were tried. A native `<details>` keeps the
+ * chain in the DOM (and in static markup) while closed — the same pattern
+ * `error-details.tsx` uses for a stack.
+ */
 function GatewayAttemptFailureList({ details }: { details?: TurnErrorGatewayDetails }) {
-  if (!details?.attemptFailures?.length) return null;
+  const failures = details?.attemptFailures;
+  if (!failures?.length) return null;
 
   return (
-    <ol className="text-muted-foreground mt-1 space-y-1 text-xs">
-      {details.attemptFailures.map((failure) => (
-        <li key={failure.attempt}>
-          <span className="text-foreground font-medium">{failureTarget(failure)}</span> ·{' '}
-          {failure.status !== undefined ? `HTTP ${failure.status} · ` : ''}
-          {String(failure.code)} · {failure.message}
-        </li>
-      ))}
-    </ol>
+    <details className="group/failures text-xs">
+      <summary
+        className={cn(
+          'text-muted-foreground hover:text-foreground flex w-fit cursor-pointer list-none',
+          'duration-fast items-center gap-1 transition-colors select-none',
+          '[&::-webkit-details-marker]:hidden',
+        )}
+      >
+        <CaretRightIcon className="size-3 shrink-0 group-open/failures:rotate-90" />
+        {failures.length === 1 ? '1 attempt' : `${failures.length} attempts`}
+      </summary>
+      <ol className="text-muted-foreground mt-1 list-decimal space-y-1 pl-4 wrap-anywhere">
+        {failures.map((failure) => (
+          <li key={failure.attempt}>
+            <span className="text-foreground font-medium">{failureTarget(failure)}</span> ·{' '}
+            {failure.status !== undefined ? `HTTP ${failure.status} · ` : ''}
+            {String(failure.code)} · {failure.message}
+          </li>
+        ))}
+      </ol>
+    </details>
   );
 }
 
@@ -255,30 +395,29 @@ export function TurnErrorDisplay({
     return <UsageLimitCard errorText={text} className={className} />;
   }
 
-  // Real errors → Checkpoint row. When the failure carries the gateway's
-  // structured envelope (provider/suggestion/request_id), fold those into the
-  // label so the provider/source of the failure stays visible.
+  // Real errors → one row, three registers. The message is the title; the
+  // gateway's suggestion (what to do about it) is the description; provider,
+  // code and request id sit in a meta line so support can find the request
+  // without the user having to read past them. Attempt failures list beneath.
   const suggestion =
     gateway?.suggestion && gateway.suggestion !== text ? gateway.suggestion : undefined;
-  const label = [
-    gateway?.provider ? `${gateway.provider}: ${text}` : text,
-    gateway?.code,
-    suggestion,
-    gateway?.requestId,
-  ]
-    .filter(Boolean)
-    .join(' · ');
 
   return (
-    <div className={className}>
-      <Checkpoint>
-        <CheckpointIcon>
-          <WarningCircleIcon className="text-muted-foreground size-4 shrink-0" />
-        </CheckpointIcon>
-        <CheckpointLabel className="overflow-visible whitespace-normal">{label}</CheckpointLabel>
-      </Checkpoint>
-      <GatewayAttemptFailureList details={gateway} />
-    </div>
+    <ErrorRow role="alert" className={className}>
+      <StatusTile tone="error">
+        <StatusGlyph icon={WarningCircleIcon} />
+      </StatusTile>
+      <ItemContent className="min-w-0 gap-1">
+        <ItemTitle className="w-full text-pretty wrap-anywhere">{text}</ItemTitle>
+        {suggestion ? (
+          <ItemDescription className="line-clamp-none text-xs text-pretty wrap-anywhere">
+            {suggestion}
+          </ItemDescription>
+        ) : null}
+        <GatewayMetaLine details={gateway} />
+        <GatewayAttemptFailureList details={gateway} />
+      </ItemContent>
+    </ErrorRow>
   );
 }
 
@@ -300,29 +439,29 @@ export function SessionRetryDisplay({
   if (!message) return null;
 
   const title = secondsLeft > 0 ? `Retrying in ${secondsLeft}s` : 'Retrying now';
-  const metadata = [details?.provider, details?.code, details?.requestId]
-    .filter(Boolean)
-    .join(' · ');
 
+  // Three registers, one idea each. Title: what is happening and when. Description:
+  // why (the gateway's sentence). Meta: which attempt, which upstream, which
+  // request. The candidate chain stays folded beneath.
+  //
+  // No status tile — this is a transient state, not a verdict. `spokes` is the
+  // spinner built to sit beside text at this size; boxing it read as a failure
+  // that had not happened yet.
   return (
     <output aria-live="polite" className="block">
-      <Item variant="muted" size="sm" className={cn('items-start', className)}>
-        <ItemMedia variant="icon">
-          <Loading className="text-muted-foreground size-4 shrink-0" />
+      <ErrorRow className={className}>
+        <ItemMedia>
+          <Loading variant="spokes" className="text-muted-foreground size-4 shrink-0" />
         </ItemMedia>
-        <ItemContent>
-          <ItemTitle className="tabular-nums">
-            {title} <span className="text-muted-foreground font-normal">#{attempt}</span>
-          </ItemTitle>
-          <ItemDescription className={cn('text-pretty', !details && 'line-clamp-2')}>
+        <ItemContent className="min-w-0 gap-1">
+          <ItemTitle className="w-full tabular-nums">{title}</ItemTitle>
+          <ItemDescription className="line-clamp-none text-xs text-pretty wrap-anywhere">
             {message}
           </ItemDescription>
-          {metadata ? (
-            <p className="text-muted-foreground mt-1 text-xs text-pretty">{metadata}</p>
-          ) : null}
+          <GatewayMetaLine leading={`Attempt ${attempt}`} details={details} />
           <GatewayAttemptFailureList details={details} />
         </ItemContent>
-      </Item>
+      </ErrorRow>
     </output>
   );
 }

--- a/packages/sdk/src/core/turns/errors.test.ts
+++ b/packages/sdk/src/core/turns/errors.test.ts
@@ -193,3 +193,103 @@ describe('extractGatewayErrorDetails — recovering the structured envelope', ()
     expect(extractGatewayErrorDetails(openCodeApiError)).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Real persisted shapes. Pulled verbatim from `kortix.session_transcript_messages`
+// `info.error` on a local stack (2026-09-02). OpenCode's `UnknownError` stores
+// `String(err)` as `data.message`, and when the thrown error's message was an
+// HTTP body, that body — JSON, prefixed, truncated, or HTML — is what the
+// transcript renders unless it is unwrapped again.
+// ---------------------------------------------------------------------------
+describe('unwrapError — a message that is itself a serialized body is unwrapped again', () => {
+  test("OpenCode UnknownError whose data.message is a JSON string (the 401 'token expired' row)", () => {
+    expect(
+      unwrapError({
+        name: 'UnknownError',
+        data: {
+          message: '{"message":"Provided authentication token is expired.","code":401}',
+        },
+      }),
+    ).toBe('Provided authentication token is expired.');
+  });
+
+  test("OpenCode UnknownError whose data.message is a JSON string (the 429 'usage limit' row)", () => {
+    expect(
+      unwrapError({
+        name: 'UnknownError',
+        data: { message: '{"message":"The usage limit has been reached","code":429}' },
+      }),
+    ).toBe('The usage limit has been reached');
+  });
+
+  test('a plain UnknownError message stays untouched', () => {
+    expect(
+      unwrapError({
+        name: 'UnknownError',
+        data: { message: "'file part media type application/zip' functionality not supported." },
+      }),
+    ).toBe("'file part media type application/zip' functionality not supported.");
+  });
+
+  test('a message nested two bodies deep resolves to the innermost human sentence', () => {
+    expect(
+      unwrapError({
+        message: JSON.stringify({ error: { message: JSON.stringify({ message: 'Overloaded' }) } }),
+      }),
+    ).toBe('Overloaded');
+  });
+
+  test('an AI SDK class-name prefix is stripped like "Error: " is', () => {
+    expect(unwrapError('AI_APICallError: Bad Gateway')).toBe('Bad Gateway');
+    expect(unwrapError('AI_APICallError: {"error":{"message":"Overloaded"}}')).toBe('Overloaded');
+    expect(
+      unwrapError(
+        'Error: 402 Error: {"error":true,"message":"Insufficient credits","status":402}',
+      ),
+    ).toBe('Insufficient credits');
+  });
+
+  test('provider bodies that key the sentence differently still yield the sentence', () => {
+    expect(unwrapError({ detail: 'Not authenticated' })).toBe('Not authenticated');
+    expect(unwrapError({ error: { error: { message: 'deep' } } })).toBe('deep');
+    expect(unwrapError({ errors: [{ message: 'first of many' }] })).toBe('first of many');
+    expect(unwrapError({ error_description: 'The access token expired' })).toBe(
+      'The access token expired',
+    );
+  });
+
+  test('a truncated JSON body still gives up its "message" field instead of the fragment', () => {
+    const truncated =
+      '{"error":{"message":"Your input exceeds the context window of this model.","type":"invalid_request_err';
+    expect(unwrapError(truncated)).toBe('Your input exceeds the context window of this model.');
+  });
+
+  test('an HTML error page collapses to its title', () => {
+    const html =
+      '<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>cloudflare</center>\r\n</body>\r\n</html>';
+    expect(unwrapError(html)).toBe('502 Bad Gateway');
+  });
+
+  test('a body with no recognizable sentence never renders "[object Object]" or empty', () => {
+    // A code or status is still a sentence's worth of information — say it.
+    expect(unwrapError({ status: 500 })).toBe('Request failed with status 500');
+    expect(unwrapError({ type: 'overloaded_error' })).toBe('Overloaded error');
+    const cyclic: Record<string, unknown> = { code: 'loop' };
+    cyclic.error = cyclic;
+    expect(unwrapError(cyclic)).toBe('Loop');
+    expect(unwrapError('{}')).toBe('An error occurred');
+    expect(unwrapError('   ')).toBe('An error occurred');
+  });
+});
+
+describe('extractGatewayErrorDetails — a gateway body serialized into data.message', () => {
+  test('recovers the envelope from an UnknownError whose data.message is the gateway JSON', () => {
+    const details = extractGatewayErrorDetails({
+      name: 'UnknownError',
+      data: { message: JSON.stringify(gatewayBody()) },
+    });
+    expect(details?.provider).toBe('openai');
+    expect(details?.code).toBe('provider_not_connected');
+    expect(details?.requestId).toBe('req_abc123');
+  });
+});

--- a/packages/sdk/src/core/turns/errors.ts
+++ b/packages/sdk/src/core/turns/errors.ts
@@ -4,46 +4,187 @@
  * creating an index.ts <-> classify.ts import cycle.
  */
 
+const GENERIC_ERROR_MESSAGE = 'An error occurred';
+
 /**
- * Extract human-readable error message from a raw error value.
- * Matches SolidJS `unwrap()` function — session-turn.tsx:34-81
+ * How many serialized layers `unwrapError` will peel. Real rows nest two deep
+ * (OpenCode `UnknownError.data.message` → a JSON body → its `error.message`);
+ * four leaves headroom without letting a pathological body recurse forever.
  */
-export function unwrapError(raw: unknown): string {
-  if (!raw) return 'An error occurred';
+const MAX_UNWRAP_DEPTH = 4;
 
-  if (typeof raw === 'string') {
-    // Strip "Error: " prefix
-    let str = raw.startsWith('Error: ') ? raw.slice(7) : raw;
+/**
+ * Body keys that carry the human sentence, in the order providers use them.
+ * `message` is OpenAI/Anthropic/our gateway, `error` is the OpenAI-compatible
+ * nesting, `detail` is FastAPI, `error_description` is OAuth, `msg` is
+ * pydantic, `errors[]` is GraphQL/Google, `data` is OpenCode's own envelope.
+ */
+const MESSAGE_KEYS = [
+  'message',
+  'error',
+  'detail',
+  'error_description',
+  'msg',
+  'errors',
+  'data',
+] as const;
 
-    // Try JSON parsing (might be double-encoded)
-    try {
-      const parsed = JSON.parse(str);
-      if (typeof parsed === 'string') {
-        str = parsed; // double-encoded string
-        try {
-          const inner = JSON.parse(str);
-          return extractErrorFromObject(inner) || str;
-        } catch {
-          return str;
-        }
-      }
-      return extractErrorFromObject(parsed) || str;
-    } catch {
-      // Not directly parseable as JSON — router/connector errors commonly wrap
-      // a JSON body inside a plain-text prefix, e.g. router tool credit
-      // failures: `Error: 402 Error: {"error":true,"message":"Insufficient
-      // credits","status":402}`. Extract the outermost {...} substring (if
-      // any) and try that instead of surfacing the raw prefixed string.
-      const embedded = extractEmbeddedJsonMessage(str);
-      return embedded ?? str;
+/**
+ * `"Error: "`, `"AI_APICallError: "`, `"402 Error: "` — the prefixes `String(err)`
+ * and the AI SDK's `toString()` bolt on, which stack when a body is re-thrown
+ * (`Error: 402 Error: {…}`). Peeled repeatedly, so the caller sees the body.
+ */
+function stripErrorPrefixes(str: string): string {
+  let s = str.trim();
+  for (let i = 0; i < MAX_UNWRAP_DEPTH; i++) {
+    const next = s.replace(/^(?:\d{3}\s+)?(?:[A-Za-z_$][\w$]*)?Error:\s*/, '').trim();
+    if (next === s) break;
+    s = next;
+  }
+  return s;
+}
+
+function tryParseJson(value: unknown): unknown {
+  if (typeof value !== 'string' || !value) return undefined;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The first `"message": "…"` (or sibling key) inside a JSON-ish string that
+ * does NOT parse — an upstream body truncated by a log limit, or a body with
+ * trailing garbage. Unescapes the captured literal through `JSON.parse` so
+ * `\"` and `\n` come out as characters, not backslashes.
+ */
+function messageFieldFromJsonish(str: string): string | undefined {
+  const match = str.match(/"(?:message|detail|error_description|msg)"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+  if (!match) return undefined;
+  const literal = tryParseJson(`"${match[1]}"`);
+  return typeof literal === 'string' && literal.trim() ? literal.trim() : undefined;
+}
+
+/**
+ * A gateway or CDN error page (`<html><title>502 Bad Gateway</title>…`). The
+ * title is the sentence; failing that, the visible text, capped so a whole
+ * page never lands in a transcript row.
+ */
+function textFromHtml(str: string): string | undefined {
+  if (!/^\s*<(?:!doctype|html|head|body)\b/i.test(str)) return undefined;
+  const title = str.match(/<title[^>]*>([^<]*)<\/title>/i)?.[1]?.trim();
+  if (title) return title;
+  const text = str
+    .replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text ? text.slice(0, 200) : undefined;
+}
+
+/** `overloaded_error` → `Overloaded error`; `rate_limit_exceeded` → `Rate limit exceeded`. */
+function humanizeCode(code: string): string {
+  const words = code.replace(/[_-]+/g, ' ').trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : words;
+}
+
+/**
+ * `depth` counts DESERIALIZATION layers (a string parsed into a body), not key
+ * hops inside one body — `error.error.message` is one layer, not three. Object
+ * nesting is bounded separately by `seen`, which also stops a cyclic
+ * `Error.cause` chain from recursing.
+ */
+function unwrapValue(value: unknown, depth: number, seen: WeakSet<object>): string | undefined {
+  if (typeof value === 'string') return unwrapString(value, depth, seen);
+  if (value && typeof value === 'object') return unwrapObject(value, depth, seen);
+  return undefined;
+}
+
+function unwrapString(
+  raw: string,
+  depth: number,
+  seen: WeakSet<object> = new WeakSet(),
+): string | undefined {
+  const str = stripErrorPrefixes(raw);
+  if (!str) return undefined;
+  if (depth >= MAX_UNWRAP_DEPTH) return str;
+
+  // The whole string is a body (possibly a double-encoded one).
+  const parsed = tryParseJson(str);
+  if (parsed !== undefined) {
+    if (typeof parsed === 'string') return unwrapString(parsed, depth + 1, seen);
+    if (parsed && typeof parsed === 'object') return unwrapObject(parsed, depth + 1, seen);
+    return String(parsed);
+  }
+
+  // A body wrapped in a plain-text prefix the regex above did not know —
+  // router/connector errors commonly do this. Extract the outermost {...}.
+  const embedded = embeddedJsonSubstring(str);
+  if (embedded) {
+    const parsedEmbedded = tryParseJson(embedded);
+    if (parsedEmbedded && typeof parsedEmbedded === 'object') {
+      const fromEmbedded = unwrapObject(parsedEmbedded, depth + 1, seen);
+      if (fromEmbedded) return fromEmbedded;
     }
   }
 
-  // (`!raw` at the top already excluded null — typeof alone suffices here.)
-  if (typeof raw === 'object') {
-    return extractErrorFromObject(raw) || 'An error occurred';
+  // JSON-ish but unparseable (truncated, trailing text): pull the sentence.
+  if (str.includes('{')) {
+    const field = messageFieldFromJsonish(str);
+    if (field) return unwrapString(field, depth + 1, seen) ?? field;
   }
 
+  return textFromHtml(str) ?? str;
+}
+
+function unwrapObject(
+  obj: object,
+  depth: number,
+  seen: WeakSet<object> = new WeakSet(),
+): string | undefined {
+  if (depth >= MAX_UNWRAP_DEPTH || seen.has(obj)) return undefined;
+  seen.add(obj);
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      const fromItem = unwrapValue(item, depth, seen);
+      if (fromItem) return fromItem;
+    }
+    return undefined;
+  }
+  const record = obj as Record<string, unknown>;
+  for (const key of MESSAGE_KEYS) {
+    const fromKey = unwrapValue(record[key], depth, seen);
+    if (fromKey) return fromKey;
+  }
+  // No sentence anywhere. A code or a status is still more useful than
+  // "An error occurred" — say what the body did say.
+  const code = record.type ?? record.code;
+  if (typeof code === 'string' && code.trim()) return humanizeCode(code);
+  const status = record.status ?? record.statusCode ?? record.upstream_status;
+  if (typeof status === 'number' && Number.isFinite(status)) {
+    return `Request failed with status ${status}`;
+  }
+  return undefined;
+}
+
+/**
+ * Extract the human-readable sentence from a raw error value, however many
+ * layers of serialization it arrived in.
+ *
+ * OpenCode's `UnknownError` stores `String(err)` as `data.message`; when the
+ * thrown error's message was an HTTP body, that body reaches the transcript
+ * as a JSON string — `{"message":"Provided authentication token is
+ * expired.","code":401}` — unless it is unwrapped AGAIN. So every string this
+ * function extracts is fed back through the same unwrapping, bounded by
+ * `MAX_UNWRAP_DEPTH`, until a plain sentence falls out.
+ *
+ * Never returns raw JSON, an HTML page, `[object Object]`, or an empty string.
+ */
+export function unwrapError(raw: unknown): string {
+  if (!raw) return GENERIC_ERROR_MESSAGE;
+  if (typeof raw === 'string') return unwrapString(raw, 0) ?? GENERIC_ERROR_MESSAGE;
+  if (typeof raw === 'object') return unwrapObject(raw, 0) ?? GENERIC_ERROR_MESSAGE;
   return String(raw);
 }
 
@@ -51,8 +192,8 @@ export function unwrapError(raw: unknown): string {
  * Best-effort substring spanning the first `{` to the last `}` in a larger
  * non-JSON string — correct for the common single-object case (nested
  * double-wrapped errors don't nest braces inside the outer text). Shared by
- * `extractEmbeddedJsonMessage` (message-only) and `extractGatewayErrorDetails`
- * (full structured envelope) below.
+ * `unwrapString` (message-only) and `extractGatewayErrorDetails` (full
+ * structured envelope) below.
  */
 function embeddedJsonSubstring(str: string): string | undefined {
   const start = str.indexOf('{');
@@ -61,25 +202,10 @@ function embeddedJsonSubstring(str: string): string | undefined {
   return str.slice(start, end + 1);
 }
 
-/**
- * Best-effort extraction of a human message from a JSON object embedded
- * somewhere inside a larger non-JSON string. Cheap; falls back to `undefined`
- * (never throws) if that substring isn't valid JSON or has no recognizable
- * error shape.
- */
-function extractEmbeddedJsonMessage(str: string): string | undefined {
-  const substring = embeddedJsonSubstring(str);
-  if (!substring) return undefined;
-  try {
-    return extractErrorFromObject(JSON.parse(substring));
-  } catch {
-    return undefined;
-  }
-}
-
+/** The one-level `message`/`error`/`data.message`/`error.message` read the
+ *  gateway-envelope code below still uses for its own `message` field. */
 function extractErrorFromObject(obj: unknown): string | undefined {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) return undefined;
-  // Try common error shapes
   const record = obj as Record<string, unknown>;
   if (typeof record.message === 'string' && record.message) return record.message;
   if (typeof record.error === 'string' && record.error) return record.error;
@@ -172,15 +298,6 @@ function attemptFailuresFrom(value: unknown): GatewayAttemptFailure[] | undefine
   return failures.length > 0 ? failures : undefined;
 }
 
-function tryParseJson(value: unknown): unknown {
-  if (typeof value !== 'string' || !value) return undefined;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return undefined;
-  }
-}
-
 /** Pull the gateway envelope's fields off a single object level (no
  *  unwrapping of nested shapes — that's `extractGatewayErrorDetails`'s job).
  *  Returns `undefined` when NONE of the gateway-specific fields are present,
@@ -234,7 +351,7 @@ export function extractGatewayErrorDetails(raw: unknown): GatewayErrorDetails | 
   if (raw == null) return undefined;
 
   if (typeof raw === 'string') {
-    const str = raw.startsWith('Error: ') ? raw.slice(7) : raw;
+    const str = stripErrorPrefixes(raw);
     const parsed = tryParseJson(str) ?? tryParseJson(embeddedJsonSubstring(str));
     return parsed !== undefined ? extractGatewayErrorDetails(parsed) : undefined;
   }
@@ -258,6 +375,13 @@ export function extractGatewayErrorDetails(raw: unknown): GatewayErrorDetails | 
       const fromBody = extractGatewayErrorDetails(parsedBody);
       if (fromBody) return fromBody;
     }
+  }
+  // OpenCode's `UnknownError` has no `responseBody` — `String(err)` is all it
+  // keeps, in `data.message`. When that string IS the gateway body (a JSON
+  // string, possibly prefixed), the envelope is still in there.
+  if (data && typeof data.message === 'string') {
+    const fromMessage = extractGatewayErrorDetails(data.message);
+    if (fromMessage) return fromMessage;
   }
 
   const cause = record.cause;

--- a/packages/sdk/src/react/use-session.test.ts
+++ b/packages/sdk/src/react/use-session.test.ts
@@ -303,6 +303,18 @@ describe('classifySendError', () => {
     expect(result.gateway).toBeUndefined();
   });
 
+  // The thrown error's message is often an HTTP body, not a sentence — the
+  // same `{"message":…,"code":401}` string OpenCode persists into
+  // `UnknownError.data.message`. The runtime-error message must be the
+  // sentence inside it, never the serialized body.
+  test('a runtime-error whose message is a JSON body reports the sentence inside it', () => {
+    const result = classifySendError(
+      new Error('{"message":"Provided authentication token is expired.","code":401}'),
+    );
+    expect(result.kind).toBe('runtime-error');
+    expect(result.message).toBe('Provided authentication token is expired.');
+  });
+
   // ERROR-TAXONOMY fix: a runtime-error carrying the gateway's structured
   // envelope (provider/code/suggestion/request_id) surfaces those fields on
   // `.gateway` instead of discarding everything but the bare message.

--- a/packages/sdk/src/react/use-session.ts
+++ b/packages/sdk/src/react/use-session.ts
@@ -52,7 +52,7 @@ import { RuntimeNotReadyError, getClient } from '../core/runtime/client';
 import { setCurrentRuntime } from '../core/session/current-runtime';
 import { openSessionBundle } from '../core/session/open-bundle';
 import { messagesBeforeRewind } from '../core/session/rewind';
-import { extractGatewayErrorDetails } from '../core/turns/errors';
+import { extractGatewayErrorDetails, unwrapError } from '../core/turns/errors';
 import { clearStartStash, readStartStash } from './session-start-stash';
 import { reconcileHydratedSessionTitle } from './session-title-sync';
 import { useCanonicalOpenCodeSession } from './use-canonical-opencode-session';
@@ -588,7 +588,9 @@ export function classifySendError(error: unknown): KortixSendError {
     kind: 'runtime-error',
     // Prefer the gateway's own message (already human-written server-side per
     // status/cause) over opencode's raw runtime-error formatting when present.
-    message: gateway?.message || formatted.message,
+    // The fallback is unwrapped too: a thrown error's message is often an HTTP
+    // body (`{"message":…,"code":401}`), and a body is not a sentence.
+    message: gateway?.message || unwrapError(formatted.message),
     ...(gateway
       ? {
           gateway: {


### PR DESCRIPTION
## Summary

The transcript rendered raw JSON for turn failures. OpenCode's `UnknownError` stores `String(err)` as `data.message`; when that string is an HTTP body, `unwrapError` returned it verbatim. Two rows persisted on a local stack:

```
{"message":"Provided authentication token is expired.","code":401}
{"message":"The usage limit has been reached","code":429}
```

**SDK** (`packages/sdk/src/core/turns/errors.ts`, `react/use-session.ts`)
- `unwrapError` re-unwraps every extracted string, capped at 4 deserialization layers; object nesting bounded by a `WeakSet`.
- Strips stacked prefixes (`Error: `, `AI_APICallError: `, `402 Error: `); reads `detail`, `error_description`, `msg`, `errors[]`, nested `error.error`; pulls `"message"` out of truncated JSON; collapses an HTML page to its `<title>`; falls back to a humanized code or `Request failed with status N`.
- `extractGatewayErrorDetails` recovers the gateway envelope from `UnknownError.data.message`.
- `classifySendError` runs the runtime-error fallback through `unwrapError`.
- No exported name, type, or signature changed.

**Web** (`apps/web/src/features/session/session-error-banner.tsx`)
- `Checkpoint` removed; every card is `Item variant="muted" size="sm"` with a hairline border.
- Tinted `size-8` status tile: `kortix-red` failure, `kortix-orange` billing.
- Failure row: message as title, gateway suggestion as description, `provider · code · requestId` meta line, attempt chain folded behind a native `<details>`.
- Billing rows: remedy buttons in a trailing `ItemActions`, far right on `sm+`, own row below `sm`.
- Retry row: `Loading variant="spokes"` beside text, no tile; `Attempt N` leads the meta line.
- `usage limit` routes to the upgrade card; `wrap-anywhere` on every text run.

## Test plan

- [x] `pnpm --filter @kortix/sdk test` → 2789 pass, 0 fail (baseline 2778); 10 new cases from the persisted shapes, each seen red first
- [x] `pnpm --filter @kortix/sdk typecheck` → clean
- [x] `pnpm --filter @kortix/sdk run smoke:install` → passed
- [x] `bun test session-error-banner*.test.tsx` → 12 pass, 0 fail
- [x] `npx eslint` + `kortix-brand-guidelines/audit.sh` on the banner → clean
- [x] `tsc --noEmit -p apps/web` → 0 errors in `src`
- [x] Every branch rendered on a temporary `/debug/error-banner` harness against the running dev server (HTTP 200, expected strings present); harness deleted before commit
- [ ] After dev deploy: trigger a turn failure on dev.kortix.com and confirm the sentence, not the JSON, renders

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956977&installation_model_id=434224&pr_number=7096&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7096&signature=833f58b1f24f80f7b31c2e387c53f1dd55427755dd7f2406016501811e24617f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->