### PR TITLE
feat(desktop): sign-in dialog for the dev/staging HTTP Basic gate

### DIFF
--- a/apps/desktop-electron/README.md
+++ b/apps/desktop-electron/README.md
@@ -46,7 +46,31 @@ KORTIX_DESKTOP_URL=https://kortix.com/projects pnpm --filter @kortix/desktop-ele
 
 At runtime you can also switch via the native **Kortix → Frontend URL** menu
 (Production / Dev / Local / Custom… / Reset). The choice is remembered across
-launches (stored in `userData/frontend_url`).
+launches (stored in `userData/frontend_url`). `KORTIX_DESKTOP_USER_DATA=<dir>`
+runs against an isolated profile instead of the real one.
+
+### The dev/staging environment password (HTTP Basic)
+
+`dev.kortix.com` and `staging.kortix.com` sit behind one shared HTTP Basic
+credential (`apps/web/src/middleware.ts` answers `401 Authentication required.`).
+Chrome pops its own username/password dialog for that; Electron does not, so the
+shell handles the challenge itself (`src/main.js` → `answerBasicChallenge`, policy
+in `src/basic-auth.js`):
+
+1. `KORTIX_DESKTOP_BASIC_PASSWORD` (+ optional `KORTIX_DESKTOP_BASIC_USER`,
+   default `kortix`) answers silently — for CI and scripted launches.
+2. Otherwise a credential the user entered earlier for that host answers
+   silently. "Remember on this device" stores it in `userData/basic_auth.json`,
+   encrypted with Electron `safeStorage` (macOS Keychain / DPAPI / libsecret).
+3. Otherwise a native-style sign-in dialog (`assets/basic-auth.html`) opens over
+   the app window. A rejected password (the server re-challenges within 60 s)
+   drops the remembered copy and reopens the dialog with an error. Cancel leaves
+   the bare 401 page, like Chrome; reload asks again.
+
+The credential is only ever sent to the configured app origin. Any other host
+(sandbox previews, iframes) that returns a Basic challenge is refused.
+**Kortix → Frontend URL → Forget Saved Environment Password** clears the
+remembered credential for the current host.
 
 ### Testing login (the `kortix://` deep link)
 

--- a/apps/desktop-electron/assets/basic-auth.html
+++ b/apps/desktop-electron/assets/basic-auth.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline';" />
+    <title>Sign in</title>
+    <style>
+      :root { color-scheme: dark; }
+      html, body {
+        margin: 0;
+        height: 100%;
+        background: #141414;
+        color: rgba(255, 255, 255, 0.92);
+        font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        -webkit-user-select: none;
+        user-select: none;
+        overflow: hidden;
+      }
+      form {
+        box-sizing: border-box;
+        height: 100%;
+        padding: 20px 20px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+      h1 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        line-height: 18px;
+      }
+      #host { font-weight: 600; }
+      p.sub {
+        margin: 0 0 4px;
+        color: rgba(255, 255, 255, 0.6);
+      }
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        color: rgba(255, 255, 255, 0.7);
+        font-size: 12px;
+      }
+      input[type="text"], input[type="password"] {
+        box-sizing: border-box;
+        width: 100%;
+        height: 30px;
+        padding: 0 9px;
+        border-radius: 6px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        background: #0a0a0a;
+        color: inherit;
+        font: inherit;
+        outline: none;
+        -webkit-user-select: text;
+        user-select: text;
+      }
+      input:focus { border-color: rgba(255, 255, 255, 0.45); }
+      .remember {
+        flex-direction: row;
+        align-items: center;
+        gap: 7px;
+        margin-top: 2px;
+      }
+      .remember input { margin: 0; accent-color: #ffffff; }
+      #error {
+        min-height: 16px;
+        font-size: 12px;
+        color: #ff6b6b;
+      }
+      .actions {
+        margin-top: auto;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+      button {
+        height: 30px;
+        padding: 0 14px;
+        border-radius: 6px;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        font-weight: 500;
+        cursor: default;
+      }
+      button.primary {
+        background: #ffffff;
+        border-color: #ffffff;
+        color: #0a0a0a;
+      }
+      button:focus-visible { outline: 2px solid rgba(255, 255, 255, 0.45); outline-offset: 1px; }
+    </style>
+  </head>
+  <body>
+    <form id="form" autocomplete="off">
+      <h1>Sign in to <span id="host"></span></h1>
+      <p class="sub" id="realm"></p>
+      <label>
+        Username
+        <input id="user" type="text" name="username" autocapitalize="off" spellcheck="false" />
+      </label>
+      <label>
+        Password
+        <input id="pass" type="password" name="password" />
+      </label>
+      <label class="remember">
+        <input id="remember" type="checkbox" checked />
+        <span id="remember-label">Remember on this device</span>
+      </label>
+      <div id="error" role="alert" aria-live="assertive"></div>
+      <div class="actions">
+        <button type="button" id="cancel">Cancel</button>
+        <button type="submit" class="primary" id="submit">Sign In</button>
+      </div>
+    </form>
+    <script>
+      // Values arrive from the main process via preload (contextBridge); the
+      // page never sees Node. Every string is set with textContent — the host
+      // and realm come from the network and must never be parsed as HTML.
+      const api = window.kortixBasicAuth;
+      const $ = (id) => document.getElementById(id);
+      api.onInit((init) => {
+        $('host').textContent = init.host;
+        $('realm').textContent = init.realm
+          ? `The site says: "${init.realm}"`
+          : 'This site requires a username and password.';
+        $('user').value = init.user || '';
+        $('error').textContent = init.error || '';
+        if (!init.canRemember) {
+          $('remember').checked = false;
+          $('remember').disabled = true;
+          $('remember-label').textContent = 'Remember (unavailable: no OS keychain)';
+        }
+        ($('user').value ? $('pass') : $('user')).focus();
+      });
+      $('form').addEventListener('submit', (e) => {
+        e.preventDefault();
+        api.submit({
+          user: $('user').value,
+          password: $('pass').value,
+          remember: $('remember').checked && !$('remember').disabled,
+        });
+      });
+      $('cancel').addEventListener('click', () => api.cancel());
+      window.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') api.cancel();
+      });
+    </script>
+  </body>
+</html>

