### PR TITLE
infra(pi-js-router): open_access is the operator's override

### DIFF
--- a/.github/workflows/deploy-pi-js-router.yml
+++ b/.github/workflows/deploy-pi-js-router.yml
@@ -90,11 +90,14 @@ jobs:
         run: |
           set -euo pipefail
           printf '%s' "$PT_PREVIEW_TOKEN" | npx --yes wrangler@4 secret put PT_PREVIEW_TOKEN
-          if [ -n "${ACCESS_TOKEN:-}" ]; then
+          if [ "$OPEN_ACCESS" = "true" ]; then
+            # The operator chose an open name: a bearer left on the Worker from
+            # an earlier gated deploy must not stay stored beside it.
+            npx --yes wrangler@4 secret delete ACCESS_TOKEN --force >/dev/null 2>&1 || true
+            echo "::warning::pi-js.kortix.com is OPEN (open_access=true) — the JS agent has no auth of its own"
+          elif [ -n "${ACCESS_TOKEN:-}" ]; then
             printf '%s' "$ACCESS_TOKEN" | npx --yes wrangler@4 secret put ACCESS_TOKEN
             echo "pi-js.kortix.com requires a bearer (PI_JS_ACCESS_TOKEN is set)"
-          else
-            echo "::warning::pi-js.kortix.com is OPEN (open_access=true, no PI_JS_ACCESS_TOKEN) — the JS agent has no auth of its own"
           fi
       - name: Read the name back
         run: |

--- a/infra/cloudflare/workers/pi-js-router/worker.mjs
+++ b/infra/cloudflare/workers/pi-js-router/worker.mjs
@@ -15,12 +15,13 @@
  *   1. The cell's port is NOT public on the Platinum edge. The edge wants the
  *      exposure token (`?t=` or `x-pt-preview-token`); this Worker injects it
  *      from the PT_PREVIEW_TOKEN secret, so the token never reaches a browser.
- *   2. The name FAILS CLOSED. With ACCESS_TOKEN set, every request must carry
+ *   2. The name FAILS CLOSED unless the deploy says otherwise. OPEN_ACCESS=true
+ *      (a plain var, visible in the deploy command) opens it — pi.kortix.com
+ *      parity, chosen by the operator; the workflow also deletes any stored
+ *      bearer. Otherwise ACCESS_TOKEN must be set and every request must carry
  *      `Authorization: Bearer <ACCESS_TOKEN>` or `x-kortix-access: <ACCESS_TOKEN>`
- *      (consumed here, never forwarded). With no ACCESS_TOKEN the Worker answers
- *      503 — unless the operator deployed with the plain var OPEN_ACCESS=true,
- *      which is pi.kortix.com parity stated out loud in the deploy, not a
- *      default a cleared secret can fall into (Strix review of #7125, CWE-306).
+ *      (consumed here, never forwarded); with neither the Worker answers 503,
+ *      not an open door a cleared secret can fall into (Strix on #7125, CWE-306).
  *
  * The upstream URL is built from the TARGET origin and then given the incoming
  * path and query — never by resolving the incoming path against the origin. A
@@ -78,8 +79,13 @@ export function presentedAccess(headers) {
 export function accessRefusal(request, env) {
   const required = (env.ACCESS_TOKEN || '').trim();
   const openAccess = (env.OPEN_ACCESS || '').trim() === 'true';
+  // OPEN_ACCESS=true is the operator's explicit, visible choice at deploy time
+  // (a plain var in the deploy command) and wins even over a bearer that is
+  // still stored: the owner opened the name on 2026-09-05 and the stored
+  // bearer kept answering 401. Deleting the secret is the workflow's job; the
+  // Worker must not keep a door shut that the deploy said to open.
+  if (openAccess) return null;
   if (!required) {
-    if (openAccess) return null;
     return Response.json(
       { error: 'pi-js.kortix.com is not configured: set the ACCESS_TOKEN secret, or deploy with OPEN_ACCESS=true to run it open' },
       { status: 503, headers: { 'retry-after': '60' } },

--- a/tests/unit/pi-js-router.test.ts
+++ b/tests/unit/pi-js-router.test.ts
@@ -54,8 +54,11 @@ describe('accessRefusal — the name fails closed', () => {
     expect(wrong?.status).toBe(401);
     expect(wrong?.headers.get('www-authenticate')).toContain('Bearer');
     expect(accessRefusal(req(), env)?.status).toBe(401);
-    // OPEN_ACCESS does not weaken a configured token.
-    expect(accessRefusal(req(), { ...env, OPEN_ACCESS: 'true' })?.status).toBe(401);
+    // OPEN_ACCESS=true is the operator's explicit deploy-time choice and wins
+    // over a bearer still stored — the owner opened the name and a stale
+    // ACCESS_TOKEN kept answering 401 (2026-09-05).
+    expect(accessRefusal(req(), { ...env, OPEN_ACCESS: 'true' })).toBeNull();
+    expect(accessRefusal(req(), { ...env, OPEN_ACCESS: 'yes' })?.status).toBe(401);
   });
 
   it('presentedAccess reads the bearer first, then x-kortix-access, trimmed', () => {


### PR DESCRIPTION
pi-js.kortix.com was opened (open_access=true) but a stored bearer still answered 401. OPEN_ACCESS=true now wins and the workflow deletes the stored ACCESS_TOKEN when opening. Unit claims updated.

https://claude.ai/code/session_015oeeN1DhSwfuztYD4wDYeh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791219103&installation_model_id=434224&pr_number=7134&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7134&signature=0680c475a6809df30cdb2a176df80256e34f545c7850066bcdc7034c1a96c228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->