### PR TITLE
fix(preview): a branch environment heals itself, and a failed deploy keeps the last good stack

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4112,3 +4112,60 @@ the class.
 *Fix:* Platinum migration `0068_sandbox_idempotency_keys_expected.sql`
 (`ADD COLUMN IF NOT EXISTS "expected" jsonb`, expand-only) plus journal idx 68.
 *Enforcer:* none yet in Platinum — rule 1 is the CI lane to add there.
+
+## A persistent environment needs a self-healer on its own box, and a preview fix on a feature branch is inert (2026-09-04)
+
+`pi.kortix.com` — the `pi-worker` branch environment, one Platinum sandbox
+reused across every push — answered Cloudflare 502 for hours on three separate
+days, each time for a reason the deploy could not repair once it had returned:
+
+1. **Disk.** Every deploy pulls ~2.5 GB of new images and nothing pruned the
+   superseded ones. At 100% `supabase-db` crash-loops on `could not write lock
+   file "postmaster.pid": No space left on device`. Measured: 64 images, 34 GB,
+   25 GB unreferenced, 0 bytes free.
+2. **A failed deploy leaves nothing serving.** The bootstrap's retry runs
+   `compose down`, the second `up` fails the same way, the script exits, and
+   every container stays in `Created`. The hostname guard correctly refuses to
+   re-point at a dead stack — but the stack it keeps pointing at IS that box.
+3. **Checkout.** A reused sandbox keeps the rootfs of the template it came
+   from, so `pnpm install --offline` dies the day the branch adds a dependency
+   (`ERR_PNPM_NO_OFFLINE_TARBALL` on `@earendil-works/pi-agent-core`).
+
+The part that made every one of these last for hours: **fixes committed on the
+branch did nothing.** `deploy-preview.yml` is `pull_request_target`, and its
+deploy job checks out the DEFAULT branch, so the bootstrap, the Caddyfile and
+the compose overlay always come from `main`'s `tests/`. Four fixes for exactly
+these failures sat on `pi-worker` and `ino/preview-parity` — prune before
+pull, Caddy swap tolerance, the git-cache volume, the offline fallback — each
+verified in a unit test, none ever executed by a deploy.
+
+**The rules.**
+
+1. **A change to `tests/src/core/preview-stack.ts`, `sandbox-preview.ts` or
+   `deploy-preview.yml` reaches a preview only from `main`.** Land it there
+   first, in its own PR; a branch preview cannot test it and will keep failing
+   in the way the branch already fixed.
+2. **A persistent environment carries its own watcher.** The deploy is on the
+   box for ~14 minutes a day; the environment is expected to serve for the
+   other 1,426. `tests/src/core/preview-guard.ts` runs as a container on the
+   sandbox: prunes unreferenced images when the disk passes 75%, brings the
+   stack back up when the edge stops answering and no deploy is in flight, and
+   keeps Caddy swap-tolerant. It never runs `down -v`. Installed on every
+   deploy, keyed on its own hash, so a recreated sandbox gets it too. Proven
+   by hand on pi.kortix.com before it was committed: installed at 12:41:40,
+   recovered the dead stack at 12:43:27, Caddy patched at 12:44:27.
+3. **A deploy that cannot bring the new stack up puts the last good one
+   back.** The health check saves the proven `.env` (image tags) to
+   `last-good.env`; a stack failure restores it and runs `compose up` before
+   exiting 1. The deploy still fails; the name keeps answering.
+4. **Removing the `preview` label deletes the environment and its data.**
+   That is the design (the label is the off switch), but re-adding it creates
+   an EMPTY environment: new sandbox id, fresh Postgres, no accounts, no
+   projects, no git mirrors. On 2026-09-03 10:19 the label was toggled off and
+   on; the test account and the `pi-lab` project stopped existing.
+
+*Fix:* this entry's PR — `preview-guard.ts`, the bootstrap changes, the two
+preview-parity ports. *Enforcer:* `tests/unit/preview-guard.test.ts`
+(`sh -n` on the guard, never `-v`, deploy-in-flight gate, hash-keyed install)
+and `tests/unit/sandbox-preview.test.ts` (prune before pull, fallback install,
+rollback after the health check, guard before configure).

--- a/tests/src/core/preview-guard.ts
+++ b/tests/src/core/preview-guard.ts
@@ -4,7 +4,7 @@
  * A branch environment (`previewSandboxIdentity` with `branchEnv`) is one
  * sandbox reused across every push, fronted by a stable public name. Between
  * deploys nothing on that box watches it, and three failure modes each took
- * pi.kortix.com dark for hours, all observed on 2026-09-04:
+ * the pi-worker branch environment dark for hours, all observed on 2026-09-04:
  *
  *   1. DISK. Every deploy pulls ~2.5 GB of new images and nothing pruned the
  *      superseded ones; at 100% supabase-db crash-loops on `postmaster.pid`

