### PR TITLE
docs(sdk): fix broken AGENTS.md link in GETTING-STARTED.md

### DIFF
--- a/packages/sdk/GETTING-STARTED.md
+++ b/packages/sdk/GETTING-STARTED.md
@@ -197,7 +197,7 @@ pnpm --filter @kortix/sdk run smoke:install  # pack → install → import, herm
 
 `test` without built bundles skips the 2 bundle-content tests; run it after
 `build:bundles` for the full count. If you change anything here, read
-[AGENTS.md](./AGENTS.md) first — this package is live on npm, and the rules
+[AGENTS.md](../../AGENTS.md) first — this package is live on npm, and the rules
 (TDD, never weaken a test, exported names are forever) are enforced by the
 tripwires you just ran.
 


### PR DESCRIPTION
## Summary

`packages/sdk/GETTING-STARTED.md` links to `AGENTS.md` with a root-relative-looking path that actually 404s from where the file lives.

Line 200:

> If you change anything here, read [AGENTS.md](./AGENTS.md) first — this package is live on npm...

The file is at `packages/sdk/GETTING-STARTED.md`, so `./AGENTS.md` resolves to `packages/sdk/AGENTS.md`, which does not exist. The intended target is the repo-root `AGENTS.md`, which does exist. The doc itself already refers to it as "the root `AGENTS.md`" on line 83, and a nearby link on line 133 correctly walks up two levels (`[...](../../docs/KORTIX_AS_A_BACKEND_GUIDE.md)`).

Fix: change `./AGENTS.md` to `../../AGENTS.md` so the link points at the root file, consistent with the existing `../../docs/...` link in the same file.

This matters because `packages/sdk` is published to npm and `GETTING-STARTED.md` ships with it, so the broken link reaches readers on npm too.

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

Verified path resolution by hand from `packages/sdk/`:
- `./AGENTS.md` -> `packages/sdk/AGENTS.md` (does not exist)
- `../../AGENTS.md` -> repo-root `AGENTS.md` (exists)

Confirmed the other relative links in the file are unaffected: `[README.md](./README.md)` and `[API-MAP.md](./API-MAP.md)` correctly point at sibling files in `packages/sdk/`, and `../../docs/KORTIX_AS_A_BACKEND_GUIDE.md` already uses the two-levels-up pattern this change matches. Only the single `AGENTS.md` link was changed.

## Security & data review

- [x] No secrets, keys, or credentials are committed (docs-only change)
- [x] Authorization checks are in place for any new/changed endpoints (N/A — no code)
- [x] User input is validated and output is safe (N/A — no code)
- [x] No sensitive data is written to logs (N/A — no code)
- [x] DB schema / migration changes are reviewed and reversible (N/A — no schema change)
- [x] Touches auth / IAM / crypto / billing / migrations (N/A — docs only)

## Rollout / rollback

Docs-only, single-line link change. Revert the commit to roll back; no migrations, flags, or env vars.

## Reviewer checklist

- [x] Change is scoped and understandable
- [x] Tests/CI pass and cover the change
- [x] Security & data review above is satisfied

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790992554&installation_model_id=434224&pr_number=7106&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7106&signature=178f4e1e8376845af2fe174ca0138531425f38562ddee6e903be8e87007bb834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->