### PR TITLE
project home: hero column dead centre again

### DIFF
--- a/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
+++ b/apps/web/src/features/workspace/project-layout/home/welcome-body.tsx
@@ -25,38 +25,18 @@ import {
  * thing to do. One column with one gap gives the checklist a reason to be
  * where it is, and gives both blocks the same left and right edges.
  *
- * ## Where the column sits: the BOTTOM of the top half
+ * ## Where the column sits: dead centre
  *
- * Cut the viewport in two. The ask group is pinned to the bottom edge of the
- * upper half, so the composer's lower edge sits on the page's midline and the
- * heading stacks up from there; the lower half is empty ballast. Not centred
- * within the half — that put the group a quarter of the way down, which read
- * as floating (Jay, 2026-09-03: "it should be running to the extremely bottom
- * side" of the upper section). Anchored to the midline it reads as a fixed
- * position rather than a fraction of whatever the viewport happens to be.
- *
- * This layout was tried once before and reverted, for two reasons that were
- * true then and are not true now. Both are worth keeping on record:
- *
- * 1. The slot under the composer used to hold the setup checklist or the
- *    starter band, and the column was nearly as tall as the top half. Centring
- *    inside a half is only distinguishable from pinning to the top while the
- *    content is much shorter than that half, so the maths put it flush against
- *    the top edge with the whole bottom half dead. That slot is now empty by
- *    decision (see the comment at the bottom of the JSX), the column is a
- *    heading plus a composer, and the half is comfortably taller than it.
- * 2. The reason it was introduced — the column sliding when the checklist was
- *    dismissed — is also gone, because there is nothing left to dismiss. It is
- *    here now for the position, not to stop a slide.
- *
- * The two halves are `basis-1/2` flex children of the scroller. The upper one
- * is `shrink-0` so it grows past its half when the container is shorter than
- * the content — a phone in landscape, or the on-screen keyboard halving the
- * viewport — and the lower one is plain `shrink` ballast that gives its space
- * back first. Once the ballast is gone the scroller scrolls, with nothing
- * unreachable above the column: the top margin is the auto one, and it
- * resolves to zero when free space is negative, so the column simply starts
- * at the top.
+ * `m-auto` on the column, in a scroller that is a flex column: centred on
+ * both axes, the same distance from the top edge as from the bottom. #7103
+ * had pinned the group to the page midline (composer's lower edge on the
+ * half-way line, heading stacking up, the lower half empty ballast); Marko
+ * saw it on dev and asked why it was "not dead center anymore" (2026-09-04).
+ * With nothing under the composer any more the column is short, and a short
+ * block reads as centred only when it IS centred — anchored to the midline
+ * it sits visibly high. When the container is shorter than the column the
+ * auto margins resolve to zero and the scroller scrolls from the top, so
+ * nothing is ever unreachable.
  *
  * Shared by the project index page AND the instant session shell's empty
  * state, so a brand-new session opens onto the identical surface.
@@ -127,40 +107,15 @@ export function ProjectHomeWelcomeBody({
   return (
     <div className="relative z-10 flex min-h-0 flex-1 flex-col overflow-y-auto">
       {/*
-        The upper half. `basis-1/2` of the scroller, `shrink-0` so it is never
-        squashed below its content, and a flex column so the ask group can
-        `mt-auto` itself to the bottom edge of THIS half — the page's midline.
-        See the component header for why it is pinned there and not centred.
+        `m-auto` — centred on both axes (see the header). `py-8` is symmetric,
+        so it cannot bias the centre; it is breathing room for a short
+        container, where the auto margins have gone to zero. `shrink-0` so a
+        short container scrolls the column rather than compressing it.
+        `gap-10` separates the ask group from whatever a host puts beneath it.
       */}
-      <div className="flex shrink-0 basis-1/2 flex-col">
-        {/*
-          Left-aligned, one edge. Every block in this column — the heading and the
-          composer card — starts at the same x, so the eye has a single rail to
-          run down instead of a centred axis it has to re-find on every line.
-
-          No `items-center` anywhere: each child is `w-full` and aligns itself.
-          Centring a column whose children all span it does nothing except hide
-          which rule is actually doing the work.
-
-          `gap-10` separates the ask group from whatever a host puts beneath it.
-          Nothing does today (see the comment below the group), so it currently
-          has one child and does no work. Every gap inside the group is owned by
-          the group.
-
-          `mx-auto mt-auto` — horizontally centred, vertically pushed to the
-          bottom of the upper half, so the composer ends on the page's midline.
-          No bottom margin: the ballast half below is the only thing under it.
-
-          `py-8`: the bottom half is breathing room between the composer and
-          the midline, and the top half keeps the heading off the container's
-          edge when the half is short and the auto margin has gone to zero.
-
-          `shrink-0` so a short container scrolls the column rather than
-          compressing it.
-        */}
-        <div className="mx-auto mt-auto flex w-full max-w-3xl shrink-0 flex-col gap-10 py-12 sm:px-4">
-          <div className="flex w-full flex-col gap-6">
-            {/*
+      <div className="m-auto flex w-full max-w-3xl shrink-0 flex-col gap-10 py-8 sm:px-4">
+        <div className="flex w-full flex-col gap-6">
+          {/*
               `w-full` with no `max-w`: the line runs the full column and breaks
               where the column ends, which is the composer's own right edge.
 
@@ -176,9 +131,9 @@ export function ProjectHomeWelcomeBody({
               centred block, and this one is ragged-right by design; pretty just
               keeps the last line off a single orphan word.
             */}
-            <h1 className="text-muted-foreground w-full px-4 text-3xl leading-[1.2] tracking-tight text-balance max-sm:text-2xl">
-              {greeting.before}{' '}
-              {/*
+          <h1 className="text-muted-foreground w-full px-4 text-3xl leading-[1.2] tracking-tight text-balance max-sm:text-2xl">
+            {greeting.before}{' '}
+            {/*
                 A real <button>, not a <span> with an onClick: this is the only
                 interactive thing in the heading, and it has to be reachable by
                 keyboard and announced as pressable. A button is phrasing content,
@@ -197,61 +152,56 @@ export function ProjectHomeWelcomeBody({
                 noise on every load for a control nobody needs to find. The
                 pointer cursor and the tooltip are the whole invitation.
               */}
-              <button
-                type="button"
-                title="Throw some confetti"
-                onClick={(event) => {
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  setBurst((current) => ({
-                    id: (current?.id ?? 0) + 1,
-                    // Canvas fractions, measured against the viewport, because
-                    // the confetti canvas is portalled to <body> at `fixed
-                    // inset-0`. Centre of the word, so the burst comes out of
-                    // the name rather than from somewhere near it.
-                    origin: {
-                      x: (rect.left + rect.width / 2) / window.innerWidth,
-                      y: (rect.top + rect.height / 2) / window.innerHeight,
-                    },
-                  }));
-                }}
-                className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
-              >
-                {displayName}
-              </button>
-              {spaceBefore(greeting.after) ? ' ' : ''}
-              {greeting.after}
-            </h1>
+            <button
+              type="button"
+              title="Throw some confetti"
+              onClick={(event) => {
+                const rect = event.currentTarget.getBoundingClientRect();
+                setBurst((current) => ({
+                  id: (current?.id ?? 0) + 1,
+                  // Canvas fractions, measured against the viewport, because
+                  // the confetti canvas is portalled to <body> at `fixed
+                  // inset-0`. Centre of the word, so the burst comes out of
+                  // the name rather than from somewhere near it.
+                  origin: {
+                    x: (rect.left + rect.width / 2) / window.innerWidth,
+                    y: (rect.top + rect.height / 2) / window.innerHeight,
+                  },
+                }));
+              }}
+              className="text-foreground focus-visible:ring-ring inline cursor-pointer rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {displayName}
+            </button>
+            {spaceBefore(greeting.after) ? ' ' : ''}
+            {greeting.after}
+          </h1>
 
-            {/* Keyed on the press count, so each press is a fresh mount and a
+          {/* Keyed on the press count, so each press is a fresh mount and a
               fresh burst. Rendered here rather than inside the <h1> because a
               canvas is not phrasing content; it portals to <body> anyway, so
               its position in this tree has no visual effect. */}
-            {burst ? (
-              <IdentityConfetti
-                key={burst.id}
-                label={name}
-                emoji={icon?.icon}
-                glyph={icon?.icon_glyph}
-                origin={burst.origin}
-              />
-            ) : null}
+          {burst ? (
+            <IdentityConfetti
+              key={burst.id}
+              label={name}
+              emoji={icon?.icon}
+              glyph={icon?.icon_glyph}
+              origin={burst.origin}
+            />
+          ) : null}
 
-            {composer ? <div className="flex w-full flex-col gap-4">{composer}</div> : null}
-          </div>
+          {composer ? <div className="flex w-full flex-col gap-4">{composer}</div> : null}
+        </div>
 
-          {/* Nothing under the composer, on purpose (Marko, 2026-09-02: "just
+        {/* Nothing under the composer, on purpose (Marko, 2026-09-02: "just
             have the chat input there & that's it"). The "Get started" setup
             checklist (`ProjectHomeSections`) and the "Start with" starter
             prompts (`StarterPromptBand`) both used to fill this slot; both
             components still exist for hosts that want them, and the setup
             steps stay reachable from Customize. `onPickSuggestion` stays on
             the props so those hosts keep their contract. */}
-        </div>
       </div>
-      {/* The lower half: empty ballast. `basis-1/2` so the upper half is a
-          half and not the whole, and `shrink` (the default) so it is the first
-          thing to give way when the viewport is shorter than the content. */}
-      <div className="basis-1/2" aria-hidden />
     </div>
   );
 }


### PR DESCRIPTION
Restores true vertical centering of the project-home hero (heading + composer).

#7103 changed the welcome body to pin the group to the page midline with an empty lower-half ballast. With nothing under the composer any more the block is short, so anchored to the midline it sits visibly above centre (Marko on dev, 2026-09-04). Back to `m-auto` on the column: centred on both axes; when the container is shorter than the content the auto margins resolve to zero and the scroller scrolls from the top.

Verified: web tsc clean, eslint clean, project-layout tests 122/122, column centre == container centre in the browser.

https://claude.ai/code/session_017zunezSHvrxtzceDbcSVdP

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069673&installation_model_id=434224&pr_number=7112&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7112&signature=0ab69afb36ca875fce68b0bc2a5a12e15d12a1a45b0203472603746814c2e689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->