### PR TITLE
Fix session busy status during response streaming

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,24 @@ linked, not inlined.
 
 ## Register
 
+### Every streamed transcript mutation refreshes runtime activity (2026-09-05)
+
+**When:** adding or changing a wire event that mutates visible assistant output.
+Refresh `sessionActivityAt` after the mutation applies. Do not cover only full
+part snapshots; delta-only streams can run past the 45-second observation bound.
+Ignore replayed event IDs because history is not current activity. *Incident:*
+reasoning text kept growing while the composer changed from Stop to Send and the
+turn busy indicator disappeared. *Enforcer:* `sync-store.test.ts`.
+
+### Protocol adapters emit the target vocabulary; consumers fail active-safe (2026-09-04)
+
+**When:** adapting runtime lifecycle events into the OpenCode session protocol.
+Emit only `idle`, `busy`, or `retry`. Treat only explicit `idle` as idle when
+reading an untrusted status discriminator. *Incident:* the pi worker emitted
+`running`; the SDK converted it to `idle`, so the composer and sidebar hid their
+busy indicators while parts continued to stream. *Enforcer:*
+`session-status.test.ts` and `use-session-working.test.ts`.
+
 ### A durable FIFO has one order key and advances at one boundary (2026-09-03)
 
 **When:** implementing a queue whose enqueue requests can race. Define one total