--- a/tests/src/core/preview-guard.ts
+++ b/tests/src/core/preview-guard.ts
@@ -1,0 +1,190 @@
+/**
+ * The self-healing guard a persistent branch environment runs on its own box.
+ *
+ * A branch environment (`previewSandboxIdentity` with `branchEnv`) is one
+ * sandbox reused across every push, fronted by a stable public name. Between
+ * deploys nothing on that box watches it, and three failure modes each took
+ * pi.kortix.com dark for hours, all observed on 2026-09-04:
+ *
+ *   1. DISK. Every deploy pulls ~2.5 GB of new images and nothing pruned the
+ *      superseded ones; at 100% supabase-db crash-loops on `postmaster.pid`
+ *      and the whole stack goes down (34 GB of images, 25 GB unreferenced).
+ *   2. A FAILED DEPLOY leaves every container in `Created` and nothing
+ *      serving: the bootstrap's retry does `compose down`, the second attempt
+ *      fails the same way, and the script exits.
+ *   3. CONTAINER SWAPS. A redeploy recreates frontend/kortix-api under a Caddy
+ *      that keeps running; for the 10–30 s that takes every request answers
+ *      502 unless the Caddyfile carries the swap-tolerance snippet.
+ *
+ * The guard is a container (docker:cli, host network, docker.sock and the
+ * preview state dir mounted at the SAME paths as the host, so every compose
+ * file path resolves) that wakes every 60 s. It never fights a deploy: while
+ * the bootstrap's phase file says a deploy is in flight it only prunes disk.
+ * Otherwise: prune when the disk is tight, bring the stack back up when the
+ * edge is not answering, and keep Caddy swap-tolerant.
+ *
+ * It is installed by the bootstrap (`buildPreviewGuardInstall`) on every
+ * deploy — idempotently, keyed on the script's own hash — so a recreated
+ * sandbox gets it too. The deploy's own retry logic stays; the guard covers
+ * the time when no deploy is running, which is almost all of the time.
+ *
+ * POSIX sh: it runs under busybox. Kept as one string so the bootstrap can
+ * embed it in a quoted heredoc and the unit test can hand it to `sh -n`.
+ */
+export const PREVIEW_GUARD_CONTAINER = 'kortix-preview-guard';
+
+/** The heredoc delimiter; the script must never contain this line. */
+export const PREVIEW_GUARD_HEREDOC = 'KORTIX_PREVIEW_GUARD_EOF';
+
+export const PREVIEW_GUARD_SCRIPT = `#!/bin/sh
+# kortix-preview-guard — keeps a persistent branch environment serving.
+# Written by the deploy bootstrap (tests/src/core/preview-guard.ts); edits made
+# here on the box are overwritten by the next deploy.
+DIR=/workspace/kortix-preview
+LOG="$DIR/guard.log"
+INSTANCE="\${KORTIX_PREVIEW_INSTANCE:-$(ls "$DIR/self-host" 2>/dev/null | head -1)}"
+INSTDIR="$DIR/self-host/$INSTANCE"
+PROJECT="kortix-$INSTANCE"
+PHASE="$DIR/kortix-preview.phase"
+EXIT="$DIR/kortix-preview.exit"
+CADDY="$DIR/Caddyfile.preview"
+EDGE="$PROJECT-preview-edge-1"
+HEALTH=http://127.0.0.1:8080/v1/health
+PRUNE_AT=75
+RECOVER_COOLDOWN=300
+last_recover=0
+
+log() { echo "$(date '+%Y-%m-%dT%H:%M:%S') $1" >> "$LOG"; }
+compose() {
+  docker compose --project-name "$PROJECT" --env-file "$INSTDIR/.env" \\
+    -f "$INSTDIR/docker-compose.yml" -f "$DIR/docker-compose.preview.yml" "$@"
+}
+# df on the bind-mounted state dir reports the HOST filesystem, not this
+# container's.
+disk_used() { df -P "$DIR" | awk 'NR==2 { gsub("%", "", $5); print $5 }'; }
+healthy() { wget -qO- --timeout=8 "$HEALTH" 2>/dev/null | grep -q '"status":"ok"'; }
+# The bootstrap removes both files at start, writes the phase as it goes, and
+# writes the exit file from its EXIT trap. A phase with no exit that is younger
+# than 30 min is a deploy in flight; older is one that died without its trap.
+deploy_running() {
+  [ -f "$PHASE" ] || return 1
+  [ -f "$EXIT" ] && return 1
+  case "$(cat "$PHASE" 2>/dev/null)" in ready|tests-skipped|tests) return 1 ;; esac
+  [ -n "$(find "$PHASE" -mmin -30 2>/dev/null)" ]
+}
+
+prune_if_full() {
+  used="$(disk_used)"
+  [ -n "$used" ] && [ "$used" -ge "$PRUNE_AT" ] || return 0
+  log "disk at \${used}%: pruning unreferenced images"
+  # -a removes images with NO container (running, stopped or created), so the
+  # current stack's images and this guard's own image are never taken.
+  docker image prune -af >> "$LOG" 2>&1
+  docker builder prune -af >> "$LOG" 2>&1
+  log "disk now at $(disk_used)%"
+}
+
+# Caddy: hold requests through a container swap instead of 502ing. The deploy
+# regenerates the Caddyfile; when the generated one already carries the
+# snippet this is a no-op, otherwise it is patched in and validated BEFORE the
+# edge is asked to reload it.
+ensure_caddy_tolerant() {
+  [ -f "$CADDY" ] || return 0
+  grep -q swap_tolerant "$CADDY" && return 0
+  docker inspect "$EDGE" >/dev/null 2>&1 || return 0
+  tmp=/tmp/Caddyfile.tolerant
+  {
+    printf '(swap_tolerant) {\\n  lb_try_duration 30s\\n  lb_try_interval 250ms\\n}\\n\\n'
+    sed -E \\
+      -e 's/^([[:space:]]*)reverse_proxy ([a-z0-9-]+:[0-9]+)[[:space:]]*$/\\1reverse_proxy \\2 {\\n\\1  import swap_tolerant\\n\\1}/' \\
+      -e 's/^([[:space:]]*)reverse_proxy ([a-z0-9-]+:[0-9]+)[[:space:]]*\\{[[:space:]]*$/\\1reverse_proxy \\2 {\\n\\1  import swap_tolerant/' \\
+      "$CADDY"
+  } > "$tmp"
+  if docker exec -i "$EDGE" caddy validate --adapter caddyfile --config /dev/stdin < "$tmp" > /tmp/caddy-validate.log 2>&1; then
+    cp "$tmp" "$CADDY"
+    if docker exec "$EDGE" caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile >> "$LOG" 2>&1; then
+      log "caddy: swap tolerance applied and reloaded"
+    else
+      log "caddy: reload FAILED after a valid config; file left in place"
+    fi
+  else
+    log "caddy: patched config did not validate; edge left untouched"
+  fi
+}
+
+recover() {
+  now="$(date +%s)"
+  [ $((now - last_recover)) -ge "$RECOVER_COOLDOWN" ] || return 0
+  last_recover="$now"
+  log "stack unhealthy and no deploy in flight: compose up"
+  prune_if_full
+  if compose up -d --wait --wait-timeout 300 >> "$LOG" 2>&1; then
+    log "stack recovered"
+    return 0
+  fi
+  log "compose up failed; clearing containers (volumes kept) and retrying"
+  compose logs --no-color --tail 40 supabase-db kortix-migrate >> "$LOG" 2>&1 || true
+  # Never with -v: the named volumes carry this environment's data.
+  compose down --remove-orphans --timeout 30 >> "$LOG" 2>&1 || true
+  sleep 10
+  if compose up -d --wait --wait-timeout 300 >> "$LOG" 2>&1; then
+    log "stack recovered on retry"
+  else
+    log "stack recovery FAILED; retrying after the cooldown"
+  fi
+}
+
+log "guard started (pid $$) instance=$INSTANCE project=$PROJECT"
+while true; do
+  sleep 60
+  prune_if_full
+  if deploy_running; then continue; fi
+  if healthy; then
+    ensure_caddy_tolerant
+    continue
+  fi
+  recover
+done
+`;
+
+/**
+ * The bash the bootstrap runs to (re)install the guard on the box, right after
+ * the docker daemon is up and before anything that can fail.
+ *
+ * Idempotent: the container carries the script's sha256 as a label, and it is
+ * recreated only when the script changed. The image is the same docker:cli
+ * the self-host updater already uses, so it is present on a warm sandbox.
+ */
+export function buildPreviewGuardInstall(input: {
+  stateDir: string;
+  instance: string;
+  dockerCliImage: string;
+}): string {
+  if (!/^[a-z0-9-]+$/.test(input.instance)) throw new Error(`invalid preview instance: ${input.instance}`);
+  if (!/^[a-z0-9./:@-]+$/i.test(input.dockerCliImage)) {
+    throw new Error(`invalid docker cli image: ${input.dockerCliImage}`);
+  }
+  if (PREVIEW_GUARD_SCRIPT.split('\n').includes(PREVIEW_GUARD_HEREDOC)) {
+    throw new Error('guard script contains its own heredoc delimiter');
+  }
+  const guard = `${input.stateDir}/guard.sh`;
+  return `printf 'guard\\n' > "$PHASE"
+cat > ${guard}.tmp <<'${PREVIEW_GUARD_HEREDOC}'
+${PREVIEW_GUARD_SCRIPT}${PREVIEW_GUARD_HEREDOC}
+chmod 0755 ${guard}.tmp && mv ${guard}.tmp ${guard}
+guard_sha="$(sha256sum ${guard} | cut -c1-16)"
+running_sha="$(docker inspect --format '{{ index .Config.Labels "kortix.guard-sha" }}' ${PREVIEW_GUARD_CONTAINER} 2>/dev/null || true)"
+if [ "$running_sha" != "$guard_sha" ]; then
+  docker rm -f ${PREVIEW_GUARD_CONTAINER} >/dev/null 2>&1 || true
+  docker run -d --name ${PREVIEW_GUARD_CONTAINER} --restart unless-stopped --network host \\
+    --label "kortix.guard-sha=$guard_sha" \\
+    -e KORTIX_PREVIEW_INSTANCE=${input.instance} \\
+    -v /var/run/docker.sock:/var/run/docker.sock \\
+    -v ${input.stateDir}:${input.stateDir} \\
+    ${input.dockerCliImage} sh ${guard} >/dev/null
+  echo "preview guard installed ($guard_sha)" >&2
+else
+  echo "preview guard already current ($guard_sha)" >&2
+fi
+`;
+}

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -70,7 +70,28 @@ export function validatePreviewRuntimeSecrets(
 }
 
 export function buildPreviewCaddyfile(publicHost: string): string {
-  return `:8080 {
+  // Ride out a redeploy instead of 502ing through it.
+  //
+  // A branch environment is REUSED in place: \`compose up -d\` recreates
+  // \`frontend\` and \`kortix-api\` while \`preview-edge\` keeps running. For the
+  // ~10-30s that takes, Caddy's dial to the upstream is refused and every
+  // request — the browser's own document included — answers 502. Observed on
+  // pi.kortix.com repeatedly: the edge started 19:08:58, the app containers
+  // were recreated at 22:12:45, and the 502 screenshot is stamped 22:12:52.
+  //
+  // \`lb_try_duration\` makes Caddy hold the request and re-dial until the new
+  // container listens, so a deploy costs latency rather than an error page. It
+  // retries CONNECTION failures only — a 502 the app itself returns is passed
+  // straight through, so this cannot mask a real upstream fault.
+  //
+  // A snippet is a TOP-LEVEL form: declaring it inside the site block fails the
+  // adapter with \`File to import not found: swap_tolerant\`.
+  return `(swap_tolerant) {
+  lb_try_duration 30s
+  lb_try_interval 250ms
+}
+
+:8080 {
   encode zstd gzip
 
   # A deployed environment gives the API a host of its own, so EVERY path it
@@ -80,16 +101,22 @@ export function buildPreviewCaddyfile(publicHost: string): string {
   # with the non-\`/v1\` mounts in \`apps/api/src/index.ts\`.
   @api path /v1* /health /health/* /metrics /scim/v2/* /internal/* /.well-known/oauth-authorization-server
   handle @api {
-    reverse_proxy kortix-api:8008
+    reverse_proxy kortix-api:8008 {
+      import swap_tolerant
+    }
   }
 
   @supabase path /auth/v1* /rest/v1* /storage/v1* /realtime/v1* /functions/v1* /graphql/v1*
   handle @supabase {
-    reverse_proxy supabase-kong:8000
+    reverse_proxy supabase-kong:8000 {
+      import swap_tolerant
+    }
   }
 
   handle_path /_gateway/* {
-    reverse_proxy llm-gateway:8090
+    reverse_proxy llm-gateway:8090 {
+      import swap_tolerant
+    }
   }
 
   handle_path /_tests/* {
@@ -98,7 +125,18 @@ export function buildPreviewCaddyfile(publicHost: string): string {
   }
 
   handle_path /_mailpit/* {
-    reverse_proxy mailpit:8025
+    reverse_proxy mailpit:8025 {
+      import swap_tolerant
+    }
+  }
+
+  # Only reached when the retry budget above is exhausted — i.e. the upstream is
+  # really gone, not merely restarting. A plain page beats the provider's raw
+  # 502, and \`Retry-After\` tells a client this is transient.
+  handle_errors {
+    header Retry-After 15
+    header Cache-Control "no-store"
+    respond "Deploying. This environment is restarting - retry in a few seconds." {http.error.status_code}
   }
 
   handle {
@@ -112,6 +150,7 @@ export function buildPreviewCaddyfile(publicHost: string): string {
       # host so the guard compares like with like.
       header_up X-Forwarded-Host ${publicHost}
       header_up X-Forwarded-Proto https
+      import swap_tolerant
     }
   }
 }
@@ -159,6 +198,28 @@ export function buildPreviewComposeOverlay(
   supabase-db:
     ports:
       - "127.0.0.1:15432:5432"
+  # The git mirror must outlive the container.
+  #
+  # \`cacheRoot()\` (apps/api/src/projects/git/mirror.ts) is
+  # \`/tmp/kortix/git-cache\`, and kortix-api runs with NO volumes — so every
+  # redeploy recreates the container and deletes every project's mirror. On a
+  # deployment whose managed repos exist on GitHub that is only a slow re-clone.
+  # On a PREVIEW it is data loss: the preview's GitHub App cannot create repos
+  # (403 \`Resource not accessible by integration\`), so a seeded project's
+  # history lives ONLY in that cache. Losing it leaves the project unopenable —
+  # \`POST /sessions\` answers 500 \`could not read Username for
+  # 'https://github.com'\` because the re-clone has no upstream to clone from.
+  #
+  # Measured on pi.kortix.com 2026-09-01: container restarted 10:14:06, and
+  # every session create for the branch's own test project failed from 10:12
+  # onward with that exact error; \`ls /tmp/kortix/git-cache\` -> no such
+  # directory, and the managed org held none of the preview's repos.
+  kortix-api:
+    volumes:
+      - "kortix-git-cache:/tmp/kortix"
+
+volumes:
+  kortix-git-cache:
 `;
 }
 

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -76,7 +76,7 @@ export function buildPreviewCaddyfile(publicHost: string): string {
   // \`frontend\` and \`kortix-api\` while \`preview-edge\` keeps running. For the
   // ~10-30s that takes, Caddy's dial to the upstream is refused and every
   // request — the browser's own document included — answers 502. Observed on
-  // pi.kortix.com repeatedly: the edge started 19:08:58, the app containers
+  // the pi-worker branch environment repeatedly: the edge started 19:08:58, the app containers
   // were recreated at 22:12:45, and the 502 screenshot is stamped 22:12:52.
   //
   // \`lb_try_duration\` makes Caddy hold the request and re-dial until the new
@@ -210,7 +210,7 @@ export function buildPreviewComposeOverlay(
   # \`POST /sessions\` answers 500 \`could not read Username for
   # 'https://github.com'\` because the re-clone has no upstream to clone from.
   #
-  # Measured on pi.kortix.com 2026-09-01: container restarted 10:14:06, and
+  # Measured on the pi-worker branch environment 2026-09-01: container restarted 10:14:06, and
   # every session create for the branch's own test project failed from 10:12
   # onward with that exact error; \`ls /tmp/kortix/git-cache\` -> no such
   # directory, and the managed org held none of the preview's repos.

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -1,3 +1,5 @@
+import { buildPreviewGuardInstall } from './preview-guard';
+
 export type SandboxPreviewProvider = 'auto' | 'platinum' | 'daytona';
 
 export interface SandboxPreviewInput {
@@ -38,6 +40,14 @@ export interface PreviewSandboxRecord {
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
+
+/**
+ * The image the self-healing guard runs from: the same docker:cli the
+ * self-host updater already pins, so it is present on a warm sandbox and
+ * installing the guard never needs a pull.
+ */
+export const PREVIEW_DOCKER_CLI_IMAGE =
+  'docker:29.6.1-cli@sha256:862099ada15c669000bef53aa4cb9d821262829f45b0dda2159ccb276443043b';
 
 export function buildPreviewBootstrapScript(input: {
   repository: string;
@@ -105,7 +115,13 @@ test "$actual_sha" = "${input.sha}"
 
 cd "$ROOT"
 corepack enable
-pnpm install --offline --frozen-lockfile
+# A reused branch sandbox keeps the rootfs of the template it was created
+# from, so its pnpm store can predate a dependency the branch has since added.
+# Offline is the fast path; when the store is short of a tarball, repair it
+# from the frozen lockfile instead of failing the deploy at checkout — which is
+# how every pi-worker deploy died on @earendil-works/pi-agent-core on
+# 2026-09-04 while the stack behind the public name stayed down.
+pnpm install --offline --frozen-lockfile || pnpm install --frozen-lockfile
 
 printf 'docker\n' > "$PHASE"
 for module in overlay bridge br_netfilter veth nf_tables ip_tables iptable_nat; do
@@ -118,6 +134,10 @@ if ! docker info >/dev/null 2>&1; then
 fi
 docker info >/dev/null
 
+# The self-healing guard, installed before anything below can fail so that a
+# deploy which dies at configure or stack still leaves a watcher behind. See
+# tests/src/core/preview-guard.ts.
+${buildPreviewGuardInstall({ stateDir: state, instance, dockerCliImage: PREVIEW_DOCKER_CLI_IMAGE })}
 printf 'configure\n' > "$PHASE"
 bun apps/cli/src/index.ts self-host init --yes --local-images --no-restrict-account-creation --instance ${instance}
 PREVIEW_INSTANCE_DIR=${shellQuote(instanceDir)} \
@@ -128,12 +148,44 @@ PREVIEW_SECRETS_FILE="$SECRETS" \
 bun tests/bin/preview-stack.ts
 
 printf 'stack\n' > "$PHASE"
+
+# Reclaim BEFORE pulling. A full disk is precisely the state in which the
+# stack cannot become healthy — supabase-db crash-loops on \`could not write
+# lock file "postmaster.pid": No space left on device\` — and every deploy adds
+# ~2.5 GB of images that nothing else removes. \`image prune -af\` spares any
+# image a container references (running, created or exited), so the stack
+# standing here keeps everything it needs; only superseded deploys go.
+# Measured on pi.kortix.com 2026-09-04: 34 GB of images, 25 GB unreferenced,
+# 0 bytes free, every container in Created.
+used="$(df --output=pcent / | tail -1 | tr -dc '0-9')"
+echo "disk before pull: \${used:-?}%" >&2
+if [ "\${used:-0}" -ge 70 ]; then
+  docker image prune -af >/dev/null 2>&1 || true
+  docker builder prune -af >/dev/null 2>&1 || true
+  df -h / | tail -1 >&2
+fi
+
+# When the NEW stack cannot come up, put the LAST GOOD one back rather than
+# leaving nothing serving. The image tags live in the instance .env, and the
+# health check below saves a copy of the .env that last proved healthy; a
+# failed deploy then restores it and brings that stack up before reporting
+# failure, so the public name keeps answering on the previous commit. The
+# deploy still fails — this is a fallback, not a pass.
+restore_last_good() {
+  if [ -f "$STATE/last-good.env" ]; then
+    echo "stack failed on this commit; restoring the last good image set" >&2
+    cp "$STATE/last-good.env" ${shellQuote(`${instanceDir}/.env`)}
+    ${compose} up -d --wait --wait-timeout 300 >&2 || true
+  fi
+  exit 1
+}
+
 ${compose} pull --policy always frontend kortix-api llm-gateway preview-edge mailpit
 for stack_attempt in 1 2; do
   if ${compose} up -d --wait --wait-timeout 300; then
     break
   fi
-  test "$stack_attempt" -lt 2
+  test "$stack_attempt" -lt 2 || restore_last_good
 
   # WHY THE STACK FAILED, in the log, before anything retries.
   #
@@ -188,6 +240,8 @@ for _ in $(seq 1 60); do
   sleep 2
 done
 curl -fsS --max-time 10 "$HEALTH" | jq -e --arg sha ${shellQuote(input.sha)} '.status == "ok" and .environment == "preview" and .commit == $sha' >/dev/null
+# This image set is proven; it is what restore_last_good falls back to.
+cp ${shellQuote(`${instanceDir}/.env`)} "$STATE/last-good.env"
 
 ${
     input.runTests === false

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -155,7 +155,7 @@ printf 'stack\n' > "$PHASE"
 # ~2.5 GB of images that nothing else removes. \`image prune -af\` spares any
 # image a container references (running, created or exited), so the stack
 # standing here keeps everything it needs; only superseded deploys go.
-# Measured on pi.kortix.com 2026-09-04: 34 GB of images, 25 GB unreferenced,
+# Measured on the pi-worker branch environment 2026-09-04: 34 GB of images, 25 GB unreferenced,
 # 0 bytes free, every container in Created.
 used="$(df --output=pcent / | tail -1 | tr -dc '0-9')"
 echo "disk before pull: \${used:-?}%" >&2

--- a/tests/unit/preview-guard.test.ts
+++ b/tests/unit/preview-guard.test.ts
@@ -1,0 +1,76 @@
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import {
+  PREVIEW_GUARD_CONTAINER,
+  PREVIEW_GUARD_HEREDOC,
+  PREVIEW_GUARD_SCRIPT,
+  buildPreviewGuardInstall,
+} from '../src/core/preview-guard';
+
+describe('preview guard — the self-healer a branch environment runs on its own box', () => {
+  it('is valid POSIX shell', () => {
+    // busybox sh runs it on the sandbox; `sh -n` here is the closest local
+    // parse. A heredoc typo would otherwise surface as a guard that never
+    // starts, on a box nobody is watching.
+    const parsed = spawnSync('sh', ['-n'], { input: PREVIEW_GUARD_SCRIPT, encoding: 'utf8' });
+    expect(parsed.stderr).toBe('');
+    expect(parsed.status).toBe(0);
+  });
+
+  it('never fights a deploy, and never touches the data volumes', () => {
+    // A phase file with no exit file is a deploy in flight: the guard may
+    // prune disk but must not restart anything under a running bootstrap.
+    expect(PREVIEW_GUARD_SCRIPT).toContain('deploy_running() {');
+    expect(PREVIEW_GUARD_SCRIPT).toContain('if deploy_running; then continue; fi');
+    expect(PREVIEW_GUARD_SCRIPT).toContain('[ -f "$EXIT" ] && return 1');
+    // `down` clears wreckage; `down -v` would delete this environment's
+    // Postgres. The guard must never carry the flag.
+    expect(PREVIEW_GUARD_SCRIPT).toContain('compose down --remove-orphans --timeout 30');
+    expect(PREVIEW_GUARD_SCRIPT).not.toMatch(/down[^\n]*\s-v\b/);
+    expect(PREVIEW_GUARD_SCRIPT).not.toContain('--volumes');
+    // Recovery is rate-limited so a stack that cannot come up is not hammered.
+    expect(PREVIEW_GUARD_SCRIPT).toContain('RECOVER_COOLDOWN=300');
+  });
+
+  it('prunes only unreferenced images, and only when the disk is tight', () => {
+    expect(PREVIEW_GUARD_SCRIPT).toContain('PRUNE_AT=75');
+    expect(PREVIEW_GUARD_SCRIPT).toContain('docker image prune -af');
+    // `df` on the mounted state dir, not on `/` — inside the container `/` is
+    // the container's own filesystem and would never look full.
+    expect(PREVIEW_GUARD_SCRIPT).toContain('df -P "$DIR"');
+  });
+
+  it('validates a patched Caddyfile before asking the edge to reload it', () => {
+    const validate = PREVIEW_GUARD_SCRIPT.indexOf('caddy validate --adapter caddyfile --config /dev/stdin');
+    const reload = PREVIEW_GUARD_SCRIPT.indexOf('caddy reload --config /etc/caddy/Caddyfile');
+    expect(validate).toBeGreaterThan(-1);
+    expect(reload).toBeGreaterThan(validate);
+    expect(PREVIEW_GUARD_SCRIPT).toContain('lb_try_duration 30s');
+  });
+
+  it('is installed idempotently, keyed on its own hash', () => {
+    const install = buildPreviewGuardInstall({
+      stateDir: '/workspace/kortix-preview',
+      instance: 'pr-6998',
+      dockerCliImage: 'docker:29.6.1-cli@sha256:' + 'a'.repeat(64),
+    });
+    // A quoted heredoc: nothing in the guard is expanded by the bootstrap's
+    // shell, so its `$DIR` and `$(...)` reach the box intact.
+    expect(install).toContain(`<<'${PREVIEW_GUARD_HEREDOC}'`);
+    expect(install).toContain(PREVIEW_GUARD_SCRIPT);
+    expect(install).toContain(`--label "kortix.guard-sha=$guard_sha"`);
+    expect(install).toContain(`if [ "$running_sha" != "$guard_sha" ]; then`);
+    expect(install).toContain(`docker rm -f ${PREVIEW_GUARD_CONTAINER}`);
+    // Host network is what lets the guard probe 127.0.0.1:8080; the socket
+    // and the state dir at the SAME path are what let compose resolve files.
+    expect(install).toContain('--network host');
+    expect(install).toContain('-v /var/run/docker.sock:/var/run/docker.sock');
+    expect(install).toContain('-v /workspace/kortix-preview:/workspace/kortix-preview');
+    expect(install).toContain('-e KORTIX_PREVIEW_INSTANCE=pr-6998');
+    // The delimiter can never appear inside the script it delimits.
+    expect(PREVIEW_GUARD_SCRIPT.split('\n')).not.toContain(PREVIEW_GUARD_HEREDOC);
+    expect(() => buildPreviewGuardInstall({ stateDir: '/x', instance: 'bad instance', dockerCliImage: 'docker:cli' })).toThrow(
+      /invalid preview instance/,
+    );
+  });
+});

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -39,6 +39,29 @@ describe('ephemeral self-host preview stack', () => {
     expect(caddy).toContain('reverse_proxy frontend:3000');
   });
 
+  // 2026-08-30: pi.kortix.com answered 502 through every redeploy. A branch
+  // environment is reused in place, so `compose up -d` recreates `frontend` and
+  // `kortix-api` while `preview-edge` keeps running — and for the ~10-30s the
+  // swap takes, Caddy's dial is refused and the browser gets a raw 502. The
+  // stable hostname is only as stable as its worst upstream window.
+  it('rides out a container swap instead of 502ing through a redeploy', () => {
+    const caddy = buildPreviewCaddyfile('preview.example.test');
+    // A snippet is a TOP-LEVEL form. Declared inside the site block, the
+    // adapter fails outright with `File to import not found: swap_tolerant`.
+    expect(caddy.indexOf('(swap_tolerant) {')).toBeLessThan(caddy.indexOf(':8080 {'));
+    expect(caddy).toContain('lb_try_duration 30s');
+    expect(caddy).toContain('lb_try_interval 250ms');
+    // Every upstream that a deploy recreates, not just the frontend.
+    for (const upstream of ['kortix-api:8008', 'supabase-kong:8000', 'llm-gateway:8090', 'frontend:3000']) {
+      const block = caddy.slice(caddy.indexOf(`reverse_proxy ${upstream}`));
+      expect(block.slice(0, block.indexOf('\n  }'))).toContain('import swap_tolerant');
+    }
+    // And when the budget really is exhausted, a coherent page rather than the
+    // provider's bare 502.
+    expect(caddy).toContain('handle_errors {');
+    expect(caddy).toContain('Retry-After 15');
+  });
+
   it('accepts either a GitHub App or a PAT as managed-git configuration', () => {
     const base = [
       'POSTGRES_PASSWORD=p',
@@ -77,6 +100,24 @@ describe('ephemeral self-host preview stack', () => {
     expect(overlay).toContain('GOTRUE_RATE_LIMIT_TOKEN_REFRESH: "10000"');
     expect(overlay).toContain('GOTRUE_RATE_LIMIT_EMAIL_SENT: "10000"');
     expect(overlay).not.toContain('volumes/db/data');
+  });
+
+  // 2026-09-01: a redeploy of pi.kortix.com made every `POST /sessions` answer
+  // 500 `could not read Username for 'https://github.com'`. Cause: the git
+  // mirror lives at `/tmp/kortix/git-cache` (mirror.ts `cacheRoot()`) and
+  // kortix-api had NO volumes, so recreating the container deleted it. On a
+  // real deployment that is a slow re-clone; on a preview it is DATA LOSS,
+  // because the preview App cannot create repos (403) and a seeded project's
+  // history therefore exists nowhere else. The org held none of the preview's
+  // repos, and `/tmp/kortix/git-cache` was simply gone.
+  it('keeps the git mirror across a container recreate', () => {
+    const overlay = buildPreviewComposeOverlay('/workspace/suna/tests/test-results');
+    // Mounted at the PARENT of git-cache so sibling caches survive too.
+    expect(overlay).toContain('kortix-git-cache:/tmp/kortix');
+    // A named volume needs its top-level declaration or compose refuses the file.
+    expect(overlay).toMatch(/\nvolumes:\n  kortix-git-cache:/);
+    const apiBlock = overlay.slice(overlay.indexOf('  kortix-api:'));
+    expect(apiBlock.slice(0, apiBlock.indexOf('\n\nvolumes:'))).toContain('volumes:');
   });
 
   it('rejects every runtime secret outside the explicit allowlist', () => {

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -79,6 +79,55 @@ describe('provider-neutral preview lifecycle', () => {
     }
   });
 
+  it('keeps a branch environment serving through the three ways it went dark', () => {
+    // pi.kortix.com, 2026-09-04: 34 GB of images and 0 bytes free took the
+    // stack down; a failed deploy then left every container in Created; and
+    // the next deploys died at checkout because the reused sandbox's pnpm
+    // store predated a dependency the branch had added. Each has its own line
+    // in the bootstrap now, and each is asserted here by the text a deploy
+    // actually runs.
+    const script = buildPreviewBootstrapScript({
+      repository: 'kortix-ai/suna',
+      ref: 'pi-worker',
+      sha: 'a'.repeat(40),
+      prNumber: 6998,
+      origin: 'https://pi.example.test',
+      runTests: false,
+    });
+    // 1. The offline install is the fast path, not the only path.
+    expect(script).toContain('pnpm install --offline --frozen-lockfile || pnpm install --frozen-lockfile');
+    // 2. Disk is reclaimed BEFORE the ~2.5 GB pull, gated on the disk being tight.
+    const prune = script.indexOf('docker image prune -af');
+    const pull = script.indexOf('pull --policy always');
+    expect(prune).toBeGreaterThan(-1);
+    expect(prune).toBeLessThan(pull);
+    expect(script).toContain('if [ "${used:-0}" -ge 70 ]; then');
+    // 3. A stack that cannot come up puts the last good image set back and
+    //    still fails the deploy — a fallback, never a pass.
+    expect(script).toContain('restore_last_good() {');
+    expect(script).toContain('cp "$STATE/last-good.env"');
+    expect(script).toContain('test "$stack_attempt" -lt 2 || restore_last_good');
+    const restoreBody = script.slice(script.indexOf('restore_last_good() {'), script.indexOf('pull --policy always'));
+    expect(restoreBody).toContain('exit 1');
+    // The copy that makes the fallback possible is taken only AFTER the
+    // health check proves this image set on this commit.
+    const health = script.indexOf('curl -fsS --max-time 10 "$HEALTH"');
+    const saved = script.indexOf('"$STATE/last-good.env"', health);
+    expect(saved).toBeGreaterThan(health);
+    // 4. The guard is installed as soon as docker is up, before configure or
+    //    stack can fail — a dead deploy still leaves a watcher behind.
+    const guard = script.indexOf('docker run -d --name kortix-preview-guard');
+    // The phase markers are written with a REAL newline inside the quotes (the
+    // template's \n), so the search string needs one too.
+    const configure = script.indexOf("printf 'configure\n' > \"$PHASE\"");
+    expect(guard).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(configure);
+    expect(script).toContain("<<'KORTIX_PREVIEW_GUARD_EOF'");
+    expect(script).toContain('-e KORTIX_PREVIEW_INSTANCE=pr-6998');
+    // Same instance dir the deploy uses; the guard's compose resolves the same files.
+    expect(script).toContain('-v /workspace/kortix-preview:/workspace/kortix-preview');
+  });
+
   it('health-checks the stack locally, never through the public name', () => {
     // The public name is served by a proxy that is only re-pointed at this
     // sandbox AFTER the deploy returns. Checking through it would deadlock the


### PR DESCRIPTION
## Why

`pi.kortix.com` (the `pi-worker` branch environment) went dark for hours on three separate days. Each cause is one the deploy cannot repair once it has returned, and each already had a fix — on a feature branch, where it is inert: `deploy-preview.yml` is `pull_request_target` and its deploy job checks out **main's** `tests/`.

| cause | measured | fix here |
|---|---|---|
| disk full — every deploy pulls ~2.5 GB, nothing pruned | 64 images, 34 GB, 25 GB unreferenced, 0 B free; `supabase-db` crash-looping on `postmaster.pid` | prune unreferenced images **before** the pull past 70%; the guard prunes past 75% between deploys |
| failed deploy leaves every container in `Created` | 2026-09-04 07:24Z–12:43Z, `pi.kortix.com` 502 the whole time | `last-good.env` saved after the health check; a stack failure restores it and brings that stack up before exiting 1; the guard restarts a dead stack when no deploy is in flight |
| reused sandbox's pnpm store predates a new dependency | `ERR_PNPM_NO_OFFLINE_TARBALL` on `@earendil-works/pi-agent-core`, 3 deploys in a row | `pnpm install --offline --frozen-lockfile \|\| pnpm install --frozen-lockfile` |
| 502 during the container swap of every redeploy | Caddy dial refused for 10–30 s per deploy | Caddy swap tolerance (port of c2345cba64) |
| git mirrors deleted on every `kortix-api` recreate | preview projects unopenable | git-cache volume (port of 43002cf9c2) |

## What

- **`tests/src/core/preview-guard.ts`** — a self-healing guard the bootstrap installs on the sandbox on every deploy (docker:cli container, host network, docker.sock; hash-keyed so it is recreated only when the script changes). Every 60 s: prune when the disk is tight; if the edge is not answering and the bootstrap's phase file says no deploy is in flight, `compose up` (then `down` **without `-v`** + `up`); keep the Caddyfile swap-tolerant, validated before reload.
- **bootstrap** (`sandbox-preview.ts`): guard install right after docker is up (before configure/stack can fail), prune before pull, offline-install fallback, `restore_last_good`.
- **`preview-stack.ts`**: swap tolerance snippet + `kortix-git-cache` volume.
- learnings entry.

## Verified

- `bun test tests/unit/preview-stack.test.ts tests/unit/sandbox-preview.test.ts tests/unit/preview-guard.test.ts` → 32 pass, 0 fail.
- rendered bootstrap: `bash -n` clean; embedded guard: `sh -n` clean; the quoted heredoc keeps the guard's `$` intact.
- **The guard itself, live:** installed by hand on the pi.kortix.com sandbox at 12:41:40 with the identical script; it found the dead stack at 12:42:40, `compose up` finished 12:43:27, the public name answered 200; Caddy swap tolerance applied and reloaded 12:44:27 (`caddy validate`: Valid configuration).

## Not verifiable before merge

The bootstrap changes run only from main. The first pi-worker deploy after this merges is the test: its log should show `preview guard already current (<sha>)` (the hand-installed guard has a different hash, so the first deploy will replace it), `disk before pull: NN%`, and — on a healthy deploy — a `last-good.env` in `/workspace/kortix-preview`.

## Still needs a human

- `PREVIEW_MANAGED_GIT_GITHUB_TOKEN` does not exist as a repo secret, so `MANAGED_GIT_GITHUB_TOKEN` is empty on every preview and project creation fails. Needs repo admin.
- Removing the `preview` label deletes the environment **and its data** (by design); re-adding creates an empty one. That is what reset pi.kortix.com's database on 2026-09-03 10:19.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791118112&installation_model_id=434224&pr_number=7114&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7114&signature=0ad819c59589ad2cbdf8da9a8730443c213896540a6b78426a5e2b6c6d5787a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->