--- a/apps/desktop-electron/src/basic-auth-preload.js
+++ b/apps/desktop-electron/src/basic-auth-preload.js
@@ -1,0 +1,16 @@
+// Preload for the HTTP Basic credential dialog (assets/basic-auth.html).
+// Isolated context; the page gets three functions and nothing else.
+
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('kortixBasicAuth', {
+  /** Main → page: host / realm / prefilled user / error text. */
+  onInit: (cb) => ipcRenderer.on('kortix:basic-auth:init', (_e, init) => cb(init)),
+  submit: ({ user, password, remember }) =>
+    ipcRenderer.send('kortix:basic-auth:submit', {
+      user: String(user ?? ''),
+      password: String(password ?? ''),
+      remember: Boolean(remember),
+    }),
+  cancel: () => ipcRenderer.send('kortix:basic-auth:cancel'),
+});

--- a/apps/desktop-electron/src/basic-auth.js
+++ b/apps/desktop-electron/src/basic-auth.js
@@ -1,0 +1,136 @@
+// HTTP Basic credential policy for the Kortix desktop shell — pure, no Electron.
+//
+// Dev and staging sit behind one shared HTTP Basic credential
+// (apps/web/src/middleware.ts answers 401 "Authentication required."). Chrome
+// pops its own username/password dialog for that; Electron does not, so the
+// shell has to decide, per challenge, whether to answer silently or ask the
+// user. That decision lives here so it can be unit-tested without a window.
+//
+// Sources, in precedence order:
+//   1. KORTIX_DESKTOP_BASIC_PASSWORD env (CI / scripted launches)
+//   2. a credential the user entered earlier for this host (memory, and on
+//      disk via safeStorage when the user ticked "Remember")
+//   3. a dialog
+//
+// Rejection detection: Chromium re-issues the `login` event for the same URL
+// when the server answers 401 to the credential we supplied. There is no
+// explicit "rejected" signal, so a second challenge for the same host within
+// REJECT_WINDOW_MS of our last answer is treated as "that credential was
+// wrong" — the stored copy is dropped and the dialog opens with an error.
+
+const REJECT_WINDOW_MS = 60_000;
+const DEFAULT_USER = 'kortix';
+
+/**
+ * Decide how to answer one Basic challenge.
+ *
+ * @param {object} input
+ * @param {string} input.host           challenge host (already origin-checked)
+ * @param {{ user?: string, password?: string }} [input.env]
+ *   KORTIX_DESKTOP_BASIC_USER / KORTIX_DESKTOP_BASIC_PASSWORD
+ * @param {{ user: string, password: string } | null} [input.stored]
+ *   credential remembered for this host
+ * @param {{ source: 'env'|'stored'|'prompt', at: number } | null} [input.lastAnswer]
+ *   what we last sent for this host, and when
+ * @param {number} input.now
+ * @returns {
+ *   | { action: 'answer', source: 'env'|'stored', user: string, password: string }
+ *   | { action: 'prompt', user: string, error: string | null, dropStored: boolean }
+ * }
+ */
+function decideChallenge({ host, env, stored, lastAnswer, now }) {
+  const rejected =
+    !!lastAnswer && typeof lastAnswer.at === 'number' && now - lastAnswer.at < REJECT_WINDOW_MS;
+
+  if (env && env.password && !(rejected && lastAnswer.source === 'env')) {
+    return {
+      action: 'answer',
+      source: 'env',
+      user: env.user || DEFAULT_USER,
+      password: env.password,
+    };
+  }
+
+  // A credential typed into the dialog becomes the stored one, so a rejected
+  // 'prompt' answer means the stored copy is wrong too — never retry it.
+  const storedRejected = rejected && lastAnswer.source !== 'env';
+  if (stored && stored.password && !storedRejected) {
+    return { action: 'answer', source: 'stored', user: stored.user || DEFAULT_USER, password: stored.password };
+  }
+
+  // Everything silent has been tried (or was just rejected) — ask the user.
+  const prefillUser =
+    (rejected && stored && stored.user) || (env && env.user) || (stored && stored.user) || DEFAULT_USER;
+  return {
+    action: 'prompt',
+    user: prefillUser,
+    error: rejected ? `${host} rejected the username or password.` : null,
+    // A stored credential that was just rejected must not be retried silently
+    // on the next launch.
+    dropStored: storedRejected && !!stored,
+  };
+}
+
+/* ─── On-disk store (host → { user, secret }) ───────────────────────────────
+   `secret` is opaque here: the caller encrypts with safeStorage before
+   `upsertHost` and decrypts after `lookupHost`. Only the JSON shape is owned by
+   this module. */
+
+const STORE_VERSION = 1;
+
+function emptyStore() {
+  return { version: STORE_VERSION, hosts: {} };
+}
+
+/** @param {string | null | undefined} raw file contents */
+function parseStore(raw) {
+  if (!raw) return emptyStore();
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return emptyStore();
+  }
+  if (!data || data.version !== STORE_VERSION || typeof data.hosts !== 'object' || !data.hosts) {
+    return emptyStore();
+  }
+  const hosts = {};
+  for (const [host, entry] of Object.entries(data.hosts)) {
+    if (entry && typeof entry.user === 'string' && typeof entry.secret === 'string') {
+      hosts[host] = { user: entry.user, secret: entry.secret };
+    }
+  }
+  return { version: STORE_VERSION, hosts };
+}
+
+function serializeStore(store) {
+  return JSON.stringify({ version: STORE_VERSION, hosts: store.hosts }, null, 2) + '\n';
+}
+
+function lookupHost(store, host) {
+  return store.hosts[host] || null;
+}
+
+function upsertHost(store, host, entry) {
+  return {
+    version: STORE_VERSION,
+    hosts: { ...store.hosts, [host]: { user: entry.user, secret: entry.secret } },
+  };
+}
+
+function removeHost(store, host) {
+  const hosts = { ...store.hosts };
+  delete hosts[host];
+  return { version: STORE_VERSION, hosts };
+}
+
+module.exports = {
+  DEFAULT_USER,
+  REJECT_WINDOW_MS,
+  decideChallenge,
+  parseStore,
+  serializeStore,
+  lookupHost,
+  upsertHost,
+  removeHost,
+};

