### PR TITLE
infra: pi-js.kortix.com — a stable name for the JS pi agent on Platinum dev

### DIFF
--- a/.github/workflows/deploy-pi-js-router.yml
+++ b/.github/workflows/deploy-pi-js-router.yml
@@ -1,0 +1,91 @@
+# Point pi-js.kortix.com at a Platinum cell.
+#
+# The JS pi agent (apps/pi-worker-js) runs as a Platinum Worker cell on Platinum
+# DEV; infra/cloudflare/workers/pi-js-router is the Cloudflare Worker that gives
+# it the stable name. Run this once to create the name, and again whenever the
+# cell is recreated (its origin is derived from the sandbox id — stop/start keeps
+# it, delete + recreate changes it).
+#
+# Inputs: the cell's exposure origin, e.g.
+#   https://8080-01m1s178mtjdff5gst7jqvc735.eu-west.sbx-dev.platinum.dev
+# Secrets (repo): CLOUDFLARE_APPS_EDGE_API_TOKEN (same as pi-router),
+#   PI_JS_PREVIEW_TOKEN (the cell's exposure token — the Worker sends it to the
+#   Platinum edge as x-pt-preview-token, so the port stays private),
+#   PI_JS_ACCESS_TOKEN (optional — when set, the public name requires it as a
+#   bearer; when absent the name is open, as pi.kortix.com is).
+#
+# Deliberately gated on the target serving /health: re-pointing the name at a
+# dead cell is how pi.kortix.com went dark on 2026-08-29 (see deploy-preview.yml).
+name: deploy-pi-js-router
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_origin:
+        description: "the pi-js cell's exposure origin (https://8080-<cell>.eu-west.sbx-dev.platinum.dev)"
+        required: true
+        type: string
+
+concurrency:
+  group: pi-js-router
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
+      TARGET_ORIGIN: ${{ inputs.target_origin }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: The target must be a Platinum DEV cell origin and must answer /health
+        env:
+          PT_PREVIEW_TOKEN: ${{ secrets.PI_JS_PREVIEW_TOKEN }}
+        run: |
+          set -euo pipefail
+          case "$TARGET_ORIGIN" in
+            https://8080-*.sbx-dev.platinum.dev|https://8080-*.sbx-dev.platinum.dev/) ;;
+            *) echo "::error::target_origin must look like https://8080-<cell>[.<region>].sbx-dev.platinum.dev — got '$TARGET_ORIGIN'"; exit 1 ;;
+          esac
+          [ -n "${PT_PREVIEW_TOKEN:-}" ] || { echo "::error::PI_JS_PREVIEW_TOKEN is not set — the cell's port is private and the Worker cannot reach it without the token"; exit 1; }
+          ok=
+          for _ in $(seq 1 12); do
+            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 -H "x-pt-preview-token: $PT_PREVIEW_TOKEN" "${TARGET_ORIGIN%/}/health" || true)"
+            if [ "$code" = "200" ]; then ok=1; break; fi
+            echo "health → $code (a stopped cell cold-boots in ~4 s; waiting)"
+            sleep 5
+          done
+          [ -n "$ok" ] || { echo "::error::${TARGET_ORIGIN} does not answer /health with the token — leaving pi-js.kortix.com on its previous target"; exit 1; }
+      - name: Publish the Worker with the new target
+        working-directory: infra/cloudflare/workers/pi-js-router
+        run: npx --yes wrangler@4 deploy --var "TARGET_ORIGIN:${TARGET_ORIGIN%/}"
+      - name: Store the Worker's secrets
+        working-directory: infra/cloudflare/workers/pi-js-router
+        env:
+          PT_PREVIEW_TOKEN: ${{ secrets.PI_JS_PREVIEW_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.PI_JS_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$PT_PREVIEW_TOKEN" | npx --yes wrangler@4 secret put PT_PREVIEW_TOKEN
+          if [ -n "${ACCESS_TOKEN:-}" ]; then
+            printf '%s' "$ACCESS_TOKEN" | npx --yes wrangler@4 secret put ACCESS_TOKEN
+            echo "pi-js.kortix.com requires a bearer (PI_JS_ACCESS_TOKEN is set)"
+          else
+            echo "::notice::PI_JS_ACCESS_TOKEN is not set — pi-js.kortix.com is OPEN (pi.kortix.com parity); the JS agent has no auth of its own"
+          fi
+      - name: Read the name back
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 12); do
+            code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 https://pi-js.kortix.com/health || true)"
+            case "$code" in
+              200) echo "pi-js.kortix.com → 200 (open)"; exit 0 ;;
+              401) echo "pi-js.kortix.com → 401 (gated by PI_JS_ACCESS_TOKEN)"; exit 0 ;;
+            esac
+            echo "pi-js.kortix.com → $code (custom domain / cert may still be provisioning)"; sleep 10
+          done
+          echo "::warning::pi-js.kortix.com did not answer 200/401 within 2 minutes — Cloudflare may still be issuing the certificate; check again shortly"

