### PR TITLE
fix(docker): keep the built docs site in the image context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,16 @@ node_modules
 .next
 **/.next
 
+# ── Whitelist: the built docs site ──
+# `docs` / `**/docs` above is meant for documentation SOURCE, but it also matches
+# apps/web/public/docs — the Blume static build that serves /docs. Without these
+# two lines the image ships a public/ with a docs-shaped hole: Blume builds, next
+# build succeeds, the deploy goes green, and /docs 404s in production. Nothing
+# fails, because Docker reads this file long after the build hook's checks ran.
+# Must come after `**/docs` to override it.
+!apps/web/public/docs
+!apps/web/public/docs/**
+
 # ── Whitelist: frontend standalone output (MUST come LAST to override excludes above) ──
 !apps/web/.next
 !apps/web/.next/standalone

--- a/apps/web/blume.config.ts
+++ b/apps/web/blume.config.ts
@@ -179,9 +179,14 @@ export default defineConfig({
     tabs: [
       { label: 'Docs', path: '/' },
       {
+        // The URL sits in `path`, not `href`. Blume validates every tab whose
+        // path starts with "/" against the page tree and warns when nothing
+        // matches — `/api-reference` is not a page here, so it warned on every
+        // build. nav-diagnostics skips non-"/" paths outright, which is the
+        // supported way to point a tab off-site. `href` would be redundant:
+        // Header.astro renders `tab.href ?? tab.path`.
         label: 'API reference',
-        path: '/api-reference',
-        href: 'https://api.kortix.com/v1/docs',
+        path: 'https://api.kortix.com/v1/docs',
       },
     ],
     sidebar: {


### PR DESCRIPTION
## Summary

`dev.kortix.com/docs` returns 404 since #7121 merged. This is the fix.

`.dockerignore` excludes `docs` and `**/docs` to keep documentation source out of the image. That pattern also matches **`apps/web/public/docs`** — the Blume static build that *is* the docs site — so the image ships a `public/` with a docs-shaped hole.

Nothing failed on the way in, which is why it reached dev:

- Blume built its 33 pages in CI (`[start] [blume] Building 33 page(s) (static output)`)
- `next build` succeeded
- The frontend image built and deployed green
- `COPY apps/web/public` copied a `public/` that no longer contained `docs/`

`next.config.ts` does verify the build landed in `public/`, and that check passed — it runs during `next build`, long before Docker reads `.dockerignore`. A local `pnpm build && pnpm start` cannot catch this either, because Docker is not involved.

The whitelist goes after the `**/docs` excludes, the same way the standalone output already is.

## Test plan

Verified against real Docker, not by reading the pattern:

```
# before
COPY apps/web/public/docs /probe/docs
  ERROR: "/apps/web/public/docs": not found

# after
RUN ls /probe/docs
  404.html
  README.md
  __probe.html

# and through the path the real Dockerfile uses
COPY apps/web/public ./apps/web/public
RUN test -f ./apps/web/public/docs/__probe.html
  PUBLIC/DOCS PRESENT IN IMAGE
```

- [x] `COPY apps/web/public/docs` fails before the change, succeeds after
- [x] `COPY apps/web/public` — the real Dockerfile line — carries `docs/` into the image
- [x] Change is one file; no application code touched

After merge, the dev deploy should be followed to completion and `dev.kortix.com/docs` checked in a browser — that is the only environment where this class of bug is observable.

## Also in this PR — the nav warning

Every build logged:

```
[warn] [blume] Navigation entry "API reference" points to /api-reference,
       but no page matches it.
```

Blume validates each tab whose `path` starts with `/` against the page tree. `/api-reference` is not a page — the tab links to the external API docs — so it warned on every build while working correctly.

`nav-diagnostics.ts` skips any path that does not start with `/`, which is the supported way to aim a tab off-site. The URL moves into `path`, and `href` goes away as redundant, since `Header.astro` renders `tab.href ?? tab.path`.

- [x] Rendered link unchanged: `API reference -> https://api.kortix.com/v1/docs`
- [x] Build is clean of `BLUME_NAV` diagnostics
- [x] Both tabs still render, sidebar complete (0 missing sub-pages), 33 pages, tsc 17
- [x] The tab still matches no route, so it never falsely highlights
