### PR TITLE
docs(learnings): the two near-misses the v0.13.10 release surfaced

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,41 @@ linked, not inlined.
 
 ## Register
 
+### A `[skip ci]` release-prep commit deadlocks the lane that ships releases (2026-09-02)
+
+**When:** adding `[skip ci]` to any commit that lands on a branch whose deploy
+resolves an artifact BY that commit's SHA. `chore(release): staging VERSION ->
+0.13.10 [skip ci]` landed on `staging`, so `Build Staging Artifacts` never ran
+for it, so no `staging-e2586057` image existed — and `Deploy Staging` resolves
+staging HEAD and pulls that exact tag. Every staging deploy then failed with
+`docker.io/kortix/kortix-api:staging-e2586057: not found`, and staging served
+Aug-30 code for three days while the branch said otherwise. Nothing alerted:
+the deploy failure is one red run in a list, and staging's own `/health` keeps
+answering `ok` on the stale build. **The rule:** a commit that a deploy will
+resolve an image for must build. Either drop `[skip ci]` from release-prep
+commits, or make the deploy resolve the last BUILT ancestor instead of HEAD.
+*Blast radius:* prod could not have shipped wrong — `tests-release` asserts
+staging is serving `RELEASE_SOURCE_SHA` — but no release could ship at all,
+and a security fix (CVE-2026-56854, merged to `main` 2026-09-01) sat unshippable
+until an unrelated commit unwedged the lane. *Enforcement:* none yet — this is
+a TODO to build the enforcer. Related: [[a-read-that-fails-is-not-an-admin-decision]].
+
+### One health read during a rolling deploy proves nothing (2026-09-02)
+
+**When:** gating ANY promote, verification, or "is it deployed?" check on an
+HTTP health response. ECS rolls tasks gradually behind one load balancer, so
+old and new answer the same URL concurrently. Measured mid-roll on staging:
+10 consecutive `/v1/health` reads returned `8d5cf2ac, 8d5cf2ac, 8d5cf2ac,
+3693c556, 3693c556, 3693c556, 3693c556, 3693c556, 3693c556, 8d5cf2ac`. A
+single read had already fired a promote gate that then had to be revoked.
+**The rule:** require the deploy run to be `completed/success` AND N
+consecutive reads (>=8) agreeing on the expected SHA. The same shape applies to
+browser assertions: a redirect chain commits only its FINAL url, so
+`framenavigated` cannot see an intermediate hop — observe navigation REQUESTS.
+And any negative assertion ("it did NOT redirect") needs a positive control arm
+proving the mechanism fires at all, or it passes against dead code.
+*Incident:* caught pre-promote during the v0.13.10 release; no outage.
+
 ### A read that fails is not an admin decision — health flags fail open (2026-09-02)
 
 **When:** writing any code path that answers "is the platform in maintenance /


### PR DESCRIPTION
Both caught before they cost anything. Per the repo rule, an incident that leaves no learning behind is not finished.

### 1. A `[skip ci]` release-prep commit deadlocks the lane that ships releases

`chore(release): staging VERSION → 0.13.10 [skip ci]` landed on `staging`, so `Build Staging Artifacts` never ran for it, so no `staging-e2586057` image existed. `Deploy Staging` resolves staging HEAD and pulls that exact tag:

```
ERROR: docker.io/kortix/kortix-api:staging-e2586057: not found
```

Staging then served Aug-30 code for three days while the branch said otherwise. **Nothing alerted** — the failure is one red run in a list, and a stale staging keeps answering `/health` with `ok`.

Blast radius was bounded: `tests-release` asserts staging is serving `RELEASE_SOURCE_SHA`, so prod could not have shipped the wrong thing. But no release could ship *at all*, and CVE-2026-56854 (critical SSH auth bypass, fixed on `main` 2026-09-01) sat unshippable until an unrelated commit unwedged the lane.

### 2. One health read during a rolling deploy proves nothing

ECS rolls tasks gradually behind one load balancer. Measured mid-roll on staging:

```
8d5cf2ac, 8d5cf2ac, 8d5cf2ac, 3693c556, 3693c556,
3693c556, 3693c556, 3693c556, 3693c556, 8d5cf2ac
```

A single read had already fired a promote gate that had to be revoked. The rule: deploy run `completed/success` **and** ≥8 consecutive reads agreeing.

Same shape in browser verification, learned the hard way twice in this session:
- a redirect chain commits only its **final** url, so `framenavigated` cannot see the intermediate hop — observe navigation **requests**
- a negative assertion ("it did NOT redirect") needs a positive control arm proving the mechanism fires at all, or it passes against dead code

Neither entry claims an enforcer, because neither has one yet — both are written as the TODO they are.

https://claude.ai/code/session_01QaCVMX58YGvpNUEPsEwq52

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964880&installation_model_id=434224&pr_number=7101&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7101&signature=711a7c66917ca75dc3d061be248350ee152f94466e6c989dd60c804555eae842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->