--- a/apps/desktop-electron/src/basic-auth.test.js
+++ b/apps/desktop-electron/src/basic-auth.test.js
@@ -1,0 +1,151 @@
+const { describe, it, expect } = require('bun:test');
+const {
+  decideChallenge,
+  parseStore,
+  serializeStore,
+  lookupHost,
+  upsertHost,
+  removeHost,
+  REJECT_WINDOW_MS,
+} = require('./basic-auth');
+
+const HOST = 'dev.kortix.com';
+const NOW = 1_000_000;
+
+describe('decideChallenge', () => {
+  it('prompts with the default user when nothing is known', () => {
+    expect(decideChallenge({ host: HOST, now: NOW })).toEqual({
+      action: 'prompt',
+      user: 'kortix',
+      error: null,
+      dropStored: false,
+    });
+  });
+
+  it('answers from env first, defaulting the user to kortix', () => {
+    expect(
+      decideChallenge({
+        host: HOST,
+        env: { password: 'pw' },
+        stored: { user: 'u', password: 'stored' },
+        now: NOW,
+      }),
+    ).toEqual({ action: 'answer', source: 'env', user: 'kortix', password: 'pw' });
+    expect(
+      decideChallenge({ host: HOST, env: { user: 'me', password: 'pw' }, now: NOW }),
+    ).toMatchObject({ source: 'env', user: 'me' });
+  });
+
+  it('answers from the stored credential when env is unset', () => {
+    expect(
+      decideChallenge({ host: HOST, stored: { user: 'u', password: 'stored' }, now: NOW }),
+    ).toEqual({ action: 'answer', source: 'stored', user: 'u', password: 'stored' });
+  });
+
+  it('treats a re-challenge inside the window as a rejection of the stored credential', () => {
+    const res = decideChallenge({
+      host: HOST,
+      stored: { user: 'u', password: 'bad' },
+      lastAnswer: { source: 'stored', at: NOW - 1_000 },
+      now: NOW,
+    });
+    expect(res).toEqual({
+      action: 'prompt',
+      user: 'u',
+      error: 'dev.kortix.com rejected the username or password.',
+      dropStored: true,
+    });
+  });
+
+  it('retries the stored credential silently once the window has passed', () => {
+    const res = decideChallenge({
+      host: HOST,
+      stored: { user: 'u', password: 'ok' },
+      lastAnswer: { source: 'stored', at: NOW - REJECT_WINDOW_MS },
+      now: NOW,
+    });
+    expect(res).toMatchObject({ action: 'answer', source: 'stored' });
+  });
+
+  it('falls through to the dialog when the env credential is rejected, without dropping storage', () => {
+    const res = decideChallenge({
+      host: HOST,
+      env: { user: 'ci', password: 'bad' },
+      lastAnswer: { source: 'env', at: NOW - 5 },
+      now: NOW,
+    });
+    expect(res).toEqual({
+      action: 'prompt',
+      user: 'ci',
+      error: 'dev.kortix.com rejected the username or password.',
+      dropStored: false,
+    });
+  });
+
+  it('re-prompts with an error when a typed credential is rejected', () => {
+    const res = decideChallenge({
+      host: HOST,
+      lastAnswer: { source: 'prompt', at: NOW - 5 },
+      now: NOW,
+    });
+    expect(res).toMatchObject({ action: 'prompt', error: expect.stringContaining('rejected') });
+    expect(res.dropStored).toBe(false);
+  });
+
+  it('does not silently retry a typed credential that was just rejected (it is now the stored one)', () => {
+    const res = decideChallenge({
+      host: HOST,
+      stored: { user: 'kortix', password: 'typed-wrong' },
+      lastAnswer: { source: 'prompt', at: NOW - 5 },
+      now: NOW,
+    });
+    expect(res).toEqual({
+      action: 'prompt',
+      user: 'kortix',
+      error: 'dev.kortix.com rejected the username or password.',
+      dropStored: true,
+    });
+  });
+
+  it('after a rejected env credential, still trusts a remembered one', () => {
+    const res = decideChallenge({
+      host: HOST,
+      env: { password: 'bad' },
+      stored: { user: 'kortix', password: 'good' },
+      lastAnswer: { source: 'env', at: NOW - 5 },
+      now: NOW,
+    });
+    expect(res).toEqual({ action: 'answer', source: 'stored', user: 'kortix', password: 'good' });
+  });
+});
+
+describe('store', () => {
+  it('round-trips through serialize/parse', () => {
+    let store = parseStore(null);
+    store = upsertHost(store, HOST, { user: 'kortix', secret: 'enc:abc' });
+    const parsed = parseStore(serializeStore(store));
+    expect(lookupHost(parsed, HOST)).toEqual({ user: 'kortix', secret: 'enc:abc' });
+    expect(lookupHost(parsed, 'other')).toBeNull();
+  });
+
+  it('removes a host without touching the others', () => {
+    let store = upsertHost(parseStore(null), HOST, { user: 'a', secret: 's1' });
+    store = upsertHost(store, 'staging.kortix.com', { user: 'b', secret: 's2' });
+    store = removeHost(store, HOST);
+    expect(lookupHost(store, HOST)).toBeNull();
+    expect(lookupHost(store, 'staging.kortix.com')).toEqual({ user: 'b', secret: 's2' });
+  });
+
+  it('discards corrupt, foreign-version, or malformed entries', () => {
+    expect(parseStore('not json')).toEqual({ version: 1, hosts: {} });
+    expect(parseStore(JSON.stringify({ version: 2, hosts: { a: { user: 'x', secret: 'y' } } }))).toEqual({
+      version: 1,
+      hosts: {},
+    });
+    expect(
+      parseStore(
+        JSON.stringify({ version: 1, hosts: { good: { user: 'x', secret: 'y' }, bad: { user: 1 } } }),
+      ),
+    ).toEqual({ version: 1, hosts: { good: { user: 'x', secret: 'y' } } });
+  });
+});

