### PR TITLE
fix(triggers): record a reuse/keyed/pinned delivery handoff as fired, not queued (staging hotfix)

### DIFF
--- a/apps/api/src/__tests__/e2e-project-triggers.test.ts
+++ b/apps/api/src/__tests__/e2e-project-triggers.test.ts
@@ -816,6 +816,7 @@ function seedRuntimeCron(opts: {
   slug: string;
   prompt: string;
   nextFireAt: Date;
+  sessionMode?: string;
 }) {
   runtimeRows.push({
     projectId: PROJECT_ID,
@@ -851,7 +852,7 @@ function seedRuntimeCron(opts: {
       runAt: null,
       timezone: 'UTC',
       secretEnv: null,
-      sessionMode: 'fresh',
+      sessionMode: opts.sessionMode ?? 'fresh',
       pinnedSessionId: null,
       sessionKey: null,
       filter: null,
@@ -1486,6 +1487,69 @@ describe('git-backed triggers — runtime fire paths', () => {
     expect(triggerExecutionRows[1]?.scheduledFor.toISOString()).toBe(
       '2026-01-01T00:00:31.000Z',
     );
+  });
+
+  test('reuse trigger cron sweep records fired (not queued) for a prompt-enqueued delivery handoff', async () => {
+    seedManifest(cronEntry({
+      slug: 'reuse-stale',
+      name: 'Reuse Stale',
+      cron: '* * * * * *',
+      prompt: 'Reuse sweep run',
+    }));
+    const scheduledFor = new Date('2026-01-01T00:00:30Z');
+    seedRuntimeCron({
+      slug: 'reuse-stale',
+      prompt: 'Reuse sweep run',
+      nextFireAt: scheduledFor,
+      sessionMode: 'reuse',
+    });
+    // Pre-seed a reusable session so the fire path finds it and enqueues (rather
+    // than creating a fresh session, which would return `fired`).
+    sessionRows.push({
+      sessionId: 'sess-reuse',
+      accountId: ACCOUNT_ID,
+      projectId: PROJECT_ID,
+      branchName: 'main',
+      baseRef: 'main',
+      sandboxProvider: 'daytona',
+      sandboxId: null,
+      sandboxUrl: null,
+      opencodeSessionId: null,
+      agentName: 'default',
+      status: 'stopped',
+      error: null,
+      createdBy: USER_ID,
+      visibility: 'private',
+      origin: 'system',
+      originRef: null,
+      secretsAllowlist: null,
+      requiredConnectors: null,
+      connectorBindingsInheritUnbound: false,
+      connectorBindingsConfigured: false,
+      metadata: { trigger_slug: 'reuse-stale', trigger_kind: 'git' },
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      updatedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+
+    const result = await runProjectTriggerSweep(scheduledFor);
+    expect(result).toMatchObject({ scanned: 1, fired: 0, failed: 0 });
+    expect(await drainTriggerExecutionQueue(scheduledFor)).toMatchObject({
+      fired: 0,
+      queued: 1,
+      failed: 0,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    // The execution drain calls `markGitTriggerFired` — the key
+    // assertion: `lastStatus` is `'fired'`, not `'queued'`, even though
+    // `fireGitTrigger` returned `{ status: 'queued', reason: 'prompt queued
+    // for delivery' }`. The `executeTriggerExecution` path now maps the
+    // delivery handoff to `fired` so the reliability operator's
+    // `QUEUED_OVER_15M` guard does not flag every `session_mode: reuse`
+    // trigger permanently.
+    expect(runtimeRows).toHaveLength(1);
+    expect(runtimeRows[0]!.lastStatus).toBe('fired');
+    expect(runtimeRows[0]!.lastFiredAt).toBeTruthy();
+    expect(sandboxProvisionCalls).toBe(0);
   });
 
   test('webhook fires verify the HMAC signature and reject impostors', async () => {

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -1187,6 +1187,20 @@ async function executeTriggerExecution(
     );
     const completedAt = new Date();
     if (result.status === 'fired' || result.status === 'queued') {
+      // `queued` means two different things to `fireGitTrigger`. A reuse/keyed/
+      // pinned fire that hands the prompt to an EXISTING session (`reason:
+      // 'prompt queued for delivery'`) is a COMPLETE fire — the session exists
+      // and the prompt is durably queued. Recording that as `last_status:
+      // 'queued'` left a healthy fire indistinguishable from a create still
+      // waiting on backpressure, so the reliability operator's
+      // `QUEUED_OVER_15M` attention flagged every `session_mode: reuse`
+      // trigger permanently. Only a create that is genuinely still pending
+      // (no session yet) stays `queued`; the delivery handoff is `fired`, the
+      // same status the webhook fire path records for the identical outcome.
+      const runtimeStatus =
+        result.status === 'queued' && result.reason === 'prompt queued for delivery'
+          ? 'fired'
+          : result.status;
       await Promise.all([
         markTriggerExecutionSucceeded({
           row,
@@ -1194,12 +1208,7 @@ async function executeTriggerExecution(
           sessionId: result.sessionId,
           commandId: result.commandId,
         }),
-        markGitTriggerFired(
-          row.projectId,
-          row.slug,
-          completedAt,
-          result.status === 'queued' ? 'queued' : 'fired',
-        ),
+        markGitTriggerFired(row.projectId, row.slug, completedAt, runtimeStatus),
       ]);
       return result.status;
     }


### PR DESCRIPTION
Cherry-pick of #7124 onto staging so the hourly-heartbeat queue-stall fix is in the next prod release candidate.

Same change as <https://github.com/kortix-ai/suna/pull/7124|#7124> — already merged to main and verified live on dev (commit e656dede).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791214746&installation_model_id=434224&pr_number=7129&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7129&signature=be5f3c1fefbbd0414db7db9a3049a2d30666b623df05b51ea8c5b46d9294cd59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->