### PR TITLE
project home: workspace name throws confetti for every project again

### DIFF
--- a/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
+++ b/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
@@ -4,7 +4,6 @@ import { useLayoutEffect, useState, type ReactNode } from 'react';
 
 import { IdentityConfetti } from '@/components/ui/identity-confetti';
 import { SessionWelcome } from '@/features/session/session-welcome';
-import { resolveConfettiFace } from '@/lib/confetti-identity';
 import { useProjectIcon, useProjectName } from '@kortix/sdk/react';
 import {
   HOME_GREETINGS,
@@ -63,11 +62,10 @@ import {
  * deliberately silent at rest — see the button's own comment for why it carries
  * no hover treatment.
  *
- * ONLY when the workspace wears an icon someone picked — an emoji or a glyph.
- * With neither, `resolveConfettiFace` degrades to the chalk initial tile, and
- * throwing thirty-eight copies of the letter already sitting in the heading is
- * not a celebration. Those workspaces render the name as plain text, so there
- * is no pointer and no tooltip offering a payoff that would fall flat.
+ * For EVERY workspace: an emoji or glyph burst when one was chosen, the chalk
+ * initial tile otherwise (`IdentityConfetti` resolves the face the same way
+ * `EntityAvatar` does). #7079 had gated letter-only workspaces out; Marko put
+ * the press back for all of them on 2026-09-03.
  */
 export function ProjectHomeWelcomeBody({
   projectId,
@@ -86,16 +84,11 @@ export function ProjectHomeWelcomeBody({
   // the name in this heading and the icon thrown out of it cannot come from
   // two caches that have diverged — and it costs no extra request.
   const icon = useProjectIcon(projectId);
-  // Only an icon someone CHOSE is worth throwing. `resolveConfettiFace` falls
-  // through to the chalk initial tile when a project has neither emoji nor
-  // glyph, and a burst of the same letter the heading is already showing reads
-  // as noise, not as a celebration. Those projects get plain text instead — no
-  // pointer, no tooltip promising a payoff that would not land. Gated on the
-  // resolver rather than on `icon?.icon` so this can never disagree with the
-  // face `EntityAvatar` draws, including the unknown-glyph fall-through.
-  const wearsChosenIcon =
-    resolveConfettiFace({ glyph: icon?.icon_glyph, emoji: icon?.icon, label: name }).kind !==
-    'initial';
+  // Every workspace name is pressable, whatever it wears. #7079 gated the
+  // burst on a chosen emoji/glyph so a letter-only project would not throw
+  // its own initial; Marko reversed that on 2026-09-03 ("bring it back") —
+  // the press is the payoff, and the chalk initial tile is that project's
+  // face everywhere else in the app, so it is the right thing to throw.
   // `id` is the remount key: `IdentityConfetti` fires on mount, so a second
   // press needs a second mount. `origin` is captured per press rather than
   // fixed, because the word moves — the heading rewraps with the viewport and
@@ -192,33 +185,27 @@ export function ProjectHomeWelcomeBody({
               noise on every load for a control nobody needs to find. The
               pointer cursor and the tooltip are the whole invitation.
             */}
-            {wearsChosenIcon ? (
-              <button
-                type="button"
-                title="Throw some confetti"
-                onClick={(event) => {
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  setBurst((current) => ({
-                    id: (current?.id ?? 0) + 1,
-                    // Canvas fractions, measured against the viewport, because
-                    // the confetti canvas is portalled to <body> at `fixed
-                    // inset-0`. Centre of the word, so the burst comes out of
-                    // the name rather than from somewhere near it.
-                    origin: {
-                      x: (rect.left + rect.width / 2) / window.innerWidth,
-                      y: (rect.top + rect.height / 2) / window.innerHeight,
-                    },
-                  }));
-                }}
-                className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
-              >
-                {displayName}
-              </button>
-            ) : (
-              // Same colour, no affordance: the name still carries the
-              // sentence's one highlight, it just is not pressable.
-              <span className="text-foreground">{displayName}</span>
-            )}
+            <button
+              type="button"
+              title="Throw some confetti"
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                setBurst((current) => ({
+                  id: (current?.id ?? 0) + 1,
+                  // Canvas fractions, measured against the viewport, because
+                  // the confetti canvas is portalled to <body> at `fixed
+                  // inset-0`. Centre of the word, so the burst comes out of
+                  // the name rather than from somewhere near it.
+                  origin: {
+                    x: (rect.left + rect.width / 2) / window.innerWidth,
+                    y: (rect.top + rect.height / 2) / window.innerHeight,
+                  },
+                }));
+              }}
+              className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {displayName}
+            </button>
             {spaceBefore(greeting.after) ? ' ' : ''}
             {greeting.after}
           </h1>


### PR DESCRIPTION
Reverts the letter-only gate from #7079: the name in the project-home heading is a button for every workspace again. Emoji/glyph workspaces burst their icon; letter-only ones burst the chalk initial tile, the same face they wear everywhere else.

Verified: web tsc clean, eslint clean, project-layout tests green.

https://claude.ai/code/session_01MckrUTv1ChEUKWZidsqtCE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791055316&installation_model_id=434224&pr_number=7110&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7110&signature=22f5564f91b9e2c4a2580555bebc405e7885bab367a4043692ab0229b67badc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->