### PR TITLE
review center: full-width inbox, inline review page, no modals

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -50,7 +50,7 @@ const buttonVariants = cva(
         success: 'bg-kortix-green/80 text-background hover:bg-kortix-green/85',
         error: 'bg-kortix-red/80 text-background hover:bg-kortix-red/85',
         info: 'bg-kortix-blue/80 text-background hover:bg-kortix-blue/85',
-        warning: 'bg-kortix-yellow/80 text-background hover:bg-kortix-yellow/85',
+        warning: 'bg-kortix-orange/80 text-background hover:bg-kortix-orange/85',
         popover: 'bg-popover text-foreground',
       },
       size: {

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -38,6 +38,7 @@ const itemVariants = cva(
         default: "bg-transparent",
         outline: "border-border",
         muted: "bg-muted/50",
+        warning: "border-kortix-orange bg-kortix-orange/20",
       },
       size: {
         default: "gap-4 p-4",

--- a/apps/web/src/features/review-center/change-files.tsx
+++ b/apps/web/src/features/review-center/change-files.tsx
@@ -1,34 +1,20 @@
 'use client';
 
 /**
- * The live "Files changed" + diff for a Change Request. Kept OUT of the friendly
- * review detail (the priority there is plain language, not code) — it lives one
- * click away in its own modal via `ChangeFilesModal`. Reuses the project-files
+ * The "Changes" section of a change's review page: every file the branch
+ * touched, each with its live diff open underneath. Reuses the project-files
  * diff stack (DiffRenderer + useChangeRequestDiff) so the review shows the REAL
- * branch state and updates as the agent revises. Connected mode only (needs a cr
- * id + ProjectFilesProvider, which the connected inbox provides).
+ * branch state and updates as the agent revises. Connected mode only (needs a
+ * cr id + ProjectFilesProvider, which the connected inbox provides).
  */
 
 import { Button } from '@/components/ui/button';
-import {
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalDescription,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-} from '@/components/ui/modal';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DiffStat } from '@/components/ui/status';
 import { DiffRenderer } from '@/features/project-files/components/diff-renderer';
 import { useChangeRequestDiff } from '@/features/project-files/hooks/use-change-requests';
 import { cn } from '@/lib/utils';
-import {
-  ArrowUpRightIcon as ArrowUpRight,
-  CaretDownIcon as ChevronDown,
-  EyeIcon as Eye,
-} from '@phosphor-icons/react';
+import { CaretDownIcon as ChevronDown } from '@phosphor-icons/react';
 import { useMemo, useState } from 'react';
 
 /** Split a unified diff into per-file patch chunks keyed by the new (b/) path. */
@@ -42,122 +28,98 @@ function splitPatchByFile(patch: string): Map<string, string> {
   return map;
 }
 
-const STATUS_CHAR: Record<string, string> = {
-  added: 'A',
-  modified: 'M',
-  deleted: 'D',
-  renamed: 'R',
-  copied: 'C',
-  typechange: 'T',
-};
-const STATUS_COLOR: Record<string, string> = {
-  added: 'text-kortix-green',
-  deleted: 'text-kortix-red',
-  renamed: 'text-kortix-blue',
-};
-
-function ChangeFilesSection({ crId }: { crId: string }) {
-  const { data, isLoading, isError } = useChangeRequestDiff(crId);
-  const [openPath, setOpenPath] = useState<string | null>(null);
-  const patchByPath = useMemo(() => splitPatchByFile(data?.patch ?? ''), [data?.patch]);
-
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        <Skeleton className="h-3.5 w-28 rounded" />
-        <Skeleton className="h-24 rounded-lg" />
-      </div>
-    );
-  }
-  if (isError || !data || data.files.length === 0) {
-    return (
-      <div className="text-muted-foreground py-8 text-center text-sm">No file changes to show.</div>
-    );
-  }
-
-  return (
-    <div>
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          Files changed · {data.files_changed}
-        </span>
-        <DiffStat additions={data.additions} deletions={data.deletions} />
-      </div>
-      <ul className="divide-border/60 bg-popover divide-y overflow-hidden rounded-lg border">
-        {data.files.map((f) => {
-          const open = openPath === f.path;
-          const patch = patchByPath.get(f.path);
-          return (
-            <li key={f.path}>
-              <button
-                type="button"
-                onClick={() => setOpenPath(open ? null : f.path)}
-                className="hover:bg-muted/40 flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors"
-              >
-                <span
-                  className={cn(
-                    'shrink-0 font-mono text-xs font-semibold',
-                    STATUS_COLOR[f.status] ?? 'text-kortix-yellow',
-                  )}
-                >
-                  {STATUS_CHAR[f.status] ?? 'M'}
-                </span>
-                <span className="text-foreground min-w-0 flex-1 truncate font-mono text-xs">
-                  {f.path}
-                </span>
-                <DiffStat additions={f.additions} deletions={f.deletions} className="shrink-0" />
-                {patch ? (
-                  <ChevronDown
-                    className={cn(
-                      'text-muted-foreground size-3.5 shrink-0 transition-transform',
-                      open && 'rotate-180',
-                    )}
-                  />
-                ) : null}
-              </button>
-              {open && patch ? (
-                <div className="border-border/60 max-h-[420px] overflow-auto border-t">
-                  <DiffRenderer patch={patch} />
-                </div>
-              ) : null}
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
+/** `src/features/constant/index.ts` → name `index.ts`, dir `src/features/constant`. */
+function splitPath(path: string): { name: string; dir: string } {
+  const slash = path.lastIndexOf('/');
+  if (slash < 0) return { name: path, dir: '' };
+  return { name: path.slice(slash + 1), dir: path.slice(0, slash) };
 }
 
-/**
- * The friendly trigger: a plain-language button that opens the code diff in its
- * own modal — so the review detail stays non-technical and the engineering view
- * is one click away.
- */
-export function ChangeFilesModal({ crId }: { crId: string }) {
-  const [open, setOpen] = useState(false);
+export function ChangeFiles({ crId }: { crId: string }) {
+  const { data, isLoading, isError } = useChangeRequestDiff(crId);
+  // Every file starts open — the diff is what a reviewer came for. Collapsing
+  // is per file and remembered until the page is left.
+  const [closed, setClosed] = useState<Set<string>>(new Set());
+  const patchByPath = useMemo(() => splitPatchByFile(data?.patch ?? ''), [data?.patch]);
+
+  const files = data?.files ?? [];
+  const allClosed = files.length > 0 && closed.size === files.length;
+
+  let body: React.ReactNode;
+  if (isLoading) {
+    body = (
+      <>
+        <Skeleton className="h-10 rounded-md" />
+        <Skeleton className="h-24 rounded-md" />
+      </>
+    );
+  } else if (isError || files.length === 0) {
+    body = (
+      <div className="bg-popover text-muted-foreground rounded-md border px-4 py-8 text-center text-sm">
+        No file changes to show.
+      </div>
+    );
+  } else {
+    body = files.map((f) => {
+      const { name, dir } = splitPath(f.path);
+      const patch = patchByPath.get(f.path);
+      const open = !closed.has(f.path);
+      return (
+        <section key={f.path} className="bg-popover overflow-hidden rounded-md border">
+          <button
+            type="button"
+            onClick={() =>
+              setClosed((prev) => {
+                const next = new Set(prev);
+                if (next.has(f.path)) next.delete(f.path);
+                else next.add(f.path);
+                return next;
+              })
+            }
+            aria-expanded={open}
+            className="hover:bg-hover duration-fast flex w-full items-center gap-2 px-4 py-2.5 text-left transition-colors"
+          >
+            <ChevronDown
+              className={cn(
+                'text-muted-foreground size-3.5 shrink-0 transition-transform',
+                !open && '-rotate-90',
+              )}
+            />
+            <span className="min-w-0 flex-1 truncate text-sm">
+              <span className="text-foreground font-medium">{name}</span>
+              {dir && <span className="text-muted-foreground ml-1.5">{dir}</span>}
+            </span>
+            <DiffStat
+              additions={f.additions}
+              deletions={f.deletions}
+              className="shrink-0 text-xs"
+            />
+          </button>
+          {open && patch ? (
+            <div className="border-border border-t">
+              <DiffRenderer patch={patch} />
+            </div>
+          ) : null}
+        </section>
+      );
+    });
+  }
+
   return (
-    <>
-      <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setOpen(true)}>
-        <Eye className="size-3.5" />
-        View the file changes
-        <ArrowUpRight className="size-3.5" />
-      </Button>
-      <Modal open={open} onOpenChange={setOpen}>
-        <ModalContent className="lg:max-w-3xl">
-          <ModalHeader>
-            <ModalTitle>File changes</ModalTitle>
-            <ModalDescription>The exact code diff for this change.</ModalDescription>
-          </ModalHeader>
-          <ModalBody className="max-h-[70vh] overflow-y-auto">
-            {open ? <ChangeFilesSection crId={crId} /> : null}
-          </ModalBody>
-          <ModalFooter>
-            <Button variant="outline-ghost" onClick={() => setOpen(false)}>
-              Close
-            </Button>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
-    </>
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-foreground text-sm font-medium">Changes</h2>
+        {files.length > 1 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setClosed(allClosed ? new Set() : new Set(files.map((f) => f.path)))}
+          >
+            {allClosed ? 'Expand all' : 'Collapse all'}
+          </Button>
+        )}
+      </div>
+      <div className="space-y-2">{body}</div>
+    </section>
   );
 }

--- a/apps/web/src/features/review-center/connector-approval-contract.test.ts
+++ b/apps/web/src/features/review-center/connector-approval-contract.test.ts
@@ -36,13 +36,17 @@ describe('connector approval review contract', () => {
   });
 
   test('Review Center uses the shared full-parameter component', () => {
-    const modal = read('./review-detail-modal.tsx');
+    const modal = read('./review-detail.tsx');
     const center = read('./review-center.tsx');
 
     expect(modal).toContain('<ApprovalRequest');
     expect(modal).toContain('argsPreview: adaptedAction.rawArgsPreview');
     expect(modal).not.toContain('Always allow this');
     expect(center).not.toContain('Approve all safe');
-    expect(center).toContain("item.kind !== 'approval'");
+    // Multi-select left the inbox UI (2026-09-03); the keyboard `d` path still
+    // routes through the outcome resolver that never answers a connector
+    // approval, and no row exposes a checkbox that could bulk-decide one.
+    expect(center).toContain('connectedBulkOutcome(');
+    expect(center).not.toContain('<Checkbox');
   });
 });

--- a/apps/web/src/features/review-center/map.ts
+++ b/apps/web/src/features/review-center/map.ts
@@ -5,7 +5,6 @@
  * labels and the actor are derived from the kind + agent. See review-center.tsx.
  */
 
-import { looksLikeMarkdown } from '@/lib/markdown-detect';
 import type { ApiReviewItem, ReviewVerdict } from '@kortix/sdk';
 import type {
   ApprovalAction,
@@ -93,29 +92,16 @@ const lines = (s: string): string[] =>
 
 function changeDetail(d: AnyRec, row: ApiReviewItem): ChangeDetail {
   const adv = rec(d.advanced);
-  // A free-form description that's real markdown (agent-written CR bodies
-  // often are) is carried whole and rendered as markdown in the modal —
-  // line-splitting it into checkmark rows would show raw `##`/`**` noise.
-  // Plain text keeps the designed per-line treatment; a native structured
-  // `whatChanged` array always wins.
+  // The description is plain text: one bullet per line. A native structured
+  // `whatChanged` array always wins over the free-form description.
   const description = str(d.description);
   const native = arrOf<string>(d.whatChanged);
-  const descriptionMarkdown =
-    !native && description && looksLikeMarkdown(description) ? description : undefined;
   const whatChanged =
-    native ??
-    (descriptionMarkdown
-      ? []
-      : description
-        ? lines(description)
-        : row.summary
-          ? [row.summary]
-          : []);
+    native ?? (description ? lines(description) : row.summary ? [row.summary] : []);
   return {
     crId: str(d.cr_id),
     number: typeof d.number === 'number' ? d.number : undefined,
     whatChanged,
-    descriptionMarkdown,
     impact: str(d.impact) ?? '',
     verification: arrOf<ChangeDetail['verification'][number]>(d.verification) ?? [],
     previewUrl: str(d.previewUrl) ?? str(d.preview_url),

--- a/apps/web/src/features/review-center/review-actions.ts
+++ b/apps/web/src/features/review-center/review-actions.ts
@@ -150,7 +150,7 @@ export function formatItemAge(iso: string, now = Date.now()): string {
 }
 
 /** Longer relative age with a trailing "ago" — the detail-modal idiom (see
- *  `rel` in review-detail-modal.tsx). */
+ *  `rel` in review-detail.tsx). */
 export function formatItemAgeLong(iso: string, now = Date.now()): string {
   const mins = Math.max(1, Math.round((now - new Date(iso).getTime()) / 60_000));
   if (mins < 60) return `${mins}m ago`;

--- a/apps/web/src/features/review-center/review-center-connected.tsx
+++ b/apps/web/src/features/review-center/review-center-connected.tsx
@@ -60,7 +60,7 @@ export function ReviewCenterConnected({
   const qc = useQueryClient();
   const router = useRouter();
   const closeCustomize = useSettingsPanelStore((s) => s.close);
-  const { data, isLoading, isFetching, isError, refetch } = useReviewItems();
+  const { data, isLoading, isFetching, isFetched, isError, refetch } = useReviewItems();
   const act = useActReviewItem();
   const bulk = useBulkActReviewItems();
   const resolve = useResolveReviewApproval();
@@ -260,6 +260,7 @@ export function ReviewCenterConnected({
       initialItems={items}
       isLoading={isLoading}
       isFetching={isFetching}
+      isFetched={isFetched}
       isError={isError}
       sessionLabels={sessionLabels}
       onAct={canAct ? handleAct : undefined}

--- a/apps/web/src/features/review-center/review-center.tsx
+++ b/apps/web/src/features/review-center/review-center.tsx
@@ -5,73 +5,80 @@
  * finished, what changed, what needs approval, and what's waiting on a decision,
  * across web and Slack-triggered sessions.
  *
- * Built for speed: keyboard-driven (j/k, Enter, a, e, d, x, 1-3, /, ?), every
- * action is undoable, multi-select + bulk approve/dismiss, and live search.
+ * Built for speed: keyboard-driven (j/k, Enter, a, e, d, 1-3, /, ?), every
+ * action is undoable, and live search. Multi-select left the UI on 2026-09-03;
+ * the bulk plumbing (`onBulkAct`, `resolveBulkOutcome`) stays for `d`.
  * Prototype: mock data, optimistic local actions. See docs/REVIEW_CENTER_DESIGN.md.
  */
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import Hint from '@/components/ui/hint';
-import { Input } from '@/components/ui/input';
+import {
+  InputGroupSearch,
+  InputGroupSearchIcon,
+  InputGroupSearchInput,
+} from '@/components/ui/input-group';
 import { Kbd } from '@/components/ui/kbd';
 import Loading from '@/components/ui/loading';
 import { Modal, ModalBody, ModalContent, ModalHeader, ModalTitle } from '@/components/ui/modal';
 import { Skeleton } from '@/components/ui/skeleton';
-import { StatusBadge } from '@/components/ui/status';
-import {
-  Tabs,
-  TabsList,
-  TabsListCompact,
-  TabsTrigger,
-  TabsTriggerCompact,
-} from '@/components/ui/tabs';
+import { DiffStat } from '@/components/ui/status';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { infoToast, successToast } from '@/components/ui/toast';
 import { EmptyState } from '@/features/layout/section/empty-state';
 import { ErrorState } from '@/features/layout/section/error-state';
 import { cn } from '@/lib/utils';
 import type { ReviewVerdict } from '@kortix/sdk';
 import {
+  ArrowUUpLeftIcon as ArrowUUpLeft,
+  CheckIcon as Check,
   CheckCircleIcon as CheckCircleSolid,
   CaretDownIcon as ChevronDown,
-  TrayIcon as InboxSolid,
-  StackIcon as Layers,
+  ClockIcon as Clock,
+  DotsThreeIcon as DotsThree,
   MagnifyingGlassIcon as Search,
   XIcon as X,
 } from '@phosphor-icons/react';
-import { AnimatePresence, m, useReducedMotion } from 'motion/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { statusToVerdict } from './map';
 import { MOCK_ITEMS } from './mock-data';
 import {
   bulkSkipMessage,
-  connectorCallId,
   formatItemAge,
   isQuickDecidableApproval,
   resolveBulkOutcome,
 } from './review-actions';
-import { type ReviewActions, ReviewDetailModal } from './review-detail-modal';
-import { KIND_META, RISK_BAR, RISK_META, SOURCE_META, STATUS_META } from './review-meta';
+import { type ReviewActions, ReviewDetail } from './review-detail';
+import { KIND_META, RISK_META, STATUS_META } from './review-meta';
 import {
   bulkSetStatus,
-  countsBySegment,
   decideApprovalAction,
   filterItems,
   groupBySession,
   sessionOptions,
   setStatus,
 } from './review-reducer';
-import { type ReviewItem, type ReviewKind, type ReviewSegment, segmentForStatus } from './types';
-
-/** Calm, premium easing for the inbox's enter/exit/layout motion. */
-const EASE = [0.2, 0, 0, 1] as const;
+import {
+  type ReviewItem,
+  type ReviewKind,
+  type ReviewSegment,
+  type ReviewStatus,
+  segmentForStatus,
+} from './types';
 
 /**
  * Relative time is client-only: it depends on `Date.now()`, which differs between
@@ -82,27 +89,6 @@ function TimeAgo({ iso }: { iso: string }) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
   return <span className="tabular-nums">{mounted ? formatItemAge(iso) : ''}</span>;
-}
-
-/** A count that rolls when it changes — the satisfying tick as you clear the inbox. */
-function AnimatedCount({ value }: { value: number }) {
-  const reduce = useReducedMotion() ?? false;
-  if (reduce) return <span className="tabular-nums">{value}</span>;
-  return (
-    <span className="relative inline-flex min-w-[1ch] justify-center overflow-hidden tabular-nums">
-      <AnimatePresence mode="popLayout" initial={false}>
-        <m.span
-          key={value}
-          initial={{ y: -7, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
-          exit={{ y: 7, opacity: 0 }}
-          transition={{ duration: 0.16, ease: EASE }}
-        >
-          {value}
-        </m.span>
-      </AnimatePresence>
-    </span>
-  );
 }
 
 const SEGMENTS: { value: ReviewSegment; label: string }[] = [
@@ -126,38 +112,54 @@ const SHORTCUTS: { keys: string[]; label: string }[] = [
   { keys: ['a'], label: 'Approve / ship' },
   { keys: ['e'], label: 'Ask for changes' },
   { keys: ['d'], label: 'Dismiss' },
-  { keys: ['x'], label: 'Select (for bulk)' },
   { keys: ['1', '2', '3'], label: 'Switch lists' },
   { keys: ['/'], label: 'Search' },
   { keys: ['?'], label: 'This help' },
 ];
 
+/** Flat rows, no chrome — the row itself lifts on hover/focus/select. */
+const LIST_CLASS = 'space-y-1 py-2.5';
+
+/** One small glyph after the title says where the item landed; the row
+ *  carries no status badge. `needs_you` has no glyph — its action button is
+ *  the state. */
+const STATUS_GLYPH: Partial<Record<ReviewStatus, { icon: typeof Check; className: string }>> = {
+  approved: { icon: Check, className: 'text-kortix-green' },
+  done: { icon: Check, className: 'text-kortix-green' },
+  waiting: { icon: Clock, className: 'text-muted-foreground' },
+  changes_requested: { icon: ArrowUUpLeft, className: 'text-kortix-orange' },
+  rejected: { icon: X, className: 'text-kortix-red' },
+  dismissed: { icon: X, className: 'text-muted-foreground' },
+};
+
+function Dot() {
+  return (
+    <span aria-hidden className="text-muted-foreground">
+      •
+    </span>
+  );
+}
+
 function ItemRow({
   item,
   idx,
   focused,
-  selected,
-  showCheck,
   fresh,
-  reduce,
   quickDecidable,
   pendingDecision,
   sessionLabel,
   onOpen,
-  onToggleSelect,
   onQuickApprove,
   onQuickDeny,
-  bulkSelectable = true,
+  onAskChanges,
+  onDismiss,
+  onOpenSession,
 }: {
   item: ReviewItem;
   idx: number;
   focused: boolean;
-  selected: boolean;
-  showCheck: boolean;
   /** Arrived on the last poll, not yet seen by the user. */
   fresh: boolean;
-  /** prefers-reduced-motion: collapse enter/stagger to instant. */
-  reduce: boolean;
   /** Whether this row exposes inline decisions. Connector approvals are false. */
   quickDecidable: boolean;
   /** 'approve' | 'deny' while this row's own resolve mutation is in flight. */
@@ -167,99 +169,93 @@ function ItemRow({
    *  Omitted in the grouped view (the session already names the group). */
   sessionLabel?: string;
   onOpen: () => void;
-  onToggleSelect: () => void;
   onQuickApprove?: () => void;
   onQuickDeny?: () => void;
-  bulkSelectable?: boolean;
+  /** Row menu — the mouse path to the `e` and `d` shortcuts. */
+  onAskChanges: () => void;
+  onDismiss: () => void;
+  onOpenSession?: () => void;
 }) {
   const kind = KIND_META[item.kind];
-  const Source = SOURCE_META[item.source];
   const segment = segmentForStatus(item.status);
-  const risk = RISK_META[item.risk];
+  const pending = segment === 'needs_you';
+  const risky = item.risk === 'medium' || item.risk === 'high';
   const busy = !!pendingDecision;
-  // Left accent bar: kind tone by default; in Needs-you it escalates to the
-  // risk tone for medium/high so risky work glows at the row's edge.
-  const barClass =
-    segment === 'needs_you' && (item.risk === 'medium' || item.risk === 'high')
-      ? RISK_BAR[item.risk]
-      : kind.bar;
+  const number = item.kind === 'change' ? item.detail.number : undefined;
+  const diff = item.kind === 'change' ? item.detail.advanced : undefined;
+  const glyph = STATUS_GLYPH[item.status];
+  // Meta line: when · who · where. The session stands in for the repo; when
+  // the group already names it, the row's own summary fills the slot.
+  const where = sessionLabel ?? item.summary;
 
   return (
-    <m.li
+    <li
       data-idx={idx}
-      layout={!reduce}
-      initial={reduce ? false : { opacity: 0, y: fresh ? -6 : 0 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={
-        reduce
-          ? { duration: 0 }
-          : { duration: 0.15, ease: EASE, delay: fresh ? 0 : Math.min(idx * 0.012, 0.06) }
-      }
       className={cn(
-        'group relative flex items-center gap-3.5 py-3 pr-4 pl-5 transition-colors',
-        'before:absolute before:inset-y-0 before:left-0 before:w-[3px]',
-        barClass,
-        focused ? 'bg-primary/[0.06] ring-kortix-blue/40 ring-1 ring-inset' : 'hover:bg-muted/40',
-        selected && 'bg-primary/[0.09]',
-        fresh && 'bg-kortix-blue/[0.05]',
+        'group relative flex items-center gap-3 rounded-md px-3 py-1.5',
+        focused ? 'bg-active' : 'hover:bg-hover',
       )}
     >
-      {segment === 'needs_you' && bulkSelectable && (
-        <Checkbox
-          checked={selected}
-          onCheckedChange={onToggleSelect}
-          aria-label={`Select ${item.title}`}
-          className={cn(
-            'shrink-0 transition-opacity',
-            showCheck || selected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
-          )}
-        />
-      )}
-      <span
-        className={cn('flex size-9 shrink-0 items-center justify-center rounded-md', kind.tile)}
-      >
-        <kind.icon className={cn('size-5', kind.iconColor)} />
-      </span>
+      {/* The leading icon names the kind by shape and the outcome by color:
+          blue while it needs you, then green/orange/red/muted once decided —
+          the same tone as the status check beside the title. */}
+      <kind.icon
+        className={cn('size-5 shrink-0', glyph ? glyph.className : kind.iconColor)}
+        aria-label={kind.label}
+      />
 
       <button
         type="button"
         onClick={onOpen}
-        className="focus-visible:ring-kortix-blue min-w-0 flex-1 rounded-sm text-left focus-visible:ring-2 focus-visible:outline-none"
+        className="focus-visible:ring-ring min-w-0 flex-1 rounded-sm text-left focus-visible:ring-2 focus-visible:outline-none"
       >
-        <div className="flex items-center gap-2">
+        <span className="flex items-center gap-1.5">
           <span className="text-foreground truncate text-sm font-medium">{item.title}</span>
-          {fresh && (
-            <StatusBadge tone="info" className="shrink-0">
-              New
-            </StatusBadge>
+          {number != null && (
+            <span className="text-muted-foreground shrink-0 text-sm tabular-nums">#{number}</span>
           )}
-          {/* Meta cluster, right-aligned to a stable column: risk (Needs-you),
-              source (desktop) and time (all sizes). */}
-          <span className="text-muted-foreground/70 ml-auto flex shrink-0 items-center gap-2 text-xs">
-            {segment === 'needs_you' && (
-              <StatusBadge
-                tone={risk.tone}
-                className={cn(item.risk === 'none' || item.risk === 'low' ? 'opacity-70' : '')}
-              >
-                {risk.label}
-              </StatusBadge>
-            )}
-            <Source.icon className="hidden size-3 sm:block" />
-            <TimeAgo iso={item.createdAt} />
-          </span>
-        </div>
-        <div className="text-muted-foreground mt-0.5 truncate text-xs">
-          <span className="text-muted-foreground/70 font-medium">{kind.label}</span>
-          {item.summary ? <span className="text-muted-foreground/40"> · </span> : null}
-          {item.summary}
-          {sessionLabel ? <span className="text-muted-foreground/40"> · </span> : null}
-          {sessionLabel}
-        </div>
+          {glyph && (
+            <Hint label={STATUS_META[item.status].label}>
+              <glyph.icon
+                className={cn('size-3.5 shrink-0', glyph.className)}
+                aria-label={STATUS_META[item.status].label}
+              />
+            </Hint>
+          )}
+          {fresh && (
+            <Badge variant="new" size="sm" className="shrink-0">
+              New
+            </Badge>
+          )}
+        </span>
+        <span className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 text-xs">
+          <TimeAgo iso={item.createdAt} />
+          <Dot />
+          <span className="truncate">{item.agent}</span>
+          {where && (
+            <>
+              <Dot />
+              <span className="truncate">{where}</span>
+            </>
+          )}
+        </span>
       </button>
 
-      <div className="flex shrink-0 items-center gap-1.5">
-        {segment === 'needs_you' ? (
-          quickDecidable ? (
+      <div className="flex shrink-0 items-center gap-2">
+        {diff && (
+          <DiffStat
+            additions={diff.additions}
+            deletions={diff.deletions}
+            className="hidden text-xs sm:inline-flex"
+          />
+        )}
+        {pending && risky && (
+          <Badge variant={RISK_META[item.risk].badge} size="sm" className="hidden sm:inline-flex">
+            {RISK_META[item.risk].label}
+          </Badge>
+        )}
+        {pending &&
+          (quickDecidable ? (
             <>
               <Button size="sm" variant="ghost" disabled={busy} onClick={onQuickDeny}>
                 {pendingDecision === 'deny' ? <Loading className="size-3.5 shrink-0" /> : null}
@@ -277,14 +273,59 @@ function ItemRow({
                   action for what it does: open the full diff to decide. */}
               {item.kind === 'change' ? 'Review' : item.primaryAction}
             </Button>
-          )
-        ) : (
-          <Badge variant={STATUS_META[item.status].badge} size="sm">
-            {STATUS_META[item.status].label}
-          </Badge>
-        )}
+          ))}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`More actions for ${item.title}`}
+              className="text-muted-foreground"
+            >
+              <DotsThree className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem onClick={onOpen}>
+              Open
+              <DropdownMenuShortcut>↵</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            {onOpenSession && (
+              <DropdownMenuItem onClick={onOpenSession}>Open session</DropdownMenuItem>
+            )}
+            {pending && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={onAskChanges}>
+                  Ask for changes
+                  <DropdownMenuShortcut>e</DropdownMenuShortcut>
+                </DropdownMenuItem>
+                <DropdownMenuItem variant="destructive" onClick={onDismiss}>
+                  Dismiss
+                  <DropdownMenuShortcut>d</DropdownMenuShortcut>
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
-    </m.li>
+    </li>
+  );
+}
+
+function ListSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <ul className={LIST_CLASS}>
+      {Array.from({ length: rows }).map((_, i) => (
+        <li key={i} className="flex items-center gap-3 px-3 py-1.5">
+          <Skeleton className="size-5 shrink-0 rounded-sm" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-2/3 rounded-sm" />
+            <Skeleton className="h-3 w-1/3 rounded-sm" />
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -324,6 +365,7 @@ export function ReviewCenter({
   onRefresh,
   isLoading,
   isFetching,
+  isFetched,
   isError,
   sessionLabels,
 }: {
@@ -344,6 +386,9 @@ export function ReviewCenter({
   isLoading?: boolean;
   /** A background poll is in flight — drives the "Live" refreshing affordance. */
   isFetching?: boolean;
+  /** The list has been fetched at least once — until then a `?id=` in the URL
+   *  holds a skeleton rather than flashing the inbox. */
+  isFetched?: boolean;
   /** The initial/only load failed — show a retry state instead of an empty
    *  inbox (an empty list and a failed fetch must never look the same). */
   isError?: boolean;
@@ -351,7 +396,6 @@ export function ReviewCenter({
   sessionLabels?: Record<string, string>;
 } = {}) {
   const connected = !!onAct;
-  const reduce = useReducedMotion() ?? false;
   const [items, setItems] = useState<ReviewItem[]>(initialItems ?? (connected ? [] : MOCK_ITEMS));
   const [segment, setSegment] = useState<ReviewSegment>('needs_you');
   const [kindFilter, setKindFilter] = useState<ReviewKind | 'all'>('all');
@@ -360,8 +404,12 @@ export function ReviewCenter({
   // a session's reviews + approvals sit together. Both operate on `sessionId`.
   const [sessionFilter, setSessionFilter] = useState<string | 'all'>('all');
   const [grouped, setGrouped] = useState(false);
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // The open review lives in the URL (`?id=<review item id>`), not in state,
+  // so a refresh or a shared link lands on the same page.
+  const search = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const idParam = search?.get('id') ?? null;
   const [focusedIdx, setFocusedIdx] = useState(0);
   // Only show the focused-row highlight while the user is actually navigating by
   // keyboard — otherwise the first row looks arbitrarily tinted on load.
@@ -384,8 +432,31 @@ export function ReviewCenter({
   // either the flat <ul> or the grouped <div>, so it's typed to the common base.
   const listRef = useRef<HTMLElement | null>(null);
 
+  // Matched against the server list when connected: `items` (the optimistic
+  // state copy) is reconciled from `initialItems` in an effect, so it lags the
+  // server list by one commit — long enough for a fresh page load to see "no
+  // match" once and flash the inbox before the review page.
+  const sourceItems = initialItems ?? items;
+  const selectedId = useMemo(
+    () => (idParam && sourceItems.some((i) => i.id === idParam) ? idParam : null),
+    [sourceItems, idParam],
+  );
+  const listLoaded = !connected || isFetched === true;
+  const setSelectedId = useCallback(
+    (id: string | null) => {
+      const params = new URLSearchParams(search?.toString() ?? '');
+      if (id) params.set('id', id);
+      else params.delete('id');
+      const suffix = params.toString();
+      const href = suffix ? `${pathname}?${suffix}` : pathname;
+      // Opening pushes so the browser's Back returns to the inbox; closing
+      // replaces so Back never lands on the page you just left.
+      if (id) router.push(href, { scroll: false });
+      else router.replace(href, { scroll: false });
+    },
+    [pathname, router, search],
+  );
   const labelFor = useMemo(() => (id: string) => sessionLabels?.[id], [sessionLabels]);
-  const counts = useMemo(() => countsBySegment(items), [items]);
   const visible = useMemo(
     () => filterItems(items, segment, kindFilter, query, sessionFilter),
     [items, segment, kindFilter, query, sessionFilter],
@@ -609,7 +680,6 @@ export function ReviewCenter({
           () => onBulkAct(outcome.act, 'dismiss'),
         );
       }
-      setSelectedIds(new Set());
       return;
     }
     apply(
@@ -618,50 +688,6 @@ export function ReviewCenter({
       'info',
       onBulkAct ? () => onBulkAct(ids, 'dismiss') : undefined,
     );
-    setSelectedIds(new Set());
-  };
-
-  const approveIds = (ids: string[]) => {
-    if (ids.length === 0) return;
-    if (connected && onBulkAct) {
-      const outcome = connectedBulkOutcome(ids, 'approve');
-      const skipped = bulkSkipMessage(outcome);
-      if (skipped) infoToast(skipped);
-      if (outcome.act.length > 0) {
-        apply(
-          bulkSetStatus(items, outcome.act, 'approved'),
-          `Approved ${outcome.act.length}`,
-          'success',
-          () => onBulkAct(outcome.act, 'approve'),
-        );
-      }
-      setSelectedIds(new Set());
-      return;
-    }
-    const itemIds = new Set(items.map((x) => x.id));
-    let next = items;
-    for (const id of ids) {
-      if (!itemIds.has(id)) continue;
-      next = setStatus(next, id, 'approved');
-    }
-    apply(
-      next,
-      `Approved ${ids.length}`,
-      'success',
-      onBulkAct ? () => onBulkAct(ids, 'approve') : undefined,
-    );
-    setSelectedIds(new Set());
-  };
-
-  const toggleSelect = (id: string) => {
-    const item = items.find((candidate) => candidate.id === id);
-    if (item?.kind === 'approval' || (connected && connectorCallId(id))) return;
-    setSelectedIds((prev) => {
-      const n = new Set(prev);
-      if (n.has(id)) n.delete(id);
-      else n.add(id);
-      return n;
-    });
   };
 
   // ── Keyboard shortcuts ──────────────────────────────────────────────────
@@ -694,10 +720,10 @@ export function ReviewCenter({
       if (e.key === 'Escape') {
         if (helpOpen) return setHelpOpen(false);
         if (typing) return (el as HTMLElement).blur();
-        if (selectedIds.size) return setSelectedIds(new Set());
+        if (selectedId) return setSelectedId(null);
         return;
       }
-      if (helpOpen || selectedId) return; // a dialog owns the keyboard
+      if (helpOpen || selectedId) return; // help or a review page owns the keyboard
       if (typing) return; // don't hijack search typing
 
       if (e.key === '/') {
@@ -728,170 +754,152 @@ export function ReviewCenter({
         if (cur) quickAskChanges(cur);
       } else if (e.key === 'd') {
         if (cur) dismissIds([cur.id]);
-      } else if (e.key === 'x') {
-        if (cur) {
-          toggleSelect(cur.id);
-          setFocusedIdx((i) => Math.min(visible.length - 1, i + 1));
-        }
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   });
 
-  const selected = items.find((i) => i.id === selectedId) ?? null;
-  const selectionCount = selectedIds.size;
+  // Prefer the optimistic copy (it carries the status you just set); fall
+  // back to the server row for the one commit before the copy catches up.
+  const selected = selectedId
+    ? (items.find((i) => i.id === selectedId) ??
+      sourceItems.find((i) => i.id === selectedId) ??
+      null)
+    : null;
+
+  const renderRow = (item: ReviewItem, idx: number, inGroup: boolean) => (
+    <ItemRow
+      key={item.id}
+      item={item}
+      idx={idx}
+      focused={kbNav && idx === focusedIdx}
+      fresh={freshIds.has(item.id)}
+      quickDecidable={connected && isQuickDecidableApproval(item)}
+      pendingDecision={pendingId === item.id ? pendingDecision : null}
+      sessionLabel={!inGroup && item.sessionId ? labelFor(item.sessionId) : undefined}
+      onOpen={() => setSelectedId(item.id)}
+      onQuickApprove={() => quickDecide(item, 'approve')}
+      onQuickDeny={() => quickDecide(item, 'deny')}
+      onAskChanges={() => quickAskChanges(item)}
+      onDismiss={() => dismissIds([item.id])}
+      onOpenSession={
+        item.sessionId && onOpenSession ? () => onOpenSession(item.sessionId!) : undefined
+      }
+    />
+  );
+
+  const listProps = {
+    ref: (el: HTMLElement | null) => {
+      listRef.current = el;
+    },
+    onPointerMove: () => {
+      setKbNav((k) => (k ? false : k));
+      markSeen();
+    },
+  };
+
+  const shortcutsButton = (
+    <button
+      type="button"
+      onClick={() => setHelpOpen(true)}
+      className="text-muted-foreground hover:text-foreground duration-fast hidden items-center gap-1.5 text-xs transition-colors sm:flex"
+    >
+      <Kbd>?</Kbd>
+      Shortcuts
+    </button>
+  );
+
+  // A `?id=` we cannot resolve yet: hold the row skeleton until the list has
+  // fetched once, so a refresh never flashes the inbox on the way to the page.
+  if (idParam && !selected && !listLoaded && !isError) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="w-full p-4">
+            <ListSkeleton />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // The review page replaces the inbox in place — same scroll container, no
+  // modal. Escape and "Back to inbox" return to the list.
+  if (selected) {
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <ReviewDetail item={selected} actions={actions} onBack={() => setSelectedId(null)} />
+        </div>
+        <KeyboardHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto w-full max-w-3xl px-4 pb-28">
-          {/* Header — dropped when embedded in the customize panel (the rail
-              already names the section); the standalone prototype keeps it. */}
-          {!connected && (
-            <header className="flex flex-col gap-2 pt-10 sm:flex-row sm:items-start sm:justify-between lg:pt-16">
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <span className="bg-kortix-base/15 flex size-7 items-center justify-center rounded-sm">
-                    <InboxSolid weight="fill" className="text-kortix-base size-4" />
-                  </span>
-                  <h1 className="text-foreground text-xl font-medium tracking-tight text-balance">
-                    Review Center
-                  </h1>
-                  {!connected && (
-                    <Badge variant="beta" size="xs">
-                      Prototype
-                    </Badge>
-                  )}
-                </div>
-                <p className="text-muted-foreground text-sm text-balance">
-                  Everything that needs your eyes — changes, approvals, outputs and questions, from
-                  the web and Slack.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setHelpOpen(true)}
-                className="text-muted-foreground hover:text-foreground hidden items-center gap-1.5 text-xs transition-colors sm:flex"
-              >
-                <Kbd>?</Kbd>
-                shortcuts
-              </button>
-            </header>
-          )}
+        <div className="w-full px-4">
+          {/* One control row: what list you're in, then how to narrow it. */}
+          <div className="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <Tabs
+              value={segment}
+              onValueChange={(v) => {
+                setSegment(v as ReviewSegment);
+                markSeen();
+              }}
+              className="min-w-0"
+            >
+              <TabsList className="flex w-full items-center justify-start">
+                {SEGMENTS.map((s) => (
+                  <TabsTrigger key={s.value} value={s.value} size="sm">
+                    {s.label}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
 
-          {/* Sticky controls */}
-          <div
-            className={cn(
-              'bg-background/95 sticky top-0 z-10 space-y-3 backdrop-blur',
-              connected ? 'pt-6 pb-3' : 'py-4',
-            )}
-          >
-            <div className="flex items-center gap-3">
-              <Tabs
-                value={segment}
-                onValueChange={(v) => {
-                  setSegment(v as ReviewSegment);
-                  markSeen();
-                }}
-                className="min-w-0 flex-1"
-              >
-                <TabsList type="underline" className="flex w-full items-center justify-start">
-                  {SEGMENTS.map((s) => (
-                    <TabsTrigger key={s.value} value={s.value} className="w-fit flex-none gap-1.5">
-                      {s.label}
-                      {counts[s.value] > 0 && (
-                        <Badge
-                          variant={
-                            s.value === 'needs_you' && freshIds.size > 0 ? 'new' : 'secondary'
-                          }
-                          size="xs"
-                        >
-                          <AnimatedCount value={counts[s.value]} />
-                        </Badge>
-                      )}
-                    </TabsTrigger>
-                  ))}
-                </TabsList>
-              </Tabs>
-              {connected && (
-                <Hint label={isFetching ? 'Refreshing…' : 'Auto-updating — click to refresh now'}>
-                  <button
-                    type="button"
-                    onClick={onRefresh}
-                    disabled={!onRefresh || isFetching}
-                    className="text-muted-foreground/70 hover:text-foreground disabled:hover:text-muted-foreground/70 hidden shrink-0 items-center gap-1.5 text-xs transition-colors sm:flex"
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button type="button" variant={kindFilter === 'all' ? 'outline' : 'secondary'}>
+                    {kindFilter === 'all'
+                      ? 'All types'
+                      : KIND_FILTERS.find((f) => f.value === kindFilter)?.label}
+                    <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-52">
+                  <DropdownMenuLabel>Type</DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={kindFilter}
+                    onValueChange={(v) => setKindFilter(v as ReviewKind | 'all')}
                   >
-                    <span
-                      className={cn(
-                        'bg-kortix-green size-1.5 rounded-full',
-                        isFetching && !reduce && 'animate-pulse',
-                      )}
-                    />
-                    Live
-                  </button>
-                </Hint>
-              )}
-            </div>
+                    {KIND_FILTERS.map((f) => (
+                      <DropdownMenuRadioItem key={f.value} value={f.value} side="left">
+                        {f.label}
+                        {(kindCounts[f.value] ?? 0) > 0 && (
+                          <Badge variant="secondary" size="xs" className="ml-auto tabular-nums">
+                            {kindCounts[f.value]}
+                          </Badge>
+                        )}
+                      </DropdownMenuRadioItem>
+                    ))}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
 
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <Tabs
-                value={kindFilter}
-                onValueChange={(v) => setKindFilter(v as ReviewKind | 'all')}
-              >
-                <TabsListCompact>
-                  {KIND_FILTERS.map((f) => (
-                    <TabsTriggerCompact key={f.value} value={f.value}>
-                      {f.label}
-                      {(kindCounts[f.value] ?? 0) > 0 && (
-                        <span className="ml-1 tabular-nums opacity-60">
-                          <AnimatedCount value={kindCounts[f.value] ?? 0} />
-                        </span>
-                      )}
-                    </TabsTriggerCompact>
-                  ))}
-                </TabsListCompact>
-              </Tabs>
-
-              <div className="relative sm:w-56">
-                <Search className="text-muted-foreground/60 pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
-                <Input
-                  id="review-search"
-                  value={query}
-                  onChange={(e) => {
-                    setQuery(e.target.value);
-                    setFocusedIdx(0);
-                  }}
-                  placeholder="Search"
-                  className="h-8 pl-8 text-sm"
-                />
-                {!query && <Kbd className="absolute top-1/2 right-2 -translate-y-1/2">/</Kbd>}
-              </div>
-            </div>
-
-            {/* Per-session view: filter to one session, and/or group by session so
-                a session's reviews + approvals sit together. Only shown once the
-                current segment actually has session-linked items. */}
-            {sessionOpts.length > 0 && (
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={grouped ? 'secondary' : 'outline'}
-                  className="h-8 gap-1.5"
-                  onClick={() => setGrouped((g) => !g)}
-                  aria-pressed={grouped}
-                >
-                  <Layers className="size-3.5" />
-                  Group by session
-                </Button>
+              {/* Per-session view: filter to one session, and/or group by session
+                  so a session's reviews + approvals sit together. Only shown once
+                  the current segment actually has session-linked items. */}
+              {sessionOpts.length > 0 && (
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
                     <Button
                       type="button"
-                      size="sm"
-                      variant={sessionFilter === 'all' ? 'outline' : 'secondary'}
-                      className="h-8 max-w-[16rem] gap-1.5"
+                      variant={sessionFilter === 'all' && !grouped ? 'outline' : 'secondary'}
+                      className="max-w-64"
                     >
                       <span className="truncate">
                         {sessionFilter === 'all'
@@ -899,219 +907,137 @@ export function ReviewCenter({
                           : (sessionOpts.find((s) => s.sessionId === sessionFilter)?.label ??
                             'Session')}
                       </span>
-                      <ChevronDown className="size-3.5 shrink-0 opacity-60" />
+                      <ChevronDown className="text-muted-foreground size-3.5 shrink-0" />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start" className="max-h-72 w-64 overflow-y-auto">
-                    <DropdownMenuItem onClick={() => setSessionFilter('all')}>
-                      All sessions
-                      <Badge variant="secondary" size="xs" className="ml-auto">
-                        {filterItems(items, segment, kindFilter, query, 'all').length}
-                      </Badge>
-                    </DropdownMenuItem>
-                    {sessionOpts.map((s) => (
-                      <DropdownMenuItem
-                        key={s.sessionId}
-                        onClick={() => setSessionFilter(s.sessionId)}
-                      >
-                        <span className="truncate">{s.label}</span>
-                        <Badge variant="secondary" size="xs" className="ml-auto shrink-0">
-                          {filterItems(items, segment, kindFilter, query, s.sessionId).length}
+                  <DropdownMenuContent align="end" className="max-h-72 w-64 overflow-y-auto">
+                    <DropdownMenuLabel>Session</DropdownMenuLabel>
+                    <DropdownMenuRadioGroup value={sessionFilter} onValueChange={setSessionFilter}>
+                      <DropdownMenuRadioItem value="all" side="left">
+                        All sessions
+                        <Badge variant="secondary" size="xs" className="ml-auto tabular-nums">
+                          {filterItems(items, segment, kindFilter, query, 'all').length}
                         </Badge>
-                      </DropdownMenuItem>
-                    ))}
+                      </DropdownMenuRadioItem>
+                      {sessionOpts.map((s) => (
+                        <DropdownMenuRadioItem key={s.sessionId} value={s.sessionId} side="left">
+                          <span className="truncate">{s.label}</span>
+                          <Badge
+                            variant="secondary"
+                            size="xs"
+                            className="ml-auto shrink-0 tabular-nums"
+                          >
+                            {filterItems(items, segment, kindFilter, query, s.sessionId).length}
+                          </Badge>
+                        </DropdownMenuRadioItem>
+                      ))}
+                    </DropdownMenuRadioGroup>
+                    <DropdownMenuSeparator />
+                    {/* `pl-8` lines this label up with the radio rows above: their
+                        check is inline (px-2.5 + size-3.5 + gap-2), this one is
+                        absolute at left-2.5, so the text needs the same start. */}
+                    <DropdownMenuCheckboxItem
+                      checked={grouped}
+                      onCheckedChange={setGrouped}
+                      className="pl-8"
+                    >
+                      Group by session
+                    </DropdownMenuCheckboxItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
-              </div>
-            )}
+              )}
 
+              <InputGroupSearch className="sm:w-56">
+                <InputGroupSearchIcon>
+                  <Search />
+                </InputGroupSearchIcon>
+                <InputGroupSearchInput
+                  id="review-search"
+                  value={query}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    setFocusedIdx(0);
+                  }}
+                  placeholder="Search"
+                  variant="popover"
+                  size="sm"
+                />
+                {!query && <Kbd className="absolute top-1/2 right-2 -translate-y-1/2">/</Kbd>}
+              </InputGroupSearch>
+            </div>
           </div>
 
           {/* List */}
           {isError && items.length === 0 ? (
-            <div className="pt-6">
-              <ErrorState
-                size="sm"
-                title="Couldn't load the review inbox"
-                description="Check your connection and try again."
-                action={
-                  <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
-                    {isFetching ? <Loading className="size-3.5 shrink-0" /> : null}
-                    Retry
-                  </Button>
-                }
-              />
-            </div>
+            <ErrorState
+              size="sm"
+              title="Couldn't load the review inbox"
+              description="Check your connection and try again."
+              action={
+                <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
+                  {isFetching ? <Loading className="size-3.5 shrink-0" /> : null}
+                  Retry
+                </Button>
+              }
+            />
           ) : isLoading && items.length === 0 ? (
-            <ul className="space-y-2">
-              {['a', 'b', 'c', 'd'].map((k) => (
-                <li key={k}>
-                  <Skeleton className="h-[58px] w-full rounded-md" />
-                </li>
-              ))}
-            </ul>
+            <ListSkeleton />
           ) : visible.length === 0 ? (
-            <m.div
-              key={`empty-${segment}-${query ? 'q' : ''}`}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.28, ease: EASE }}
-              className="pt-6"
-            >
-              <EmptyState
-                icon={CheckCircleSolid}
-                size="sm"
-                title={
-                  query
-                    ? 'No matches'
-                    : segment === 'needs_you'
-                      ? "You're all caught up"
-                      : 'Nothing here'
-                }
-                description={
-                  query
-                    ? 'Try a different search.'
-                    : segment === 'needs_you'
-                      ? 'When an agent needs a decision, an approval, or eyes on something it finished, it shows up here.'
-                      : segment === 'waiting'
-                        ? 'Items you’ve acted on that the agent is still working through will appear here.'
-                        : 'Approved, rejected and finished items land here.'
-                }
-              />
-            </m.div>
+            <EmptyState
+              icon={CheckCircleSolid}
+              size="sm"
+              title={
+                query
+                  ? 'No matches'
+                  : segment === 'needs_you'
+                    ? "You're all caught up"
+                    : 'Nothing here'
+              }
+              description={
+                query
+                  ? 'Try a different search.'
+                  : segment === 'needs_you'
+                    ? 'When an agent needs a decision, an approval, or eyes on something it finished, it shows up here.'
+                    : segment === 'waiting'
+                      ? 'Items you’ve acted on that the agent is still working through will appear here.'
+                      : 'Approved, rejected and finished items land here.'
+              }
+            />
           ) : grouped ? (
-            <div
-              ref={(el) => {
-                listRef.current = el;
-              }}
-              onPointerMove={() => {
-                setKbNav((k) => (k ? false : k));
-                markSeen();
-              }}
-              className="space-y-4"
-            >
+            <div {...listProps} className="space-y-5">
               {groups.map((g) => (
-                <div key={g.sessionId ?? '__none__'}>
-                  <div className="mb-1.5 flex items-center gap-2 px-1">
-                    <span className="text-foreground truncate text-xs font-semibold">
-                      {g.label}
-                    </span>
-                    <Badge variant="secondary" size="xs">
+                <section key={g.sessionId ?? '__none__'} className="space-y-2">
+                  <div className="flex items-center gap-2 px-1">
+                    <h2 className="text-foreground truncate text-xs font-medium">{g.label}</h2>
+                    <Badge variant="secondary" size="xs" className="tabular-nums">
                       {g.items.length}
                     </Badge>
                     {g.sessionId && onOpenSession && (
                       <button
                         type="button"
-                        className="text-muted-foreground hover:text-foreground ml-auto shrink-0 text-[11px] underline-offset-2 hover:underline"
+                        className="text-muted-foreground hover:text-foreground duration-fast ml-auto shrink-0 text-xs transition-colors"
                         onClick={() => onOpenSession(g.sessionId!)}
                       >
                         Open session
                       </button>
                     )}
                   </div>
-                  <ul className="bg-popover divide-border/60 divide-y overflow-hidden rounded-lg border">
-                    {g.items.map((item) => {
-                      const idx = visibleIndexById.get(item.id) ?? 0;
-                      return (
-                        <ItemRow
-                          key={item.id}
-                          item={item}
-                          idx={idx}
-                          focused={kbNav && idx === focusedIdx}
-                          selected={selectedIds.has(item.id)}
-                          showCheck={selectionCount > 0}
-                          fresh={freshIds.has(item.id)}
-                          reduce={reduce}
-                          quickDecidable={connected && isQuickDecidableApproval(item)}
-                          pendingDecision={pendingId === item.id ? pendingDecision : null}
-                          bulkSelectable={
-                            item.kind !== 'approval' &&
-                            (!connected || connectorCallId(item.id) === null)
-                          }
-                          onOpen={() => setSelectedId(item.id)}
-                          onToggleSelect={() => toggleSelect(item.id)}
-                          onQuickApprove={() => quickDecide(item, 'approve')}
-                          onQuickDeny={() => quickDecide(item, 'deny')}
-                        />
-                      );
-                    })}
+                  <ul className={LIST_CLASS}>
+                    {g.items.map((item) =>
+                      renderRow(item, visibleIndexById.get(item.id) ?? 0, true),
+                    )}
                   </ul>
-                </div>
+                </section>
               ))}
             </div>
           ) : (
-            <ul
-              ref={(el) => {
-                listRef.current = el;
-              }}
-              onPointerMove={() => {
-                setKbNav((k) => (k ? false : k));
-                markSeen();
-              }}
-              className="bg-popover divide-border/60 divide-y overflow-hidden rounded-lg border"
-            >
-              {visible.map((item, idx) => (
-                <ItemRow
-                  key={item.id}
-                  item={item}
-                  idx={idx}
-                  focused={kbNav && idx === focusedIdx}
-                  selected={selectedIds.has(item.id)}
-                  showCheck={selectionCount > 0}
-                  fresh={freshIds.has(item.id)}
-                  reduce={reduce}
-                  quickDecidable={connected && isQuickDecidableApproval(item)}
-                  pendingDecision={pendingId === item.id ? pendingDecision : null}
-                  bulkSelectable={
-                    item.kind !== 'approval' && (!connected || connectorCallId(item.id) === null)
-                  }
-                  sessionLabel={item.sessionId ? labelFor(item.sessionId) : undefined}
-                  onOpen={() => setSelectedId(item.id)}
-                  onToggleSelect={() => toggleSelect(item.id)}
-                  onQuickApprove={() => quickDecide(item, 'approve')}
-                  onQuickDeny={() => quickDecide(item, 'deny')}
-                />
-              ))}
+            <ul {...listProps} className={LIST_CLASS}>
+              {visible.map((item, idx) => renderRow(item, idx, false))}
             </ul>
           )}
         </div>
       </div>
 
-      {/* Floating multi-select action bar */}
-      <AnimatePresence>
-        {selectionCount > 0 && (
-          <m.div
-            initial={{ opacity: 0, y: 16 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 12 }}
-            transition={{ duration: 0.2, ease: EASE }}
-            className="pointer-events-none fixed inset-x-0 bottom-6 z-30 flex justify-center px-4"
-          >
-            <div className="bg-popover pointer-events-auto flex items-center gap-2 rounded-full border px-2 py-2 shadow-lg">
-              <span className="text-foreground flex items-center gap-1 px-2 text-sm font-medium">
-                <AnimatedCount value={selectionCount} /> selected
-              </span>
-              <Button size="sm" onClick={() => approveIds([...selectedIds])}>
-                Approve
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => dismissIds([...selectedIds])}>
-                Dismiss
-              </Button>
-              <Button
-                size="icon"
-                variant="ghost"
-                aria-label="Clear selection"
-                className="size-8"
-                onClick={() => setSelectedIds(new Set())}
-              >
-                <X className="size-4" />
-              </Button>
-            </div>
-          </m.div>
-        )}
-      </AnimatePresence>
-
-      <ReviewDetailModal item={selected} actions={actions} onClose={() => setSelectedId(null)} />
       <KeyboardHelp open={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
   );

--- a/apps/web/src/features/review-center/review-detail.tsx
+++ b/apps/web/src/features/review-center/review-detail.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * Review Center — per-kind detail modal. Friendly, plain-language content up top
- * with an "Advanced" disclosure that keeps the engineer view (refs, SHAs, raw
- * diff, args) one click away.
+ * Review Center — the per-item review page. It replaces the inbox in place
+ * (no modal): a status + title header, the branch/diff facts for a change,
+ * the plain-language body for the item's kind, and the live file diffs.
  *
  * Actions mutate parent state optimistically via the passed handlers.
  */
@@ -14,41 +14,33 @@ import {
 } from '@/components/approvals/approval-request';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Disclosure, DisclosureContent, DisclosureTrigger } from '@/components/ui/disclosure';
-import { InfoBanner } from '@/components/ui/info-banner';
+import { Item, ItemActions, ItemContent, ItemDescription, ItemTitle } from '@/components/ui/item';
 import { Kbd } from '@/components/ui/kbd';
 import Loading from '@/components/ui/loading';
-import {
-  Modal,
-  ModalBody,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalTitle,
-} from '@/components/ui/modal';
-import { StatusBadge } from '@/components/ui/status';
+import { DiffStat } from '@/components/ui/status';
 import { infoToast, successToast } from '@/components/ui/toast';
-import { useChangeRequestMergePreview } from '@/features/project-files/hooks/use-change-requests';
+import {
+  useChangeRequestDiff,
+  useChangeRequestMergePreview,
+} from '@/features/project-files/hooks/use-change-requests';
 import { cn } from '@/lib/utils';
 import {
+  ArrowLeftIcon as ArrowLeft,
   ArrowUpRightIcon as ArrowUpRight,
   CheckIcon as Check,
   CheckCircleIcon as CheckCircleSolid,
-  CaretDownIcon as ChevronDown,
   EyeIcon as Eye,
   SparkleIcon as SparklesSolid,
 } from '@phosphor-icons/react';
 import { useEffect, useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import { ChangeFilesModal } from './change-files';
+import { ChangeFiles } from './change-files';
 import { connectorCallId, formatItemAgeLong } from './review-actions';
 import {
   APPROVAL_ACTION_ICON,
   KIND_META,
   RISK_META,
-  SOURCE_META,
   STATUS_META,
+  VERIFICATION_BADGE,
 } from './review-meta';
 import { type ApprovalAction, type ReviewItem, type ReviewStatus, isSafeRisk } from './types';
 
@@ -78,98 +70,8 @@ function Panel({ children, className }: { children: React.ReactNode; className?:
   );
 }
 
-function AdvancedDisclosure({ children }: { children: React.ReactNode }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <Disclosure open={open} onOpenChange={setOpen} variant="outline" className="overflow-hidden">
-      <DisclosureTrigger variant="outline">
-        <button
-          type="button"
-          className="text-muted-foreground hover:text-foreground flex w-full items-center justify-between rounded-none px-4 py-2.5 text-xs font-medium transition-colors"
-        >
-          <span>Advanced — technical details</span>
-          <ChevronDown className={cn('size-3.5 transition-transform', open && 'rotate-180')} />
-        </button>
-      </DisclosureTrigger>
-      <DisclosureContent variant="outline" contentClassName="border-border border-t">
-        <div className="px-4 py-3">{children}</div>
-      </DisclosureContent>
-    </Disclosure>
-  );
-}
-
 function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">
-      {children}
-    </div>
-  );
-}
-
-/**
- * Compact markdown for agent-written descriptions (no Shiki/KaTeX/Mermaid —
- * same lightweight approach as the session QuestionMarkdown). Styled to the
- * modal's scale: sm body, small semibold headings, muted code chips.
- */
-function ReviewMarkdown({ content }: { content: string }) {
-  return (
-    <div className="min-w-0 text-sm">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          h1: ({ children }) => (
-            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
-              {children}
-            </h4>
-          ),
-          h2: ({ children }) => (
-            <h4 className="text-foreground mt-4 mb-1.5 text-sm font-semibold first:mt-0">
-              {children}
-            </h4>
-          ),
-          h3: ({ children }) => (
-            <h5 className="text-foreground mt-3 mb-1 text-sm font-medium first:mt-0">{children}</h5>
-          ),
-          p: ({ children }) => (
-            <p className="text-foreground/90 my-1.5 leading-relaxed text-pretty">{children}</p>
-          ),
-          strong: ({ children }) => (
-            <strong className="text-foreground font-semibold">{children}</strong>
-          ),
-          em: ({ children }) => <em>{children}</em>,
-          ul: ({ children }) => <ul className="my-1.5 list-disc space-y-1 pl-5">{children}</ul>,
-          ol: ({ children }) => <ol className="my-1.5 list-decimal space-y-1 pl-5">{children}</ol>,
-          li: ({ children }) => <li className="text-foreground/90 text-pretty">{children}</li>,
-          code: ({ children }) => (
-            <code className="bg-muted rounded px-1 py-0.5 font-mono text-xs">{children}</code>
-          ),
-          pre: ({ children }) => (
-            <pre className="bg-muted my-2 overflow-x-auto rounded-md p-3 font-mono text-xs">
-              {children}
-            </pre>
-          ),
-          a: ({ children, href }) => (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-foreground underline underline-offset-2"
-            >
-              {children}
-            </a>
-          ),
-          blockquote: ({ children }) => (
-            <blockquote className="border-border text-muted-foreground my-2 border-l-2 pl-3">
-              {children}
-            </blockquote>
-          ),
-          hr: () => <hr className="border-border my-3" />,
-        }}
-      >
-        {content}
-      </ReactMarkdown>
-    </div>
-  );
+  return <div className="text-muted-foreground mb-2 text-sm font-semibold">{children}</div>;
 }
 
 // ── change ────────────────────────────────────────────────────────────────
@@ -188,112 +90,97 @@ function ChangeBody({
   const whatChanged = d.whatChanged ?? [];
   const verification = d.verification ?? [];
   const requested = d.requestedChanges ?? [];
+  const recovering = actions.recoveringCrId === d.crId;
   return (
     <>
       {requested.length > 0 && (
-        <div className="bg-kortix-orange/[0.06] rounded-lg px-4 py-3.5">
-          <SectionLabel>You asked for changes</SectionLabel>
-          <ul className="space-y-1.5">
-            {requested.map((r) => (
-              <li key={r.at ?? r.text} className="text-foreground flex items-start gap-2 text-sm">
-                <span
-                  className="bg-kortix-orange mt-1.5 size-1.5 shrink-0 rounded-full"
-                  aria-hidden
-                />
-                <span className="text-pretty">{r.text}</span>
-              </li>
-            ))}
-          </ul>
-          {item.sessionId && actions.openSession ? (
-            <button
-              type="button"
-              onClick={() => {
-                actions.openSession?.(item.sessionId as string);
-                onClose();
-              }}
-              className="text-kortix-orange hover:text-kortix-orange/80 mt-2.5 inline-flex items-center gap-1 text-xs font-medium transition-colors"
-            >
-              Sent to the agent — see progress
-              <ArrowUpRight className="size-3" />
-            </button>
-          ) : (
-            <div className="text-muted-foreground mt-2.5 text-xs">
+        <Item variant="outline" size="sm">
+          <ItemContent>
+            <ItemTitle>You asked for changes</ItemTitle>
+            <ul className="text-foreground list-disc space-y-1 pl-5 text-sm">
+              {requested.map((r) => (
+                <li key={r.at ?? r.text} className="text-pretty">
+                  {r.text}
+                </li>
+              ))}
+            </ul>
+            <ItemDescription>
               Sent to the agent — it&apos;ll revise and update this change.
-            </div>
-          )}
-        </div>
+            </ItemDescription>
+          </ItemContent>
+          {item.sessionId && actions.openSession ? (
+            <ItemActions>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  actions.openSession?.(item.sessionId as string);
+                  onClose();
+                }}
+              >
+                See progress
+              </Button>
+            </ItemActions>
+          ) : null}
+        </Item>
       )}
 
-      {(whatChanged.length > 0 || d.descriptionMarkdown || d.impact) && (
-        <div>
-          <SectionLabel>What changed</SectionLabel>
-          {/* An agent-written markdown description renders as real markdown;
-              structured/plain-line payloads keep the checkmark treatment. */}
-          {d.descriptionMarkdown ? (
-            <ReviewMarkdown content={d.descriptionMarkdown} />
-          ) : (
-            whatChanged.length > 0 && (
-              <ul className="space-y-1.5">
-                {whatChanged.map((line) => (
-                  <li key={line} className="text-foreground flex items-start gap-2 text-sm">
-                    <Check className="text-kortix-green mt-0.5 size-4 shrink-0" />
-                    <span className="text-pretty">{line}</span>
-                  </li>
-                ))}
-              </ul>
-            )
+      {(whatChanged.length > 0 || d.impact) && (
+        <div className="space-y-2">
+          {whatChanged.length > 0 && (
+            <ul className="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
+              {whatChanged.map((line) => (
+                <li key={line} className="text-pretty">
+                  {line}
+                </li>
+              ))}
+            </ul>
           )}
-          {d.impact && (
-            <div className="text-muted-foreground mt-2 text-sm text-pretty">{d.impact}</div>
-          )}
+          {d.impact && <p className="text-muted-foreground text-sm text-pretty">{d.impact}</p>}
         </div>
       )}
-
-      {d.advanced && d.advanced.files.length > 0 && (
-        <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-          <span className="text-kortix-green font-medium tabular-nums">
-            +{d.advanced.additions.toLocaleString()}
-          </span>
-          <span className="text-kortix-orange font-medium tabular-nums">
-            −{d.advanced.deletions.toLocaleString()}
-          </span>
-          <span className="text-muted-foreground/40">·</span>
-          <span>
-            {d.advanced.files.length} {d.advanced.files.length === 1 ? 'file' : 'files'} changed
-          </span>
-        </div>
-      )}
-
-      {d.crId ? <ChangeFilesModal crId={d.crId} /> : null}
 
       {(verification.length > 0 || d.previewUrl) && (
-        <div className="flex flex-wrap items-center gap-2">
-          {verification.map((v) => (
-            <StatusBadge key={v.label} tone={v.tone}>
-              {v.label}
-            </StatusBadge>
-          ))}
+        <Item variant="outline" size="sm">
+          <ItemContent>
+            <ItemTitle>Verification</ItemTitle>
+            {verification.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5">
+                {verification.map((v) => (
+                  <Badge key={v.label} variant={VERIFICATION_BADGE[v.tone]} size="sm">
+                    {v.label}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </ItemContent>
           {d.previewUrl && (
-            <Button variant="outline" size="sm" className="gap-1.5" asChild>
-              <a href={d.previewUrl} target="_blank" rel="noopener noreferrer">
-                <Eye className="size-3.5" />
-                Open preview
-                <ArrowUpRight className="size-3.5" />
-              </a>
-            </Button>
+            <ItemActions>
+              <Button variant="outline" size="sm" asChild>
+                <a href={d.previewUrl} target="_blank" rel="noopener noreferrer">
+                  Open preview
+                </a>
+              </Button>
+            </ItemActions>
           )}
-        </div>
+        </Item>
       )}
 
       {conflicts.length > 0 && (
-        <InfoBanner
-          tone="warning"
-          title={`Merge conflicts in ${conflicts.length} ${conflicts.length === 1 ? 'file' : 'files'}`}
-          action={
+        <Item variant="warning" size="sm">
+          <ItemContent>
+            <ItemTitle>
+              Merge conflicts in {conflicts.length} {conflicts.length === 1 ? 'file' : 'files'}
+            </ItemTitle>
+            <ItemDescription>
+              Start an agent session from this change. The agent merges the latest base branch,
+              resolves the conflicts, runs checks, and opens a replacement change.
+            </ItemDescription>
+          </ItemContent>
+          <ItemActions>
             <Button
               size="sm"
-              variant="secondary"
-              disabled={actions.recoveringCrId === d.crId}
+              disabled={recovering}
               onClick={() => {
                 if (actions.recoverChange) {
                   actions.recoverChange(item, conflicts);
@@ -303,29 +190,11 @@ function ChangeBody({
                 }
               }}
             >
-              {actions.recoveringCrId === d.crId ? (
-                <Loading className="size-3.5 shrink-0" />
-              ) : (
-                <SparklesSolid className="size-3.5 shrink-0" />
-              )}
+              {recovering ? <Loading className="size-3.5 shrink-0" /> : null}
               Solve with agent
             </Button>
-          }
-        >
-          Start an agent session from this change. The agent will merge the latest base branch,
-          resolve the conflicts, run checks, and open a replacement change.
-        </InfoBanner>
-      )}
-
-      {(d.advanced?.headRef || d.advanced?.baseRef) && (
-        <AdvancedDisclosure>
-          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 font-mono text-xs">
-            <dt className="text-muted-foreground">from</dt>
-            <dd className="text-foreground truncate">{d.advanced?.headRef || '—'}</dd>
-            <dt className="text-muted-foreground">into</dt>
-            <dd className="text-foreground truncate">{d.advanced?.baseRef || '—'}</dd>
-          </dl>
-        </AdvancedDisclosure>
+          </ItemActions>
+        </Item>
       )}
     </>
   );
@@ -370,9 +239,9 @@ function ApprovalActionRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
             <span className="text-foreground text-sm font-medium">{action.title}</span>
-            <StatusBadge tone={RISK_META[action.risk].tone}>
+            <Badge variant={RISK_META[action.risk].badge} size="sm">
               {RISK_META[action.risk].label}
-            </StatusBadge>
+            </Badge>
           </div>
           <div className="text-muted-foreground mt-0.5 text-sm text-pretty">
             {action.consequence}
@@ -590,7 +459,6 @@ function OutputBody({ item }: { item: Extract<ReviewItem, { kind: 'output' }> })
           {d.previewUrl && (
             <Button variant="outline" size="sm" className="shrink-0 gap-1.5" asChild>
               <a href={d.previewUrl} target="_blank" rel="noopener noreferrer">
-                <Eye className="size-3.5" />
                 Open preview
                 <ArrowUpRight className="size-3.5" />
               </a>
@@ -691,7 +559,7 @@ function BatchBody({ item }: { item: Extract<ReviewItem, { kind: 'batch' }> }) {
               {c.status === 'done' ? (
                 <CheckCircleSolid weight="fill" className="text-kortix-green size-4 shrink-0" />
               ) : (
-                <Eye className="dark:text-kortix-yellow size-4 shrink-0 text-yellow-600" />
+                <Eye className="text-kortix-yellow size-4 shrink-0" />
               )}
               <span className="text-foreground min-w-0 flex-1 truncate text-sm">{c.title}</span>
               {c.status === 'needs_review' && (
@@ -707,7 +575,7 @@ function BatchBody({ item }: { item: Extract<ReviewItem, { kind: 'batch' }> }) {
   );
 }
 
-// ── footer ──────────────────────────────────────────────────────────────────
+// ── actions ─────────────────────────────────────────────────────────────────
 /** Optional free-text feedback returned to the agent when asking for changes. */
 function FeedbackComposer({
   onCancel,
@@ -722,7 +590,7 @@ function FeedbackComposer({
     ref.current?.focus();
   }, []);
   return (
-    <div className="w-full space-y-2">
+    <div className="bg-popover space-y-2 rounded-md border px-4 py-3">
       <textarea
         ref={ref}
         value={text}
@@ -735,11 +603,11 @@ function FeedbackComposer({
         }}
         rows={3}
         aria-label="What should the agent change?"
-        placeholder="What should the agent change? (optional — sent back as a follow-up)"
-        className="bg-popover focus-visible:border-primary/40 w-full resize-none rounded-md border px-3 py-2 text-sm outline-none"
+        placeholder="What should the agent change?"
+        className="placeholder:text-muted-foreground w-full resize-none bg-transparent text-sm outline-none"
       />
       <div className="flex items-center justify-end gap-2">
-        <span className="text-muted-foreground/60 mr-auto text-xs">
+        <span className="text-muted-foreground mr-auto text-xs">
           <Kbd>⌘</Kbd>
           <Kbd>↵</Kbd> to send
         </span>
@@ -754,139 +622,136 @@ function FeedbackComposer({
   );
 }
 
-function Footer({
+/** The header's right-hand group: what you can do to this item right now. */
+function ActionBar({
   item,
   actions,
-  onClose,
+  onBack,
   conflicts,
   checkingConflicts,
+  composing,
+  setComposing,
 }: {
   item: ReviewItem;
   actions: ReviewActions;
-  onClose: () => void;
+  onBack: () => void;
   conflicts: string[];
   checkingConflicts: boolean;
+  composing: boolean;
+  setComposing: (v: boolean) => void;
 }) {
-  const [composing, setComposing] = useState(false);
-
   if (item.status !== 'needs_you') {
     return (
-      <ModalFooter className="border-border/60 border-t pt-4">
-        <span className="text-muted-foreground mr-auto text-xs">
-          {STATUS_META[item.status].label} · {formatItemAgeLong(item.createdAt)}
-        </span>
-        <Button variant="outline-ghost" onClick={onClose}>
-          Close
-        </Button>
-      </ModalFooter>
+      <span className="text-muted-foreground text-xs">
+        {STATUS_META[item.status].label} · {formatItemAgeLong(item.createdAt)}
+      </span>
     );
   }
-
-  if (item.kind === 'decision') {
-    return (
-      <ModalFooter className="border-border/60 border-t pt-4">
-        <Button variant="outline-ghost" onClick={onClose}>
-          Decide later
-        </Button>
-      </ModalFooter>
-    );
-  }
-
-  if (item.kind === 'approval') {
-    return (
-      <ModalFooter className="border-border/60 border-t pt-4">
-        <Button variant="outline-ghost" onClick={onClose}>
-          Close
-        </Button>
-      </ModalFooter>
-    );
-  }
+  // Decisions and approvals decide inside their body.
+  if (item.kind === 'decision' || item.kind === 'approval') return null;
 
   // change · output · batch
   const secondaryLabel = item.secondaryAction;
   const hasConflicts = item.kind === 'change' && conflicts.length > 0;
 
-  if (composing && secondaryLabel) {
-    return (
-      <ModalFooter className="border-border/60 border-t pt-4">
-        <FeedbackComposer
-          onCancel={() => setComposing(false)}
-          onSend={(text) => {
-            actions.resolve(
-              item.id,
-              'changes_requested',
-              text ? `Sent to the agent: “${text}”` : `${secondaryLabel} — sent to the agent`,
-              text || undefined,
-            );
-            onClose();
-          }}
-        />
-      </ModalFooter>
-    );
-  }
-
   return (
-    <ModalFooter className="border-border/60 border-t pt-4">
-      {hasConflicts && (
-        <span className="text-muted-foreground mr-auto text-xs">The change cannot merge yet</span>
-      )}
-      {secondaryLabel && (
-        <Button variant="ghost" onClick={() => setComposing(true)}>
+    <div className="flex items-center gap-2">
+      {secondaryLabel && !composing && (
+        <Button variant="ghost" size="sm" onClick={() => setComposing(true)}>
           {secondaryLabel}
         </Button>
       )}
       {hasConflicts && item.kind === 'change' ? (
         <Button
+          size="sm"
           disabled={actions.recoveringCrId === item.detail.crId}
           onClick={() => {
             if (actions.recoverChange) {
               actions.recoverChange(item, conflicts);
             } else {
               actions.resolve(item.id, 'waiting', 'Solving the merge conflicts with an agent…');
-              onClose();
+              onBack();
             }
           }}
         >
           {actions.recoveringCrId === item.detail.crId ? (
-            <Loading className="size-4 shrink-0" />
+            <Loading className="size-3.5 shrink-0" />
           ) : (
-            <SparklesSolid className="size-4 shrink-0" />
+            <SparklesSolid weight="fill" className="size-3.5 shrink-0" />
           )}
           Solve with agent
         </Button>
       ) : (
         <Button
-          variant={item.risk === 'high' ? 'danger' : item.risk === 'medium' ? 'warning' : 'default'}
+          size="sm"
+          // Ready to ship reads as success. Only high risk keeps the brake.
+          variant={item.risk === 'high' ? 'danger' : checkingConflicts ? 'warning' : 'success'}
           disabled={checkingConflicts}
           onClick={() => {
             actions.resolve(item.id, 'approved', `${item.primaryAction} · done`);
-            onClose();
+            onBack();
           }}
         >
-          {checkingConflicts ? (
-            <Loading className="size-4 shrink-0" />
-          ) : (
-            <Check className="size-4" />
-          )}
-          {checkingConflicts ? 'Checking...' : item.primaryAction}
+          {checkingConflicts ? <Loading className="size-3.5 shrink-0" /> : null}
+          {checkingConflicts ? 'Checking…' : item.primaryAction}
         </Button>
       )}
-    </ModalFooter>
+    </div>
   );
 }
 
-export function ReviewDetailModal({
+/** `main ← feat/branch · 1 file · +38 −2` — the facts a reviewer scans first. */
+function ChangeFacts({ item }: { item: Extract<ReviewItem, { kind: 'change' }> }) {
+  const adv = item.detail.advanced;
+  const crId = item.detail.crId ?? null;
+  // The live diff query is shared with `ChangeFiles` below (same key), so this
+  // costs no extra request; it just lets the header agree with the file list.
+  const diff = useChangeRequestDiff(crId);
+  const files = diff.data?.files_changed ?? adv.files.length;
+  const additions = diff.data?.additions ?? adv.additions;
+  const deletions = diff.data?.deletions ?? adv.deletions;
+  const hasRefs = Boolean(adv.baseRef || adv.headRef);
+  const hasCounts = files > 0 || additions > 0 || deletions > 0;
+  if (!hasRefs && !hasCounts) return null;
+  return (
+    <>
+      {hasRefs && (
+        <span className="flex items-center gap-1.5">
+          <Badge variant="secondary" className="border-0 align-middle font-mono ring-0" size="sm">
+            {adv.baseRef || '—'}
+          </Badge>
+          <ArrowLeft className="text-muted-foreground size-3.5 shrink-0" aria-label="from" />
+          <Badge
+            variant="secondary"
+            size="sm"
+            className="line-clamp-1 max-w-96 truncate border-0 align-middle font-mono ring-0"
+          >
+            <span className="truncate">{adv.headRef || '—'}</span>
+          </Badge>
+        </span>
+      )}
+      {files > 0 && (
+        <span className="tabular-nums">
+          {files} {files === 1 ? 'file' : 'files'}
+        </span>
+      )}
+      <DiffStat additions={additions} deletions={deletions} />
+    </>
+  );
+}
+
+export function ReviewDetail({
   item,
   actions,
-  onClose,
+  onBack,
 }: {
-  item: ReviewItem | null;
+  item: ReviewItem;
   actions: ReviewActions;
-  onClose: () => void;
+  onBack: () => void;
 }) {
-  const crId = item?.kind === 'change' ? (item.detail.crId ?? null) : null;
+  const crId = item.kind === 'change' ? (item.detail.crId ?? null) : null;
   const mergePreview = useChangeRequestMergePreview(crId, Boolean(crId));
-  if (!item) return null;
+  const [composing, setComposing] = useState(false);
 
   const previewHasConflicts = Boolean(
     mergePreview.data && !mergePreview.data.is_up_to_date && !mergePreview.data.can_merge,
@@ -900,67 +765,94 @@ export function ReviewDetailModal({
         : (item.detail.conflicts ?? [])
       : [];
   const kind = KIND_META[item.kind];
-  const Source = SOURCE_META[item.source];
+  const number = item.kind === 'change' ? item.detail.number : undefined;
+  // A change waiting on you is "Open", the way a pull request is; every other
+  // state keeps the inbox's own label.
+  const open = item.status === 'needs_you' && item.kind === 'change';
+  const statusLabel = open ? 'Open' : STATUS_META[item.status].label;
+  const statusBadge = open ? 'success' : STATUS_META[item.status].badge;
+  const secondaryLabel = item.secondaryAction;
 
   return (
-    <Modal open={!!item} onOpenChange={(o) => !o && onClose()}>
-      <ModalContent className="lg:max-w-2xl" closeOnOutsideClick>
-        <ModalHeader>
-          <div className="flex items-start gap-3 pr-8">
-            <span
-              className={cn(
-                'mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-sm',
-                kind.tile,
-              )}
-            >
-              <kind.icon className={cn('size-5', kind.iconColor)} />
-            </span>
-            <div className="min-w-0">
-              <ModalTitle className="text-pretty">{item.title}</ModalTitle>
-              <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                <Badge variant="outline" size="xs">
-                  {kind.label}
-                </Badge>
-                {item.risk !== 'none' && (
-                  <StatusBadge tone={RISK_META[item.risk].tone}>
-                    {RISK_META[item.risk].label}
-                  </StatusBadge>
-                )}
-                <span className="text-muted-foreground/70 flex items-center gap-1 text-xs">
-                  <Source.icon className="size-3" />
-                  {Source.label}
-                </span>
-                <span className="text-muted-foreground/40">&bull;</span>
-                <span className="text-muted-foreground/70 truncate text-xs">{item.project}</span>
-              </div>
-            </div>
+    <div className="w-full p-4">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-3">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge variant={statusBadge} size="sm">
+              {statusLabel}
+            </Badge>
+            {item.kind !== 'change' && (
+              <Badge variant="outline" size="sm">
+                {kind.label}
+              </Badge>
+            )}
+            {item.risk === 'medium' || item.risk === 'high' ? (
+              <Badge variant={RISK_META[item.risk].badge} size="sm">
+                {RISK_META[item.risk].label}
+              </Badge>
+            ) : null}
           </div>
-        </ModalHeader>
-
-        <ModalBody className="space-y-3">
-          <div className="text-muted-foreground text-xs">
-            {item.agent} · {formatItemAgeLong(item.createdAt)}
+          <div className="space-y-2 mt-10">
+            <p className="text-muted-foreground text-xs">
+              {item.project}
+              {number != null && <span className="tabular-nums"> #{number}</span>}
+            </p>
+            <h1 className="text-foreground line-clamp-2 truncate text-2xl font-semibold tracking-tight text-pretty">
+              {item.title}
+            </h1>
           </div>
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm">
+            <span>{item.agent}</span>
+            {item.kind === 'change' && <ChangeFacts item={item} />}
+            <span>{formatItemAgeLong(item.createdAt)}</span>
+          </div>
+        </div>
+        <div className="shrink-0 sm:pt-1">
+          <ActionBar
+            item={item}
+            actions={actions}
+            onBack={onBack}
+            conflicts={conflicts}
+            checkingConflicts={Boolean(crId) && mergePreview.isLoading}
+            composing={composing}
+            setComposing={setComposing}
+          />
+        </div>
+      </header>
 
-          {item.kind === 'change' && (
-            <ChangeBody item={item} actions={actions} onClose={onClose} conflicts={conflicts} />
-          )}
-          {item.kind === 'approval' && <ApprovalBody item={item} actions={actions} />}
-          {item.kind === 'output' && <OutputBody item={item} />}
-          {item.kind === 'decision' && (
-            <DecisionBody item={item} actions={actions} onClose={onClose} />
-          )}
-          {item.kind === 'batch' && <BatchBody item={item} />}
-        </ModalBody>
+      <div className="mt-8 space-y-8">
+        {composing && secondaryLabel && (
+          <FeedbackComposer
+            onCancel={() => setComposing(false)}
+            onSend={(text) => {
+              actions.resolve(
+                item.id,
+                'changes_requested',
+                text ? `Sent to the agent: “${text}”` : `${secondaryLabel} — sent to the agent`,
+                text || undefined,
+              );
+              onBack();
+            }}
+          />
+        )}
 
-        <Footer
-          item={item}
-          actions={actions}
-          onClose={onClose}
-          conflicts={conflicts}
-          checkingConflicts={Boolean(crId) && mergePreview.isLoading}
-        />
-      </ModalContent>
-    </Modal>
+        <section className="space-y-3">
+          <h2 className="text-foreground text-sm font-medium">Description</h2>
+          <div className="space-y-4">
+            {item.kind === 'change' && (
+              <ChangeBody item={item} actions={actions} onClose={onBack} conflicts={conflicts} />
+            )}
+            {item.kind === 'approval' && <ApprovalBody item={item} actions={actions} />}
+            {item.kind === 'output' && <OutputBody item={item} />}
+            {item.kind === 'decision' && (
+              <DecisionBody item={item} actions={actions} onClose={onBack} />
+            )}
+            {item.kind === 'batch' && <BatchBody item={item} />}
+          </div>
+        </section>
+
+        {crId && <ChangeFiles crId={crId} />}
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/features/review-center/review-markdown.test.ts
+++ b/apps/web/src/features/review-center/review-markdown.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from 'bun:test';
 import type { ApiReviewItem } from '@kortix/sdk';
+import { describe, expect, test } from 'bun:test';
 
-import { mapApiReviewItem } from './map';
 import { looksLikeMarkdown } from '@/lib/markdown-detect';
+import { mapApiReviewItem } from './map';
 import type { ChangeDetail } from './types';
 
 describe('looksLikeMarkdown', () => {
@@ -30,7 +30,7 @@ describe('looksLikeMarkdown', () => {
   });
 });
 
-describe('mapApiReviewItem — markdown change descriptions', () => {
+describe('mapApiReviewItem — change descriptions are plain lines', () => {
   const changeRow = (description: string): ApiReviewItem =>
     ({
       review_item_id: 'rv-1',
@@ -44,26 +44,26 @@ describe('mapApiReviewItem — markdown change descriptions', () => {
       detail: { cr_id: 'cr-12', base_ref: 'main', head_ref: 'session/x', description },
     }) as unknown as ApiReviewItem;
 
-  test('a markdown description is carried whole, not line-split into checkmark rows', () => {
+  test('a markdown-looking description is still line-split — no markdown branch', () => {
     const md = '## What this changes\nMigrates `kortix.toml` to **kortix.yaml**.';
-    const item = mapApiReviewItem(changeRow(md), 'proj');
-    const d = item.detail as ChangeDetail;
-    expect(d.descriptionMarkdown).toBe(md);
-    expect(d.whatChanged).toEqual([]);
+    const d = mapApiReviewItem(changeRow(md), 'proj').detail as ChangeDetail;
+    expect(d.whatChanged).toEqual([
+      '## What this changes',
+      'Migrates `kortix.toml` to **kortix.yaml**.',
+    ]);
+    expect('descriptionMarkdown' in d).toBe(false);
   });
 
   test('a plain description keeps the per-line treatment', () => {
-    const item = mapApiReviewItem(changeRow('Updated the schema.\nFixed the tests.'), 'proj');
-    const d = item.detail as ChangeDetail;
-    expect(d.descriptionMarkdown).toBeUndefined();
+    const d = mapApiReviewItem(changeRow('Updated the schema.\nFixed the tests.'), 'proj')
+      .detail as ChangeDetail;
     expect(d.whatChanged).toEqual(['Updated the schema.', 'Fixed the tests.']);
   });
 
-  test('a native structured whatChanged array always wins over markdown detection', () => {
+  test('a native structured whatChanged array always wins over the description', () => {
     const row = changeRow('## ignored');
     (row.detail as Record<string, unknown>).whatChanged = ['Did the thing'];
     const d = mapApiReviewItem(row, 'proj').detail as ChangeDetail;
-    expect(d.descriptionMarkdown).toBeUndefined();
     expect(d.whatChanged).toEqual(['Did the thing']);
   });
 });

--- a/apps/web/src/features/review-center/review-meta.ts
+++ b/apps/web/src/features/review-center/review-meta.ts
@@ -5,7 +5,6 @@
  * a solid Kortix-token icon.
  */
 
-import type { StatusTone } from '@/components/ui/status';
 import {
   ChatsIcon as ChatMessages,
   CheckCircleIcon as CheckCircleSolid,
@@ -42,68 +41,64 @@ function filled(IconComponent: IconCmp): IconCmp {
   };
 }
 type BadgeVariant =
-  'success' | 'warning' | 'destructive' | 'secondary' | 'muted' | 'kortix' | 'outline';
+  'success' | 'warning' | 'destructive' | 'secondary' | 'muted' | 'kortix' | 'outline' | 'info';
 
 export const KIND_META: Record<
   ReviewKind,
-  { label: string; icon: IconCmp; tile: string; iconColor: string; bar: string }
+  { label: string; icon: IconCmp; tile: string; iconColor: string }
 > = {
   change: {
     label: 'Change',
     icon: GitPullRequest,
     tile: 'bg-kortix-blue/15',
     iconColor: 'text-kortix-blue',
-    bar: 'before:bg-kortix-blue',
   },
   approval: {
     label: 'Approval',
     icon: filled(ShieldCheckSolid),
     tile: 'bg-kortix-orange/15',
     iconColor: 'text-kortix-orange',
-    bar: 'before:bg-kortix-orange',
   },
   output: {
     label: 'Output',
     icon: filled(SparklesSolid),
     tile: 'bg-kortix-purple/15',
     iconColor: 'text-kortix-purple',
-    bar: 'before:bg-kortix-purple',
   },
   decision: {
     label: 'Question',
     icon: filled(QuestionCircleSolid),
     tile: 'bg-kortix-yellow/15',
-    // Darker than the tile hue — kortix-yellow (oklch L≈0.73) is the palette's
-    // lowest-contrast token for a glyph on a light tint. See a11y note.
-    iconColor: 'text-yellow-600 dark:text-kortix-yellow',
-    bar: 'before:bg-kortix-yellow',
+    // kortix-yellow is the palette's lowest-contrast glyph on a light tint. The
+    // kind is always named in text beside the tile, so the glyph is redundant
+    // and the token stays pure (no raw palette, no `dark:`).
+    iconColor: 'text-kortix-yellow',
   },
   batch: {
     label: 'Finished',
     icon: filled(CheckCircleSolid),
     tile: 'bg-kortix-green/15',
     iconColor: 'text-kortix-green',
-    bar: 'before:bg-kortix-green',
   },
 };
 
-/** Left-accent-bar class for the segment's risk tone (Needs-you escalation). */
-export const RISK_BAR: Record<ReviewRisk, string> = {
-  none: 'before:bg-kortix-green',
-  low: 'before:bg-kortix-green',
-  medium: 'before:bg-kortix-orange',
-  high: 'before:bg-destructive',
+// Every chip in the Review Center is the one `Badge` component — no second
+// pill family (Jay, 2026-09-03: "use the badge component only").
+export const RISK_META: Record<ReviewRisk, { label: string; badge: BadgeVariant }> = {
+  none: { label: 'Safe', badge: 'success' },
+  low: { label: 'Low risk', badge: 'success' },
+  medium: { label: 'Medium risk', badge: 'warning' },
+  high: { label: 'High risk', badge: 'destructive' },
 };
 
-// Risk pills use StatusBadge (faint tinted fill + colored text) rather than the
-// solid Badge variants — calmer and consistent across tones, the way the brand
-// reads (red is the brake, not the paint). See components/ui/status.tsx.
-export const RISK_META: Record<ReviewRisk, { label: string; tone: StatusTone }> = {
-  none: { label: 'Safe', tone: 'success' },
-  low: { label: 'Low risk', tone: 'success' },
-  medium: { label: 'Medium risk', tone: 'warning' },
-  high: { label: 'High risk', tone: 'destructive' },
-};
+/** A change's verification entries carry a tone; map it onto the Badge variant. */
+export const VERIFICATION_BADGE: Record<'success' | 'warning' | 'neutral' | 'info', BadgeVariant> =
+  {
+    success: 'success',
+    warning: 'warning',
+    neutral: 'secondary',
+    info: 'info',
+  };
 
 export const STATUS_META: Record<ReviewStatus, { label: string; badge: BadgeVariant }> = {
   needs_you: { label: 'Needs you', badge: 'warning' },

--- a/apps/web/src/features/review-center/types.ts
+++ b/apps/web/src/features/review-center/types.ts
@@ -60,9 +60,6 @@ export interface ChangeDetail {
   crId?: string; // the underlying Change Request id (connected mode) — enables the live diff
   number?: number;
   whatChanged: string[];
-  /** The agent's free-form description when it's real markdown — rendered as
-   *  such in the modal instead of being line-split into `whatChanged` rows. */
-  descriptionMarkdown?: string;
   impact: string;
   verification: { label: string; tone: 'success' | 'warning' | 'neutral' | 'info' }[];
   previewUrl?: string;

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-change-requests-nav.tsx
@@ -161,14 +161,14 @@ function NavItemInner({ projectId }: { projectId: string }) {
   // mid-deploy, a network blip. The flag-off branch still opens a dialog or a
   // popover in place and stays a button.
   const menuButton = reviewEnabled ? (
-    <SidebarMenuButton asChild      className="group/menu-button text-sidebar-foreground relative">
+    <SidebarMenuButton asChild className="group/menu-button text-sidebar-foreground relative">
       <Link href={capabilityTabHref(projectId, 'review')} prefetch>
         {rowContent}
       </Link>
     </SidebarMenuButton>
   ) : (
     <SidebarMenuButton
-      className="font-medium"
+      className="group/menu-button text-sidebar-foreground relative"
       onClick={c.count === 1 ? () => c.openCr(c.crs[0].cr_id) : undefined}
     >
       {rowContent}


### PR DESCRIPTION
## Summary
- Review inbox is full width with one control row (segment tabs, Type and Session dropdowns, search); rows are flat with a status glyph, diff stat, and a `···` menu. Multi-select UI removed, bulk plumbing kept.
- Opening an item renders an inline review page (`review-detail.tsx`) instead of a modal: status badge, project #N, title, `base ← head · N files · +a −d`, actions top-right, description as a plain list, and every file diff inline with Collapse all / Expand all. `?id=` keeps the page across refresh.
- Every chip is `Badge`; markdown detection removed from the change mapper; brand-audit fixes across the feature.

## Test plan
- `tsc --noEmit` clean, `eslint` 0 errors, `audit.sh apps/web/src/features/review-center` clean, `bun test src/features/review-center` 78 pass.
- On dev: open `/projects/<id>/review`, open a change, refresh with `?id=` in the URL, Back to inbox, Ship a change, Collapse all / Expand all.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790978482&installation_model_id=434224&pr_number=7104&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7104&signature=1de4fae0a835846db9fb2e5da982e681458372dd96a6bd6030da77ccea292438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->