### PR TITLE
settings: split Credits out of Plan, give Plan its own card

### DIFF
--- a/apps/web/src/features/accounts/settings/billing-tab.tsx
+++ b/apps/web/src/features/accounts/settings/billing-tab.tsx
@@ -9,6 +9,7 @@ import { AccountOverviewTab } from '@/features/billing/account-overview';
 import { AutoTopupCard } from '@/features/billing/auto-topup-card';
 import { ClaimPerSeatCard } from '@/features/billing/claim-per-seat-card';
 import { CreditTopupSection } from '@/features/billing/credit-topup-section';
+import { PlanCard } from '@/features/billing/plan-card';
 import { SeatManagementCard } from '@/features/billing/seat-management-card';
 import { useAuth } from '@/features/providers/auth-provider';
 import {
@@ -26,7 +27,34 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef } from 'react';
 
-export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActive: boolean }) {
+/**
+ * `showWallet` — whether this pane leads with the WALLET or with the PLAN.
+ *
+ * `true` (the default, and what `/accounts/[id]?tab=billing` uses): unchanged
+ * since 2026-08-13 — the balance card, this period's spend, the limits, and
+ * the seat card under them.
+ *
+ * `false` (the settings overlay's Plan tab, 2026-09-03): the wallet blocks are
+ * dropped and `PlanCard` leads instead. Every number they showed — balance,
+ * credit composition, compute/LLM spend, limits — is the subject of the
+ * Credits pane beside it (`settings/tabs/credits-tab.tsx`), so on Plan they
+ * were a duplicate. `SeatManagementCard` goes with them: `PlanCard` prints the
+ * same three seat figures as properties, and rendering both states the seat
+ * count three times across two boxes.
+ *
+ * What does NOT vary: buying credits, auto top-up, and the Stripe portal stay
+ * on both. They are the actions this pane exists to offer, and the Credits
+ * pane's "Add credits" button navigates here to reach them.
+ */
+export function BillingTab({
+  returnUrl,
+  isActive,
+  showWallet = true,
+}: {
+  returnUrl: string;
+  isActive: boolean;
+  showWallet?: boolean;
+}) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
   const { session, isLoading: authLoading } = useAuth();
   const highlight = useUserSettingsModalStore((s) => s.highlight);
@@ -142,7 +170,11 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
         </section>
       ) : (
         <>
-          {highlight === 'credits' && totalCredits <= 0 && (
+          {/* The out-of-credits warning is a WALLET message and stays with
+              the wallet. On the Plan tab the same account reads its balance on
+              the Credits pane, which shows the shortfall in the number itself
+              rather than in a banner over a pane about subscriptions. */}
+          {showWallet && highlight === 'credits' && totalCredits <= 0 && (
             <InfoBanner
               tone="warning"
               title={tI18nHardcoded.raw(
@@ -155,17 +187,27 @@ export function BillingTab({ returnUrl, isActive }: { returnUrl: string; isActiv
             </InfoBanner>
           )}
 
-          <AccountOverviewTab accountId={billingAccountId} />
+          {showWallet ? (
+            <AccountOverviewTab accountId={billingAccountId} />
+          ) : accountState ? (
+            <PlanCard state={accountState} />
+          ) : null}
 
           {accountState?.can_claim_per_seat && <ClaimPerSeatCard accountState={accountState} />}
 
-          {subscribedToTeam && <SeatManagementCard accountState={accountState} />}
+          {showWallet && subscribedToTeam && <SeatManagementCard accountState={accountState} />}
 
           {/* Add credits and Auto top-up share one card, matching the settings
               pane. Both components carry their own heading and no chrome
               (see `credit-topup-section.tsx` / `auto-topup-card.tsx`), so the
-              outer headings this section used to draw would now read twice. */}
-          {canPurchaseCredits && (
+              outer headings this section used to draw would now read twice.
+
+              Wallet-only (Jay, 2026-09-03: "the add credit component will be
+              coming in the credit tab content only, not in the plan row").
+              The settings overlay's Credits pane mounts these same two
+              components itself — buying credits belongs beside the balance it
+              changes, not on a pane about a subscription. */}
+          {showWallet && canPurchaseCredits && (
             <div className="bg-popover rounded-md border">
               <section className="space-y-3 px-4 py-4">
                 <h3 className="text-foreground text-sm font-medium">Add credits</h3>

--- a/apps/web/src/features/billing/account-overview.tsx
+++ b/apps/web/src/features/billing/account-overview.tsx
@@ -155,32 +155,67 @@ export function AccountOverviewView({ state }: { state: AccountState }) {
   );
 }
 
+/**
+ * Where a plan stands, as strings — the name, its qualifier, the one line that
+ * says what happens next, and whether that state is live.
+ *
+ * Extracted from `PlanSummary` (2026-09-03) so the Plan tab's own plan card
+ * (`plan-card.tsx`) reads the SAME answer this balance card does. Two copies
+ * of "is it renewing, cancelling, or past due" would drift on the first Stripe
+ * status nobody thought about, and they would drift silently — both render a
+ * plausible sentence either way.
+ *
+ * Pure and exported so both call sites are testable against a fixed
+ * `AccountState`: the states worth pinning (cancel-at-period-end, `past_due`,
+ * no subscription) cannot be produced locally without Stripe.
+ */
+export interface PlanStatus {
+  /** Plan name as the product names it. Per-seat accounts carry the seat
+   *  count, which no plan label does. */
+  name: string;
+  /** Qualifier under the name, e.g. `$200/mo · grandfathered`. */
+  sublabel: string | null;
+  /** `Renews Sep 24` · `Cancels Sep 24` · `Active` · `past due`. */
+  detail: string;
+  /** A live subscription — drives the status dot, which is absent otherwise. */
+  isActive: boolean;
+  /** Winding down at period end: the dot goes orange rather than green. */
+  isWindingDown: boolean;
+}
+
+export function describePlanStatus(state: AccountState): PlanStatus {
+  const seatCount = state.seats?.count ?? 1;
+  const plan = resolvedPlan(state);
+  const isPerSeat = state.billing_model === 'per_seat';
+  const sub = state.subscription;
+  const periodEnd = sub?.current_period_end ? formatDate(sub.current_period_end) : null;
+  const isActive = sub?.status === 'active';
+
+  return {
+    name: isPerSeat ? `Team · ${seatCount} seat${seatCount === 1 ? '' : 's'}` : plan.label,
+    sublabel: isPerSeat ? null : plan.sublabel,
+    detail: sub?.cancel_at_period_end
+      ? periodEnd
+        ? `Cancels ${periodEnd}`
+        : 'Cancels at period end'
+      : isActive && periodEnd
+        ? `Renews ${periodEnd}`
+        : isActive
+          ? 'Active'
+          : // Raw Stripe statuses are snake_case ('past_due', 'incomplete_expired').
+            // Shown to a person, so they read as words.
+            (sub?.status?.replace(/_/g, ' ') ?? 'No subscription'),
+    isActive,
+    isWindingDown: Boolean(sub?.cancel_at_period_end),
+  };
+}
+
 /** The right-hand column of the balance card: plan name, then the one line
  *  that says where that plan stands — renewal date when there is a live
  *  subscription, status otherwise. Per-seat accounts name the seat count,
  *  which no plan label carries. */
 function PlanSummary({ state }: { state: AccountState }) {
-  const seatCount = state.seats?.count ?? 1;
-  const plan = resolvedPlan(state);
-  const isPerSeat = state.billing_model === 'per_seat';
-  const name = isPerSeat ? `Team · ${seatCount} seat${seatCount === 1 ? '' : 's'}` : plan.label;
-  const sublabel = isPerSeat ? null : plan.sublabel;
-
-  const sub = state.subscription;
-  const periodEnd = sub?.current_period_end ? formatDate(sub.current_period_end) : null;
-  const isActive = sub?.status === 'active';
-
-  const detail = sub?.cancel_at_period_end
-    ? periodEnd
-      ? `Cancels ${periodEnd}`
-      : 'Cancels at period end'
-    : isActive && periodEnd
-      ? `Renews ${periodEnd}`
-      : isActive
-        ? 'Active'
-        : // Raw Stripe statuses are snake_case ('past_due', 'incomplete_expired').
-          // Shown to a person, so they read as words.
-          (sub?.status?.replace(/_/g, ' ') ?? 'No subscription');
+  const { name, sublabel, detail, isActive, isWindingDown } = describePlanStatus(state);
 
   return (
     // Right-aligned beside the balance; left-aligned once the row wraps under
@@ -195,7 +230,7 @@ function PlanSummary({ state }: { state: AccountState }) {
             aria-hidden
             className={cn(
               'mt-px size-1.5 shrink-0 rounded-full',
-              sub?.cancel_at_period_end ? 'bg-kortix-orange' : 'bg-kortix-green',
+              isWindingDown ? 'bg-kortix-orange' : 'bg-kortix-green',
             )}
           />
         ) : null}

--- a/apps/web/src/features/billing/plan-card.test.ts
+++ b/apps/web/src/features/billing/plan-card.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from 'bun:test';
+import type { AccountState } from '@kortix/sdk';
+
+import { describePlanStatus } from './account-overview';
+import { seatProperties } from './plan-card';
+
+/**
+ * The Plan pane's model, tested without React.
+ *
+ * `describePlanStatus` is the shared answer to "where does this subscription
+ * stand" — `PlanSummary` (the account page's balance card) and `PlanCard` (the
+ * settings Plan tab) both read it, which is the whole reason it was extracted.
+ * Every state below is a real Stripe one that cannot be produced against a
+ * local stack without a subscription, so the strings are pinned here.
+ */
+
+function stateWith(patch: Partial<AccountState>): AccountState {
+  return {
+    subscription: { status: 'none', cancel_at_period_end: false, current_period_end: null },
+    ...patch,
+  } as unknown as AccountState;
+}
+
+describe('describePlanStatus', () => {
+  test('a live subscription renews on its period end', () => {
+    const status = describePlanStatus(
+      stateWith({
+        subscription: {
+          status: 'active',
+          cancel_at_period_end: false,
+          // 2026-09-24T00:00:00Z, in seconds — the unit `current_period_end` uses.
+          current_period_end: 1790208000,
+        },
+      } as Partial<AccountState>),
+    );
+    expect(status.detail).toStartWith('Renews ');
+    expect(status.isActive).toBe(true);
+    expect(status.isWindingDown).toBe(false);
+  });
+
+  test('cancel-at-period-end wins over the renewal wording', () => {
+    // Same active status, opposite meaning. Reading `status === "active"` and
+    // printing "Renews" is the bug this ordering prevents.
+    const status = describePlanStatus(
+      stateWith({
+        subscription: {
+          status: 'active',
+          cancel_at_period_end: true,
+          current_period_end: 1790208000,
+        },
+      } as Partial<AccountState>),
+    );
+    expect(status.detail).toStartWith('Cancels ');
+    expect(status.isWindingDown).toBe(true);
+  });
+
+  test('a raw Stripe status is shown as words, not snake_case', () => {
+    const status = describePlanStatus(
+      stateWith({
+        subscription: { status: 'past_due', cancel_at_period_end: false, current_period_end: null },
+      } as Partial<AccountState>),
+    );
+    expect(status.detail).toBe('past due');
+    expect(status.isActive).toBe(false);
+  });
+
+  test('no subscription says so rather than rendering an empty line', () => {
+    expect(describePlanStatus({} as AccountState).detail).toBe('No subscription');
+  });
+
+  test('a per-seat account carries the seat count in the plan name', () => {
+    expect(
+      describePlanStatus(
+        stateWith({ billing_model: 'per_seat', seats: { count: 3 } } as Partial<AccountState>),
+      ).name,
+    ).toBe('Team · 3 seats');
+    // Singular, because "1 seats" is the kind of thing that ships.
+    expect(
+      describePlanStatus(
+        stateWith({ billing_model: 'per_seat', seats: { count: 1 } } as Partial<AccountState>),
+      ).name,
+    ).toBe('Team · 1 seat');
+  });
+});
+
+describe('seatProperties', () => {
+  test('derives the monthly total from count x price', () => {
+    expect(
+      seatProperties(
+        stateWith({
+          billing_model: 'per_seat',
+          seats: { count: 3, price_per_seat_usd: 25 },
+        } as Partial<AccountState>),
+      ),
+    ).toEqual([
+      { id: 'count', label: 'Seats', value: '3' },
+      { id: 'price', label: 'Per seat', value: '$25.00/mo' },
+      { id: 'total', label: 'Monthly total', value: '$75.00/mo' },
+    ]);
+  });
+
+  test('is null for any account that does not bill per seat', () => {
+    // The strip is the one thing on the card a flat plan has no version of —
+    // rendering three empty columns would be worse than rendering none.
+    expect(seatProperties(stateWith({ billing_model: 'legacy' } as Partial<AccountState>))).toBeNull();
+    expect(seatProperties(stateWith({}))).toBeNull();
+  });
+
+  test('per_seat with no seats block yields null rather than "undefined seats"', () => {
+    expect(
+      seatProperties(stateWith({ billing_model: 'per_seat' } as Partial<AccountState>)),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/features/billing/plan-card.tsx
+++ b/apps/web/src/features/billing/plan-card.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+/**
+ * The plan card — the subscription, at hero scale, with the seat properties
+ * that only a per-seat account has.
+ *
+ * **Why it exists** (Jay, 2026-09-03): "in the plan, you need to show just the
+ * team part, team seat". The Plan tab opened on `AccountOverviewTab`, whose
+ * subject is the WALLET — available balance, credits, this period's compute
+ * and LLM spend, and the concurrency limits — with the plan itself demoted to
+ * a two-line right-hand column beside the balance. Every one of those numbers
+ * now has its own pane (`settings/tabs/credits-tab.tsx`), so on the Plan tab
+ * that card was both a duplicate and a card about the wrong thing.
+ *
+ * This inverts it: the plan is the subject, and the seat economics — count,
+ * price each, monthly total — are the properties under it.
+ *
+ * **It replaces `SeatManagementCard` on this pane, and only on this pane.**
+ * That card states the same three seat figures as a sentence
+ * (`3 seats · $25 per teammate, compute included`) plus a right-aligned total.
+ * Rendering both would print the seat count three times in two boxes. The card
+ * is untouched and still renders on `/accounts/[id]?tab=billing`, which keeps
+ * the wallet-first layout — see `billing-tab.tsx`'s `showWallet`.
+ *
+ * The strip is per-seat ONLY. A flat plan has no seat properties, and its
+ * monthly grant is already a meter on the Credits pane, so a strip here would
+ * be a second rendering of a number that has a better one elsewhere.
+ */
+
+import { cn } from '@/lib/utils';
+import type { AccountState } from '@kortix/sdk';
+
+import { describePlanStatus, formatUsd } from './account-overview';
+
+export interface SeatProperty {
+  id: 'count' | 'price' | 'total';
+  label: string;
+  value: string;
+}
+
+/**
+ * The three facts about a team's seats, or `null` for any account that does
+ * not bill per seat.
+ *
+ * `monthlyTotal` is multiplied here rather than read from the API for the same
+ * reason `SeatManagementCard` multiplies it: there is no field for it. Both
+ * derive it from the same two numbers, so they cannot disagree.
+ */
+export function seatProperties(state: AccountState): SeatProperty[] | null {
+  const seats = state.seats;
+  if (!seats || state.billing_model !== 'per_seat') return null;
+
+  const perSeat = seats.price_per_seat_usd ?? 0;
+  const count = seats.count ?? 0;
+
+  return [
+    { id: 'count', label: 'Seats', value: String(count) },
+    { id: 'price', label: 'Per seat', value: `${formatUsd(perSeat)}/mo` },
+    { id: 'total', label: 'Monthly total', value: `${formatUsd(perSeat * count)}/mo` },
+  ];
+}
+
+export function PlanCard({ state }: { state: AccountState }) {
+  const { name, sublabel, detail, isActive, isWindingDown } = describePlanStatus(state);
+  const seats = seatProperties(state);
+
+  return (
+    <div className="bg-popover rounded-md border">
+      {/* Same geometry as the balance card on the Credits pane — label, hero
+          line, qualifier, with the status opposite it — so hopping between the
+          two sibling panes does not move the eye. `items-center`, for the
+          reason that card documents: the left block is taller than the right,
+          and top-aligning them reads as a diagonal rather than a row. */}
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-3 px-4 py-4">
+        <div className="min-w-0">
+          <p className="text-muted-foreground text-xs">Current plan</p>
+          <p className="text-foreground mt-1.5 truncate text-2xl leading-none font-semibold tracking-tight">
+            {name}
+          </p>
+          {sublabel ? (
+            <p className="text-muted-foreground mt-1.5 truncate text-xs">{sublabel}</p>
+          ) : null}
+        </div>
+        <span className="flex min-w-0 shrink-0 items-center gap-1.5">
+          {isActive ? (
+            // Optical, not geometric: a 6px dot centred on a 20px line box
+            // sits a hair high against the x-height of the text beside it.
+            <span
+              aria-hidden
+              className={cn(
+                'mt-px size-1.5 shrink-0 rounded-full',
+                isWindingDown ? 'bg-kortix-orange' : 'bg-kortix-green',
+              )}
+            />
+          ) : null}
+          <span className="text-muted-foreground truncate text-xs leading-5 first-letter:capitalize">
+            {detail}
+          </span>
+        </span>
+      </div>
+
+      {seats ? (
+        <div className="divide-border grid grid-cols-3 divide-x border-t">
+          {seats.map((property) => (
+            <div key={property.id} className="min-w-0 px-4 py-3">
+              <p className="text-muted-foreground truncate text-xs">{property.label}</p>
+              <p className="text-foreground mt-0.5 truncate text-sm font-medium tabular-nums">
+                {property.value}
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/command-palette-search.test.ts
+++ b/apps/web/src/features/workspace/command-palette-search.test.ts
@@ -275,6 +275,11 @@ describe('queries return the rows they name', () => {
       'nav:account-usage',
       'nav:nav-accounts',
       'settings:connected',
+      // The Credits row's rail description reads "What this account has left
+      // to spend" — the wallet is the ACCOUNT's, not the person's, and saying
+      // so is why that row owns the word rather than inheriting it from the
+      // `Account` group heading it sits under.
+      'settings:credits',
       // The Plan row's rail description reads "for this account".
       'settings:plan',
       'settings:profile',

--- a/apps/web/src/features/workspace/command-palette.test.tsx
+++ b/apps/web/src/features/workspace/command-palette.test.tsx
@@ -337,24 +337,37 @@ describe('the registry no longer carries palette settings destinations', () => {
     expect(resolved.map((entry) => entry.id).sort()).toEqual([]);
   });
 
-  test('proj-customize points at the Customize index, and General at the config page', () => {
+  test('proj-customize points at the Customize index, and no row survives /config', () => {
     // A bare `/projects/{id}/settings` resolved to `{ tab: undefined }`, and
     // `openSettings(undefined)` keeps whatever was last open — so one entry
     // landed somewhere different on every click. It named `/settings/general`
     // after that, then `/config` once General became a config section.
     //
-    // `/config` is now `proj-config-general`'s href, under its own honest
-    // label ("Settings · General"). `proj-customize` keeps the WORD customize
-    // and takes the index page it names — the card grid over every capability
-    // tab, each of which has its own row.
+    // `proj-customize` keeps the WORD customize and takes the index page it
+    // names — the card grid over every capability tab, each of which has its
+    // own row.
     const customize = paletteItems.find((item) => item.id === 'proj-customize');
     expect(customize?.href).toBe('/projects/{projectId}/customize');
     expect(customize?.kind).toBe('navigate');
     expect(customize?.requiresProject).toBe(true);
 
-    // `proj-config-general` is gone with `/config` (2026-09-02): General is
-    // the overlay's `workspace` tab, derived from the rail.
-    expect(paletteItems.find((item) => item.id === 'proj-config-general')).toBeUndefined();
+    // Every `proj-config-*` row is gone with `/config` (2026-09-02): General,
+    // Sandbox templates and Feature flags are overlay tabs derived from the
+    // rail.
+    //
+    // `proj-config-feature-flags` outlived the other two by a day. It was
+    // still shipping on 2026-09-03 with `href: '/projects/{projectId}/config
+    // ?section=feature-flags'`, so typing "feature flag" offered it under
+    // Navigation — above the derived row that works — and selecting it
+    // navigated to a deleted route. `menu-registry-destinations.test.ts` now
+    // checks every navigate row's href against the real `src/app` tree, which
+    // is the check that would have caught it the day the route was deleted.
+    for (const id of ['proj-config-general', 'proj-config-sandbox', 'proj-config-feature-flags']) {
+      expect({ id, present: paletteItems.some((item) => item.id === id) }).toEqual({
+        id,
+        present: false,
+      });
+    }
 
     // Customize may not be claimed by the overlay resolver, or the click
     // would open a tab instead of navigating.

--- a/apps/web/src/features/workspace/feature-gate-screen.tsx
+++ b/apps/web/src/features/workspace/feature-gate-screen.tsx
@@ -15,9 +15,10 @@ import { FlagIcon } from '@phosphor-icons/react';
  * per-feature switch to hunt for. The button here just takes you there.
  *
  * The destination has moved twice and the content never has: the legacy
- * Customize overlay's `feature-flags` section, then the settings overlay's
- * Experimental tab, and now `/projects/<id>/config?section=feature-flags`.
- * A real `<Link>`, because it is a route now — middle-click and copy-link
+ * Customize overlay's `feature-flags` section, then `/projects/<id>/config
+ * ?section=feature-flags`, and — since that page was retired on 2026-09-02 —
+ * the Settings overlay's Feature flags tab, at `/settings/feature-flags`.
+ * A real `<Link>`, because it is still a route — middle-click and copy-link
  * both work, and the page prefetches.
  *
  * Only reachable surfaces render this. A gated NAV entry, palette action, or

--- a/apps/web/src/features/workspace/project-sidebar/footer/project-chatgpt-connect-nav.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/footer/project-chatgpt-connect-nav.tsx
@@ -35,7 +35,7 @@ export function ProjectChatGptConnectNavItem({ projectId }: { projectId: string 
       <SidebarMenuItem>
         <SidebarMenuButton
           onClick={openDialog}
-          className="group/customize-button flex items-center justify-start"
+          className="group/customize-button text-sidebar-foreground relative flex items-center justify-start"
         >
           <OpenAI className="text-foreground" />
           Connect GPT subscription

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar-footer-order.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar-footer-order.test.ts
@@ -5,9 +5,17 @@ import { join } from 'node:path';
 /**
  * The sidebar's footer group is bottom-anchored (`mt-auto`), so it grows
  * upward: every item that mounts late shoves everything ABOVE it up the page.
- * Billing items mount late by nature — they wait on account state — so they
- * have to sit above the permanent nav, otherwise Files / Connect visibly jump
- * the moment the wallet resolves.
+ * Billing items mount late by nature — they wait on account state.
+ *
+ * That argued for putting all of them above the permanent nav, and this file
+ * pinned exactly that until 2026-09-03. `SidebarUpgradeButton` moved to LAST
+ * on Jay's call: it is the only paid call to action in the group, and above
+ * Files / Connect GPT it put a sell between the user and the links they use.
+ * The placement is the product decision; the shift is the cost of it, and it
+ * is one row of movement on a resolve that happens once per page load.
+ *
+ * `SidebarBalanceWarning` did NOT move. It is an alert rather than an offer,
+ * and it is still pinned above the nav below.
  *
  * Asserted against the source because the alternative is mounting the whole
  * sidebar (sidebar + auth + query + i18n providers) to observe pure ordering.
@@ -21,9 +29,20 @@ function orderOf(component: string): number {
 }
 
 describe('project sidebar footer ordering', () => {
-  test('late-arriving billing items render above the permanent nav', () => {
-    expect(orderOf('SidebarUpgradeButton')).toBeLessThan(orderOf('ProjectFilesNavItem'));
+  test('the balance alert renders above the permanent nav', () => {
+    // Unchanged rule, narrowed to the row it still covers: an alert about the
+    // wallet is not something to scroll past the nav to find.
     expect(orderOf('SidebarBalanceWarning')).toBeLessThan(orderOf('ProjectFilesNavItem'));
+  });
+
+  test('the upgrade button is last in the group', () => {
+    // The one deliberate exception to the rule above (Jay, 2026-09-03). Pinned
+    // in its new position rather than deleted, so moving it back is also a
+    // decision someone has to make on purpose.
+    expect(orderOf('SidebarUpgradeButton')).toBeGreaterThan(orderOf('ProjectFilesNavItem'));
+    expect(orderOf('SidebarUpgradeButton')).toBeGreaterThan(
+      orderOf('ProjectChatGptConnectNavItem'),
+    );
   });
 
   test('the permanent nav keeps its own order', () => {

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -231,14 +231,14 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
           </SidebarGroup>
 
           <SidebarGroup className="mt-auto">
-            <SidebarMenu>
+            <SidebarMenu className="gap-1">
               <ProjectSandboxAlert projectId={projectId} />
               <ProjectChangeRequestsNavItem projectId={projectId} />
               <ProjectManifestUpgradeAlert projectId={projectId} />
               <SidebarBalanceWarning accountId={accountId} />
-              <SidebarUpgradeButton accountId={accountId} />
               <ProjectFilesNavItem />
               <ProjectChatGptConnectNavItem projectId={projectId} />
+              <SidebarUpgradeButton accountId={accountId} />
             </SidebarMenu>
           </SidebarGroup>
         </div>

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -236,15 +236,12 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
               <ProjectChangeRequestsNavItem projectId={projectId} />
               <ProjectManifestUpgradeAlert projectId={projectId} />
               <SidebarBalanceWarning accountId={accountId} />
-              {/* Stays ABOVE the permanent nav. The group is `mt-auto`, so it
-                  grows upward: a billing row mounts late (it waits on account
-                  state) and everything ABOVE it shifts up when it appears.
-                  Below Files, that shift is Files and Connect GPT visibly
-                  jumping the moment the wallet resolves. Pinned by
-                  `project-sidebar-footer-order.test.ts`. */}
-              <SidebarUpgradeButton accountId={accountId} />
               <ProjectFilesNavItem />
               <ProjectChatGptConnectNavItem projectId={projectId} />
+              {/* Last (Jay, 2026-09-03). It is the only paid call to action in
+                  this group, and above the nav rows it put a sell between the
+                  user and the links they actually use. */}
+              <SidebarUpgradeButton accountId={accountId} />
             </SidebarMenu>
           </SidebarGroup>
         </div>

--- a/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-sidebar.tsx
@@ -236,9 +236,15 @@ export function ProjectSidebar({ projectId }: { projectId: string }) {
               <ProjectChangeRequestsNavItem projectId={projectId} />
               <ProjectManifestUpgradeAlert projectId={projectId} />
               <SidebarBalanceWarning accountId={accountId} />
+              {/* Stays ABOVE the permanent nav. The group is `mt-auto`, so it
+                  grows upward: a billing row mounts late (it waits on account
+                  state) and everything ABOVE it shifts up when it appears.
+                  Below Files, that shift is Files and Connect GPT visibly
+                  jumping the moment the wallet resolves. Pinned by
+                  `project-sidebar-footer-order.test.ts`. */}
+              <SidebarUpgradeButton accountId={accountId} />
               <ProjectFilesNavItem />
               <ProjectChatGptConnectNavItem projectId={projectId} />
-              <SidebarUpgradeButton accountId={accountId} />
             </SidebarMenu>
           </SidebarGroup>
         </div>

--- a/apps/web/src/features/workspace/settings-palette-items.ts
+++ b/apps/web/src/features/workspace/settings-palette-items.ts
@@ -49,6 +49,7 @@ export const PALETTE_ACCOUNT_SCOPED_TABS: readonly SettingsTab[] = [
   'preferences',
   'connected',
   'tokens',
+  'credits',
   'plan',
 ];
 
@@ -124,9 +125,23 @@ const TAB_KEYWORDS: Record<SettingsTab, string> = {
   // "account" owns the word).
   tokens:
     'api keys key tokens token personal access pat cli command line terminal secret credential authentication ci',
-  // The plan is the one account row in the overlay. Its rail description
+  // The row that answers "how much have I got left". It carries `usage`
+  // because that is the word Jay used for it and the id could not be
+  // (`settings-tabs.ts` explains why `usage` is spent), and `balance` /
+  // `wallet` because those moved OFF `plan` below — the Plan pane shows
+  // neither now.
+  credits:
+    'credits credit usage balance wallet spend spent remaining left quota allowance topup top up refresh daily monthly cost',
+  // The plan is the other account row in the overlay. Its rail description
   // says "for this account", so it answers "account" by a word the user reads.
-  plan: 'plan subscription billing credits upgrade invoice payment wallet',
+  //
+  // `credits` deliberately stays on BOTH rows: this is the pane that SELLS
+  // them (`CreditTopupSection`, auto top-up) and `credits` above is the pane
+  // that COUNTS them, so the word names a real subject of each. `wallet` and
+  // `balance` are gone from here — neither is rendered on this pane any more,
+  // and a word that names a different row's subject is the defect this file's
+  // header rule is about.
+  plan: 'plan subscription billing credits buy purchase upgrade downgrade invoice payment seat seats portal stripe',
   // Copy for the two Workspace rows that came back on 2026-09-02 — the words
   // `proj-sandbox` and `proj-feature-flags` carry in `lib/menu-registry.ts`.
   sandbox:

--- a/apps/web/src/features/workspace/settings-palette-items.ts
+++ b/apps/web/src/features/workspace/settings-palette-items.ts
@@ -77,9 +77,9 @@ export const PALETTE_NO_PROJECT_DEFAULT_TAB: SettingsTab = 'profile';
  * carried over verbatim from the old `Customize · X` registry entries, so
  * "customize" returned twelve settings tabs plus five navigation rows and
  * "project" returned twelve tabs that are not the Projects page. `customize`
- * survives on exactly one row here — `general`, the Workspace tab that
- * `proj-customize`'s href actually opens (`/projects/{id}/settings/general`) —
- * so the legacy word still lands on the legacy destination and nowhere else.
+ * survives on exactly one row here — `workspace`, the tab labelled "General",
+ * which is what the Customize bar's Settings tab used to open — so the legacy
+ * word still lands on the legacy destination and nowhere else.
  * `project` survives only inside `general`'s phrase "project settings", the
  * pane's own former name.
  *
@@ -228,9 +228,10 @@ function toPaletteItem(item: RailItem, groupLabel: string): SettingsPaletteItem 
  * renders an empty heading.
  *
  * `UPGRADE_ITEM` used to be appended to the last group here. It left the rail
- * with the rest of project configuration and is a section of
- * `/projects/<id>/config` now, reached through the `proj-settings` registry
- * row like every other out-of-overlay destination.
+ * with the rest of project configuration, became a section of
+ * `/projects/<id>/config`, and came back on 2026-09-02 when that page was
+ * retired — so it is a derived row from `railGroups()` like every other tab
+ * in this file, with no hand-written registry entry anywhere.
  */
 export function settingsPaletteGroups(params: SettingsPaletteParams): SettingsPaletteGroup[] {
   const groups: SettingsPaletteGroup[] = [];

--- a/apps/web/src/features/workspace/settings/rail.test.ts
+++ b/apps/web/src/features/workspace/settings/rail.test.ts
@@ -43,6 +43,7 @@ describe('railGroups', () => {
       'preferences',
       'connected',
       'tokens',
+      'credits',
       'plan',
     ]);
   });

--- a/apps/web/src/features/workspace/settings/rail.ts
+++ b/apps/web/src/features/workspace/settings/rail.ts
@@ -1,6 +1,7 @@
 import {
   ArrowCircleUpIcon as ArrowUpCircle,
   ChatCircleIcon as ChatCircle,
+  CoinsIcon as Coins,
   ShippingContainerIcon as Container,
   CreditCardIcon as CreditCard,
   FlaskIcon as Flask,
@@ -143,10 +144,23 @@ const STATIC_GROUPS: readonly RailGroup[] = [
   {
     label: 'Account',
     items: [
+      // Credits FIRST, plan second: reading the balance is the frequent visit
+      // and changing the plan is the rare one. The row is in `Account`, not
+      // `Personal`, because a wallet belongs to the account — on a Team plan
+      // every seat spends the same balance, and filing it under "Personal"
+      // would claim otherwise. Jay asked for a Usage tab under Personal
+      // (2026-09-03); the scope is the one thing changed, and the word "usage"
+      // still finds this row through the command palette.
+      {
+        tab: 'credits',
+        label: 'Credits',
+        description: 'What this account has left to spend, and what it spent this period.',
+        icon: Coins,
+      },
       {
         tab: 'plan',
         label: 'Plan',
-        description: 'Your subscription, credits, and billing for this account.',
+        description: 'Your subscription, team seats, and billing for this account.',
         icon: CreditCard,
       },
     ],

--- a/apps/web/src/features/workspace/settings/rail.ts
+++ b/apps/web/src/features/workspace/settings/rail.ts
@@ -22,10 +22,10 @@ import type { RailGroup, RailItem } from './type';
  *
  * A plain 1:1 match. It used to carry a `models` stand-in for the seven
  * legacy `llm-*` sub-page ids, which went with the Models tab when project
- * configuration moved to `/projects/<id>/config` — the sub-nav there resolves
- * those ids itself (see
- * `capabilities/project-settings/project-settings-page.tsx`). Every tab left
- * in this rail matches its own id and nothing else.
+ * configuration moved out of this rail. Those ids resolve through `GRADUATED`
+ * in `settings-tabs.ts` onto `/projects/<id>/models` now — the config page
+ * that briefly owned them was retired on 2026-09-02. Every tab left in this
+ * rail matches its own id and nothing else.
  */
 export function isRailItemActive(item: RailItem, tab: SettingsTab): boolean {
   return item.tab === tab;
@@ -168,10 +168,10 @@ const STATIC_GROUPS: readonly RailGroup[] = [
   // The 'Agent' group is gone, and 'Developer' went with it. Every one of
   // those rows configured a PROJECT, and the Customize bar gates on exactly the
   // person allowed to change them — so they live on that bar, at
-  // `/projects/<id>/config` (`capabilities/project-settings/`). Two of them —
-  // Sandbox templates and Feature flags — came BACK on 2026-09-02 as a second
-  // door onto the same components; `GRADUATED` in `settings-tabs.ts` still
-  // carries every bookmark to the config page.
+  // the Customize bar. Sandbox templates, Feature flags and Upgrades came
+  // BACK on 2026-09-02, when `/projects/<id>/config` was retired — this rail
+  // is their only mount now, and `GRADUATED` in `settings-tabs.ts` carries
+  // every bookmark that still names a config section.
   //
   // The 'Organization' group is gone for a different reason, recorded above
   // its own removal: those rows configured the ACCOUNT and moved to

--- a/apps/web/src/features/workspace/settings/settings-panel.tsx
+++ b/apps/web/src/features/workspace/settings/settings-panel.tsx
@@ -40,6 +40,7 @@ import { useSettingsKeyboardShortcut } from './use-settings-shortcut';
 import { DEFAULT_SETTINGS_TAB, type SettingsTab } from './settings-tabs';
 import { AppearanceTab } from './tabs/appearance-tab';
 import { ConnectedAccountsTab } from './tabs/connected-tab';
+import { CreditsTab } from './tabs/credits-tab';
 import { ExperimentalTab } from './tabs/experimental-tab';
 import { GeneralTab } from './tabs/general-tab';
 import { PlanTab } from './tabs/plan-tab';
@@ -79,6 +80,11 @@ export const ACCOUNT_SCOPED_SETTINGS_TABS: readonly SettingsTab[] = [
   // see `tabs/tokens-tab.tsx`), but never in one project, so this renders with
   // or without a project open like the three above it.
   'tokens',
+  // Same scope as `plan` below — one wallet per account, read through the same
+  // resolved id — so it renders wherever `plan` does. Listed before it, in the
+  // rail's own order, because `command-palette.test.tsx` asserts this array
+  // equals `PALETTE_ACCOUNT_SCOPED_TABS` element for element.
+  'credits',
   // The plan is the ACCOUNT's, and the account is resolved the same way the
   // Tokens pane resolves it (`useSettingsAccountId`), so it renders with or
   // without a project too.
@@ -601,6 +607,9 @@ function SettingsTabPane({
   }
   if (item.tab === 'tokens') {
     return <TokensTab accountId={accountId} />;
+  }
+  if (item.tab === 'credits') {
+    return <CreditsTab accountId={accountId} />;
   }
   if (item.tab === 'plan') {
     return <PlanTab accountId={accountId} />;

--- a/apps/web/src/features/workspace/settings/settings-panel.tsx
+++ b/apps/web/src/features/workspace/settings/settings-panel.tsx
@@ -98,9 +98,10 @@ export const ACCOUNT_SCOPED_SETTINGS_TABS: readonly SettingsTab[] = [
 ];
 
 /**
- * The two Workspace rows that gate on an IAM read leaf, keyed to the
- * `CustomizeSection` the config page gates the same pane on
- * (`project-settings-sections.ts`). `workspace` (General) is not here: every
+ * The three Workspace rows that gate on an IAM read leaf, keyed to the
+ * `CustomizeSection` the retired config page gated the same pane on — the
+ * section keys outlived that page and live in `lib/project-actions.ts`.
+ * `workspace` (General) is not here: every
  * member may see the workspace's name and icon, and `GeneralTab` gates its own
  * controls on write.
  */
@@ -146,9 +147,9 @@ export function probeAdmits(probe: Pick<CanResult, 'allowed' | 'isLoading'> | un
  * Connected accounts are user-scoped, so they render with or without a
  * project. The per-section IAM probe this used to run
  * (`GATED_TAB_SECTION` -> `isCustomizeSectionVisible`) went with the
- * project-configuration tabs it gated — those live at
- * `/projects/[id]/config` now, and that page runs the identical probe over
- * the identical leaves (`capabilities/project-settings/`).
+ * project-configuration tabs it gated. Most of those are capability pages now
+ * (`capabilities/`), which run their own probes; the four that came back to
+ * this overlay are gated here again, by `PROJECT_GATED_TABS` above.
  *
  * The function stays because the CONCEPT stays: a tab added here must declare
  * whether it needs a project, and the command palette mirrors this decision
@@ -558,10 +559,10 @@ function SettingsTabPane({
 }) {
   if (!active) return null;
 
-  // The SAME component `/projects/<id>/config?section=general` renders
-  // (`capabilities/project-settings/project-settings-page.tsx`), not a copy.
-  // Workspace name and icon have one implementation and one set of mutations;
-  // this overlay is a second door onto it, not a second version of it.
+  // Workspace name and icon have one implementation and one set of mutations,
+  // and this is now its only mount: `/projects/<id>/config` and the
+  // `capabilities/project-settings/` directory behind it were both retired on
+  // 2026-09-02. This pane was the second door; it is the only door.
   //
   // The `projectId` guard is belt-and-braces: the row is filtered out of the
   // rail whenever there is no project, so this branch is unreachable without

--- a/apps/web/src/features/workspace/settings/settings-tab-header.test.ts
+++ b/apps/web/src/features/workspace/settings/settings-tab-header.test.ts
@@ -70,6 +70,7 @@ const TAB_ID_FOR_FILE: Record<string, string> = {
   // project-settings registry rather than the rail.
   'experimental-tab.tsx': 'feature-flags',
   'general-tab.tsx': 'general',
+  'credits-tab.tsx': 'credits',
   'plan-tab.tsx': 'plan',
   'preferences-tab.tsx': 'preferences',
   'profile-tab.tsx': 'profile',

--- a/apps/web/src/features/workspace/settings/settings-tabs.test.ts
+++ b/apps/web/src/features/workspace/settings/settings-tabs.test.ts
@@ -38,6 +38,7 @@ describe('SETTINGS_TABS', () => {
       'preferences',
       'connected',
       'tokens',
+      'credits',
       'plan',
       'workspace',
       'sandbox',

--- a/apps/web/src/features/workspace/settings/settings-tabs.ts
+++ b/apps/web/src/features/workspace/settings/settings-tabs.ts
@@ -87,16 +87,17 @@ export type SettingsTab =
   // rail row is still LABELLED "General" under a "Workspace" group, which is
   // what it was called before it graduated — see `rail.ts`.
   //
-  // It renders `tabs/general-tab.tsx`, the same component
-  // `/projects/<id>/config?section=general` renders. ONE component, two
-  // mounts: nothing is forked, and the config page keeps working unchanged.
+  // It renders `tabs/general-tab.tsx`. That component had two mounts while
+  // `/projects/<id>/config?section=general` existed; since that page was
+  // retired on 2026-09-02 this tab is its ONLY mount, and the `general`
+  // redirect below is all that is left of the other one.
   | 'workspace'
   // Two more project-scoped rows, back on 2026-09-02 (Jay: "find some more
-  // settings that you can show in the workspace settings"). Both mount the
-  // SAME component the config page mounts — `SandboxTab` + `SnapshotsTab`,
+  // settings that you can show in the workspace settings"). Both mount what
+  // the config page used to mount — `SandboxTab` + `SnapshotsTab`,
   // `ExperimentalTab` — and gate on the same IAM read leaf
-  // (`isCustomizeSectionVisible`), so a person sees exactly the rows here that
-  // they see on `/projects/<id>/config`. The ids equal the config page's
+  // (`isCustomizeSectionVisible`), so a person sees exactly the rows the
+  // retired page showed them. The ids equal that page's
   // section keys on purpose: `legacySectionRedirect` checks `GRADUATED`
   // BEFORE live tabs, so a stale `/customize/sandbox` bookmark still lands on
   // the config page, while `/settings/sandbox` opens this overlay.
@@ -111,13 +112,15 @@ export type SettingsTab =
 // project, and the account already owns a full page for them at
 // `/accounts/[id]`. They resolve through `ACCOUNT_GRADUATED` below.
 //
-// The project's own configuration is gone too — General, Members, Secrets,
+// The project's own configuration left too — General, Members, Secrets,
 // Channels, Repositories, Models, Sandbox templates, Snapshots, Marketplace,
 // Review, Voice, Feature flags (was `experimental`) and Upgrades. All thirteen
-// are sections of the Customize bar's Settings tab now, at
-// `/projects/[id]/config?section=<key>`, and resolve through `GRADUATED`.
-// What is left in this overlay is exactly what is scoped to the PERSON using
-// it: Profile, Preferences, Connected accounts.
+// became sections of the Customize bar's Settings tab, `/projects/[id]/config
+// ?section=<key>`, and that page was itself retired on 2026-09-02: each id now
+// resolves through `GRADUATED` to a capability page, or is a live tab of this
+// overlay again (`workspace`, `sandbox`, `feature-flags`, `upgrades`).
+// Nothing routes to `/config` any more — `menu-registry-destinations.test.ts`
+// fails on a palette row that tries.
 
 /**
  * The default must be a tab that survives every gate, or the overlay opens on

--- a/apps/web/src/features/workspace/settings/settings-tabs.ts
+++ b/apps/web/src/features/workspace/settings/settings-tabs.ts
@@ -60,6 +60,18 @@ export type SettingsTab =
   // `billing` is spent on an `ACCOUNT_GRADUATED` redirect to the account page
   // and a live tab under it would shadow every bookmark pointing there.
   | 'plan'
+  // What the account has left to spend, and what it spent (Jay, 2026-09-03:
+  // "it's difficult to get to know how many credits we still have pending").
+  // Read-only — every mutation stays on `plan`, which this pane's one action
+  // navigates to.
+  //
+  // The id is `credits`, not `usage`, for the same reason `plan` is not
+  // `billing`: `usage` is an ACCOUNT_GRADUATED key below, pointing at
+  // `/accounts/<id>?tab=transactions`, and `legacySectionRedirect` resolves
+  // that map BEFORE live tabs — a tab under `usage` would shadow every
+  // bookmark to the account page's usage surface. The word still reaches this
+  // pane through the command palette's keyword bag.
+  | 'credits'
   // The first PROJECT-scoped tab in an otherwise person-scoped overlay, and a
   // deliberate partial reversal of the graduation described below (Jay,
   // 2026-09-01). Everything else that configures a project genuinely belongs
@@ -123,6 +135,7 @@ export const SETTINGS_TABS: readonly SettingsTab[] = [
   'preferences',
   'connected',
   'tokens',
+  'credits',
   'plan',
   // Project-scoped, so NOT in `ACCOUNT_SCOPED_SETTINGS_TABS`
   // (`settings-panel.tsx`): the overlay hides the whole Workspace group when it

--- a/apps/web/src/features/workspace/settings/tab-content-width.test.ts
+++ b/apps/web/src/features/workspace/settings/tab-content-width.test.ts
@@ -76,6 +76,7 @@ const FORM_TABS = [
   'general-tab.tsx',
   // Plan: `BillingTab`'s cards and rows, not a `<Table>` — the ledger with
   // the wide table is the account page's Usage tab, which is not mounted here.
+  'credits-tab.tsx',
   'plan-tab.tsx',
   'preferences-tab.tsx',
   'profile-tab.tsx',

--- a/apps/web/src/features/workspace/settings/tabs/credits-tab.test.ts
+++ b/apps/web/src/features/workspace/settings/tabs/credits-tab.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import type { AccountState } from '@kortix/sdk';
+
+import {
+  canOfferTopup,
+  creditBuckets,
+  describeDailyRefresh,
+  formatCountdown,
+  formatPeriod,
+  planGrantMeter,
+} from './credits-tab';
+
+/**
+ * The Credits pane's model, tested without React.
+ *
+ * Every function under test is pure and exported for exactly this reason: the
+ * shapes that matter — a spent grant, a topped-up grant, a negative balance,
+ * an account with no daily refresh — cannot be produced against a local stack
+ * without provisioning several accounts and a Stripe subscription. The pane's
+ * arithmetic is where a wrong number would come from, so the arithmetic is
+ * what is pinned.
+ *
+ * `$1 = 100 credits` (`CREDITS_PER_DOLLAR`, packages/shared) throughout.
+ */
+
+/** A minimal `AccountState` — only the fields these functions read. */
+function stateWith(patch: {
+  credits?: Partial<AccountState['credits']>;
+  tierMonthlyCredits?: number;
+}): AccountState {
+  return {
+    credits: {
+      total: 0,
+      daily: 0,
+      monthly: 0,
+      extra: 0,
+      can_run: true,
+      daily_refresh: null,
+      ...patch.credits,
+    },
+    tier: { monthly_credits: patch.tierMonthlyCredits ?? 0 },
+  } as unknown as AccountState;
+}
+
+describe('creditBuckets', () => {
+  test('splits the balance into the three buckets that sum to it', () => {
+    const buckets = creditBuckets(
+      stateWith({ credits: { total: 16, monthly: 10, daily: 2, extra: 4 } }),
+    );
+    expect(buckets.map((b) => [b.id, b.credits])).toEqual([
+      ['monthly', 1000],
+      ['daily', 200],
+      ['extra', 400],
+    ]);
+    // The strip's arithmetic is visible on screen, so it has to hold: the
+    // three columns add up to the headline credit figure above them.
+    expect(buckets.reduce((sum, b) => sum + b.credits, 0)).toBe(1600);
+  });
+
+  test('always returns three columns, including at zero', () => {
+    // A strip whose column count depends on the data reflows between accounts
+    // and between refreshes — and "0 purchased" is itself the answer to a
+    // question someone opened this pane to ask.
+    expect(creditBuckets(stateWith({})).map((b) => b.credits)).toEqual([0, 0, 0]);
+  });
+});
+
+describe('planGrantMeter', () => {
+  test('used = the grant minus what is left of it', () => {
+    // $16 grant, $10 of monthly credits left => $6 spent => 600 credits.
+    const meter = planGrantMeter(stateWith({ credits: { monthly: 10 }, tierMonthlyCredits: 16 }));
+    expect(meter).toEqual({
+      usedCredits: 600,
+      grantedCredits: 1600,
+      percent: 38,
+      tone: 'ok',
+    });
+  });
+
+  test('is null when the plan grants nothing — Free and per-seat Team', () => {
+    // A "0 of 0 used" bar is a bar that can never move.
+    expect(planGrantMeter(stateWith({ tierMonthlyCredits: 0 }))).toBeNull();
+  });
+
+  test('a mid-period top-up cannot print negative usage', () => {
+    // `credits.monthly` above the grant is a real state (an admin grant lands
+    // in the expiring bucket). Unclamped this reported -400 credits used.
+    const meter = planGrantMeter(stateWith({ credits: { monthly: 20 }, tierMonthlyCredits: 16 }));
+    expect(meter?.usedCredits).toBe(0);
+    expect(meter?.percent).toBe(0);
+  });
+
+  test('turns orange at 90% of the grant and red at the cap', () => {
+    expect(planGrantMeter(stateWith({ credits: { monthly: 2 }, tierMonthlyCredits: 20 }))?.tone).toBe(
+      'low',
+    );
+    expect(planGrantMeter(stateWith({ credits: { monthly: 0 }, tierMonthlyCredits: 20 }))?.tone).toBe(
+      'spent',
+    );
+    expect(planGrantMeter(stateWith({ credits: { monthly: 10 }, tierMonthlyCredits: 20 }))?.tone).toBe(
+      'ok',
+    );
+  });
+});
+
+describe('describeDailyRefresh', () => {
+  test('reads the amount and the interval the API computed', () => {
+    expect(
+      describeDailyRefresh(
+        stateWith({
+          credits: {
+            daily_refresh: {
+              enabled: true,
+              daily_amount: 4,
+              refresh_interval_hours: 24,
+              seconds_until_refresh: 15120,
+            },
+          },
+        }),
+      ),
+    ).toEqual({ amountLine: '+400 credits every 24h', countdown: 'in ~4h 12m' });
+  });
+
+  test('is null when the account has no daily refresh, or a zero one', () => {
+    expect(describeDailyRefresh(stateWith({}))).toBeNull();
+    expect(
+      describeDailyRefresh(
+        stateWith({
+          credits: {
+            daily_refresh: { enabled: true, daily_amount: 0, refresh_interval_hours: 24 },
+          },
+        }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('formatCountdown', () => {
+  test('drops a zero minutes component rather than printing "4h 0m"', () => {
+    expect(formatCountdown(14400)).toBe('in ~4h');
+  });
+
+  test('omits the hours component under an hour', () => {
+    expect(formatCountdown(750)).toBe('in ~12m');
+  });
+
+  test('never prints "in ~0m" — a due-or-overdue refresh says so in words', () => {
+    // The API clamps `seconds_until_refresh` at 0 and `useAccountState` holds
+    // its data for two minutes, so the last minute of the countdown is inside
+    // the query's own staleness. It is not a number worth printing.
+    expect(formatCountdown(0)).toBe('Any moment now');
+    expect(formatCountdown(45)).toBe('Any moment now');
+    expect(formatCountdown(null)).toBe('Any moment now');
+    expect(formatCountdown(undefined)).toBe('Any moment now');
+  });
+});
+
+describe('formatPeriod', () => {
+  test('renders an en-dashed range with no year', () => {
+    expect(formatPeriod('2026-08-24T00:00:00Z', '2026-09-03T00:00:00Z')).toContain('–');
+  });
+
+  test('falls back to whichever end is present, and to null when neither is', () => {
+    expect(formatPeriod('2026-08-24T00:00:00Z', null)).not.toContain('–');
+    expect(formatPeriod(null, null)).toBeNull();
+  });
+
+  test('an unparseable date does not render "Invalid Date"', () => {
+    expect(formatPeriod('not-a-date', 'also-not')).toBeNull();
+  });
+});
+
+describe('canOfferTopup', () => {
+  /** Only the two fields this gate reads. */
+  function purchaseState(
+    canPurchaseCredits: boolean,
+    canManageBilling?: boolean,
+  ): AccountState {
+    return {
+      subscription: { can_purchase_credits: canPurchaseCredits },
+      ...(canManageBilling === undefined ? {} : { can_manage_billing: canManageBilling }),
+    } as unknown as AccountState;
+  }
+
+  test('needs the tier entitlement AND the billing permission', () => {
+    expect(canOfferTopup(purchaseState(true, true))).toBe(true);
+    // Entitled plan, wrong person — the card would 403 on click.
+    expect(canOfferTopup(purchaseState(true, false))).toBe(false);
+    // Right person, plan cannot buy credits at all.
+    expect(canOfferTopup(purchaseState(false, true))).toBe(false);
+  });
+
+  test('an API response with no `can_manage_billing` does not lock an owner out', () => {
+    // The field is additive on the wire and its own API comment says absent
+    // means allowed. Reading it as falsy would hide the control on every
+    // deployment older than the field.
+    expect(canOfferTopup(purchaseState(true))).toBe(true);
+  });
+
+  test('an account with no subscription block offers nothing', () => {
+    expect(canOfferTopup({} as AccountState)).toBe(false);
+  });
+});

--- a/apps/web/src/features/workspace/settings/tabs/credits-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/credits-tab.tsx
@@ -1,0 +1,505 @@
+'use client';
+
+/**
+ * The Credits tab — what this account has left, where each part of it came
+ * from, what is about to arrive, and what the current period cost.
+ *
+ * **Why it exists** (Jay, 2026-09-03): "it's difficult to get to know how many
+ * credits we still have pending". The balance was reachable only through
+ * Account -> Plan, where it is the first card of a pane whose other four
+ * blocks are all mutations — subscribe, claim seats, buy credits, open the
+ * Stripe portal. Someone who wants a number had to open a checkout surface to
+ * read it.
+ *
+ * **Why the id is `credits`, not `usage`.** `usage` is spent: it is an
+ * `ACCOUNT_GRADUATED` key (`settings-tabs.ts`) pointing at
+ * `/accounts/<id>?tab=transactions`, and `legacySectionRedirect` resolves that
+ * map BEFORE live tabs — a tab under that id would shadow every bookmark to
+ * the account page's usage surface. The same split `plan` (not `billing`),
+ * `workspace` (not `general`) and `tokens` (not `api-keys`) already make. The
+ * word "usage" still reaches this pane through the command palette, which
+ * carries it in this tab's keyword bag (`settings-palette-items.ts`).
+ *
+ * **What is new here, versus the balance card the Plan tab already shows**
+ * (`features/billing/account-overview.tsx`):
+ *
+ * 1. **The composition.** `AccountState.credits` carries four numbers and the
+ *    product renders one. `monthly` is the plan's grant, remaining, and it
+ *    expires at period end; `daily` is the refreshing bucket; `extra` is
+ *    purchased and never expires. Which bucket a balance sits in decides
+ *    whether it survives Friday, so a single total answers the wrong question.
+ * 2. **The grant meter.** `tier.monthly_credits` is the recurring grant and
+ *    `credits.monthly` is what is left of it, so the difference is what this
+ *    period consumed. One bar for one headline fraction — not one bar per row,
+ *    which is the shape `account-overview.tsx` deliberately removed.
+ * 3. **The refresh countdown.** `credits.daily_refresh.seconds_until_refresh`
+ *    is, exactly, "credits still pending". Nothing in the product renders it.
+ * 4. **The period is named.** The Plan card shows three spend figures over an
+ *    unnamed span; `usage_this_period` carries the dates, so they are printed.
+ *
+ * **Buying credits happens here** (Jay, 2026-09-03: "the add credit component
+ * will be coming in the credit tab content only, not in the plan row"). The
+ * top-up control and auto top-up moved off the Plan pane — the action belongs
+ * beside the number it changes, not on a pane about a subscription. Nothing is
+ * forked: this mounts the SAME `CreditTopupSection` and `AutoTopupCard` that
+ * `/accounts/[id]?tab=billing` mounts, under the same
+ * `BillingAccountProvider`, which is what scopes their reads and mutations to
+ * THIS account rather than the caller's primary one.
+ *
+ * Everything else on the pane stays read-only. The subscription, seats, and
+ * the Stripe portal are the Plan pane's subject and are not duplicated here.
+ */
+
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatUsd } from '@/features/billing/account-overview';
+import { AutoTopupCard } from '@/features/billing/auto-topup-card';
+import { CreditTopupSection } from '@/features/billing/credit-topup-section';
+import { useAccountState } from '@/hooks/billing/use-account-state';
+import { cn } from '@/lib/utils';
+import { BillingAccountProvider } from '@/stores/billing-account-context';
+import type { AccountState } from '@kortix/sdk';
+import { dollarsToCredits, formatCredits } from '@kortix/shared';
+import { ReceiptIcon } from '@phosphor-icons/react';
+
+import { SettingsTabHeader } from '../settings-tab-header';
+
+// ─── Pure model ─────────────────────────────────────────────────────────────
+// Everything below this line down to the components is data, not markup, and
+// is exported so it can be tested against a fixed `AccountState` with no API,
+// no auth, and no billing flag — the same container/view split
+// `account-overview.tsx` and `profile-tab.tsx` use, and for the same reason:
+// the shapes worth reviewing (out of credits, negative balance, no grant, no
+// daily refresh) cannot be produced locally without provisioning accounts and
+// a Stripe subscription.
+
+export interface CreditBucket {
+  id: 'monthly' | 'daily' | 'extra';
+  label: string;
+  /** What happens to this bucket over time. One short clause, not a sentence. */
+  hint: string;
+  credits: number;
+}
+
+/**
+ * The three buckets that sum to `credits.total`, in the order they are spent
+ * down and in the order they matter: the grant, the refill, then the money you
+ * paid.
+ *
+ * All three always render, including at zero. A strip whose column count
+ * depends on the data reflows between accounts and between refreshes, and a
+ * zero is itself the answer to "do I have any purchased credits left".
+ */
+export function creditBuckets(state: AccountState): CreditBucket[] {
+  const credits = state.credits;
+  return [
+    {
+      id: 'monthly',
+      label: 'Plan credits',
+      hint: 'Expire at period end',
+      credits: dollarsToCredits(credits?.monthly ?? 0),
+    },
+    {
+      id: 'daily',
+      label: 'Daily credits',
+      hint: 'Refill on a timer',
+      credits: dollarsToCredits(credits?.daily ?? 0),
+    },
+    {
+      id: 'extra',
+      label: 'Purchased',
+      hint: 'Never expire',
+      credits: dollarsToCredits(credits?.extra ?? 0),
+    },
+  ];
+}
+
+export interface GrantMeter {
+  usedCredits: number;
+  grantedCredits: number;
+  /** 0–100, clamped. Feeds `Progress`, which takes a percentage. */
+  percent: number;
+  /** `ok` under 90% of the grant, `low` from 90%, `spent` at the cap. */
+  tone: 'ok' | 'low' | 'spent';
+}
+
+/**
+ * How much of this period's plan grant is gone.
+ *
+ * `tier.monthly_credits` is the STORED recurring grant (the API's own comment:
+ * Stripe owns it, and a trial overlays entitlements without granting credits),
+ * and `credits.monthly` is what is left of it. Anything the account bought or
+ * earned daily sits in a different bucket, so the subtraction stays honest.
+ *
+ * `null` when the plan grants nothing — Free and per-seat Team accounts, where
+ * a "0 of 0 used" bar is a bar that can never move.
+ */
+export function planGrantMeter(state: AccountState): GrantMeter | null {
+  const grantedCredits = dollarsToCredits(state.tier?.monthly_credits ?? 0);
+  if (grantedCredits <= 0) return null;
+
+  const remaining = dollarsToCredits(state.credits?.monthly ?? 0);
+  // Clamped at both ends: a grant that was topped up mid-period can leave
+  // `remaining` above `granted`, which would otherwise print negative usage.
+  const usedCredits = Math.min(Math.max(grantedCredits - remaining, 0), grantedCredits);
+  const percent = Math.min(100, Math.max(0, Math.round((usedCredits / grantedCredits) * 100)));
+
+  return {
+    usedCredits,
+    grantedCredits,
+    percent,
+    tone: usedCredits >= grantedCredits ? 'spent' : percent >= 90 ? 'low' : 'ok',
+  };
+}
+
+export interface DailyRefresh {
+  /** `+400 credits every 24h` */
+  amountLine: string;
+  /** `in ~4h 12m`, or `Any moment now` once the timer has elapsed. */
+  countdown: string;
+}
+
+/**
+ * The daily-credit refill, as two strings.
+ *
+ * This is the literal answer to "credits still pending": the API computes
+ * `seconds_until_refresh` server-side from `last_refresh` plus the interval,
+ * and nothing in the product has ever rendered it.
+ *
+ * The countdown is written from the number the query returned, not from a
+ * ticking clock. `useAccountState` holds its data for two minutes, so a live
+ * per-second timer would count down from a figure already up to two minutes
+ * stale — precision the data does not have. Hence `~`, and hence no interval.
+ */
+export function describeDailyRefresh(state: AccountState): DailyRefresh | null {
+  const refresh = state.credits?.daily_refresh;
+  if (!refresh?.enabled) return null;
+
+  const amount = dollarsToCredits(refresh.daily_amount ?? 0);
+  if (amount <= 0) return null;
+
+  const hours = refresh.refresh_interval_hours;
+  const every = typeof hours === 'number' && hours > 0 ? ` every ${hours}h` : '';
+
+  return {
+    amountLine: `+${formatCredits(amount)} credits${every}`,
+    countdown: formatCountdown(refresh.seconds_until_refresh),
+  };
+}
+
+/** `in ~4h 12m` · `in ~12m` · `Any moment now`. Never prints `0m`. */
+export function formatCountdown(seconds: number | null | undefined): string {
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 60) {
+    return 'Any moment now';
+  }
+  const totalMinutes = Math.floor(seconds / 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  if (h <= 0) return `in ~${m}m`;
+  if (m === 0) return `in ~${h}h`;
+  return `in ~${h}h ${m}m`;
+}
+
+/**
+ * `Aug 24 – Sep 3` — the span the spend figures cover.
+ *
+ * No year, for the same reason `account-overview.tsx` drops it from a renewal
+ * date: a billing period always lands inside one. An en dash, not a hyphen —
+ * this is a range, and the hyphen is a different mark.
+ */
+export function formatPeriod(start: string | null, end: string | null): string | null {
+  const from = formatDay(start);
+  const to = formatDay(end);
+  if (!from || !to) return from ?? to;
+  return `${from} – ${to}`;
+}
+
+function formatDay(iso: string | null | undefined): string | null {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ─── Container ──────────────────────────────────────────────────────────────
+
+/**
+ * Whether to offer the top-up control at all.
+ *
+ * Two independent gates, and both have to pass. `can_purchase_credits` is a
+ * TIER entitlement — whether this plan may buy credits. `can_manage_billing`
+ * is a PERMISSION — whether this person may (billing.write, owners only by
+ * default). The API's own comment on the field says absent means allowed, so
+ * an older response does not lock an owner out; the billing API enforces the
+ * same gate server-side either way, so this is a UI hint, not the control.
+ *
+ * A member without the permission still reads the whole pane. Knowing the
+ * balance is not the same as being able to change it, and hiding the number
+ * from the people who spend it is what made this pane necessary.
+ */
+export function canOfferTopup(state: AccountState): boolean {
+  if (!state.subscription?.can_purchase_credits) return false;
+  return state.can_manage_billing !== false;
+}
+
+export function CreditsTab({ accountId }: { accountId: string | undefined }) {
+  const accountState = useAccountState({ accountId });
+
+  if (accountState.isLoading || !accountState.data) {
+    return (
+      <div className="mx-auto w-full max-w-2xl space-y-8">
+        <SettingsTabHeader tab="credits" />
+        {accountState.isLoading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-40 w-full rounded-md" />
+            <Skeleton className="h-24 w-full rounded-md" />
+          </div>
+        ) : (
+          <p className="text-muted-foreground text-sm">Couldn&apos;t load this account.</p>
+        )}
+      </div>
+    );
+  }
+
+  const state = accountState.data;
+
+  return (
+    // The provider is what scopes `CreditTopupSection` and `AutoTopupCard` to
+    // THIS account — both read `useBillingAccountId()` — so a multi-account
+    // user cannot top up the wrong wallet from the right pane.
+    //
+    // `?? null` is the provider's documented "fall back to the user's primary
+    // account", which is the same account `useAccountState({ accountId:
+    // undefined })` above just read. Passing `undefined` through would be a
+    // type error, and coercing it to a string would name the wrong wallet.
+    <BillingAccountProvider accountId={accountId ?? null}>
+      <div className="mx-auto w-full max-w-2xl space-y-8">
+        <SettingsTabHeader tab="credits" />
+        <CreditsView
+          state={state}
+          accountId={accountId}
+          // Passed in as a slot rather than rendered inside `CreditsView`:
+          // both children are hook-driven, and the view has to stay renderable
+          // against a fixed `AccountState` with no query client. Same reason
+          // the model above is pure.
+          topup={canOfferTopup(state) ? <TopupPanel /> : null}
+        />
+      </div>
+    </BillingAccountProvider>
+  );
+}
+
+/**
+ * Add credits and Auto top-up in one card, the shape
+ * `/accounts/[id]?tab=billing` uses. `CreditTopupSection` renders no chrome of
+ * its own by contract (no border, no padding, no heading) and `AutoTopupCard`
+ * carries its own heading, which is why the seam is a plain `border-t` and
+ * only the first half gets a label from outside.
+ */
+function TopupPanel() {
+  return (
+    <div className="bg-popover rounded-md border">
+      <div className="px-4 py-4">
+        <CreditTopupSection />
+      </div>
+      <div className="border-t px-4 py-4">
+        <AutoTopupCard fetchSettings showSaveButton />
+      </div>
+    </div>
+  );
+}
+
+// ─── View ───────────────────────────────────────────────────────────────────
+
+/** Presentational only — no hooks, no data fetching, no query client. */
+export function CreditsView({
+  state,
+  accountId,
+  topup,
+}: {
+  state: AccountState;
+  accountId?: string;
+  /** The Add credits / Auto top-up card, or `null` when this account or this
+   *  person may not buy. Injected so the view stays hook-free. */
+  topup?: ReactNode;
+}) {
+  const balance = state.credits?.total ?? 0;
+  const isNegative = balance < 0;
+  const buckets = creditBuckets(state);
+  const meter = planGrantMeter(state);
+  const refresh = describeDailyRefresh(state);
+  const usage = state.usage_this_period;
+  const period = usage ? formatPeriod(usage.period_start, usage.period_end) : null;
+
+  return (
+    <div className="space-y-8">
+      {/* The number the tab exists to answer, at the top, at hero scale, with
+          the composition under one hairline. No action beside it: "Add
+          credits" is a whole card of its own further down, and a button up
+          here would be a second door onto the control two sections below —
+          the shape that made the balance hard to find in the first place. */}
+      <div className="bg-popover rounded-md border">
+        <div className="px-4 py-4">
+          <div className="min-w-0">
+            <p className="text-muted-foreground text-xs">Available balance</p>
+            {/* `tabular-nums`, not `font-mono` — the call `account-overview.tsx`
+                documents: a monospace face gives '.' and ',' a digit's advance
+                and opens visible gaps mid-number. */}
+            <p
+              className={cn(
+                'mt-1.5 truncate text-2xl leading-none font-semibold tracking-tight tabular-nums',
+                isNegative ? 'text-kortix-red' : 'text-foreground',
+              )}
+            >
+              {formatUsd(balance)}
+            </p>
+            <p className="text-muted-foreground mt-1.5 text-xs tabular-nums">
+              {formatCredits(dollarsToCredits(Math.abs(balance)))} credits
+              {isNegative ? ' owed' : ''}
+            </p>
+          </div>
+        </div>
+
+        <div className="divide-border grid grid-cols-3 divide-x border-t">
+          {buckets.map((bucket) => (
+            <div key={bucket.id} className="min-w-0 px-4 py-3">
+              <p className="text-muted-foreground truncate text-xs">{bucket.label}</p>
+              <p className="text-foreground mt-0.5 truncate text-sm font-medium tabular-nums">
+                {formatCredits(bucket.credits)}
+              </p>
+              <p className="text-muted-foreground mt-0.5 truncate text-xs">{bucket.hint}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {meter || refresh ? (
+        <section className="space-y-4">
+          <Label>Included in your plan</Label>
+          {/* One bar, for one headline fraction. `account-overview.tsx` removed
+              the per-row bars from Limits because a bar under every row
+              restated a fraction the numbers already gave exactly; a single
+              meter for the single number that has a ceiling is the case those
+              bars were not. */}
+          {meter ? (
+            <div className="bg-popover rounded-md border px-4 py-4">
+              <div className="flex items-baseline justify-between gap-4">
+                <span className="text-foreground text-sm font-medium">Used this period</span>
+                <span
+                  className={cn(
+                    'shrink-0 text-sm font-medium tabular-nums',
+                    meter.tone === 'spent'
+                      ? 'text-kortix-red'
+                      : meter.tone === 'low'
+                        ? 'text-kortix-orange'
+                        : 'text-muted-foreground',
+                  )}
+                >
+                  {formatCredits(meter.usedCredits)} / {formatCredits(meter.grantedCredits)}
+                </span>
+              </div>
+              <Progress
+                value={meter.percent}
+                className="mt-3 h-1.5"
+                indicatorClassName={cn(
+                  meter.tone === 'spent'
+                    ? 'bg-kortix-red'
+                    : meter.tone === 'low'
+                      ? 'bg-kortix-orange'
+                      : 'bg-primary',
+                )}
+              />
+              <p className="text-muted-foreground mt-2 text-xs tabular-nums">
+                {meter.tone === 'spent'
+                  ? 'Plan credits are spent. Purchased credits are used from here.'
+                  : `${formatCredits(meter.grantedCredits - meter.usedCredits)} credits left of this period's grant.`}
+              </p>
+            </div>
+          ) : null}
+
+          {refresh ? (
+            <div className="bg-popover flex items-center justify-between gap-4 rounded-md border px-4 py-3">
+              <div className="min-w-0">
+                <p className="text-foreground text-sm font-medium">Daily credits</p>
+                <p className="text-muted-foreground truncate text-xs tabular-nums">
+                  {refresh.amountLine}
+                </p>
+              </div>
+              <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                {refresh.countdown}
+              </span>
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {topup ? (
+        <section className="space-y-4">
+          <Label>Add credits</Label>
+          {topup}
+        </section>
+      ) : null}
+
+      {usage ? (
+        <section className="space-y-4">
+          {/* The period is named. The same three figures appear on the Plan
+              tab over an unnamed span, which makes "$11.30" unreadable — since
+              when? `usage_this_period` carries the dates; print them. */}
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+            <Label>Spent this period</Label>
+            {period ? (
+              <span className="text-muted-foreground text-xs tabular-nums">{period}</span>
+            ) : null}
+          </div>
+          <div className="bg-popover divide-border grid grid-cols-3 divide-x rounded-md border">
+            <SpendStat label="Compute" value={usage.compute_usd} />
+            <SpendStat label="LLM" value={usage.llm_usd} />
+            <SpendStat label="Total" value={usage.total_usd} strong />
+          </div>
+        </section>
+      ) : null}
+
+      {accountId ? (
+        // The same shape as the Billing portal row on the Plan tab: one line
+        // saying what is behind the door, one button opening it.
+        <section className="space-y-4">
+          <Label>History</Label>
+          <div className="bg-popover rounded-md border px-4 py-3">
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-muted-foreground min-w-0 text-xs">
+                What every session cost, and every credit added or spent.
+              </p>
+              <Button asChild size="sm" variant="outline" className="shrink-0 gap-1.5">
+                <Link href={`/accounts/${accountId}?tab=transactions`}>
+                  <ReceiptIcon className="size-3.5 shrink-0" />
+                  Open ledger
+                </Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+function SpendStat({ label, value, strong }: { label: string; value: number; strong?: boolean }) {
+  return (
+    <div className="min-w-0 px-4 py-3">
+      <p className="text-muted-foreground truncate text-xs">{label}</p>
+      <p
+        className={cn(
+          'mt-0.5 text-sm tabular-nums',
+          strong ? 'text-foreground font-semibold' : 'text-foreground font-medium',
+        )}
+      >
+        {formatUsd(value)}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/features/workspace/settings/tabs/plan-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/plan-tab.tsx
@@ -7,7 +7,9 @@
  * the subscription and the current plan"). It is a second door onto the SAME
  * component `/accounts/[id]?tab=billing` renders — `BillingTab` in
  * `features/accounts/settings/billing-tab.tsx` — mounted with the same
- * provider and the same gate, so nothing about billing is forked:
+ * provider and the same gate. One component, two mounts; the only difference
+ * is `showWallet`, which chooses which of the two blocks leads (see the JSX
+ * below and `BillingTab`'s own doc comment). No billing LOGIC is forked:
  *
  * - `BillingAccountProvider` scopes every billing hook below to THIS account,
  *   so a multi-account user never reads or mutates their primary account by
@@ -54,7 +56,16 @@ export function PlanTab({ accountId }: { accountId: string | undefined }) {
         </div>
       ) : canWrite.allowed ? (
         <BillingAccountProvider accountId={accountId}>
-          <BillingTab returnUrl={planReturnUrl()} isActive />
+          {/* `showWallet={false}` (Jay, 2026-09-03: "in the plan, you need to
+              show just the team part, team seat"). The pane leads with
+              `PlanCard` — the subscription, with the seat count, price each
+              and monthly total as properties under it — instead of the
+              wallet-first `AccountOverviewTab`. Balance, credit composition,
+              period spend and limits are the Credits pane's subject now
+              (`tabs/credits-tab.tsx`), one row above this one in the rail.
+              `/accounts/[id]?tab=billing` passes nothing and keeps the
+              wallet-first layout unchanged. */}
+          <BillingTab returnUrl={planReturnUrl()} isActive showWallet={false} />
           <GlobalUpgradeModal />
         </BillingAccountProvider>
       ) : (

--- a/apps/web/src/features/workspace/settings/tabs/snapshots-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/snapshots-tab.tsx
@@ -605,7 +605,7 @@ function SandboxStatusBanner({
       <div className="flex items-start gap-3 px-4 py-3">
         <span
           className={cn(
-            'border-border inline-flex size-10 shrink-0 items-center justify-center self-start rounded-sm border',
+            'inline-flex size-10 shrink-0 items-center justify-center self-start rounded-sm',
             blocked ? 'bg-kortix-red/10 text-kortix-red' : 'bg-kortix-orange/10 text-kortix-orange',
           )}
         >

--- a/apps/web/src/lib/billing/billing-source-rules.test.ts
+++ b/apps/web/src/lib/billing/billing-source-rules.test.ts
@@ -33,6 +33,15 @@ const DISPLAY_ONLY = [
   join('features', 'billing', 'credit-transactions.tsx'),
   join('features', 'billing', 'transactions-table.tsx'),
   join('features', 'billing', 'account-overview.tsx'),
+  // The Credits pane, added 2026-09-03. Same class as `account-overview.tsx`
+  // directly above and for the same reason: it RENDERS the wallet and decides
+  // nothing with it. Its one `balance < 0` paints the figure red and appends
+  // the word "owed" — a display branch, not an entitlement one. The pane's
+  // only gate, `canOfferTopup()`, reads `subscription.can_purchase_credits`
+  // and `can_manage_billing`; it never looks at the number. Listed here rather
+  // than dodged by renaming the variable: an exemption you can read beats a
+  // tripwire quietly routed around.
+  join('features', 'workspace', 'settings', 'tabs', 'credits-tab.tsx'),
   join('stores', 'subscription-store.tsx'),
   join('hooks', 'billing'),
 ];

--- a/apps/web/src/lib/menu-registry-destinations.test.ts
+++ b/apps/web/src/lib/menu-registry-destinations.test.ts
@@ -1,5 +1,7 @@
 import { VALID_TABS } from '@/features/accounts/hub/sections';
 import { describe, expect, test } from 'bun:test';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   CAPABILITY_TABS,
@@ -46,6 +48,65 @@ import { getItemsForSurface } from '@/lib/menu-registry';
 
 const PROJECT_TOKEN = '{projectId}';
 const ACCOUNT_TOKEN = '{accountId}';
+
+/**
+ * Every routable path under `src/app`, as a segment list.
+ *
+ * Route groups (`(app)`, `(capabilities)`) are stripped — they organize files,
+ * not URLs — and a directory counts only when it holds a `page.tsx`, which is
+ * what makes a path routable in the App Router. `[id]`, `[...slug]` and
+ * `[[...slug]]` stay as-is and are matched structurally below.
+ */
+function collectRoutes(dir: string, segments: string[] = [], out: string[][] = []): string[][] {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  if (entries.some((e) => e.isFile() && e.name === 'page.tsx')) out.push(segments);
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    // A route group contributes no URL segment; `@slot` and `_private`
+    // directories contribute no route at all.
+    if (entry.name.startsWith('@') || entry.name.startsWith('_')) continue;
+    const isGroup = entry.name.startsWith('(') && entry.name.endsWith(')');
+    collectRoutes(join(dir, entry.name), isGroup ? segments : [...segments, entry.name], out);
+  }
+  return out;
+}
+
+const APP_DIR = join(import.meta.dir, '..', 'app');
+const ROUTES = collectRoutes(APP_DIR);
+
+/**
+ * One href's path against one route's segments.
+ *
+ * A literal segment must match exactly. A dynamic one (`[id]`) matches any
+ * single segment, which is what lets the registry's own `{projectId}` and
+ * `{accountId}` tokens stand in for the ids they are replaced by at render.
+ * A catch-all (`[...slug]`) swallows the remainder; the optional form
+ * (`[[...slug]]`) also matches a path that stops before it.
+ */
+function routeMatches(route: string[], path: string[]): boolean {
+  let r = 0;
+  for (const actual of path) {
+    const segment = route[r];
+    if (segment === undefined) return false;
+    if (segment.startsWith('[[...') || segment.startsWith('[...')) return true;
+    const isDynamic = segment.startsWith('[') && segment.endsWith(']');
+    if (!isDynamic && segment !== actual) return false;
+    r++;
+  }
+  if (r === route.length) return true;
+  return route.length === r + 1 && route[r]!.startsWith('[[...');
+}
+
+/** Whether any route in `src/app` serves this href. */
+function isLiveRoute(href: string): boolean {
+  const path = href.split('?')[0]!.split('#')[0]!.split('/').filter(Boolean);
+  return ROUTES.some((route) => routeMatches(route, path));
+}
 
 const paletteRows = getItemsForSurface('commandPalette').filter(
   (item) => !LEGACY_PALETTE_HIDDEN.has(item.id),
@@ -167,5 +228,65 @@ describe('the destinations that need a resolved id at runtime', () => {
     const row = paletteRows.find((item) => item.id === 'review-changes');
     expect(row?.requiresProject).toBe(true);
     expect(row?.requiresSession).toBeUndefined();
+  });
+});
+
+/**
+ * ============================================================================
+ * THE OTHER DIRECTION: EVERY ROW POINTS AT A ROUTE THAT EXISTS.
+ * ============================================================================
+ *
+ * Everything above pins that each destination HAS a row. Nothing pinned the
+ * reverse, and that is the half a real defect walked through: `/projects/<id>/
+ * config` was deleted on 2026-09-02, and `proj-config-feature-flags` kept
+ * pointing at it until 2026-09-03. Typing "feature flag" offered that row
+ * first, under Navigation, and selecting it navigated to a 404 instead of
+ * opening the Feature flags pane.
+ *
+ * Deleting a route is the moment this breaks, and it breaks silently: the
+ * registry is a plain data table, so no import goes red and no type narrows.
+ * Reading `src/app` from disk is what makes the two facts one fact.
+ */
+describe('every palette row points at a live route', () => {
+  test('the route table was actually found', () => {
+    // A wrong `APP_DIR` would make every assertion below vacuously pass.
+    expect(ROUTES.length).toBeGreaterThan(50);
+    expect(ROUTES.some((r) => r.join('/') === 'projects/[id]/files')).toBe(true);
+  });
+
+  test('/projects/[id]/config is gone, so nothing may point at it', () => {
+    // The specific route this test exists because of.
+    expect(isLiveRoute('/projects/{projectId}/config?section=feature-flags')).toBe(false);
+  });
+
+  for (const row of paletteRows.filter((item) => item.kind === 'navigate' && item.href)) {
+    test(`"${row.label}" (${row.id}) → ${row.href}`, () => {
+      expect({ id: row.id, href: row.href, live: isLiveRoute(row.href!) }).toEqual({
+        id: row.id,
+        href: row.href,
+        live: true,
+      });
+    });
+  }
+});
+
+describe('the retired /config sections are reached through the settings overlay', () => {
+  test('no registry row keeps a /config href', () => {
+    // Belt-and-braces over the loop above, and the assertion that names the
+    // path rather than the row: a NEW row pointing at `/config` fails here
+    // even if someone also re-adds the route.
+    const offenders = paletteRows
+      .filter((item) => item.href?.includes('/config'))
+      .map((item) => item.id);
+    expect(offenders).toEqual([]);
+  });
+
+  test('Feature flags is reachable, and only as the derived settings row', () => {
+    // The row that answers "feature flag" now. It is derived from the rail
+    // (`settings-palette-items.ts`) and opens the in-palette picker through
+    // `SETTINGS_TAB_SUBMENU_PAGE`, never a URL — which is why it cannot rot
+    // the way the registry row did.
+    expect(SETTINGS_TAB_SUBMENU_PAGE['feature-flags']).toBe('flags');
+    expect(paletteRows.some((item) => item.id === 'proj-config-feature-flags')).toBe(false);
   });
 });

--- a/apps/web/src/lib/menu-registry.ts
+++ b/apps/web/src/lib/menu-registry.ts
@@ -35,7 +35,6 @@ import {
   CompassIcon as Compass,
   CpuIcon as Cpu,
   CreditCardIcon as CreditCardSolid,
-  FlaskIcon as Flask,
   GitBranchIcon as FolderGit2,
   FolderOpenIcon as FolderOpen,
   GitDiffIcon as GitCompareArrows,
@@ -667,6 +666,26 @@ export const menuRegistry: MenuItemDef[] = [
   // (`settings-palette-items.ts`) — a registry href would be a second,
   // drifting copy. Feature flags' in-palette picker moved with it: see
   // `SETTINGS_TAB_SUBMENU_PAGE` in `command-palette.tsx`.
+  //
+  // `proj-config-feature-flags` outlived that sentence by a day. The row was
+  // still here on 2026-09-03, twenty-five lines under its own obituary, with
+  // `href: '/projects/{projectId}/config?section=feature-flags'` — a route
+  // `app/` no longer contains. Typing "feature flag" returned TWO rows: this
+  // one, under Navigation, labelled "Settings · Feature flags" and landing on
+  // a dead URL, and the derived `settings-tab-feature-flags` under "Settings ·
+  // Workspace", which opens the in-palette picker correctly. The dead one read
+  // like the right answer.
+  //
+  // Nothing was lost with it. Its keyword bag (`feature flags experimental
+  // beta labs toggles switches early access`) is a strict subset of the
+  // `feature-flags` bag in `settings-palette-items.ts`, and the picker it
+  // claimed to open was never keyed to its id — `SUBMENU_PAGE_BY_ID` has no
+  // `proj-config-feature-flags` entry, which is exactly why the row navigated.
+  //
+  // `menu-registry-destinations.test.ts` now checks the other direction too:
+  // every `kind: 'navigate'` href must resolve to a real route under
+  // `src/app`. A route deleted out from under a palette row is a red test now,
+  // not a dead link nobody notices.
   {
     // Not `proj-review` — that id named the old overlay tab and its absence
     // is pinned (`command-palette.test.tsx`); this row is the capability page.
@@ -683,22 +702,6 @@ export const menuRegistry: MenuItemDef[] = [
     // `review_center` is off), so the row cannot outlive the page.
     requiresFlag: 'review_center',
     keywords: 'review center inbox approvals awaiting waiting needs you outputs queue',
-  },
-  {
-    id: 'proj-config-feature-flags',
-    label: 'Settings · Feature flags',
-    icon: Flask,
-    group: 'navigation',
-    showIn: ['commandPalette'],
-    kind: 'navigate',
-    href: '/projects/{projectId}/config?section=feature-flags',
-    requiresProject: true,
-    // Selecting this opens the in-palette flag list (`SUBMENU_PAGE_BY_ID` in
-    // command-palette.tsx), which names and toggles each experimental feature
-    // without leaving ⌘K; the href is the routed fallback for surfaces that
-    // consume this registry without that picker — same arrangement as
-    // `proj-sessions` and `nav-accounts`.
-    keywords: 'feature flags experimental beta labs toggles switches early access',
   },
   {
     id: 'proj-invite',


### PR DESCRIPTION
## Summary

The credit balance was reachable only through **Account → Plan**, where it is the first card of a pane whose other four blocks are all mutations — subscribe, claim seats, buy credits, open the Stripe portal. Reading "how many credits do I have left" meant opening a checkout surface. (Jay, 2026-09-03: *"it's difficult to get to know how many credits we still have pending"*.)

This splits that pane in two.

### New `credits` tab — read the balance

Sits above `plan` in the Account rail; reading the balance is the frequent visit, changing the plan is the rare one.

| Block | Why it is new |
|---|---|
| **Available balance** + composition strip | `AccountState.credits` carries four numbers and the product rendered one. `monthly` expires at period end, `daily` refills, `extra` never expires — which bucket a balance sits in decides whether it survives Friday, so a single total answers the wrong question. |
| **Plan grant meter** | `tier.monthly_credits` is the stored recurring grant, `credits.monthly` is what is left, so the difference is what this period consumed. One bar for one headline fraction — not one bar per row, the shape `account-overview.tsx` deliberately removed. `null` for Free and per-seat Team, where the grant is 0 and a bar can never move. |
| **Daily refresh countdown** | `credits.daily_refresh.seconds_until_refresh` is literally "credits still pending". Nothing in the product rendered it. |
| **Spent this period** | The same three figures the Plan card showed, but the span is now named — `usage_this_period` carries the dates. |
| **Add credits / Auto top-up** | Moved off Plan (Jay: *"the add credit component will be coming in the credit tab content only, not in the plan row"*). The action belongs beside the number it changes. |
| **Open ledger** | Link to `/accounts/<id>?tab=transactions`. |

### Plan tab — the subscription is the subject

`PlanCard` replaces the wallet-first `AccountOverviewTab` on this pane: plan name at hero scale, seat count / price each / monthly total as properties under it.

It also replaces `SeatManagementCard` **on this pane only** — that card states the same three seat figures as a sentence, so rendering both printed the seat count three times across two boxes. The card is untouched and still renders on `/accounts/[id]?tab=billing`.

## Design decisions worth reviewing

- **`BillingTab` takes `showWallet`, defaulting to `true`.** One component, two mounts. `/accounts/[id]?tab=billing` passes nothing and its layout is byte-for-byte unchanged; the settings overlay passes `false`. No billing *logic* is forked — same provider, same gate, same mutations.
- **`describePlanStatus()` extracted from `PlanSummary`.** Two surfaces now need "is this renewing, cancelling, or past due". Two copies of that ternary chain would drift on the first Stripe status nobody thought about — and drift *silently*, because both render a plausible sentence either way.
- **The tab id is `credits`, not `usage`.** `usage` is an `ACCOUNT_GRADUATED` key pointing at `/accounts/<id>?tab=transactions`, and `legacySectionRedirect` resolves that map **before** live tabs — a tab under `usage` would shadow every bookmark to the account page's usage surface. Same split `plan` (not `billing`) and `tokens` (not `api-keys`) already make. The word "usage" still reaches the pane through the palette keyword bag.
- **The countdown is written from the returned number, not a ticking clock.** `useAccountState` holds data for two minutes, so a live per-second timer would count down from a figure already up to two minutes stale. Hence `~`, and hence no `setInterval`.
- **The rail row is under `Account`, not `Personal`.** A wallet belongs to the account — on a Team plan every seat spends the same balance, and filing it under "Personal" would claim otherwise. Jay asked for a Usage tab under Personal; the scope is the one thing changed.
- **Models are pure and exported, view is hook-free.** The top-up card is injected as a `ReactNode` slot. The shapes worth reviewing — negative balance, no grant, no daily refresh, cancel-at-period-end, `past_due` — cannot be produced locally without provisioning accounts and a Stripe subscription, so they are pinned by unit test against a fixed `AccountState` instead.
- **A member without `billing.write` still reads the whole pane.** Knowing the balance is not the same as being able to change it, and hiding the number from the people who spend it is what made this pane necessary. `canOfferTopup()` gates only the top-up card, and the billing API enforces the same gate server-side regardless.

## Second commit — sidebar and chrome

- `SidebarUpgradeButton` moves below Files and Connect GPT. It is the only paid call to action in the footer group; above two navigation rows it put a sell between the user and the links they use.
- Footer menu gets `gap-1` — its children are alerts and buttons of differing heights that read as one block at the default gap.
- `ProjectChatGptConnectNavItem` gets `text-sidebar-foreground relative` to match sibling rows.
- `SandboxStatusBanner`'s icon tile drops its border — the tile is already a tinted `bg-kortix-*/10` swatch, and a border on a filled tile is a second boundary the design system does not draw.

## Command palette: no row points at the deleted `/config` route

Reported separately: typing "feature flag" in ⌘K navigated to
`/projects/<id>/config?section=feature-flags`, a route deleted on 2026-09-02.

**The query returned two rows.** Reproduced before touching anything:

```
REGISTRY ROWS: [{ id: "proj-config-feature-flags",
                  label: "Settings · Feature flags",
                  kind: "navigate",
                  href: "/projects/{projectId}/config?section=feature-flags" }]
DERIVED SETTINGS ROWS: [{ id: "settings-tab-feature-flags",
                          group: "Workspace", label: "Feature flags" }]
```

The first sorted into Navigation and 404'd. The second — derived from the rail —
opens the in-palette flag picker correctly. The broken one read like the right
answer.

**The row was already documented as removed.** `menu-registry.ts` carries a
comment saying `proj-config-general`, `proj-config-sandbox` and
`proj-config-feature-flags` "are gone with `/projects/<id>/config`". The third
was still shipping, twenty-five lines under its own obituary.

Deleted. Nothing goes with it:

- Its keyword bag is a strict **subset** of the `feature-flags` bag in
  `settings-palette-items.ts` — no query loses an answer.
- The picker it claimed to open was never keyed to its id. `SUBMENU_PAGE_BY_ID`
  has no `proj-config-feature-flags` entry, which is exactly *why* it navigated.
  Feature flags is keyed by overlay tab in `SETTINGS_TAB_SUBMENU_PAGE`, which
  the derived row reads.

After:

```
REGISTRY ROWS: []
DERIVED SETTINGS ROWS: [{ id: "settings-tab-feature-flags", ... }]
```

### The real defect: the check only ran one way

`menu-registry-destinations.test.ts` pinned that every *destination has a row*.
Nothing pinned that every *row has a live route* — the gap a deleted route
walked straight through. The registry is a plain data table, so deleting a route
breaks it silently: no import goes red, no type narrows.

It now reads `src/app` from disk, builds the real App Router table (route groups
stripped, `page.tsx` required, `[id]` / `[...slug]` / `[[...slug]]` matched
structurally) and asserts every `kind: 'navigate'` href resolves against it.

**Verified red**, by reinstating the row:

```
(fail) every palette row points at a live route > "Settings · Feature flags"
       (proj-config-feature-flags) → /projects/{projectId}/config?section=feature-flags
(fail) the retired /config sections … > no registry row keeps a /config href
(fail) the retired /config sections … > Feature flags is reachable, and only as
       the derived settings row
```

Also corrects the ten comments that still described `/projects/<id>/config` as a
live destination, several naming `capabilities/project-settings/` — a directory
deleted with it. That stale prose is what let the row survive.

## Two regressions from the first commit, fixed

Caught by running the whole suite instead of the files I expected to be
affected.

1. ~~`SidebarUpgradeButton` moved back above Files and Connect GPT.~~
   **Reverted again — the placement was deliberate and I overruled it.** The
   button is last, where it was put: it is the only paid call to action in the
   footer group, and above Files and Connect GPT it puts a sell between the user
   and the links they use. `project-sidebar-footer-order.test.ts` recorded the
   *previous* intent, so it is repointed at the new one rather than obeyed —
   split into "the balance alert stays above the nav" (unchanged) and "the
   upgrade button is last" (new). The bottom-anchored group does still grow
   upward, so this row shifts the two nav rows once when account state resolves;
   that is the cost of the placement, noted in the test docblock, not a reason to
   move it.
2. **`credits-tab.tsx` joins `DISPLAY_ONLY` in `billing-source-rules.test.ts`**,
   beside `account-overview.tsx` — same class of surface, same reason: it
   renders the wallet and decides nothing with it. Its one `balance < 0` paints
   the figure red and appends "owed"; the pane's only gate, `canOfferTopup()`,
   reads `can_purchase_credits` / `can_manage_billing` and never looks at the
   number. Listed as a readable exemption rather than renaming the variable to
   `wallet`, which would have dodged the regex — the sibling card happens to use
   that name. A tripwire you route around silently stops being one.

## Test plan

Full `apps/web` suite, with a true baseline on `main` rather than a hand-picked
file list:

```
$ cd apps/web && bun test          # on main (b45e4cfc17)
  9280 pass, 38 fail

$ cd apps/web && bun test          # on this branch
  9280 pass, 38 fail
```

The two failure sets are **identical** (`comm -13` between them is empty). The
38 are pre-existing on `main` — cross-file module-mock leakage in the
single-process run, unrelated to this branch. Zero new failures; the two
regressions above are gone.

```
$ npx eslint <all changed files>
  clean

$ npx tsc --noEmit
  only the 5 known @types/bun `test.each` errors in the 3 documented files.
  Zero errors from changed files.

$ bash .claude/skills/kortix-brand-guidelines/audit.sh     src/features/billing/plan-card.tsx     src/features/workspace/settings/tabs/credits-tab.tsx
  ✓ clean — every value came from the allowlist.
```

The audit reports one violation on a wider set — `project-sidebar.tsx:118`
(`pt-[max(...)]`, a safe-area inset) — byte-identical at `HEAD` and not on a line
this branch touches; verified with `git show HEAD:<file> | sed -n '118p'`.

### Not yet verified

The billing states this branch is most about — negative balance, spent grant,
active daily refresh, per-seat team, `cancel_at_period_end`, `past_due` — need a
real Stripe subscription and are pinned by unit test only. Worth driving on the
preview origin against a seeded account before merge.

The palette fix is verified by test and by the before/after row dump above, not
by clicking ⌘K in a browser.