--- a/apps/kortix-worker/src/chat-events.ts
+++ b/apps/kortix-worker/src/chat-events.ts
@@ -81,7 +81,9 @@ export class ChatEventAdapter {
     const sessionID = this.sessionID;
     switch (event.type) {
       case 'agent_start':
-        return [{ type: 'session.status', properties: { sessionID, status: { type: 'running' } } }];
+        // OpenCode accepts only idle, busy, and retry. Emitting another value
+        // makes strict consumers report an active session as idle.
+        return [{ type: 'session.status', properties: { sessionID, status: { type: 'busy' } } }];
 
       case 'message_start': {
         // Only ASSISTANT messages translate. The worker publishes the USER

--- a/apps/kortix-worker/src/session-status.test.ts
+++ b/apps/kortix-worker/src/session-status.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { ChatEventAdapter } from './chat-events.ts';
+
+describe('session.status vocabulary', () => {
+  test('agent_start reports the canonical busy state', () => {
+    const adapter = new ChatEventAdapter({ sessionID: 'ses-pi' });
+    const status = adapter
+      .translate({ type: 'agent_start' })
+      .find((wire) => wire.type === 'session.status');
+
+    expect(status?.properties.status).toEqual({ type: 'busy' });
+  });
+
+  test('agent_end reports the canonical idle state', () => {
+    const adapter = new ChatEventAdapter({ sessionID: 'ses-pi' });
+    const status = adapter
+      .translate({ type: 'agent_end' })
+      .find((wire) => wire.type === 'session.status');
+
+    expect(status?.properties.status).toEqual({ type: 'idle' });
+  });
+});

--- a/packages/sdk/src/browser/stores/sync-store.test.ts
+++ b/packages/sdk/src/browser/stores/sync-store.test.ts
@@ -931,6 +931,28 @@ describe("useSyncStore — session.error attaches to the turn that failed", () =
 });
 
 describe("useSyncStore — applyEvent(message.part.delta) creates a stub part + message", () => {
+	test("stamps runtime activity while a streamed delta changes the visible transcript", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", userMessage("msg_user"));
+
+		store.applyEvent({
+			id: "evt_live_delta",
+			type: "message.part.delta",
+			properties: {
+				messageID: "msg_asst",
+				partID: "prt_reasoning",
+				sessionID: "ses_1",
+				field: "text",
+				delta: "Still thinking",
+			},
+		} as never);
+
+		// `projectWorking` expires old status and turn observations after 45s.
+		// A delta is the runtime itself producing output, so it must refresh the
+		// activity evidence that keeps Stop and the busy indicator visible.
+		expect(useSyncStore.getState().sessionActivityAt.ses_1).toBeGreaterThan(0);
+	});
+
 	test("auto-creates the assistant message + part so a delta before message.part.updated still renders", () => {
 		const store = useSyncStore.getState();
 		store.upsertMessage("ses_1", userMessage("msg_user"));
@@ -973,6 +995,28 @@ describe("useSyncStore — applyEvent(message.part.delta) creates a stub part + 
 	});
 });
 
+describe("useSyncStore — streamed part activity follows resolved session identity", () => {
+	test("stamps activity when message.part.updated omits sessionID but its message identifies the session", () => {
+		const store = useSyncStore.getState();
+		store.upsertMessage("ses_1", assistantMessage("msg_asst"));
+
+		store.applyEvent({
+			id: "evt_part_without_session",
+			type: "message.part.updated",
+			properties: {
+				part: {
+					id: "prt_reasoning",
+					messageID: "msg_asst",
+					type: "reasoning",
+					text: "Still thinking",
+				},
+			},
+		} as never);
+
+		expect(useSyncStore.getState().sessionActivityAt.ses_1).toBeGreaterThan(0);
+	});
+});
+
 // T14 — `applyPartDelta` used to be `existing + delta` with no
 // identity consulted anywhere in the pipeline, so a duplicate delivery of
 // the SAME `message.part.delta` doubled the streamed text. `eventID` is the
@@ -986,6 +1030,19 @@ describe("useSyncStore — applyPartDelta idempotency (part-delta duplicate deli
 		store.applyPartDelta("ses_1", "msg_1", "prt_1", "text", "lo", "evt_1"); // duplicate
 
 		expect((useSyncStore.getState().parts.msg_1[0] as TextPart).text).toBe("Hello");
+	});
+
+	test("a replayed delta does not refresh runtime activity", () => {
+		const store = useSyncStore.getState();
+		store.upsertPart("msg_1", textPart("prt_1", "msg_1", "Hel"));
+		store.applyPartDelta("ses_1", "msg_1", "prt_1", "text", "lo", "evt_1");
+
+		// Move the activity stamp behind the observation window without waiting.
+		// A duplicate delivery is reconnect history, not live runtime output.
+		useSyncStore.setState({ sessionActivityAt: { ses_1: 1 } });
+		store.applyPartDelta("ses_1", "msg_1", "prt_1", "text", "lo", "evt_1");
+
+		expect(useSyncStore.getState().sessionActivityAt.ses_1).toBe(1);
 	});
 
 	test("replaying an identical delta STREAM twice (a stacked second SSE connection) produces byte-identical text", () => {

--- a/packages/sdk/src/browser/stores/sync-store.ts
+++ b/packages/sdk/src/browser/stores/sync-store.ts
@@ -1266,6 +1266,7 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 
 	applyPartDelta: (sessionID, messageID, partID, field, delta, eventID) => {
 		trackId(deltaActiveParts, sessionID, partID);
+		let applied = false;
 		set((s) => {
 			const list = s.parts[messageID];
 			if (!list) return s;
@@ -1304,8 +1305,14 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 				| undefined;
 			(part as Record<string, unknown>)[field] = (existing ?? "") + delta;
 			next[result.index] = part as Part;
+			applied = true;
 			return { parts: { ...s.parts, [messageID]: next } };
 		});
+		// The delta changed the visible transcript. This is the runtime itself
+		// producing output, so it refreshes the activity evidence used by
+		// `projectWorking`. Stamp only after a real apply: reconnect replays with
+		// an already-consumed event id are history, not current activity.
+		if (applied) get().noteSessionActivity(sessionID);
 	},
 
 	setStatus: (sessionID, status, origin = "wire") =>
@@ -2433,15 +2440,6 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 			case "message.part.updated": {
 				const part = (event.properties as { part: Part }).part;
 				if (!part?.messageID) return;
-				// The runtime just produced output. This is the evidence
-				// `projectWorking` trusts above every observer — see
-				// `sessionActivityAt`.
-				{
-					const sid =
-						part.sessionID ?? (event.properties as { sessionID?: string })?.sessionID;
-					if (sid) get().noteSessionActivity(sid);
-				}
-
 				const eventSessionID =
 					(event.properties as { sessionID?: string })?.sessionID;
 				let resolvedSessionID: string | undefined =
@@ -2456,6 +2454,13 @@ export const useSyncStore = create<SyncState>()((set, get) => ({
 						}
 					}
 				}
+
+				// The runtime just produced output. This is the evidence
+				// `projectWorking` trusts above every observer — see
+				// `sessionActivityAt`. Stamp AFTER the message-id fallback: some
+				// producers omit sessionID from the part while still updating a
+				// known message, and that visible output is runtime activity too.
+				if (resolvedSessionID) get().noteSessionActivity(resolvedSessionID);
 
 				const existingMsgs = resolvedSessionID
 					? get().messages[resolvedSessionID]

--- a/packages/sdk/src/react/use-session-working.test.ts
+++ b/packages/sdk/src/react/use-session-working.test.ts
@@ -142,7 +142,7 @@ describe('buildWorkingInputs', () => {
     expect(inputs.server).toEqual({ turns: [], lastEnded: undefined, atMs: T0 - 500 });
   });
 
-  test('busy and retry frames are working; every other status is idle', () => {
+  test('only an explicit idle frame is idle; unknown runtime states fail safe as working', () => {
     const at = (status: { type: string } | undefined) =>
       buildWorkingInputs({
         turn: undefined,
@@ -159,9 +159,44 @@ describe('buildWorkingInputs', () => {
     expect(at({ type: 'busy' })).toEqual({ type: 'busy', origin: 'wire', atMs: T0 });
     expect(at({ type: 'retry' })).toEqual({ type: 'retry', origin: 'wire', atMs: T0 });
     expect(at({ type: 'idle' })).toEqual({ type: 'idle', origin: 'wire', atMs: T0 });
+    // Runtime adapters must speak the OpenCode vocabulary, but a newer or
+    // malformed active state must not hide the user's Stop control.
+    expect(at({ type: 'running' })).toEqual({ type: 'busy', origin: 'wire', atMs: T0 });
+    expect(at({ type: 'compacting' })).toEqual({ type: 'busy', origin: 'wire', atMs: T0 });
     // No status frame observed at all is NOT an idle frame — silence is not
     // an observation, and treating it as one is how a live turn got unmasked.
     expect(at(undefined)).toBeNull();
+  });
+
+  test('an unknown active status cannot hide a long server-authorized turn', () => {
+    const nowMs = T0 + STREAM_OBSERVATION_MAX_MS + 1;
+    const inputs = buildWorkingInputs({
+      turn: {
+        turns: [
+          {
+            turn_token: 'tt-pi',
+            state: 'active' as const,
+            message_id: 'msg-pi',
+            opencode_session_id: 'ses-pi',
+            started_at: new Date(T0).toISOString(),
+            accepted_at: null,
+          },
+        ],
+        atMs: nowMs,
+      },
+      inbox: undefined,
+      status: { type: 'running' } as never,
+      statusAtMs: T0,
+      activityAtMs: T0,
+      optimistic: null,
+      nowMs,
+    });
+
+    expect(projectWorking(inputs)).toMatchObject({
+      state: 'working',
+      source: 'server',
+      serverOpenTurnToken: 'tt-pi',
+    });
   });
 
   test('a local origin is threaded through to the stream input', () => {

--- a/packages/sdk/src/react/use-session-working.ts
+++ b/packages/sdk/src/react/use-session-working.ts
@@ -114,10 +114,14 @@ export function buildWorkingInputs(input: {
     // live turns whenever a frame was dropped.
     stream: input.status
       ? {
+          // Only an explicit terminal state can clear an active session. An
+          // unknown producer state must preserve the user's Stop control.
           type:
-            input.status.type === 'busy' || input.status.type === 'retry'
-              ? input.status.type
-              : 'idle',
+            input.status.type === 'idle'
+              ? 'idle'
+              : input.status.type === 'retry'
+                ? 'retry'
+                : 'busy',
           origin: input.statusOrigin ?? 'wire',
           atMs: input.statusAtMs,
         }


### PR DESCRIPTION
## Summary

- Keep the Stop control and turn busy indicator visible while response deltas stream.
- Emit the canonical `busy` session status from the worker.
- Treat unknown active status values as busy instead of idle.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Infrastructure / CI
- [ ] Security fix
- [ ] Breaking change

## How was this tested?

- `pnpm test` — all five core lanes passed; API/CLI flows passed 388/388.
- Firefox local journey — Stop remained visible after 82.5 seconds and 85 streamed markers.
- `pnpm --filter @kortix/sdk typecheck`
- `pnpm --filter @kortix/sdk smoke:install`
- Worker build and focused status tests.

## Security & data review

- [x] No secrets, keys, or credentials are committed.
- [x] No authorization, endpoint, logging, or database behavior changed.

## Rollout / rollback

No migration or configuration change. Revert commit `0310883dbc` to roll back.

## Reviewer checklist

- [x] Change is scoped and understandable.
- [x] Tests cover the reported failure.
- [x] Security and data impact reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791144275&installation_model_id=434224&pr_number=7118&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7118&signature=623e7c75e57960890b52f279936481d897bd1eea6672a4f6e2ed5c8518d9d81c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->