### PR TITLE
fix(slack,teams): a live run lost its thread after 15 quiet minutes

### DIFF
--- a/apps/api/src/__tests__/unit-slack-turn.test.ts
+++ b/apps/api/src/__tests__/unit-slack-turn.test.ts
@@ -68,7 +68,7 @@ let dbWrites: Array<{ op: string; payload?: unknown }> = [];
 
 function makeChain(op: string): any {
   const chain: any = {};
-  for (const m of ['from', 'where', 'limit', 'onConflictDoUpdate', 'returning']) {
+  for (const m of ['from', 'where', 'limit', 'onConflictDoUpdate', 'onConflictDoNothing', 'returning']) {
     chain[m] = () => chain;
   }
   chain.values = (payload: unknown) => {
@@ -262,23 +262,81 @@ describe('relayTurnStep (chat.update model)', () => {
   });
 });
 
-describe('expired turn rows', () => {
-  test('drops a late answer relay without posting — but clears the stranded ⏳', async () => {
+// Regression cover for the 2026-09-04/05 Slack incident threads: a run whose
+// quiet stretches outlived STREAM_TTL_MS lost its stream, and every later step
+// plus the final answer was dropped on the floor. `expires_at` is no longer a
+// reaper in loadTurn, and an answer with no row left is still delivered.
+describe('a turn row past expires_at is still live', () => {
+  test('delivers a late answer instead of dropping it', async () => {
     dbResults = [
-      [streamRow({ expiresAt: new Date(Date.now() - 60_000) })], // loadTurn (expired)
-      [], // delete expired turn
+      [streamRow({ expiresAt: new Date(Date.now() - 60_000) })], // loadTurn (past expiry)
+      [{ sessionId: 'sess-1' }], // claimFinalize
+      [], // deleteTurn
     ];
 
     const ok = await relayTurnAnswer('sess-1', 'Late answer.');
-    expect(ok).toBe(false);
-    expect(dbWrites.map((w) => w.op)).toEqual(['delete']);
-    expect(calls('postMessage').length).toBe(0);
+    expect(ok).toBe(true);
+    const [update] = calls('updateBlocks');
+    expect(update?.args[3]).toBe('Task complete');
+    expect(calls('addReaction').length).toBe(1); // ✅ on a real answer
+    expect(calls('removeReaction').length).toBe(1); // ⏳ cleared
+  });
+
+  test('keeps streaming steps instead of reaping the row mid-run', async () => {
+    dbResults = [
+      [streamRow({ expiresAt: new Date(Date.now() - 60_000) })], // loadTurn (past expiry)
+      [], // saveTurn upsert
+    ];
+
+    const ok = await relayTurnStep('sess-1', 'Still working');
+    expect(ok).toBe(true);
+    expect(calls('updateBlocks').length).toBe(1); // plan repainted, not dropped
+    expect(dbWrites.some((w) => w.op === 'delete')).toBe(false);
+    // The step re-arms the row's own bound, so a live run cannot age out.
+    const saved = dbWrites.find((w) => w.op === 'insert.values')?.payload as { expiresAt: Date };
+    expect(saved.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+});
+
+describe('answer rescue when the GC already deleted the row', () => {
+  const sessionRow = (metadata: unknown) => [{ projectId: 'proj-1', metadata }];
+
+  test('posts the answer into the Slack thread from session metadata', async () => {
+    dbResults = [
+      [], // loadTurn — row gone (GC closed and deleted it)
+      sessionRow({ slack: { channel: 'C1', thread_ts: '10.10' } }),
+      [{ eventId: 'slack:answerrescue:sess-1' }], // claimAnswerRescue wins
+    ];
+
+    const ok = await relayTurnAnswer('sess-1', 'The fix is deployed.');
+    expect(ok).toBe(true);
+    const [post] = calls('postBlocks');
+    expect(post?.args[1]).toBe('C1'); // channel
+    expect(post?.args[4]).toBe('10.10'); // posted in-thread, not top-level
+    const blocks = post?.args[3] as Array<{ type: string }>;
+    expect(blocks.map((b) => b.type)).toEqual(['section', 'context']);
+  });
+
+  test('stays silent for a session that did not come from Slack', async () => {
+    dbResults = [
+      [], // loadTurn — no row
+      sessionRow({ source: 'ui' }), // no metadata.slack
+    ];
+
+    expect(await relayTurnAnswer('sess-1', 'x')).toBe(false);
     expect(calls('postBlocks').length).toBe(0);
-    expect(calls('updateBlocks').length).toBe(0);
-    expect(calls('addReaction').length).toBe(0);
-    // The expired un-finalized row had a ⏳ on the user's message — reaping it now
-    // clears that reaction so it doesn't linger forever.
-    expect(calls('removeReaction').length).toBe(1);
+    expect(calls('postMessage').length).toBe(0);
+  });
+
+  test('a duplicate slack send cannot post the answer twice', async () => {
+    dbResults = [
+      [], // loadTurn — no row
+      sessionRow({ slack: { channel: 'C1', thread_ts: '10.10' } }),
+      [], // claimAnswerRescue loses — a rescue already posted
+    ];
+
+    expect(await relayTurnAnswer('sess-1', 'again')).toBe(false);
+    expect(calls('postBlocks').length).toBe(0);
   });
 });
 

--- a/apps/api/src/__tests__/unit-teams-turn.test.ts
+++ b/apps/api/src/__tests__/unit-teams-turn.test.ts
@@ -139,6 +139,19 @@ describe('relayTurnAnswer', () => {
     expect(await relayTurnAnswer('sess-1', 'x')).toBe(false);
     expect(apiCalls).toHaveLength(0);
   });
+
+  // Same defect as the Slack side: STREAM_TTL_MS is refreshed only by a step
+  // relay, so a quiet stretch of real agent work longer than 15 minutes used to
+  // delete the row here and drop the answer. The GC sweep is the only reaper.
+  test('a row past expires_at still delivers its answer', async () => {
+    dbResults = [
+      [streamRow({ messageTs: 'act-1', expiresAt: new Date(Date.now() - 60_000) })],
+      [{ sessionId: 'sess-1' }],
+      [],
+    ];
+    expect(await relayTurnAnswer('sess-1', 'Late answer.')).toBe(true);
+    expect(apiCalls.map((c) => c.fn)).toEqual(['updateCard']);
+  });
 });
 
 describe('relayTurnEnd', () => {

--- a/apps/api/src/channels/slack/turn.ts
+++ b/apps/api/src/channels/slack/turn.ts
@@ -1,5 +1,5 @@
 import { and, eq, lt } from 'drizzle-orm';
-import { chatEventDedup, chatTurnStreams } from '@kortix/db';
+import { chatEventDedup, chatTurnStreams, projectSessions } from '@kortix/db';
 import { db } from '../../shared/db';
 import { registerSessionFailureNotifier } from '../../shared/session-failure-notifier';
 import { config } from '../../config';
@@ -37,7 +37,31 @@ export function rowToHandle(row: typeof chatTurnStreams.$inferSelect, token: str
   };
 }
 
-/** Hydrate a DB row into a usable handle (loads the bot token for its project). */
+/**
+ * Hydrate a DB row into a usable handle (loads the bot token for its project).
+ *
+ * `expires_at` IS NOT A REAPER HERE. It used to delete the row and return null
+ * the moment it passed, and `STREAM_TTL_MS` is 15 minutes that ONLY a `slack
+ * step` refreshes (see relayTurnStep) — the agent's own work refreshes nothing.
+ * So a run that thought for 16 minutes, or sat in one long install, silently
+ * lost its stream: every later step AND the final `slack send` found no row and
+ * were dropped, leaving the thread frozen on one stale step while the agent
+ * worked on.
+ *
+ * PROD 2026-09-05, session e58ddd55 (Slack thread 1788612689.109129 in
+ * C0BQCDKMTGX). `slack step` at 12:54:42, next at 13:19:22 — a 24m40s gap — so
+ * the row was reaped at 13:09:42 and the following five steps plus the answer
+ * went nowhere while the agent ran two more hours. The agent noticed the silence
+ * and started its own `while sleep 200; do slack step` keepalive at 13:37; by
+ * then there was nothing left to keep alive. Three incident threads that week
+ * (d91f2ff5, d08cccb4, 11f9e9e9) died the same way and read in Slack as
+ * "Kortix ignored the incident".
+ *
+ * The GC sweep below is the reaper, and the honest one: it is keyed on
+ * `updated_at` (30 minutes with no relay at all) and it POSTS before it deletes.
+ * Reaping here raced that sweep and won silently. `expires_at` stays written for
+ * bookkeeping and its index; nothing reads it as authority any more.
+ */
 export async function loadTurn(sessionId: string): Promise<LiveTurn | null> {
   if (!sessionId) return null;
   const [row] = await db
@@ -46,22 +70,6 @@ export async function loadTurn(sessionId: string): Promise<LiveTurn | null> {
     .where(eq(chatTurnStreams.sessionId, sessionId))
     .limit(1);
   if (!row) return null;
-  const expiry = new Date(row.expiresAt).getTime();
-  if (!Number.isFinite(expiry) || expiry <= Date.now()) {
-    // Reaping an expired un-finalized row: best-effort clear the ⏳ first so a
-    // stale hourglass doesn't sit on the user's message forever (the GC only
-    // sweeps live rows; once this row is gone nothing else can clear it).
-    if (!row.finalized) {
-      const ev = row.originatingEvent as SlackEvent | undefined;
-      const triggerTs = row.triggerTs || ev?.ts;
-      if (row.channel && triggerTs) {
-        const token = await loadSlackTokenForProject(row.projectId);
-        if (token) await removeReaction(token, row.channel, triggerTs, WORKING_EMOJI).catch(() => {});
-      }
-    }
-    await deleteTurn(sessionId);
-    return null;
-  }
   const token = await loadSlackTokenForProject(row.projectId);
   if (!token) return null;
   return rowToHandle(row, token);
@@ -539,13 +547,96 @@ export async function relayTurnAnswer(
   blocks?: unknown[],
 ): Promise<boolean> {
   const handle = await loadTurn(sessionId);
-  if (!handle || handle.finalized) return false;
+  // NO ROW AT ALL → the turn was closed and deleted (the 30-minute GC sweep)
+  // while the run was still going. The answer is real and the thread is still
+  // waiting for it, so deliver it anyway instead of returning false into an HTTP
+  // 200 the agent reads as "sent". See postAnswerWithoutTurn.
+  if (!handle) return postAnswerWithoutTurn(sessionId, text, blocks);
+  // A FINALIZED row is a turn already closed WITH its reply — a duplicate
+  // `slack send`, or a `session.idle` that won the race. Stay quiet.
+  if (handle.finalized) return false;
   // Win the finalize race against a late session.idle/error relay (or a duplicate
   // send) so the turn is closed exactly once.
   if (!(await claimFinalize(sessionId))) return false;
   await finalizeTurn(handle, { answer: markdownToMrkdwn(text), blocks });
   await deleteTurn(sessionId);
   return true;
+}
+
+// ── Last-resort answer delivery, with no turn row left ────────────────────────
+// The row can legitimately be gone by the time the agent answers: the GC closes
+// a turn after 30 minutes with no relay, posts "Run timed out", and deletes it.
+// The RUN does not stop — prod 2026-09-04 session d08cccb4 posted three steps,
+// went quiet, was closed at 30 minutes, and only finished at 09:06:28, 2h58m
+// after it started. `relayTurnAnswer` found no handle, returned false, and the
+// route answered the sandbox HTTP 200 `{ok:false}` (projects/routes/r4.ts), so
+// the agent believed it had replied and the thread never saw a word of it.
+//
+// A Slack-started session carries everything needed to reach its own thread in
+// `project_sessions.metadata.slack` (channel + thread_ts, written at create time
+// in channels/slack/session.ts), so the answer can always be posted. A session
+// from any other source has no `metadata.slack` and is left alone.
+const ANSWER_RESCUE_TTL_MS = STREAM_TTL_MS;
+
+// One rescue per session per TTL, so a duplicate `slack send` cannot post the
+// answer twice. The window is safe: a row must live at least STREAM_TTL_MS
+// before anything can reap it, so two genuine rescues are always further apart
+// than this claim.
+async function claimAnswerRescue(sessionId: string): Promise<boolean> {
+  try {
+    const inserted = await db
+      .insert(chatEventDedup)
+      .values({
+        eventId: `slack:answerrescue:${sessionId}`,
+        expiresAt: new Date(Date.now() + ANSWER_RESCUE_TTL_MS),
+      })
+      .onConflictDoNothing({ target: chatEventDedup.eventId })
+      .returning({ eventId: chatEventDedup.eventId });
+    return inserted.length > 0;
+  } catch (err) {
+    // Fail CLOSED. The whole point is to not post twice into a thread someone is
+    // reading; a dropped rescue is still recoverable from the session link.
+    console.warn('[slack-webhook] answer-rescue claim failed (suppressing)', err);
+    return false;
+  }
+}
+
+/**
+ * Post an agent answer into its Slack thread when no turn row exists.
+ * Returns true only when Slack accepted the message.
+ */
+export async function postAnswerWithoutTurn(
+  sessionId: string,
+  text: string,
+  blocks?: unknown[],
+): Promise<boolean> {
+  const [row] = await db
+    .select({ projectId: projectSessions.projectId, metadata: projectSessions.metadata })
+    .from(projectSessions)
+    .where(eq(projectSessions.sessionId, sessionId))
+    .limit(1);
+  if (!row) return false;
+  const slack = (row.metadata as { slack?: { channel?: string; thread_ts?: string } } | null)?.slack;
+  const channel = slack?.channel;
+  const threadTs = slack?.thread_ts;
+  if (!channel || !threadTs) return false; // not a Slack-started session
+  const token = await loadSlackTokenForProject(row.projectId);
+  if (!token) return false;
+  if (!(await claimAnswerRescue(sessionId))) return false;
+
+  const rendered = markdownToMrkdwn(text);
+  const truncated = rendered.length > MAX_BODY;
+  const body = rendered.slice(0, MAX_BODY);
+  const url = sessionWebUrl(config.FRONTEND_URL, row.projectId, sessionId);
+  const footer = { type: 'context', elements: [{ type: 'mrkdwn', text: `<${url}|Open session in Kortix ↗>` }] };
+  const finalBlocks =
+    blocks && blocks.length > 0 ? [...blocks, footer] : [...toSectionBlocks(body, truncated), footer];
+
+  const ts = await postBlocks(token, channel, body, finalBlocks, threadTs);
+  if (ts) return true;
+  // Block render rejected (a section caps at 3000 chars) — never lose the answer.
+  const fallback = await postMessage(token, channel, `${body}\n\n<${url}|Open session in Kortix ↗>`, threadTs);
+  return fallback != null;
 }
 
 // Called when the agent's turn ends — opencode `session.idle` (finished) or

--- a/apps/api/src/channels/teams/turn.ts
+++ b/apps/api/src/channels/teams/turn.ts
@@ -43,6 +43,14 @@ function rowToHandle(row: typeof chatTurnStreams.$inferSelect): TeamsLiveTurn {
   };
 }
 
+/**
+ * `expires_at` is not a reaper here — identical reasoning to the Slack side, see
+ * channels/slack/turn.ts loadTurn. `STREAM_TTL_MS` is refreshed only by a `slack
+ * step` relay, so any quiet stretch of real agent work longer than 15 minutes
+ * deleted the row and silently dropped every later step and the final answer.
+ * The GC sweep below is the reaper: keyed on `updated_at`, and it posts before
+ * it deletes.
+ */
 export async function loadTurn(sessionId: string): Promise<TeamsLiveTurn | null> {
   if (!sessionId) return null;
   const [row] = await db
@@ -51,11 +59,6 @@ export async function loadTurn(sessionId: string): Promise<TeamsLiveTurn | null>
     .where(eq(chatTurnStreams.sessionId, sessionId))
     .limit(1);
   if (!row || !row.channelRef) return null;
-  const expiry = new Date(row.expiresAt).getTime();
-  if (!Number.isFinite(expiry) || expiry <= Date.now()) {
-    await deleteTurn(sessionId);
-    return null;
-  }
   return rowToHandle(row);
 }
 


### PR DESCRIPTION
## The report

"Kortix doesn't respond when we tag it on an incident — the last 5 didn't, and the one that did never finished."

## What is actually happening

Ingress is fine. All four incident mentions I traced created their session in the right project within 5 seconds of the Slack event:

| Slack root ts | UTC | Session | Δ create | Turn ended |
|---|---|---|---|---|
| `1788612689.109129` | 09-05 12:51:29 | `e58ddd55` | +1.9s | still running |
| `1788588042.924019` | 09-05 06:00:42 | `d91f2ff5` | +3.9s | 06:30:24 `unknown` |
| `1788502072.103999` | 09-04 06:07:52 | `d08cccb4` | +4.4s | 09:06:28 `unknown` |
| `1788483216.407779` | 09-04 00:53:36 | `11f9e9e9` | +4.5s | 03:49:02 `unknown` |

All `source: slack`, channel `C0BQCDKMTGX`, project `Kortix Company` (`fda4e35e`), binding correct. **The agent runs. Its output is thrown away.**

## Root cause

`chat_turn_streams.expires_at` was a reaper inside `loadTurn`. `STREAM_TTL_MS` is **15 minutes**, and only a `slack step` relay refreshes it (`relayTurnStep`) — model tokens, tool calls, edits, installs refresh nothing.

So a run that goes quiet for 16 minutes loses its stream. Every later `slack step` and the **final `slack send`** then find no row and are dropped, while `POST /projects/:id/sessions/:sid/turn-stream` still answers the sandbox `200 {"ok":false}` — so the agent believes it replied.

Proof from `e58ddd55`'s live OpenCode transcript (107 messages, still running):

```
12:54:42  slack step "Locating the orchestrator settlement code"   ← expiry now 13:09:42
13:19:22  slack step "Root cause confirmed"          ← 24m40s gap: row already reaped
13:20:50  slack step "Root cause confirmed"          ← dropped
13:36:22  slack step "Standing up the isolated repro" ← dropped
13:37:21  while sleep 200; do slack step "Still..."   ← the agent built its own keepalive, too late
14:42:10  slack step "Fix verified in isolation"     ← dropped
```

That thread shows one stale step and nothing else while the agent works on for two more hours.

`d08cccb4` is the "started but never finished" one: three steps, then the 30-minute GC closed it as *"Run timed out"*, and the run itself only ended at 09:06:28 — 2h58m in — with its answer nowhere to go.

## The change

1. **`loadTurn` (slack + teams) no longer reaps on `expires_at`.** The GC sweep is the reaper, and the honest one: keyed on `updated_at` (30 minutes with no relay at all) and it posts before it deletes. The reap raced that sweep and won silently. `expires_at` stays written for bookkeeping and its index.
2. **`relayTurnAnswer` delivers an answer that arrives with no row left.** A Slack-started session carries its own `channel` + `thread_ts` in `project_sessions.metadata.slack`, so the reply can always reach the thread. Claimed once per session per TTL so a duplicate `slack send` cannot double-post; fail-closed on a claim error.
3. **The test that asserted the old behaviour encoded the bug.** `"drops a late answer relay without posting"` now asserts the answer is delivered, plus cover for a step relay past expiry, the rescue path, a non-Slack session, and the duplicate-send guard.

Teams carries the identical `loadTurn` defect and gets the same fix plus a regression test.

## Verification

- `apps/api` `tsc --noEmit` → **0 errors**
- `bun test --isolate --env-file=scripts/test.env src/__tests__/unit-slack-turn.test.ts` → **22 pass / 0 fail**
- `biome check` on the four changed files → **43 diagnostics, identical to base** (all pre-existing `!` style in the test files); no new ones
- Full `apps/api` suite + preview origin: see the checks on this PR

## Deliberately not in this change

The 30-minute GC still closes a turn whose session is provably still running. Teaching it to read the turn ledger (`session_turns.state <> 'ended'`) would remove the premature *"Run timed out"* entirely; the answer rescue makes it non-fatal in the meantime.

Separately, and unrelated to this: `link-bot` is broken in prod because `users.info`/`users.list` are POSTed as JSON, so Slack drops the params and answers `user_not_found`. Fix already exists on `fix/slack-usersinfo-formencode` (`70d0102d66`) and is **not merged to main, staging or prod**.

https://claude.ai/code/session_016EucSvmVwuV6NKFg2VqKdh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791213514&installation_model_id=434224&pr_number=7127&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7127&signature=e0879c2efa711a5df7cc8bed7c03aa3e277d8929b684f46acc1e76d05067102e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->