--- a/apps/desktop-electron/src/main.js
+++ b/apps/desktop-electron/src/main.js
@@ -19,13 +19,16 @@ const {
   app,
   BrowserWindow,
   Menu,
+  dialog,
   shell,
   ipcMain,
   nativeTheme,
+  safeStorage,
 } = require('electron');
 const path = require('node:path');
 const fs = require('node:fs');
 const { setupAutoUpdates, checkForUpdatesInteractive } = require('./updater');
+const basicAuth = require('./basic-auth');
 const {
   DESKTOP_CHROME_JS,
   configureNativeWindowControls,
@@ -37,7 +40,13 @@ const {
 // and so we never inherit another "Kortix" app's stale Chromium state (per-site
 // zoom / GPU cache) — a real cause of blurry rendering. `${name} Desktop` keeps
 // us off the bare "Kortix" Application Support folder.
-app.setPath('userData', path.join(app.getPath('appData'), `${app.getName()} Desktop`));
+// KORTIX_DESKTOP_USER_DATA points a launch at an isolated profile (automated
+// runs, side-by-side test sessions) without touching the real one.
+app.setPath(
+  'userData',
+  process.env.KORTIX_DESKTOP_USER_DATA ||
+    path.join(app.getPath('appData'), `${app.getName()} Desktop`),
+);
 
 /* ─── Config ──────────────────────────────────────────────────────────── */
 
@@ -491,6 +500,225 @@ function navigateMainWindow(url) {
   mainWindow.focus();
 }
 
+/* ─── HTTP Basic credentials (dev/staging environment password) ────────────
+   Policy is basicAuth.decideChallenge(); this section owns the side effects:
+   the safeStorage-encrypted file userData/basic_auth.json, the per-session
+   memory, the dialog window, and the "was that rejected?" bookkeeping. */
+
+/** host → { user, password } for this process lifetime (remembered or not). */
+const sessionBasicCredentials = new Map();
+/** host → { source: 'env'|'stored'|'prompt', at } — last credential we sent. */
+const lastBasicAnswers = new Map();
+/** host → Promise resolving to the dialog result; dedupes parallel challenges. */
+const pendingBasicPrompts = new Map();
+
+function basicAuthStorePath() {
+  return path.join(app.getPath('userData'), 'basic_auth.json');
+}
+
+function readBasicAuthStore() {
+  try {
+    return basicAuth.parseStore(fs.readFileSync(basicAuthStorePath(), 'utf8'));
+  } catch {
+    return basicAuth.parseStore(null);
+  }
+}
+
+function writeBasicAuthStore(store) {
+  try {
+    fs.mkdirSync(path.dirname(basicAuthStorePath()), { recursive: true });
+    fs.writeFileSync(basicAuthStorePath(), basicAuth.serializeStore(store), { mode: 0o600 });
+  } catch (e) {
+    console.warn(`[kortix] could not write ${basicAuthStorePath()}: ${e}`);
+  }
+}
+
+function canRememberBasicCredential() {
+  try {
+    return safeStorage.isEncryptionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+/** Remembered credential for `host` — memory first, then the encrypted file. */
+function loadBasicCredential(host) {
+  const inMemory = sessionBasicCredentials.get(host);
+  if (inMemory) return inMemory;
+  const entry = basicAuth.lookupHost(readBasicAuthStore(), host);
+  if (!entry || !canRememberBasicCredential()) return null;
+  try {
+    const password = safeStorage.decryptString(Buffer.from(entry.secret, 'base64'));
+    const cred = { user: entry.user, password };
+    sessionBasicCredentials.set(host, cred);
+    return cred;
+  } catch (e) {
+    // Keychain changed / different user account — the blob is unreadable.
+    console.warn(`[kortix] dropping unreadable saved credential for ${host}: ${e}`);
+    writeBasicAuthStore(basicAuth.removeHost(readBasicAuthStore(), host));
+    return null;
+  }
+}
+
+function rememberBasicCredential(host, cred, persist) {
+  sessionBasicCredentials.set(host, cred);
+  if (!persist || !canRememberBasicCredential()) return;
+  const secret = safeStorage.encryptString(cred.password).toString('base64');
+  writeBasicAuthStore(basicAuth.upsertHost(readBasicAuthStore(), host, { user: cred.user, secret }));
+}
+
+function forgetBasicCredential(host) {
+  sessionBasicCredentials.delete(host);
+  lastBasicAnswers.delete(host);
+  const store = readBasicAuthStore();
+  const had = !!basicAuth.lookupHost(store, host);
+  if (had) writeBasicAuthStore(basicAuth.removeHost(store, host));
+  return had;
+}
+
+function forgetBasicCredentialForAppHost() {
+  let host;
+  try {
+    host = new URL(resolveAppUrl()).hostname;
+  } catch {
+    return;
+  }
+  const had = forgetBasicCredential(host);
+  dialog.showMessageBox({
+    type: 'info',
+    message: had
+      ? `Forgot the saved environment password for ${host}.`
+      : `No environment password is saved for ${host}.`,
+    detail: had ? 'The next time this host asks, the sign-in dialog opens again.' : undefined,
+  });
+}
+
+/**
+ * Open the credential dialog. Resolves to { user, password, remember } or null
+ * on cancel/close. Parallel challenges for one host share one dialog.
+ */
+function promptForBasicCredential({ host, realm, user, error }) {
+  const pending = pendingBasicPrompts.get(host);
+  if (pending) return pending;
+
+  // The first challenge fires before the app has painted, while the main
+  // window is still hidden behind the splash. Chrome shows its dialog over a
+  // blank page; do the same — the dark main window is the parent.
+  if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+    dismissSplash();
+    mainWindow.show();
+  }
+
+  const promise = new Promise((resolve) => {
+    const parent = mainWindow && !mainWindow.isDestroyed() ? mainWindow : undefined;
+    const win = new BrowserWindow({
+      width: 400,
+      height: 320,
+      parent,
+      modal: !!parent,
+      show: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      title: 'Sign in',
+      backgroundColor: '#141414',
+      webPreferences: {
+        preload: path.join(__dirname, 'basic-auth-preload.js'),
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+    win.setMenuBarVisibility(false);
+
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      console.log(`[kortix] Basic sign-in dialog for ${host}: ${result ? 'submitted' : 'cancelled'}.`);
+      ipcMain.removeListener('kortix:basic-auth:submit', onSubmit);
+      ipcMain.removeListener('kortix:basic-auth:cancel', onCancel);
+      pendingBasicPrompts.delete(host);
+      if (!win.isDestroyed()) win.destroy();
+      resolve(result);
+    };
+    const fromThisDialog = (event) => !win.isDestroyed() && event.sender === win.webContents;
+    const onSubmit = (event, payload) => {
+      if (!fromThisDialog(event)) return;
+      finish({
+        user: String(payload?.user ?? '').trim() || basicAuth.DEFAULT_USER,
+        password: String(payload?.password ?? ''),
+        remember: Boolean(payload?.remember),
+      });
+    };
+    const onCancel = (event) => {
+      if (fromThisDialog(event)) finish(null);
+    };
+    ipcMain.on('kortix:basic-auth:submit', onSubmit);
+    ipcMain.on('kortix:basic-auth:cancel', onCancel);
+    win.on('closed', () => finish(null));
+
+    win.webContents.once('did-finish-load', () => {
+      win.webContents.send('kortix:basic-auth:init', {
+        host,
+        realm: realm || '',
+        user,
+        error,
+        canRemember: canRememberBasicCredential(),
+      });
+      win.show();
+    });
+    win.loadFile(path.join(__dirname, '..', 'assets', 'basic-auth.html'));
+  });
+  pendingBasicPrompts.set(host, promise);
+  return promise;
+}
+
+/** Answer one app-origin Basic challenge (env → remembered → dialog). */
+async function answerBasicChallenge(authInfo, callback) {
+  const host = authInfo.host;
+  const decision = basicAuth.decideChallenge({
+    host,
+    env: {
+      user: process.env.KORTIX_DESKTOP_BASIC_USER,
+      password: process.env.KORTIX_DESKTOP_BASIC_PASSWORD,
+    },
+    stored: loadBasicCredential(host),
+    lastAnswer: lastBasicAnswers.get(host) || null,
+    now: Date.now(),
+  });
+
+  if (decision.action === 'answer') {
+    console.log(`[kortix] Basic challenge from ${host}: answering from ${decision.source}.`);
+    lastBasicAnswers.set(host, { source: decision.source, at: Date.now() });
+    callback(decision.user, decision.password);
+    return;
+  }
+  console.log(`[kortix] Basic challenge from ${host}: asking the user.`);
+
+  if (decision.dropStored) {
+    console.warn(`[kortix] ${host} rejected the saved environment password — forgetting it.`);
+    forgetBasicCredential(host);
+  }
+  const result = await promptForBasicCredential({
+    host,
+    realm: authInfo.realm,
+    user: decision.user,
+    error: decision.error,
+  });
+  if (!result) {
+    // Cancel → the request fails and the page renders the 401 body, same as
+    // Chrome. A reload re-challenges.
+    lastBasicAnswers.delete(host);
+    callback();
+    return;
+  }
+  rememberBasicCredential(host, { user: result.user, password: result.password }, result.remember);
+  lastBasicAnswers.set(host, { source: 'prompt', at: Date.now() });
+  callback(result.user, result.password);
+}
+
 /* ─── Native menu (incl. hidden "Frontend URL" switcher) ───────────────────*/
 
 function buildMenu() {
@@ -542,6 +770,13 @@ function buildMenu() {
           clearUrlOverride();
           navigateMainWindow(appBaseUrl());
         },
+      },
+      { type: 'separator' },
+      {
+        // Drops the HTTP Basic credential remembered for the current app host
+        // (dev/staging environment password) so the next challenge asks again.
+        label: 'Forget Saved Environment Password',
+        click: () => forgetBasicCredentialForAppHost(),
       },
     ],
   };
@@ -723,32 +958,28 @@ if (!gotLock) {
   // Chrome shows its own username/password dialog for these. Electron does NOT:
   // if nothing handles 'login' the request is simply cancelled, so the window
   // renders the bare 401 body with no way to get past it. That is exactly what
-  // a dev build pointed at dev.kortix.com looks like.
+  // a dev build pointed at dev.kortix.com looked like before this handler.
+  //
+  // Order: KORTIX_DESKTOP_BASIC_PASSWORD env → credential remembered for this
+  // host → a native-style dialog (assets/basic-auth.html). Policy, including
+  // "was our last answer rejected?", is the pure decideChallenge() in
+  // src/basic-auth.js so it is unit-tested.
   //
   // The credential is answered ONLY for the configured app origin. Untrusted
   // in-app content (sandbox previews, iframes) can point at any host, and a
   // 401 Basic challenge is all an attacker host would need to harvest it.
   app.on('login', (event, _webContents, _details, authInfo, callback) => {
-    if (!authInfo.isProxy && authInfo.scheme === 'basic') {
-      if (!isAppOriginChallenge(authInfo)) {
-        console.warn(
-          `[kortix] ignoring HTTP Basic challenge from ${authInfo.host} — not the app origin.`,
-        );
-        event.preventDefault();
-        callback();
-        return;
-      }
-      const password = process.env.KORTIX_DESKTOP_BASIC_PASSWORD;
-      if (password) {
-        event.preventDefault();
-        callback(process.env.KORTIX_DESKTOP_BASIC_USER || 'kortix', password);
-        return;
-      }
+    if (authInfo.isProxy || authInfo.scheme !== 'basic') return;
+    if (!isAppOriginChallenge(authInfo)) {
       console.warn(
-        `[kortix] ${authInfo.host} requires HTTP Basic auth and no credential is set. ` +
-          `Re-run with KORTIX_DESKTOP_BASIC_PASSWORD=… (user defaults to "kortix").`,
+        `[kortix] ignoring HTTP Basic challenge from ${authInfo.host} — not the app origin.`,
       );
+      event.preventDefault();
+      callback();
+      return;
     }
+    event.preventDefault();
+    answerBasicChallenge(authInfo, callback);
   });
 
   app.on('second-instance', (_event, argv) => {


### PR DESCRIPTION
## Problem

The desktop app pointed at `dev.kortix.com` / `staging.kortix.com` shows a bare page reading `Authentication required.` and nothing else. That is the HTTP Basic gate in `apps/web/src/middleware.ts`. Chrome pops a username/password dialog for it. Electron cancels the request unless the app handles the `login` event, so the only way through was `KORTIX_DESKTOP_BASIC_PASSWORD` at launch, which a packaged build cannot receive.

## Change

`apps/desktop-electron` answers app-origin Basic challenges in this order:

1. `KORTIX_DESKTOP_BASIC_PASSWORD` (+ `KORTIX_DESKTOP_BASIC_USER`, default `kortix`) env, unchanged.
2. A credential the user entered earlier for that host. "Remember on this device" persists it to `userData/basic_auth.json`, encrypted with Electron `safeStorage` (Keychain / DPAPI / libsecret), file mode 600.
3. A modal sign-in dialog (`assets/basic-auth.html`) over the app window.

A re-challenge within 60 s of our last answer means the server rejected it: the remembered copy is dropped and the dialog reopens with `<host> rejected the username or password.` Cancel leaves the 401 body, same as Chrome. Parallel challenges for one host share one dialog. Challenges from any other host (sandbox previews, iframes) are still refused.

- Policy is the pure `decideChallenge()` in `src/basic-auth.js`, 13 bun tests in `src/basic-auth.test.js`.
- Menu: Kortix → Frontend URL → **Forget Saved Environment Password**.
- `KORTIX_DESKTOP_USER_DATA=<dir>` runs the shell against an isolated profile.
- README section "The dev/staging environment password (HTTP Basic)".

## Verification

Unit: `cd apps/desktop-electron && bun test src/` → 27 pass, 0 fail (3 files).

End to end against `https://dev.kortix.com`, driving the real Electron shell over CDP (Playwright cannot attach: its launch waits on the main navigation, which the pending challenge blocks). 19/19 assertions:

| Run | Setup | Observed |
| --- | --- | --- |
| 1 | empty profile, no env | dialog opens: host `dev.kortix.com`, realm `Kortix test environment`, user `kortix`, password focused. Wrong password → second dialog with the rejection error. Right password → `/auth` renders, `basic_auth.json` written for `dev.kortix.com`, secret does not contain the password, mode `600`. Main log: ask → submitted → ask → submitted. |
| 2 | same profile, access cookie deleted | no dialog; main log `answering from stored`; `/auth` renders. |
| 3 | fresh profile, `KORTIX_DESKTOP_BASIC_PASSWORD=wrong` | main log `answering from env` → `asking the user`; dialog carries the error; Cancel → page body is exactly `Authentication required.` |

No `preview` label: the preview origin builds the web stack and cannot exercise the Electron shell.

## Not verified

- A packaged, signed build. The flow is the same code path; only `electron .` was run.
- Windows / Linux `safeStorage` backends.

https://claude.ai/code/session_01LLp3ZXkTtbry1M8QQpDeGb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791059821&installation_model_id=434224&pr_number=7111&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7111&signature=cc4774ffcab0e5c0e65d0d14b6472936c71eb62a93ec1506c92804d9ed32691f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->