--- a/.github/workflows/deploy-pi-js-router.yml
+++ b/.github/workflows/deploy-pi-js-router.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}

--- a/.github/workflows/deploy-pi-js-router.yml
+++ b/.github/workflows/deploy-pi-js-router.yml
@@ -8,11 +8,14 @@
 #
 # Inputs: the cell's exposure origin, e.g.
 #   https://8080-01m1s178mtjdff5gst7jqvc735.eu-west.sbx-dev.platinum.dev
+# and `open_access` — the name FAILS CLOSED: without PI_JS_ACCESS_TOKEN the
+# Worker answers 503 unless this input is set, which deploys OPEN_ACCESS=true
+# (pi.kortix.com parity, stated out loud here rather than fallen into).
 # Secrets (repo): CLOUDFLARE_APPS_EDGE_API_TOKEN (same as pi-router),
 #   PI_JS_PREVIEW_TOKEN (the cell's exposure token — the Worker sends it to the
 #   Platinum edge as x-pt-preview-token, so the port stays private),
-#   PI_JS_ACCESS_TOKEN (optional — when set, the public name requires it as a
-#   bearer; when absent the name is open, as pi.kortix.com is).
+#   PI_JS_ACCESS_TOKEN (the bearer the public name requires; optional only when
+#   open_access is chosen).
 #
 # Deliberately gated on the target serving /health: re-pointing the name at a
 # dead cell is how pi.kortix.com went dark on 2026-08-29 (see deploy-preview.yml).
@@ -25,6 +28,11 @@ on:
         description: "the pi-js cell's exposure origin (https://8080-<cell>.eu-west.sbx-dev.platinum.dev)"
         required: true
         type: string
+      open_access:
+        description: "run the name OPEN (no bearer) — pi.kortix.com parity; the JS agent has no auth of its own"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: pi-js-router
@@ -37,14 +45,16 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
       TARGET_ORIGIN: ${{ inputs.target_origin }}
+      OPEN_ACCESS: ${{ inputs.open_access && 'true' || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: The target must be a Platinum DEV cell origin and must answer /health
+      - name: The target must be a Platinum DEV cell origin and must answer /health; the name must have an access policy
         env:
           PT_PREVIEW_TOKEN: ${{ secrets.PI_JS_PREVIEW_TOKEN }}
+          ACCESS_TOKEN: ${{ secrets.PI_JS_ACCESS_TOKEN }}
         run: |
           set -euo pipefail
           case "$TARGET_ORIGIN" in
@@ -52,6 +62,10 @@ jobs:
             *) echo "::error::target_origin must look like https://8080-<cell>[.<region>].sbx-dev.platinum.dev — got '$TARGET_ORIGIN'"; exit 1 ;;
           esac
           [ -n "${PT_PREVIEW_TOKEN:-}" ] || { echo "::error::PI_JS_PREVIEW_TOKEN is not set — the cell's port is private and the Worker cannot reach it without the token"; exit 1; }
+          if [ -z "${ACCESS_TOKEN:-}" ] && [ "$OPEN_ACCESS" != "true" ]; then
+            echo "::error::PI_JS_ACCESS_TOKEN is not set and open_access was not chosen — refusing to deploy a name that would answer 503; set the secret, or re-run with open_access=true to run it open on purpose"
+            exit 1
+          fi
           ok=
           for _ in $(seq 1 12); do
             code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 -H "x-pt-preview-token: $PT_PREVIEW_TOKEN" "${TARGET_ORIGIN%/}/health" || true)"
@@ -60,9 +74,9 @@ jobs:
             sleep 5
           done
           [ -n "$ok" ] || { echo "::error::${TARGET_ORIGIN} does not answer /health with the token — leaving pi-js.kortix.com on its previous target"; exit 1; }
