### PR TITLE
docs(learnings): the Caddyfile and overlay come from the branch checkout, not main

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4132,19 +4132,26 @@ days, each time for a reason the deploy could not repair once it had returned:
    (`ERR_PNPM_NO_OFFLINE_TARBALL` on `@earendil-works/pi-agent-core`).
 
 The part that made every one of these last for hours: **fixes committed on the
-branch did nothing.** `deploy-preview.yml` is `pull_request_target`, and its
-deploy job checks out the DEFAULT branch, so the bootstrap, the Caddyfile and
-the compose overlay always come from `main`'s `tests/`. Four fixes for exactly
-these failures sat on `pi-worker` and `ino/preview-parity` — prune before
-pull, Caddy swap tolerance, the git-cache volume, the offline fallback — each
-verified in a unit test, none ever executed by a deploy.
+branch did nothing where it mattered.** `deploy-preview.yml` is
+`pull_request_target`, and its deploy job checks out the DEFAULT branch, so the
+BOOTSTRAP (`buildPreviewBootstrapScript`, written to the box as
+`run-kortix-preview.sh`) always comes from `main`'s `tests/`. The bootstrap
+then runs `bun tests/bin/preview-stack.ts` INSIDE the box, from the PR-head
+checkout at `/workspace/suna` — so the Caddyfile and the compose overlay come
+from the BRANCH. Two provenances, verified on the first deploy after this
+landed: the guard install and `disk before pull` (bootstrap, main) ran, while
+the generated Caddyfile still lacked `swap_tolerant` (preview-stack, branch)
+until the guard patched it 60 s later. Know which file you are changing:
+`sandbox-preview.ts` → main; `preview-stack.ts` → the branch under test, and
+main only after the branch merges main.
 
 **The rules.**
 
-1. **A change to `tests/src/core/preview-stack.ts`, `sandbox-preview.ts` or
-   `deploy-preview.yml` reaches a preview only from `main`.** Land it there
-   first, in its own PR; a branch preview cannot test it and will keep failing
-   in the way the branch already fixed.
+1. **A change to `sandbox-preview.ts` or `deploy-preview.yml` reaches a
+   preview only from `main`; a change to `preview-stack.ts` reaches it from
+   the branch being deployed.** Land bootstrap and workflow fixes on `main`
+   first, in their own PR; put Caddyfile and overlay fixes on the branch (and
+   on `main`, or the next branch loses them).
 2. **A persistent environment carries its own watcher.** The deploy is on the
    box for ~14 minutes a day; the environment is expected to serve for the
    other 1,426. `tests/src/core/preview-guard.ts` runs as a container on the


### PR DESCRIPTION
Correction to the learnings entry merged in #7114.

It claimed the bootstrap, the Caddyfile and the compose overlay all come from main's `tests/`. Only the bootstrap does (the deploy job checks out main and writes `run-kortix-preview.sh`). That script then runs `bun tests/bin/preview-stack.ts` **inside the box from the PR-head checkout**, so `buildPreviewCaddyfile` and `buildPreviewComposeOverlay` are the branch's.

Observed on the first pi-worker deploy after #7114 merged (run 33876096752): `preview guard installed (a22b7159e1fce629)` and `disk before pull: 50%` ran from main's bootstrap, while the generated Caddyfile had no `swap_tolerant` until the guard patched it at 13:11:13 — the branch's `preview-stack.ts` predates that port.

Consequence for `pi-worker`: the Caddy swap tolerance and git-cache volume ported in #7114 reach its environment when the branch next merges main; the on-box guard covers Caddy in the meantime.

Docs only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791119971&installation_model_id=434224&pr_number=7115&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7115&signature=9fb528c3faa32cdd066180f37863cd2d1d0f85435d6e6afafb38d94599738c97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->