### PR TITLE
ci(pi-js-router): read its tokens from the pi-js environment

### DIFF
--- a/.github/workflows/deploy-pi-js-router.yml
+++ b/.github/workflows/deploy-pi-js-router.yml
@@ -11,7 +11,8 @@
 # and `open_access` — the name FAILS CLOSED: without PI_JS_ACCESS_TOKEN the
 # Worker answers 503 unless this input is set, which deploys OPEN_ACCESS=true
 # (pi.kortix.com parity, stated out loud here rather than fallen into).
-# Secrets (repo): CLOUDFLARE_APPS_EDGE_API_TOKEN (same as pi-router),
+# Secrets — CLOUDFLARE_APPS_EDGE_API_TOKEN on the repo (same as pi-router); the
+# two below in the `pi-js` ENVIRONMENT (the job declares it):
 #   PI_JS_PREVIEW_TOKEN (the cell's exposure token — the Worker sends it to the
 #   Platinum edge as x-pt-preview-token, so the port stays private),
 #   PI_JS_ACCESS_TOKEN (the bearer the public name requires; optional only when
@@ -42,6 +43,10 @@ jobs:
   deploy:
     runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
     timeout-minutes: 10
+    # The secrets live in the `pi-js` ENVIRONMENT, not on the repo: repo-level
+    # secret writes on this repository answer HTTP 400 even for a repo admin
+    # (2026-09-05), environment-scoped ones do not.
+    environment: pi-js
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_APPS_EDGE_API_TOKEN }}
       TARGET_ORIGIN: ${{ inputs.target_origin }}


### PR DESCRIPTION
Follow-up to #7125: the deploy job declares `environment: pi-js`, where PI_JS_PREVIEW_TOKEN and PI_JS_ACCESS_TOKEN now live (repo-level writes answer 400 here).

https://claude.ai/code/session_015oeeN1DhSwfuztYD4wDYeh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791215917&installation_model_id=434224&pr_number=7130&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7130&signature=4c048c6e4055c59be18985f7fb5cbdb934e2cf94fde4ad78fa95798c0fec6238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->