### PR TITLE
Ask a person's role before letting them delete a branch

### DIFF
--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -421,9 +421,10 @@ async function gateReceivePack(
   // Pure policy first: it needs no I/O and answers every ordinary push. Only a
   // denial is worth an authorization check, so a session pushing its own branch
   // and a person pushing anything both reach the upstream without one.
-  const denials = denialsAfterScopes(
+  const denials = await denialsAfterScopes(
     c,
     auth.principal,
+    { projectId: auth.project.projectId, accountId: auth.project.accountId },
     evaluateRefUpdates(auth.principal, { defaultBranch: auth.project.defaultBranch }, parsed.updates),
   );
   if (denials.length > 0) {

--- a/apps/api/src/git-proxy/receive-pack-gate.test.ts
+++ b/apps/api/src/git-proxy/receive-pack-gate.test.ts
@@ -29,13 +29,28 @@ let agentGrant: any = null;
 /** Refs the fake upstream actually received — empty means nothing was forwarded. */
 let upstreamReceived: string[] = [];
 
+/** What IAM answers for a human's ref-scope question; swapped per test. */
+let iamAllowsHuman = true;
+const realActor = await import('../iam/actor');
+mock.module('../iam/actor', () => ({ ...realActor, actorForToken: async () => ({ userId: 'u1' }) }));
+const realAuthorize = await import('../iam/authorize');
+mock.module('../iam/authorize', () => ({
+  ...realAuthorize,
+  authorize: async () => ({ allowed: iamAllowsHuman }),
+}));
+
 const realProjects = await import('../projects');
 mock.module('../projects', () => ({
   ...realProjects,
   authorizeGitProxy: async () => ({
     ok: true,
     principal,
-    project: { projectId: PROJECT_ID, defaultBranch: DEFAULT_BRANCH, metadata: {} },
+    project: {
+      projectId: PROJECT_ID,
+      accountId: 'acc-1',
+      defaultBranch: DEFAULT_BRANCH,
+      metadata: {},
+    },
   }),
   resolveProjectUpstream: async () => ({ url: upstreamUrl, headers: {} }),
 }));
@@ -250,7 +265,8 @@ describe('a session principal', () => {
 
 describe('a user principal', () => {
   beforeAll(() => {
-    principal = { kind: 'user', userId: 'user-1' };
+    principal = { kind: 'user', userId: 'user-1', tokenId: 'tok-1' };
+    iamAllowsHuman = true;
   });
 
   test('CAN push the default branch — `kortix ship` on main still works', async () => {
@@ -264,6 +280,23 @@ describe('a user principal', () => {
     const { code } = await push('origin', '--delete', 'refs/heads/feature');
     expect(code).toBe(0);
     expect(upstreamReceived).toEqual(['refs/heads/feature']);
+  });
+
+  test('WITHOUT project.gitops.ref.delete, cannot delete even an ordinary branch', async () => {
+    // `project.gitops.push` authorizes a push, not a deletion: a branch is
+    // frequently someone else's, and the delete is not recoverable from the
+    // client that issued it. `manager` is seeded with the leaf, so a manager is
+    // unaffected; this is a plain member with push rights.
+    await push('--force', 'origin', 'HEAD:refs/heads/revokable');
+    iamAllowsHuman = false;
+    try {
+      const { code, output } = await push('origin', '--delete', 'refs/heads/revokable');
+      expect(code).not.toBe(0);
+      expect(output).toContain('[remote rejected]');
+      expect(upstreamReceived).toEqual([]);
+    } finally {
+      iamAllowsHuman = true;
+    }
   });
 
   test('is refused deleting the default branch', async () => {

--- a/apps/api/src/git-proxy/ref-policy.ts
+++ b/apps/api/src/git-proxy/ref-policy.ts
@@ -39,9 +39,13 @@
  *              merges. Widened by `project.gitops.ref.any` / `.ref.delete`.
  *   monitor  → nothing. Monitor boxes clone at default-branch HEAD and never
  *              push; there is no principal behind one to hold a scope.
- *   user     → any ref. A human at a laptop running `kortix ship` on `main` is
- *              a shipped, advertised flow, and they hold the ref scopes through
- *              their project role rather than being re-derived per push.
+ *   user     → any ref they may PUSH; deletion is asked of their project role.
+ *              `kortix ship` on `main` is a shipped, advertised flow and stays
+ *              free, but `project.gitops.push` authorizes a push, not every
+ *              destructive shape of one: a deletion is not recoverable from the
+ *              client that issued it and the branch is frequently someone
+ *              else's. `manager` is seeded with `.ref.delete`, so a manager is
+ *              unaffected; a plain member with push rights is refused.
  *   internal → unconstrained above the floor. Server-side writers
  *              (change-request merge, dashboard config commits) do not traverse
  *              this proxy at all; the variant exists so that "who may move a
@@ -69,8 +73,14 @@ export type GitPrincipal =
   | { kind: 'session'; sessionId: string; branch: string }
   /** A monitor box's sandbox token — no session row by design. */
   | { kind: 'monitor' }
-  /** A human credential: account API key, CLI PAT, dashboard. */
-  | { kind: 'user'; userId: string | null }
+  /**
+   * A human credential: account API key, CLI PAT, dashboard. `tokenId` is
+   * threaded so the agent-grant fold fires when a ref scope is resolved — a
+   * bare authorize() would silently skip it, the same trap `authorizeGitProxy`
+   * documents on its own capability check. Null on an account API key, which
+   * carries no user identity.
+   */
+  | { kind: 'user'; userId: string | null; tokenId?: string | null }
   /** Server-side Kortix machinery. Never reaches the proxy today. */
   | { kind: 'internal' };
 
@@ -171,10 +181,8 @@ function denyFor(
 
     case 'user':
       // Deletion is stated as a requirement for every principal so the policy
-      // asks one question rather than branching on who is asking. A person
-      // holds both leaves through their project role (see ref-scopes.ts), so
-      // this is behaviour-neutral today — and the day we want to narrow a
-      // human role, the question is already being asked here.
+      // asks one question rather than branching on who is asking. For a person
+      // ref-scopes.ts resolves it against their project role.
       if (isDelete(update)) {
         return {
           reason: `deleting ${update.ref} requires git ref-delete authority`,

--- a/apps/api/src/git-proxy/ref-scopes.test.ts
+++ b/apps/api/src/git-proxy/ref-scopes.test.ts
@@ -9,69 +9,116 @@
  * Reading the git ref leaves through that helper would hand unrestricted ref
  * authority to precisely the projects this change exists to protect.
  */
-import { describe, expect, test } from 'bun:test';
-import { denialsAfterScopes, principalHoldsRefScope } from './ref-scopes';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+/** What the IAM engine will answer for the next human ref-scope question. */
+let iamAllows = true;
+let iamAsked: string[] = [];
+const realActor = await import('../iam/actor');
+mock.module('../iam/actor', () => ({ ...realActor, actorForToken: async () => ({ userId: 'u1' }) }));
+const realAuthorize = await import('../iam/authorize');
+mock.module('../iam/authorize', () => ({
+  ...realAuthorize,
+  authorize: async (_actor: unknown, action: string) => {
+    iamAsked.push(action);
+    return { allowed: iamAllows };
+  },
+}));
+
+const { denialsAfterScopes, principalHoldsRefScope } = await import('./ref-scopes');
 import type { GitPrincipal, GitRefScope } from './ref-policy';
+
+const PROJECT = { projectId: 'proj-1', accountId: 'acc-1' };
+
+beforeEach(() => {
+  iamAllows = true;
+  iamAsked = [];
+});
 
 const SESSION_ID = 'sess-1';
 const session: GitPrincipal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID };
 const monitor: GitPrincipal = { kind: 'monitor' };
-const user: GitPrincipal = { kind: 'user', userId: 'u1' };
+const user: GitPrincipal = { kind: 'user', userId: 'u1', tokenId: 'tok-1' };
 const internal: GitPrincipal = { kind: 'internal' };
 
-/** Minimal Hono-context stand-in: the resolver only ever reads `agentGrant`. */
+/**
+ * Minimal Hono-context stand-in. The resolver reads `agentGrant` for a session,
+ * and `deriveRequestContext` reads request headers for a person (IP / AAL are
+ * folded into the authorize cache key).
+ */
 function ctxWithGrant(grant: unknown): any {
-  return { get: (key: string) => (key === 'agentGrant' ? grant : undefined) };
+  return {
+    get: (key: string) => (key === 'agentGrant' ? grant : undefined),
+    req: { header: () => undefined },
+  };
 }
 
 const ANY: GitRefScope = 'project.gitops.ref.any';
 const DEL: GitRefScope = 'project.gitops.ref.delete';
 
 describe('principalHoldsRefScope — session', () => {
-  test('an UNGOVERNED project (null grant) does NOT widen a session', () => {
+  test('an UNGOVERNED project (null grant) does NOT widen a session', async () => {
     const c = ctxWithGrant(null);
-    expect(principalHoldsRefScope(c, session, ANY)).toBe(false);
-    expect(principalHoldsRefScope(c, session, DEL)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, DEL)).toBe(false);
   });
 
-  test('a governed project that did not list the leaf does not widen either', () => {
+  test('a governed project that did not list the leaf does not widen either', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: ['project.gitops.push'] });
-    expect(principalHoldsRefScope(c, session, ANY)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(false);
   });
 
-  test('an explicitly listed leaf widens exactly that leaf', () => {
+  test('an explicitly listed leaf widens exactly that leaf', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: ['project.gitops.push', ANY] });
-    expect(principalHoldsRefScope(c, session, ANY)).toBe(true);
-    expect(principalHoldsRefScope(c, session, DEL)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(true);
+    expect(await principalHoldsRefScope(c, session, PROJECT, DEL)).toBe(false);
   });
 
-  test('a wildcard grant widens both', () => {
+  test('a wildcard grant widens both', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: 'all' });
-    expect(principalHoldsRefScope(c, session, ANY)).toBe(true);
-    expect(principalHoldsRefScope(c, session, DEL)).toBe(true);
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(true);
+    expect(await principalHoldsRefScope(c, session, PROJECT, DEL)).toBe(true);
   });
 
-  test('an empty list is deny, not wildcard', () => {
+  test('an empty list is deny, not wildcard', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: [] });
-    expect(principalHoldsRefScope(c, session, ANY)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(false);
   });
 });
 
 describe('principalHoldsRefScope — other principals', () => {
-  test('a person holds both: their authority came from their project role', () => {
+  test('a person is ASKED of the IAM engine, not assumed', async () => {
     const c = ctxWithGrant(null);
-    expect(principalHoldsRefScope(c, user, ANY)).toBe(true);
-    expect(principalHoldsRefScope(c, user, DEL)).toBe(true);
+    iamAllows = true;
+    expect(await principalHoldsRefScope(c, user, PROJECT, DEL)).toBe(true);
+    expect(iamAsked).toEqual(['project.gitops.ref.delete']);
   });
 
-  test('internal holds both', () => {
-    expect(principalHoldsRefScope(ctxWithGrant(null), internal, ANY)).toBe(true);
+  test('a person WITHOUT the leaf cannot delete a branch', async () => {
+    // The tightening: `project.gitops.push` authorizes a push, not a deletion.
+    // `manager` is seeded with .ref.delete by the migration, so a manager is
+    // unaffected; a plain member with push rights is now refused.
+    iamAllows = false;
+    expect(await principalHoldsRefScope(ctxWithGrant(null), user, PROJECT, DEL)).toBe(false);
   });
 
-  test('a monitor holds nothing — there is no principal behind it', () => {
+  test('an ACCOUNT API KEY has no user identity, so ownership stands alone', async () => {
+    // authorizeGitProxy already proved the account owns the project; there is
+    // no principal to evaluate a role against, and no IAM question to ask.
+    const key: GitPrincipal = { kind: 'user', userId: null };
+    iamAllows = false;
+    expect(await principalHoldsRefScope(ctxWithGrant(null), key, PROJECT, DEL)).toBe(true);
+    expect(iamAsked).toEqual([]);
+  });
+
+  test('internal holds both', async () => {
+    expect(await principalHoldsRefScope(ctxWithGrant(null), internal, PROJECT, ANY)).toBe(true);
+  });
+
+  test('a monitor holds nothing — there is no principal behind it', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: 'all' });
-    expect(principalHoldsRefScope(c, monitor, ANY)).toBe(false);
-    expect(principalHoldsRefScope(c, monitor, DEL)).toBe(false);
+    expect(await principalHoldsRefScope(c, monitor, PROJECT, ANY)).toBe(false);
+    expect(await principalHoldsRefScope(c, monitor, PROJECT, DEL)).toBe(false);
   });
 });
 
@@ -80,34 +127,34 @@ describe('denialsAfterScopes', () => {
   const scoped: Denial = { ref: 'refs/heads/main', reason: 'nope', requires: [ANY] };
   const structural: Denial = { ref: 'refs/heads/main', reason: 'floor' };
 
-  test('a structural denial stands even under a wildcard grant', () => {
+  test('a structural denial stands even under a wildcard grant', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: 'all' });
-    expect(denialsAfterScopes(c, session, [structural])).toEqual([structural]);
+    expect(await denialsAfterScopes(c, session, PROJECT, [structural])).toEqual([structural]);
   });
 
-  test('a scoped denial is lifted by the matching grant', () => {
+  test('a scoped denial is lifted by the matching grant', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: [ANY] });
-    expect(denialsAfterScopes(c, session, [scoped])).toEqual([]);
+    expect(await denialsAfterScopes(c, session, PROJECT, [scoped])).toEqual([]);
   });
 
-  test('a COMPOUND denial needs every leaf — holding one is not enough', () => {
+  test('a COMPOUND denial needs every leaf — holding one is not enough', async () => {
     const compound: Denial = { ref: 'refs/heads/x', reason: 'nope', requires: [ANY, DEL] };
     const onlyAny = ctxWithGrant({ agent: 'main', kortixCli: [ANY] });
-    expect(denialsAfterScopes(onlyAny, session, [compound])).toEqual([compound]);
+    expect(await denialsAfterScopes(onlyAny, session, PROJECT, [compound])).toEqual([compound]);
     const both = ctxWithGrant({ agent: 'main', kortixCli: [ANY, DEL] });
-    expect(denialsAfterScopes(both, session, [compound])).toEqual([]);
+    expect(await denialsAfterScopes(both, session, PROJECT, [compound])).toEqual([]);
   });
 
-  test('a scoped denial stands without the grant', () => {
-    expect(denialsAfterScopes(ctxWithGrant(null), session, [scoped])).toEqual([scoped]);
+  test('a scoped denial stands without the grant', async () => {
+    expect(await denialsAfterScopes(ctxWithGrant(null), session, PROJECT, [scoped])).toEqual([scoped]);
   });
 
-  test('a mixed push keeps the structural denial and drops the granted one', () => {
+  test('a mixed push keeps the structural denial and drops the granted one', async () => {
     const c = ctxWithGrant({ agent: 'main', kortixCli: [ANY] });
-    expect(denialsAfterScopes(c, session, [scoped, structural])).toEqual([structural]);
+    expect(await denialsAfterScopes(c, session, PROJECT, [scoped, structural])).toEqual([structural]);
   });
 
-  test('no denials means no scope is ever consulted', () => {
+  test('no denials means no scope is ever consulted', async () => {
     // The hot path: the resolver must be reachable only through a denial, so an
     // empty list can never trigger an authorization read.
     const c = {
@@ -115,6 +162,6 @@ describe('denialsAfterScopes', () => {
         throw new Error('agentGrant must not be read when nothing was denied');
       },
     } as any;
-    expect(denialsAfterScopes(c, session, [])).toEqual([]);
+    expect(await denialsAfterScopes(c, session, PROJECT, [])).toEqual([]);
   });
 });

--- a/apps/api/src/git-proxy/ref-scopes.ts
+++ b/apps/api/src/git-proxy/ref-scopes.ts
@@ -27,28 +27,51 @@
 import type { Context } from 'hono';
 
 import { getAgentGrant } from '../iam/agent-scope';
+import { actorForToken } from '../iam/actor';
+import { authorize } from '../iam/authorize';
+import { deriveRequestContext } from '../iam/cache';
 import type { GitPrincipal, GitRefScope } from './ref-policy';
 
 /**
  * True when the principal holds `scope`.
  *
- * `user` and `internal` principals hold both by construction: a person's ref
- * authority comes from their project role, which the proxy already checked when
- * it authorized the push, and server-side machinery is gated at its own routes.
- * Only a session principal is narrowed here.
+ * A SESSION reads its agent grant; a PERSON is asked of the IAM engine, the
+ * same way every other project route asks. `project.gitops.push` authorizes
+ * *a* push, not every destructive shape of one: deleting a ref is not
+ * recoverable from the client that issued it, and a branch is frequently
+ * someone else's — another session's head, a colleague's feature branch. The
+ * migration seeds `.ref.delete` into `manager`, so a manager is unaffected and
+ * a plain member with push rights can no longer delete a branch.
+ *
+ * `internal` is server-side machinery, gated at its own routes.
  */
-export function principalHoldsRefScope(
+export async function principalHoldsRefScope(
   c: Context,
   principal: GitPrincipal,
+  project: { projectId: string; accountId: string },
   scope: GitRefScope,
-): boolean {
+): Promise<boolean> {
   switch (principal.kind) {
-    case 'user':
     case 'internal':
       return true;
     case 'monitor':
       // No principal behind a monitor box to hold anything.
       return false;
+    case 'user': {
+      // An account-scoped API key carries NO user identity, so there is no
+      // principal to evaluate a role against — the same reasoning
+      // `authorizeGitProxy` applies when it lets account ownership stand alone.
+      // Ownership was already proven to get here.
+      if (!principal.userId) return true;
+      const verdict = await authorize(
+        await actorForToken(principal.userId, project.accountId, principal.tokenId, {
+          ctx: deriveRequestContext(c),
+        }),
+        scope,
+        { type: 'project', id: project.projectId },
+      );
+      return verdict.allowed;
+    }
     case 'session': {
       const grant = getAgentGrant(c);
       if (!grant) return false; // Default-deny — see the header note.
@@ -64,15 +87,30 @@ export function principalHoldsRefScope(
  * A denial with no `requires` is structural and always stands. A denial that
  * names scopes stands unless the principal holds EVERY one of them.
  */
-export function denialsAfterScopes<T extends { requires?: GitRefScope[] }>(
+export async function denialsAfterScopes<T extends { requires?: GitRefScope[] }>(
   c: Context,
   principal: GitPrincipal,
+  project: { projectId: string; accountId: string },
   denials: T[],
-): T[] {
-  return denials.filter((denial) => {
-    if (!denial.requires || denial.requires.length === 0) return true; // structural
+): Promise<T[]> {
+  const standing: T[] = [];
+  for (const denial of denials) {
+    if (!denial.requires || denial.requires.length === 0) {
+      standing.push(denial); // structural
+      continue;
+    }
     // EVERY named leaf must be held. Deleting another ref names both `.ref.any`
-    // and `.ref.delete`; holding only one must not authorize it.
-    return !denial.requires.every((scope) => principalHoldsRefScope(c, principal, scope));
-  });
+    // and `.ref.delete`; holding only one must not authorize it. Sequential, not
+    // Promise.all: the common case is one leaf, and a denied first leaf should
+    // not pay for a second authorization round trip.
+    let holdsAll = true;
+    for (const scope of denial.requires) {
+      if (!(await principalHoldsRefScope(c, principal, project, scope))) {
+        holdsAll = false;
+        break;
+      }
+    }
+    if (!holdsAll) standing.push(denial);
+  }
+  return standing;
 }

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -914,7 +914,12 @@ async function authorizeGitProxyUncached(
     return {
       ok: true,
       project,
-      principal: sessionPrincipal ?? { kind: 'user', userId: result.userId ?? null },
+      principal:
+        sessionPrincipal ?? {
+          kind: 'user',
+          userId: result.userId ?? null,
+          tokenId: result.tokenId ?? null,
+        },
     };
   }
 


### PR DESCRIPTION
Follow-up to #7073, from a fair objection: a human with push rights could still delete any non-default branch.

`project.gitops.push` was authorizing a push **and every destructive shape of one**. `principalHoldsRefScope` short-circuited `user` to `true`, so anyone who could push could delete another session's head or a colleague's feature branch — and a deletion is not recoverable from the client that issued it.

The scope already existed and was already seeded: the #7073 migration puts `project.gitops.ref.delete` on `manager`. It simply was never asked. Now it is, through the same IAM engine every other project route uses, with the acting token threaded so the agent-grant fold fires instead of being silently skipped.

| principal | before | after |
| --- | --- | --- |
| `manager` | delete | delete (holds the leaf) |
| member with push | **delete** | **refused** |
| session | refused | refused (agent grant, already default-deny) |
| account API key | delete | delete — no user identity to evaluate a role against, ownership proven upstream |

`kortix ship` on `main` is untouched; this narrows deletion only.

## Still lazy

The resolver runs **only on a denial**, and for a person the policy denies only a delete — so an ordinary push pays no authorization round trip. The leaf loop is sequential rather than `Promise.all`, so a denied first leaf never pays for a second call.

## Tests

API **8744 pass / 0 fail**, tsc clean. The wire test drives a real `git push --delete` at the real app with the leaf withheld and asserts both the rejection and that nothing reached the upstream. Resolver tests pin that a person is *asked* rather than assumed, and that an account API key asks nothing.

https://claude.ai/code/session_01RAeaWxg7Px2aYKeZ2Ej2Zw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791040200&installation_model_id=434224&pr_number=7107&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7107&signature=f822794418e15664243975b1463f4e8f1141561db0a1c645de7a60023ff7b9a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->