### PR TITLE
fix(ci): forward all preview runtime secrets

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,14 @@ linked, not inlined.
 
 ## Register
 
+### Preview bootstrap secrets must derive from the runtime allowlist (2026-09-05)
+
+**When:** adding a preview runtime secret. Build the forwarded secret object from
+`PREVIEW_RUNTIME_SECRET_ALLOWLIST`; do not duplicate its keys in the default-branch
+controller. *Incident:* PR #7109 received `PREVIEW_MANAGED_GIT_GITHUB_TOKEN` in Actions,
+but the preview API kept using an under-permissioned App because the controller omitted
+the PAT. *Enforcer:* `preview-stack.test.ts` checks every allowlisted key.
+
 ### Every streamed transcript mutation refreshes runtime activity (2026-09-05)
 
 **When:** adding or changing a wire event that mutates visible assistant output.

--- a/tests/bin/sandbox-preview.ts
+++ b/tests/bin/sandbox-preview.ts
@@ -16,7 +16,7 @@ import {
   teardownDaytonaPreview,
   teardownPlatinumPreview,
 } from '../src/core/sandbox-preview-providers';
-import type { PreviewRuntimeSecrets } from '../src/core/preview-stack';
+import { readPreviewRuntimeSecrets } from '../src/core/preview-stack';
 
 function value(name: string, fallback = ''): string {
   return process.env[name]?.trim() || fallback;
@@ -38,20 +38,6 @@ function provider(): SandboxPreviewProvider {
   const selected = value('PREVIEW_SANDBOX_PROVIDER', 'auto').toLowerCase();
   if (selected === 'auto' || selected === 'platinum' || selected === 'daytona') return selected;
   throw new Error(`PREVIEW_SANDBOX_PROVIDER must be auto, platinum, or daytona; received ${selected}`);
-}
-
-function runtimeSecrets(): PreviewRuntimeSecrets {
-  return {
-    DAYTONA_API_KEY: value('DAYTONA_API_KEY'),
-    KE2E_STRIPE_SECRET_KEY: value('KE2E_STRIPE_SECRET_KEY'),
-    KE2E_STRIPE_WEBHOOK_SECRET: value('KE2E_STRIPE_WEBHOOK_SECRET'),
-    KORTIX_GITHUB_APP_ID: value('KORTIX_GITHUB_APP_ID'),
-    KORTIX_GITHUB_APP_PRIVATE_KEY: value('KORTIX_GITHUB_APP_PRIVATE_KEY'),
-    KORTIX_GITHUB_APP_SLUG: value('KORTIX_GITHUB_APP_SLUG'),
-    MANAGED_GIT_GITHUB_INSTALL_ID: value('MANAGED_GIT_GITHUB_INSTALL_ID'),
-    MANAGED_GIT_GITHUB_OWNER: value('MANAGED_GIT_GITHUB_OWNER'),
-    OPENROUTER_API_KEY: value('OPENROUTER_API_KEY'),
-  };
 }
 
 async function writeOutput(name: string, outputValue: string): Promise<void> {
@@ -168,7 +154,7 @@ if (action === 'deploy') {
     runAttempt: value('GITHUB_RUN_ATTEMPT', '1'),
     root: resolve(value('PREVIEW_ROOT', resolve(import.meta.dir, '../..'))),
     lockfileHash: required('PREVIEW_LOCKFILE_SHA256'),
-    secrets: runtimeSecrets(),
+    secrets: readPreviewRuntimeSecrets(process.env),
     platinum,
     daytona,
   };

--- a/tests/src/core/preview-stack.ts
+++ b/tests/src/core/preview-stack.ts
@@ -14,6 +14,14 @@ export const PREVIEW_RUNTIME_SECRET_ALLOWLIST = [
 export type PreviewRuntimeSecretName = (typeof PREVIEW_RUNTIME_SECRET_ALLOWLIST)[number];
 export type PreviewRuntimeSecrets = Partial<Record<PreviewRuntimeSecretName, string>>;
 
+export function readPreviewRuntimeSecrets(
+  environment: Readonly<Record<string, string | undefined>>,
+): PreviewRuntimeSecrets {
+  return Object.fromEntries(
+    PREVIEW_RUNTIME_SECRET_ALLOWLIST.map((key) => [key, environment[key]?.trim() ?? '']),
+  );
+}
+
 export interface PreviewStackInput {
   origin: string;
   sha: string;

--- a/tests/unit/preview-stack.test.ts
+++ b/tests/unit/preview-stack.test.ts
@@ -4,12 +4,23 @@ import {
   applyPreviewEnvironment,
   buildPreviewCaddyfile,
   buildPreviewComposeOverlay,
+  readPreviewRuntimeSecrets,
   validatePreviewRuntimeSecrets,
 } from '../src/core/preview-stack';
 
 const SHA = 'a'.repeat(40);
 
 describe('ephemeral self-host preview stack', () => {
+  it('reads every allowlisted runtime secret from the workflow environment', () => {
+    const environment = Object.fromEntries(
+      PREVIEW_RUNTIME_SECRET_ALLOWLIST.map((key) => [key, ` ${key} `]),
+    );
+
+    expect(readPreviewRuntimeSecrets(environment)).toEqual(
+      Object.fromEntries(PREVIEW_RUNTIME_SECRET_ALLOWLIST.map((key) => [key, key])),
+    );
+  });
+
   it('routes every public surface through one origin', () => {
     const caddy = buildPreviewCaddyfile('preview.example.test');
     expect(caddy).toContain(':8080');


### PR DESCRIPTION
## Problem

The default-branch preview controller duplicated the runtime-secret allowlist. It omitted `MANAGED_GIT_GITHUB_TOKEN`. Actions received the secret, but the preview API container did not. Target-full then used an under-permissioned GitHub App and failed project creation with HTTP 403.

## Change

- Derive preview runtime secrets from `PREVIEW_RUNTIME_SECRET_ALLOWLIST`.
- Add a contract that covers every allowlisted key.
- Record the incident rule in the append-only learnings register.

## Verification

- `bun test tests/unit/preview-stack.test.ts tests/unit/sandbox-preview.test.ts`
- Result: 28 passed, 0 failed, 125 assertions.
- `git diff --check`: passed.

## Delivery dependency

This controller runs from `main` by design. The change cannot affect any preview until this PR merges. Do not merge without explicit approval.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791216521&installation_model_id=434224&pr_number=7132&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7132&signature=ec358758e43169e532c5a87e5a4751e066a4db9da7642b513079463b29a2455b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->