-      - name: Publish the Worker with the new target
+      - name: Publish the Worker with the new target and access policy
         working-directory: infra/cloudflare/workers/pi-js-router
-        run: npx --yes wrangler@4 deploy --var "TARGET_ORIGIN:${TARGET_ORIGIN%/}"
+        run: npx --yes wrangler@4 deploy --var "TARGET_ORIGIN:${TARGET_ORIGIN%/}" --var "OPEN_ACCESS:${OPEN_ACCESS}"
       - name: Store the Worker's secrets
         working-directory: infra/cloudflare/workers/pi-js-router
         env:
@@ -75,7 +89,7 @@ jobs:
             printf '%s' "$ACCESS_TOKEN" | npx --yes wrangler@4 secret put ACCESS_TOKEN
             echo "pi-js.kortix.com requires a bearer (PI_JS_ACCESS_TOKEN is set)"
           else
-            echo "::notice::PI_JS_ACCESS_TOKEN is not set — pi-js.kortix.com is OPEN (pi.kortix.com parity); the JS agent has no auth of its own"
+            echo "::warning::pi-js.kortix.com is OPEN (open_access=true, no PI_JS_ACCESS_TOKEN) — the JS agent has no auth of its own"
           fi
       - name: Read the name back
         run: |
@@ -85,6 +99,7 @@ jobs:
             case "$code" in
               200) echo "pi-js.kortix.com → 200 (open)"; exit 0 ;;
               401) echo "pi-js.kortix.com → 401 (gated by PI_JS_ACCESS_TOKEN)"; exit 0 ;;
+              503) echo "::error::pi-js.kortix.com → 503 — the Worker has no access policy (ACCESS_TOKEN secret missing and OPEN_ACCESS not true)"; exit 1 ;;
             esac
             echo "pi-js.kortix.com → $code (custom domain / cert may still be provisioning)"; sleep 10
           done

--- a/infra/cloudflare/workers/pi-js-router/worker.mjs
+++ b/infra/cloudflare/workers/pi-js-router/worker.mjs
@@ -15,11 +15,18 @@
  *   1. The cell's port is NOT public on the Platinum edge. The edge wants the
  *      exposure token (`?t=` or `x-pt-preview-token`); this Worker injects it
  *      from the PT_PREVIEW_TOKEN secret, so the token never reaches a browser.
- *   2. If ACCESS_TOKEN is set, the public name itself requires
+ *   2. The name FAILS CLOSED. With ACCESS_TOKEN set, every request must carry
  *      `Authorization: Bearer <ACCESS_TOKEN>` or `x-kortix-access: <ACCESS_TOKEN>`
- *      (the header is consumed here, not forwarded). Unset = open, which is
- *      pi.kortix.com parity — an explicit choice for the operator, not a default
- *      this file makes silently: the 401 body names the missing header.
+ *      (consumed here, never forwarded). With no ACCESS_TOKEN the Worker answers
+ *      503 — unless the operator deployed with the plain var OPEN_ACCESS=true,
+ *      which is pi.kortix.com parity stated out loud in the deploy, not a
+ *      default a cleared secret can fall into (Strix review of #7125, CWE-306).
+ *
+ * The upstream URL is built from the TARGET origin and then given the incoming
+ * path and query — never by resolving the incoming path against the origin. A
+ * path that starts with `//` is a scheme-relative reference, and
+ * `new URL('//evil/x', target)` would send the request — with the exposure
+ * token attached — to evil. Such paths are refused with 400 (CWE-918).
  *
  * WebSocket upgrades pass through untouched (the agent streams turn events over
  * a socket); SSE/streaming bodies are piped, not buffered.
@@ -38,6 +45,24 @@ function sameSecret(a, b) {
   return diff === 0;
 }
 
+/**
+ * The upstream URL for an incoming request URL, or null when the path must not
+ * be forwarded. The origin is ALWAYS the configured target: the path and query
+ * are copied onto it, never resolved against it.
+ */
+export function upstreamUrl(target, requestUrl) {
+  const incoming = new URL(requestUrl);
+  // `//host/...` and `/\host/...` are scheme-relative to a URL parser; a proxy
+  // that resolved them would leave its own origin. Nothing legitimate here
+  // starts a path that way.
+  if (/^\/[\/\\]/.test(incoming.pathname)) return null;
+  const upstream = new URL(target);
+  upstream.pathname = incoming.pathname;
+  upstream.search = incoming.search;
+  upstream.hash = '';
+  return upstream;
+}
+
 /** The credential the caller presented for pi-js.kortix.com itself, if any. */
 export function presentedAccess(headers) {
   const bearer = headers.get('authorization') || '';
@@ -45,10 +70,21 @@ export function presentedAccess(headers) {
   return (headers.get('x-kortix-access') || '').trim();
 }
 
-/** null = let it through; otherwise the Response to answer with. */
+/**
+ * null = let it through; otherwise the Response to answer with.
+ * Fails closed: no ACCESS_TOKEN and no explicit OPEN_ACCESS=true is a 503, not
+ * an open door in front of a shell-capable agent.
+ */
 export function accessRefusal(request, env) {
   const required = (env.ACCESS_TOKEN || '').trim();
-  if (!required) return null;
+  const openAccess = (env.OPEN_ACCESS || '').trim() === 'true';
+  if (!required) {
+    if (openAccess) return null;
+    return Response.json(
+      { error: 'pi-js.kortix.com is not configured: set the ACCESS_TOKEN secret, or deploy with OPEN_ACCESS=true to run it open' },
+      { status: 503, headers: { 'retry-after': '60' } },
+    );
+  }
   if (sameSecret(presentedAccess(request.headers), required)) return null;
   return Response.json(
     { error: 'pi-js.kortix.com requires Authorization: Bearer <access token> (or x-kortix-access)' },
@@ -68,13 +104,13 @@ export default {
     const refused = accessRefusal(request, env);
     if (refused) return refused;
 
-    const url = new URL(request.url);
-    const upstream = new URL(`${url.pathname}${url.search}`, target);
+    const upstream = upstreamUrl(target, request.url);
+    if (!upstream) return Response.json({ error: 'invalid path' }, { status: 400 });
 
     const headers = new Headers(request.headers);
     for (const name of STRIPPED) headers.delete(name);
     for (const name of CONSUMED) headers.delete(name);
-    headers.set('x-forwarded-host', url.host);
+    headers.set('x-forwarded-host', new URL(request.url).host);
     headers.set('x-forwarded-proto', 'https');
     // The Platinum edge's exposure token. Accepted as a header so it is never
     // part of a URL a browser could see or a log could keep.

--- a/infra/cloudflare/workers/pi-js-router/worker.mjs
+++ b/infra/cloudflare/workers/pi-js-router/worker.mjs
@@ -1,0 +1,113 @@
+/**
+ * `pi-js.kortix.com` — the stable front door for the JS pi agent
+ * (apps/pi-worker-js) running as a Platinum Worker cell on Platinum DEV.
+ *
+ * Same job as pi-router for pi.kortix.com: the cell's own origin
+ * (`8080-<cell>.eu-west.sbx-dev.platinum.dev`) is derived from its sandbox id,
+ * survives stop/start (the cell scales to zero and cold-boots on the next
+ * request) but not a delete + recreate, and is unmemorable either way. The
+ * Platinum edge routes by HOSTNAME, so a proxied CNAME cannot carry the name;
+ * a Worker rebuilds the request against the target origin.
+ *
+ * Two things pi-router does not do, because the JS agent has no auth of its
+ * own (a request names a session with `?c=` and gets an agent with shell
+ * tools):
+ *   1. The cell's port is NOT public on the Platinum edge. The edge wants the
+ *      exposure token (`?t=` or `x-pt-preview-token`); this Worker injects it
+ *      from the PT_PREVIEW_TOKEN secret, so the token never reaches a browser.
+ *   2. If ACCESS_TOKEN is set, the public name itself requires
+ *      `Authorization: Bearer <ACCESS_TOKEN>` or `x-kortix-access: <ACCESS_TOKEN>`
+ *      (the header is consumed here, not forwarded). Unset = open, which is
+ *      pi.kortix.com parity — an explicit choice for the operator, not a default
+ *      this file makes silently: the 401 body names the missing header.
+ *
+ * WebSocket upgrades pass through untouched (the agent streams turn events over
+ * a socket); SSE/streaming bodies are piped, not buffered.
+ */
+
+/** Hop-by-hop headers must not be forwarded; `host` is set by the target URL. */
+const STRIPPED = ['host', 'connection', 'keep-alive', 'transfer-encoding', 'upgrade-insecure-requests'];
+/** Never forwarded: the caller's own credential to THIS name. */
+const CONSUMED = ['authorization', 'x-kortix-access'];
+
+/** Constant-time-ish comparison; both sides are short ASCII secrets. */
+function sameSecret(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+/** The credential the caller presented for pi-js.kortix.com itself, if any. */
+export function presentedAccess(headers) {
+  const bearer = headers.get('authorization') || '';
+  if (bearer.toLowerCase().startsWith('bearer ')) return bearer.slice(7).trim();
+  return (headers.get('x-kortix-access') || '').trim();
+}
+
+/** null = let it through; otherwise the Response to answer with. */
+export function accessRefusal(request, env) {
+  const required = (env.ACCESS_TOKEN || '').trim();
+  if (!required) return null;
+  if (sameSecret(presentedAccess(request.headers), required)) return null;
+  return Response.json(
+    { error: 'pi-js.kortix.com requires Authorization: Bearer <access token> (or x-kortix-access)' },
+    { status: 401, headers: { 'www-authenticate': 'Bearer realm="pi-js.kortix.com"' } },
+  );
+}
+
+export default {
+  async fetch(request, env) {
+    const target = (env.TARGET_ORIGIN || '').trim();
+    if (!target) {
+      return Response.json(
+        { error: 'pi-js.kortix.com has no target origin configured' },
+        { status: 503, headers: { 'retry-after': '30' } },
+      );
+    }
+    const refused = accessRefusal(request, env);
+    if (refused) return refused;
+
+    const url = new URL(request.url);
+    const upstream = new URL(`${url.pathname}${url.search}`, target);
+
+    const headers = new Headers(request.headers);
+    for (const name of STRIPPED) headers.delete(name);
+    for (const name of CONSUMED) headers.delete(name);
+    headers.set('x-forwarded-host', url.host);
+    headers.set('x-forwarded-proto', 'https');
+    // The Platinum edge's exposure token. Accepted as a header so it is never
+    // part of a URL a browser could see or a log could keep.
+    const previewToken = (env.PT_PREVIEW_TOKEN || '').trim();
+    if (previewToken) headers.set('x-pt-preview-token', previewToken);
+
+    let response;
+    try {
+      response = await fetch(
+        new Request(upstream, {
+          method: request.method,
+          headers,
+          body: request.body,
+          redirect: 'manual',
+        }),
+      );
+    } catch {
+      return Response.json(
+        { error: 'the pi-js cell is not reachable', target },
+        { status: 502, headers: { 'retry-after': '15' } },
+      );
+    }
+
+    // Cloudflare attaches the accepted socket to this non-standard property.
+    // Rebuilding the Response would drop it and break the agent's WebSocket.
+    if (response.status === 101 || response.webSocket) return response;
+
+    const output = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+    output.headers.set('x-kortix-environment', 'pi-js');
+    return output;
+  },
+};

--- a/infra/cloudflare/workers/pi-js-router/wrangler.toml
+++ b/infra/cloudflare/workers/pi-js-router/wrangler.toml
@@ -1,0 +1,41 @@
+# Cloudflare Worker that serves `pi-js.kortix.com` — the stable name for the JS
+# pi agent (apps/pi-worker-js) running as a Platinum Worker cell on Platinum
+# DEV, the way pi.kortix.com is the stable name for the pi-worker branch
+# environment on Platinum prod.
+#
+# Deploy (first time and every re-point):
+#   wrangler deploy --var TARGET_ORIGIN:https://8080-<cell>.eu-west.sbx-dev.platinum.dev
+#   wrangler secret put PT_PREVIEW_TOKEN      # the cell's exposure token (see below)
+#   wrangler secret put ACCESS_TOKEN          # optional: a shared bearer that gates the name
+#
+# `custom_domain = true`: Cloudflare creates and owns the DNS record and the
+# certificate for pi-js.kortix.com, so there is no separate DNS step.
+#
+# Auth: CLOUDFLARE_APPS_EDGE_API_TOKEN (Account Workers Scripts Write; kortix.com
+# zone DNS Write, Workers Routes Write, SSL and Certificates Write, Zone Read) —
+# the same token pi-router and configure-preview-edge.yml use.
+#
+# Why a token, unlike pi-router: pi.kortix.com's sandbox exposes its port
+# PUBLIC because the Kortix stack behind it has its own auth. The JS agent has
+# none — a request names a session with `?c=` and gets an agent with shell
+# tools — so its cell's port stays token-protected on the Platinum edge and this
+# Worker injects the token (x-pt-preview-token). With ACCESS_TOKEN set, the
+# public name itself requires `Authorization: Bearer <ACCESS_TOKEN>` (or the
+# `x-kortix-access` header); unset, the name is open — pi.kortix.com parity.
+#
+# TARGET_ORIGIN is a plain var: the cell's origin is derived from its sandbox
+# id, which survives stop/start (scale-to-zero) but not a delete + recreate.
+# .github/workflows/deploy-pi-js-router.yml re-publishes it on demand.
+
+main = "worker.mjs"
+compatibility_date = "2026-08-01"
+workers_dev = false
+account_id = "9785405a992435bb0c7bd19f9b6d26d5"
+
+name = "kortix-pi-js-router"
+routes = [
+  { pattern = "pi-js.kortix.com", custom_domain = true },
+]
+
+[vars]
+TARGET_ORIGIN = ""

--- a/infra/cloudflare/workers/pi-router/worker.mjs
+++ b/infra/cloudflare/workers/pi-router/worker.mjs
@@ -30,7 +30,16 @@ export default {
     }
 
     const url = new URL(request.url);
-    const upstream = new URL(`${url.pathname}${url.search}`, target);
+    // The origin is ALWAYS the configured target: copy the path and query onto
+    // it, never resolve the incoming path against it. `//host/x` is a
+    // scheme-relative reference — `new URL('//evil/x', target)` would have sent
+    // the request to evil (found by the Strix review of #7125, CWE-918).
+    if (/^\/[\/\\]/.test(url.pathname)) {
+      return Response.json({ error: 'invalid path' }, { status: 400 });
+    }
+    const upstream = new URL(target);
+    upstream.pathname = url.pathname;
+    upstream.search = url.search;
 
     const headers = new Headers(request.headers);
     for (const name of STRIPPED) headers.delete(name);

--- a/tests/unit/pi-js-router.test.ts
+++ b/tests/unit/pi-js-router.test.ts
@@ -1,0 +1,66 @@
+// pi-js.kortix.com fronts a shell-capable agent with no auth of its own, so the
+// Worker's two guards are claimed here: the upstream origin can never be moved
+// by the incoming path, and the name fails closed without an access policy.
+// Both were findings on #7125 (Strix: CWE-918, CWE-306).
+import { describe, expect, it } from 'vitest';
+import { accessRefusal, presentedAccess, upstreamUrl } from '../../infra/cloudflare/workers/pi-js-router/worker.mjs';
+
+const TARGET = 'https://8080-01m1s178mtjdff5gst7jqvc735.eu-west.sbx-dev.platinum.dev';
+
+describe('upstreamUrl — the origin is always the configured target', () => {
+  it('copies path and query onto the target origin', () => {
+    const u = upstreamUrl(TARGET, 'https://pi-js.kortix.com/session-read?c=abc&x=1#frag');
+    expect(u?.origin).toBe(TARGET);
+    expect(u?.pathname).toBe('/session-read');
+    expect(u?.search).toBe('?c=abc&x=1');
+    expect(u?.hash).toBe('');
+  });
+
+  it('refuses a scheme-relative path instead of forwarding the exposure token to another host', () => {
+    // new URL('//evil.example/x', TARGET) resolves to https://evil.example/x — the bug this replaces.
+    expect(upstreamUrl(TARGET, 'https://pi-js.kortix.com//evil.example/x')).toBeNull();
+    expect(upstreamUrl(TARGET, 'https://pi-js.kortix.com/\\evil.example/x')).toBeNull();
+    // A path that merely CONTAINS a double slash later is ordinary and stays on the target.
+    expect(upstreamUrl(TARGET, 'https://pi-js.kortix.com/a//b')?.origin).toBe(TARGET);
+  });
+
+  it('never resolves against the target even for absolute-looking paths', () => {
+    const u = upstreamUrl(TARGET, 'https://pi-js.kortix.com/https://evil.example/x');
+    expect(u?.origin).toBe(TARGET);
+    expect(u?.pathname).toBe('/https://evil.example/x');
+  });
+});
+
+describe('accessRefusal — the name fails closed', () => {
+  const req = (headers: Record<string, string> = {}) => new Request('https://pi-js.kortix.com/health', { headers });
+
+  it('answers 503 when there is no ACCESS_TOKEN and open access was not chosen', async () => {
+    const r = accessRefusal(req(), {});
+    expect(r?.status).toBe(503);
+    expect((await r!.json()).error).toMatch(/not configured/);
+  });
+
+  it('is open only when the operator deployed OPEN_ACCESS=true — and only the exact string', () => {
+    expect(accessRefusal(req(), { OPEN_ACCESS: 'true' })).toBeNull();
+    expect(accessRefusal(req(), { OPEN_ACCESS: 'yes' })?.status).toBe(503);
+    expect(accessRefusal(req(), { OPEN_ACCESS: '1' })?.status).toBe(503);
+  });
+
+  it('with ACCESS_TOKEN set: the right bearer or x-kortix-access passes, anything else is 401 with a challenge', () => {
+    const env = { ACCESS_TOKEN: 'k-secret-1' };
+    expect(accessRefusal(req({ authorization: 'Bearer k-secret-1' }), env)).toBeNull();
+    expect(accessRefusal(req({ 'x-kortix-access': 'k-secret-1' }), env)).toBeNull();
+    const wrong = accessRefusal(req({ authorization: 'Bearer k-secret-2' }), env);
+    expect(wrong?.status).toBe(401);
+    expect(wrong?.headers.get('www-authenticate')).toContain('Bearer');
+    expect(accessRefusal(req(), env)?.status).toBe(401);
+    // OPEN_ACCESS does not weaken a configured token.
+    expect(accessRefusal(req(), { ...env, OPEN_ACCESS: 'true' })?.status).toBe(401);
+  });
+
+  it('presentedAccess reads the bearer first, then x-kortix-access, trimmed', () => {
+    expect(presentedAccess(new Headers({ authorization: 'bearer  abc ' }))).toBe('abc');
+    expect(presentedAccess(new Headers({ 'x-kortix-access': ' xyz' }))).toBe('xyz');
+    expect(presentedAccess(new Headers({ authorization: 'Basic zzz' }))).toBe('');
+  });
+});


### PR DESCRIPTION
pi.kortix.com is a Cloudflare Worker (pi-router) that gives the pi-worker
branch environment one name by rebuilding each request against the Platinum
sandbox's own origin. pi-js.kortix.com does the same for apps/pi-worker-js
running as a Platinum Worker cell on Platinum DEV.

Two differences, both because the JS agent has no auth of its own (a request
names a session with ?c= and gets an agent with shell tools):
- the cell's port stays token-protected on the Platinum edge; the Worker
  injects the exposure token as x-pt-preview-token from a Worker secret, so
  the token never reaches a browser;
- with ACCESS_TOKEN set, the public name requires a bearer (401 otherwise,
  header consumed, never forwarded); unset, the name is open — pi.kortix.com
  parity, chosen by the operator, not by this file.

deploy-pi-js-router.yml (workflow_dispatch, input: the cell's origin) refuses
anything but a *.sbx-dev.platinum.dev origin, requires the target to answer
/health with the token before re-pointing (a dead target left pi.kortix.com
on Cloudflare's 502 on 2026-08-29), publishes the Worker, stores its secrets
from repo secrets, and reads the name back.

Cell: sandbox pi-js (sbx_01M1S178MTJDFF5GST7JQVC735) on api-dev.platinum.dev,
worker pi-agent version 088c79b2 (the branch's current bundle), port 8080
exposed private with a one-year token.

Needs on merge (org admin): repository secret `PI_JS_PREVIEW_TOKEN` = the cell's exposure token (the API refuses repo-secret writes from a repo admin with HTTP 400), optionally `PI_JS_ACCESS_TOKEN` to gate the name. Then Actions → deploy-pi-js-router → run with target_origin `https://8080-01m1s178mtjdff5gst7jqvc735.eu-west.sbx-dev.platinum.dev`.

https://claude.ai/code/session_015oeeN1DhSwfuztYD4wDYeh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791213034&installation_model_id=434224&pr_number=7125&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7125&signature=b9970eff3ef9aef00993cde0a7f9ab335a6b18b615142b97821e127eb65497b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->