### PR TITLE
fix(preview): raise Node engine floor and recover provider caches

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4202,3 +4202,23 @@ preview-parity ports. *Enforcer:* `tests/unit/preview-guard.test.ts`
 (`sh -n` on the guard, never `-v`, deploy-in-flight gate, hash-keyed install)
 and `tests/unit/sandbox-preview.test.ts` (prune before pull, fallback install,
 rollback after the health check, guard before configure).
+
+## A failed content-addressed template must change the next create idempotency key (2026-09-05)
+
+PR #7109 could not deploy its branch preview. Platinum returned two failed
+records for `kortix-ci-v11-03a0eb30070ddb14-base`. The controller correctly
+rejected both records as reusable, but retried `POST /v1/templates/from-spec`
+with the original idempotency key. Platinum returned the same failed create
+result. The branch environment could not fall back to Daytona because that
+would change its stable origin.
+
+**The rule.** A content-addressed resource can reuse its normal idempotency key
+until the provider records a terminal failure. The next create key must include
+a deterministic fingerprint of the known failed resource IDs. Concurrent
+retries for the same failure set still deduplicate. A newly failed retry changes
+the failure set and therefore changes the next create key.
+
+*Fix:* `platinumTemplateCreateIdempotencyKey()` fingerprints failed template
+IDs for base and warm template creation. *Enforcer:*
+`tests/unit/platinum-ci.test.ts` verifies stable concurrent retry keys and a new
+key after another terminal failure.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4222,3 +4222,20 @@ the failure set and therefore changes the next create key.
 IDs for base and warm template creation. *Enforcer:*
 `tests/unit/platinum-ci.test.ts` verifies stable concurrent retry keys and a new
 key after another terminal failure.
+
+## An explicit fallback preview must not inherit the persistent provider identity (2026-09-05)
+
+PR #7109 needed Daytona after Platinum failed twice while building its base
+template. The manual dispatch selected `daytona`, but the workflow still set
+`PREVIEW_BRANCH_ENV` to the pull request branch. The provider guard rejected
+Daytona before sandbox creation because that value reserves the stable branch
+origin for Platinum.
+
+**The rule.** A manual Daytona fallback verifies the exact pull request SHA on
+an ephemeral provider origin. It must leave `PREVIEW_BRANCH_ENV` empty. Normal
+automatic and Platinum runs must keep the persistent branch identity.
+
+*Fix:* `deploy-preview.yml` emits an empty `persistent_branch` only for an
+explicit workflow-dispatch Daytona run. *Enforcer:*
+`tests/unit/web-ecs-workflow.test.ts` asserts both the selection condition and
+the deploy environment output.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4239,3 +4239,21 @@ automatic and Platinum runs must keep the persistent branch identity.
 explicit workflow-dispatch Daytona run. *Enforcer:*
 `tests/unit/web-ecs-workflow.test.ts` asserts both the selection condition and
 the deploy environment output.
+
+## A dependency engine floor must invalidate the preview base image (2026-09-05)
+
+PR #7109 failed to build both Platinum and Daytona base caches. The preview
+base image pinned Node `22.22.0`. The resolved `write-file-atomic@8.0.0`
+package requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. The exact provider
+command exited at `pnpm install --frozen-lockfile` with
+`ERR_PNPM_UNSUPPORTED_ENGINE`.
+
+**The rule.** The preview base image Node version must satisfy every resolved
+package engine. A Node image change must also increment the Platinum and
+Daytona base-cache versions. Failed caches must never retain the old runtime.
+
+*Fix:* the shared preview image now pins the multi-platform digest for Node
+`22.22.2-bookworm`. Platinum base cache `v12` and Daytona base cache `v4`
+force fresh builds. *Enforcer:* `tests/unit/platinum-ci.test.ts` and
+`tests/unit/daytona-ci.test.ts` assert both new cache names and the exact image
+digest.

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -64,6 +64,7 @@ jobs:
       ref: ${{ steps.preview.outputs.ref }}
       lockfile_sha256: ${{ steps.preview.outputs.lockfile_sha256 }}
       head_branch: ${{ steps.preview.outputs.head_branch }}
+      persistent_branch: ${{ steps.preview.outputs.persistent_branch }}
       public_origin: ${{ steps.preview.outputs.public_origin }}
       public_worker: ${{ steps.preview.outputs.public_worker }}
       provider: ${{ steps.preview.outputs.provider }}
@@ -129,13 +130,19 @@ jobs:
             exit 1
           }
 
+          branch="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.ref)"
+          # A manual Daytona run verifies the exact PR SHA on an ephemeral
+          # origin after Platinum fails. It must not claim or replace the
+          # branch's persistent Platinum identity.
+          persistent_branch=$([ "$EVENT_NAME" = workflow_dispatch ] && [ "$provider" = daytona ] && printf '' || printf '%s' "$branch")
+
           {
             echo "pr_number=$num"
             echo "sha=$sha"
             echo "ref=refs/pull/${num}/head"
             echo "lockfile_sha256=$lockfile_sha256"
-            branch="$(gh api "repos/${REPO}/pulls/${num}" --jq .head.ref)"
             echo "head_branch=$branch"
+            echo "persistent_branch=$persistent_branch"
             # A branch MAY be fronted by a stable hostname instead of being
             # reached at the provider's own url. PREVIEW_PUBLIC_ORIGINS maps
             # `branch=https://host`, one per line; anything unlisted — which is
@@ -334,7 +341,7 @@ jobs:
       # --target-full on each one would make the label unusable for working in.
       # Re-run it any time from the Actions tab with 'Run workflow'.
       PREVIEW_RUN_TESTS: ${{ (github.event.action == 'labeled' || github.event_name == 'workflow_dispatch') && '1' || '0' }}
-      PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.head_branch }}
+      PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.persistent_branch }}
       PREVIEW_PUBLIC_ORIGIN: ${{ needs.authorize.outputs.public_origin }}
       PREVIEW_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
       PREVIEW_SHA: ${{ needs.authorize.outputs.sha }}

--- a/tests/src/core/daytona-ci.ts
+++ b/tests/src/core/daytona-ci.ts
@@ -12,7 +12,7 @@ import {
 } from './platinum-ci';
 
 export const DAYTONA_CI_SNAPSHOT_VERSION = 'v4';
-const DAYTONA_CI_BASE_SNAPSHOT_VERSION = 'v3';
+const DAYTONA_CI_BASE_SNAPSHOT_VERSION = 'v4';
 
 const POLL_MS = 3_000;
 const SNAPSHOT_TIMEOUT_MS = 45 * 60_000;

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -3,9 +3,9 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, resolve } from 'node:path';
 
 export const PLATINUM_CI_TEMPLATE_VERSION = 'v14';
-const PLATINUM_CI_BASE_TEMPLATE_VERSION = 'v11';
+const PLATINUM_CI_BASE_TEMPLATE_VERSION = 'v12';
 export const PLATINUM_CI_NODE_IMAGE =
-  'node:22.22.0-bookworm@sha256:2e3d655fd1e3ffaa6b5f23ee9f3905a0fd9e8c0a65df94c8ae6e4d18a0f48870';
+  'node:22.22.2-bookworm@sha256:62e4daa6819762bbd3072af77cc282ab72c631c4aed30dd7980192babaf385b3';
 export const PLATINUM_CI_BUN_VERSION = '1.3.14';
 export const PLATINUM_CI_PNPM_VERSION = '8.11.0';
 export const CI_DOCKER_COMPOSE_VERSION = 'v2.40.3';

--- a/tests/src/core/platinum-ci.ts
+++ b/tests/src/core/platinum-ci.ts
@@ -74,12 +74,16 @@ export class PlatinumHttpError extends Error {
 
 export function isRetryablePlatinumError(error: unknown): boolean {
   if (error instanceof PlatinumHttpError) {
-    return TRANSIENT_STATUS_CODES.has(error.status)
-      || (error.status === 500 && /operation was aborted/i.test(error.message));
+    return (
+      TRANSIENT_STATUS_CODES.has(error.status) ||
+      (error.status === 500 && /operation was aborted/i.test(error.message))
+    );
   }
   if (error instanceof SyntaxError) return true;
   const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-  return /abort|connection reset|econnreset|fetch failed|network|socket|timed?\s*out/i.test(message);
+  return /abort|connection reset|econnreset|fetch failed|network|socket|timed?\s*out/i.test(
+    message,
+  );
 }
 
 export function platinumRetryDelayMs(attempt: number): number {
@@ -93,8 +97,8 @@ export async function retryPlatinumOperation<T>(input: {
   sleep?: (ms: number) => Promise<void>;
 }): Promise<T> {
   const attempts = input.attempts ?? API_MAX_ATTEMPTS;
-  const sleep = input.sleep
-    ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const sleep =
+    input.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
@@ -116,9 +120,29 @@ export function selectReusablePlatinumTemplate(
   templates: PlatinumTemplate[],
   name: string,
 ): PlatinumTemplate | null {
-  return templates.find((template) =>
-    template.name === name && ['ready', 'building'].includes(String(template.state ?? '').toLowerCase())
-  ) ?? null;
+  return (
+    templates.find(
+      (template) =>
+        template.name === name &&
+        ['ready', 'building'].includes(String(template.state ?? '').toLowerCase()),
+    ) ?? null
+  );
+}
+
+export function platinumTemplateCreateIdempotencyKey(
+  name: string,
+  templates: PlatinumTemplate[],
+): string {
+  const failedIds = templates
+    .filter(
+      (template) =>
+        template.name === name && String(template.state ?? '').toLowerCase() === 'failed',
+    )
+    .map((template) => template.id)
+    .sort();
+  if (failedIds.length === 0) return `kortix-ci-template-${name}`;
+  const failureSet = createHash('sha256').update(failedIds.join('\n')).digest('hex').slice(0, 12);
+  return `kortix-ci-template-${name}-retry-${failureSet}`;
 }
 
 export interface PlatinumSandbox {
@@ -484,9 +508,9 @@ export class PlatinumApi {
       ...(init.body === undefined ? {} : { 'content-type': 'application/json' }),
       ...(init.headers ?? {}),
     };
-    const retryable = retryOptions.retry ?? (
-      ['GET', 'PUT', 'DELETE'].includes(method) || new Headers(headers).has('idempotency-key')
-    );
+    const retryable =
+      retryOptions.retry ??
+      (['GET', 'PUT', 'DELETE'].includes(method) || new Headers(headers).has('idempotency-key'));
     const operation = async () => {
       const response = await fetch(`${this.base}${path}`, {
         ...init,
@@ -495,7 +519,10 @@ export class PlatinumApi {
       });
       const body = await response.text();
       if (!response.ok) {
-        throw new PlatinumHttpError(`Platinum ${method} ${path} -> ${response.status}: ${body}`, response.status);
+        throw new PlatinumHttpError(
+          `Platinum ${method} ${path} -> ${response.status}: ${body}`,
+          response.status,
+        );
       }
       return (body ? JSON.parse(body) : null) as T;
     };
@@ -522,7 +549,10 @@ export class PlatinumApi {
           },
         );
         if (!response.ok) {
-          throw new PlatinumHttpError(`Platinum file write -> ${response.status}: ${await response.text()}`, response.status);
+          throw new PlatinumHttpError(
+            `Platinum file write -> ${response.status}: ${await response.text()}`,
+            response.status,
+          );
         }
       },
     });
@@ -546,7 +576,10 @@ export class PlatinumApi {
           signal: AbortSignal.timeout(60_000),
         });
         if (!response.ok) {
-          throw new PlatinumHttpError(`Platinum file read ${path} -> ${response.status}: ${await response.text()}`, response.status);
+          throw new PlatinumHttpError(
+            `Platinum file read ${path} -> ${response.status}: ${await response.text()}`,
+            response.status,
+          );
         }
         return new Uint8Array(await response.arrayBuffer());
       },
@@ -594,11 +627,7 @@ export async function cleanupPlatinumCiSandboxes(input: {
     sandboxes.push(...page.rows);
     if (!page.has_more || page.rows.length === 0) break;
   }
-  const ids = selectOutstandingPlatinumSandboxIds(
-    sandboxes,
-    input.runId,
-    input.runAttempt,
-  );
+  const ids = selectOutstandingPlatinumSandboxIds(sandboxes, input.runId, input.runAttempt);
   for (const id of ids) {
     try {
       await api.json(
@@ -615,7 +644,10 @@ export async function cleanupPlatinumCiSandboxes(input: {
   return ids.length;
 }
 
-async function waitForTemplate(api: PlatinumApi, template: PlatinumTemplate): Promise<PlatinumTemplate> {
+async function waitForTemplate(
+  api: PlatinumApi,
+  template: PlatinumTemplate,
+): Promise<PlatinumTemplate> {
   const deadline = Date.now() + TEMPLATE_TIMEOUT_MS;
   let lastState = '';
   let observationFailures = 0;
@@ -647,25 +679,27 @@ async function waitForTemplate(api: PlatinumApi, template: PlatinumTemplate): Pr
     }
     if (state === 'ready') return current;
     if (state === 'failed') {
-      throw new Error(`Platinum template ${current.id} failed: ${current.build_logs ?? current.buildLogs ?? ''}`);
+      throw new Error(
+        `Platinum template ${current.id} failed: ${current.build_logs ?? current.buildLogs ?? ''}`,
+      );
     }
     await Bun.sleep(POLL_MS);
   }
-  throw new Error(`Platinum template ${template.id} did not become ready within ${TEMPLATE_TIMEOUT_MS}ms`);
+  throw new Error(
+    `Platinum template ${template.id} did not become ready within ${TEMPLATE_TIMEOUT_MS}ms`,
+  );
 }
 
 export async function ensureTemplate(
   api: PlatinumApi,
   spec: PlatinumTemplateSpec,
 ): Promise<PlatinumTemplate> {
-  const existing = selectReusablePlatinumTemplate(
-    await api.json<PlatinumTemplate[]>(
-      `/v1/templates?name=${encodeURIComponent(spec.name)}&limit=20`,
-      {},
-      { attempts: 20 },
-    ),
-    spec.name,
+  const templates = await api.json<PlatinumTemplate[]>(
+    `/v1/templates?name=${encodeURIComponent(spec.name)}&limit=20`,
+    {},
+    { attempts: 20 },
   );
+  const existing = selectReusablePlatinumTemplate(templates, spec.name);
   if (existing) {
     console.log(`[platinum-ci] template=${spec.name} cache=hit id=${existing.id}`);
     return waitForTemplate(api, existing);
@@ -673,7 +707,7 @@ export async function ensureTemplate(
   console.log(`[platinum-ci] template=${spec.name} cache=miss`);
   const queued = await api.json<PlatinumTemplate>('/v1/templates/from-spec', {
     method: 'POST',
-    headers: { 'idempotency-key': `kortix-ci-template-${spec.name}` },
+    headers: { 'idempotency-key': platinumTemplateCreateIdempotencyKey(spec.name, templates) },
     body: JSON.stringify(spec),
   });
   return waitForTemplate(api, queued);
@@ -685,14 +719,12 @@ export async function ensureWarmTemplate(
   lockHash: string,
 ): Promise<PlatinumTemplate> {
   const name = platinumTemplateName(lockHash);
-  const existing = selectReusablePlatinumTemplate(
-    await api.json<PlatinumTemplate[]>(
-      `/v1/templates?name=${encodeURIComponent(name)}&limit=20`,
-      {},
-      { attempts: 20 },
-    ),
-    name,
+  const templates = await api.json<PlatinumTemplate[]>(
+    `/v1/templates?name=${encodeURIComponent(name)}&limit=20`,
+    {},
+    { attempts: 20 },
   );
+  const existing = selectReusablePlatinumTemplate(templates, name);
   if (existing) {
     console.log(`[platinum-ci] template=${name} cache=hit id=${existing.id}`);
     return waitForTemplate(api, existing);
@@ -700,7 +732,7 @@ export async function ensureWarmTemplate(
   console.log(`[platinum-ci] template=${name} cache=miss parent=${base.id}`);
   const derived = await api.json<PlatinumTemplate>(`/v1/templates/${base.id}/derive`, {
     method: 'POST',
-    headers: { 'idempotency-key': `kortix-ci-template-${name}` },
+    headers: { 'idempotency-key': platinumTemplateCreateIdempotencyKey(name, templates) },
     body: JSON.stringify(buildPlatinumWarmTemplateRequest(lockHash)),
   });
   return waitForTemplate(api, derived);
@@ -720,9 +752,13 @@ export async function observePlatinumSandboxStart(input: {
   const sleep = input.sleep ?? Bun.sleep;
   const deadline = input.startedAt + (input.timeoutMs ?? SANDBOX_START_TIMEOUT_MS);
   const pollMs = input.pollMs ?? POLL_MS;
-  const write = input.write ?? ((state: string, sandbox: PlatinumSandbox) => {
-    console.log(`[platinum-ci] sandbox=${sandbox.id} state=${state} via=${sandbox.via ?? 'unknown'}`);
-  });
+  const write =
+    input.write ??
+    ((state: string, sandbox: PlatinumSandbox) => {
+      console.log(
+        `[platinum-ci] sandbox=${sandbox.id} state=${state} via=${sandbox.via ?? 'unknown'}`,
+      );
+    });
   const terminalStates = new Set(['archived', 'deleted', 'error', 'failed', 'stopped']);
   let current = input.sandbox;
   let lastState = '';
@@ -746,7 +782,9 @@ export async function observePlatinumSandboxStart(input: {
       const observed = await input.readSandbox();
       current = { ...current, ...observed, via: observed.via ?? current.via };
       if (observationFailures > 0) {
-        console.warn(`[platinum-ci] sandbox polling recovered after ${observationFailures} failure(s)`);
+        console.warn(
+          `[platinum-ci] sandbox polling recovered after ${observationFailures} failure(s)`,
+        );
         observationFailures = 0;
       }
     } catch (error) {
@@ -765,9 +803,7 @@ export async function observePlatinumSandboxStart(input: {
   );
 }
 
-export function platinumWarmReadinessTimeoutMs(
-  via: PlatinumSandbox['via'],
-): number {
+export function platinumWarmReadinessTimeoutMs(via: PlatinumSandbox['via']): number {
   return via === 'cold-boot' ? WARM_PREPARE_TIMEOUT_MS : PLATINUM_CI_WARM_TIMEOUT_MS;
 }
 
@@ -786,9 +822,11 @@ export async function waitForWarmSandbox(
           await Bun.sleep(POLL_MS);
           continue;
         }
-        const marker = new TextDecoder().decode(
-          await api.read(sandboxId, '/workspace/.kortix-ci-warm-ready', undefined, undefined, 1),
-        ).trim();
+        const marker = new TextDecoder()
+          .decode(
+            await api.read(sandboxId, '/workspace/.kortix-ci-warm-ready', undefined, undefined, 1),
+          )
+          .trim();
         console.log(`[platinum-ci] warm_sandbox_ready=1 ${marker}`);
         return;
       }
@@ -823,10 +861,14 @@ export async function exec(
   command: string[],
   retry = false,
 ): Promise<NonNullable<PlatinumExecResult['result']>> {
-  const response = await api.json<PlatinumExecResult>(`/v1/sandboxes/${sandboxId}/exec`, {
-    method: 'POST',
-    body: JSON.stringify({ cmd: command, timeout_ms: 300_000 }),
-  }, { retry });
+  const response = await api.json<PlatinumExecResult>(
+    `/v1/sandboxes/${sandboxId}/exec`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ cmd: command, timeout_ms: 300_000 }),
+    },
+    { retry },
+  );
   if (response.error) throw new Error(response.error);
   if (response.result?.error) throw new Error(response.result.error);
   if (!response.result) throw new Error('Platinum exec response did not include a result');
@@ -880,7 +922,9 @@ export async function observePlatinumWorker(input: PlatinumWorkerObserverInput):
       if (!isRetryablePlatinumError(error)) throw error;
       statusFailures += 1;
       if (shouldReportObservationFailure(statusFailures)) {
-        warn(`[platinum-ci] worker status unavailable failures=${statusFailures} error=${String(error)}`);
+        warn(
+          `[platinum-ci] worker status unavailable failures=${statusFailures} error=${String(error)}`,
+        );
       }
     }
 
@@ -901,7 +945,9 @@ export async function observePlatinumWorker(input: PlatinumWorkerObserverInput):
     } catch (error) {
       logFailures += 1;
       if (shouldReportObservationFailure(logFailures)) {
-        warn(`[platinum-ci] incremental log unavailable failures=${logFailures} error=${String(error)}`);
+        warn(
+          `[platinum-ci] incremental log unavailable failures=${logFailures} error=${String(error)}`,
+        );
       }
     }
 
@@ -911,15 +957,17 @@ export async function observePlatinumWorker(input: PlatinumWorkerObserverInput):
   throw new Error(`Platinum worker exceeded ${timeoutMs}ms`);
 }
 
-async function readWorkerExitCode(
-  api: PlatinumApi,
-  sandboxId: string,
-): Promise<number | null> {
-  const result = await exec(api, sandboxId, [
-    'bash',
-    '-lc',
-    'if [[ -f /workspace/kortix-test.exit ]]; then cat /workspace/kortix-test.exit; else exit 3; fi',
-  ], true);
+async function readWorkerExitCode(api: PlatinumApi, sandboxId: string): Promise<number | null> {
+  const result = await exec(
+    api,
+    sandboxId,
+    [
+      'bash',
+      '-lc',
+      'if [[ -f /workspace/kortix-test.exit ]]; then cat /workspace/kortix-test.exit; else exit 3; fi',
+    ],
+    true,
+  );
   if (result?.exit_code === 3) return null;
   if ((result?.exit_code ?? 0) !== 0) {
     throw new Error(`Platinum worker status check failed: ${result?.stderr ?? ''}`);
@@ -929,10 +977,7 @@ async function readWorkerExitCode(
   return exitCode;
 }
 
-async function readWorkerExitCodeFile(
-  api: PlatinumApi,
-  sandboxId: string,
-): Promise<number | null> {
+async function readWorkerExitCodeFile(api: PlatinumApi, sandboxId: string): Promise<number | null> {
   const status = await stat(api, sandboxId, '/workspace/kortix-test.exit', 1);
   if (!status) return null;
   const bytes = await api.read(sandboxId, '/workspace/kortix-test.exit', undefined, undefined, 1);
@@ -965,8 +1010,7 @@ async function streamWorker(
       }
     },
     statLog: () => stat(api, sandboxId, '/workspace/kortix-test.log', 1),
-    readLog: (offset, limit) =>
-      api.read(sandboxId, '/workspace/kortix-test.log', offset, limit, 1),
+    readLog: (offset, limit) => api.read(sandboxId, '/workspace/kortix-test.log', offset, limit, 1),
   });
 }
 
@@ -1046,13 +1090,15 @@ export async function runPlatinumCi(input: PlatinumCiInput): Promise<number> {
       {
         method: 'POST',
         headers: { 'idempotency-key': `kortix-ci-${input.runId}-${input.runAttempt}` },
-        body: JSON.stringify(buildPlatinumWorkerRequest({
-          templateId: template.id,
-          repository: input.repository,
-          sha: input.sha,
-          runId: input.runId,
-          runAttempt: input.runAttempt,
-        })),
+        body: JSON.stringify(
+          buildPlatinumWorkerRequest({
+            templateId: template.id,
+            repository: input.repository,
+            sha: input.sha,
+            runId: input.runId,
+            runAttempt: input.runAttempt,
+          }),
+        ),
       },
     );
     sandboxId = created.id;
@@ -1070,11 +1116,7 @@ export async function runPlatinumCi(input: PlatinumCiInput): Promise<number> {
 
     const workerScript = buildWorkerScript(input);
     await api.write(`${sandboxId}:/workspace/run-kortix-tests.sh`, workerScript, '0755');
-    const launch = await exec(api, sandboxId, [
-      'bash',
-      '-lc',
-      platinumWorkerLaunchCommand(),
-    ]);
+    const launch = await exec(api, sandboxId, ['bash', '-lc', platinumWorkerLaunchCommand()]);
     if ((launch?.exit_code ?? 0) !== 0) {
       throw new Error(`Platinum worker launch failed: ${launch?.stderr ?? ''}`);
     }

--- a/tests/unit/daytona-ci.test.ts
+++ b/tests/unit/daytona-ci.test.ts
@@ -40,7 +40,7 @@ describe('Daytona CI worker plan', () => {
   test('uses one content-addressed warm snapshot for one lockfile', () => {
     expect(DAYTONA_CI_SNAPSHOT_VERSION).toBe('v4');
     expect(daytonaSnapshotName(lockHash)).toBe('kortix-ci-daytona-v4-bbbbbbbbbbbbbbbb');
-    expect(daytonaBaseSnapshotName(lockHash)).toBe('kortix-ci-daytona-v3-bbbbbbbbbbbbbbbb-base');
+    expect(daytonaBaseSnapshotName(lockHash)).toBe('kortix-ci-daytona-v4-bbbbbbbbbbbbbbbb-base');
   });
 
   test('builds the same pinned toolchain and repository cache as Platinum', () => {
@@ -49,7 +49,9 @@ describe('Daytona CI worker plan', () => {
       cacheSha: sha,
     });
 
-    expect(dockerfile).toContain('node:22.22.0-bookworm@sha256:');
+    expect(dockerfile).toContain(
+      'node:22.22.2-bookworm@sha256:62e4daa6819762bbd3072af77cc282ab72c631c4aed30dd7980192babaf385b3',
+    );
     expect(dockerfile).toContain('docker.io');
     expect(dockerfile).toContain('docker-compose-linux-x86_64');
     expect(dockerfile).toContain('sha256sum -c -');

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -19,6 +19,7 @@ import {
   observePlatinumSandboxStart,
   observePlatinumWorker,
   platinumBaseTemplateName,
+  platinumTemplateCreateIdempotencyKey,
   platinumWorkerLaunchCommand,
   retryPlatinumOperation,
   selectReusablePlatinumTemplate,
@@ -129,13 +130,15 @@ describe('Platinum CI worker plan', () => {
   });
 
   test('uses Platinum persistent restore but still treats every worker as disposable', () => {
-    expect(buildPlatinumWorkerRequest({
-      templateId: 'tpl_warm',
-      repository: 'kortix-ai/suna',
-      sha,
-      runId: '31295265205',
-      runAttempt: '4',
-    })).toEqual({
+    expect(
+      buildPlatinumWorkerRequest({
+        templateId: 'tpl_warm',
+        repository: 'kortix-ai/suna',
+        sha,
+        runId: '31295265205',
+        runAttempt: '4',
+      }),
+    ).toEqual({
       name: 'kortix-ci-31295265205-4',
       template: 'tpl_warm',
       type: 'persistent',
@@ -168,11 +171,13 @@ describe('Platinum CI worker plan', () => {
       }
       if (url.endsWith('/v1/sandboxes?paginated=true&limit=100&offset=100')) {
         return Response.json({
-          rows: [{
-            id: 'exact',
-            name: 'kortix-ci-31289428402-1',
-            metadata: { owner: 'kortix-ci', run_id: '31289428402' },
-          }],
+          rows: [
+            {
+              id: 'exact',
+              name: 'kortix-ci-31289428402-1',
+              metadata: { owner: 'kortix-ci', run_id: '31289428402' },
+            },
+          ],
           total: 2,
           has_more: false,
         });
@@ -183,12 +188,14 @@ describe('Platinum CI worker plan', () => {
       return Response.json({ error: 'unexpected request' }, { status: 500 });
     });
 
-    await expect(cleanupPlatinumCiSandboxes({
-      apiUrl: 'https://api.platinum.dev',
-      apiKey: 'test',
-      runId: '31289428402',
-      runAttempt: '1',
-    })).resolves.toBe(1);
+    await expect(
+      cleanupPlatinumCiSandboxes({
+        apiUrl: 'https://api.platinum.dev',
+        apiKey: 'test',
+        runId: '31289428402',
+        runAttempt: '1',
+      }),
+    ).resolves.toBe(1);
     expect(requests).toEqual([
       'GET https://api.platinum.dev/v1/sandboxes?paginated=true&limit=100&offset=0',
       'GET https://api.platinum.dev/v1/sandboxes?paginated=true&limit=100&offset=100',
@@ -276,13 +283,41 @@ describe('Platinum CI worker plan', () => {
   });
 
   test('reuses the exact ready or building content-addressed template', () => {
-    expect(selectReusablePlatinumTemplate([
-      { id: 'failed', name: 'kortix-ci-v2-other', state: 'failed' },
-      { id: 'ready', name: 'kortix-ci-v2-target', state: 'ready' },
-    ], 'kortix-ci-v2-target')?.id).toBe('ready');
-    expect(selectReusablePlatinumTemplate([
-      { id: 'failed', name: 'kortix-ci-v2-target', state: 'failed' },
-    ], 'kortix-ci-v2-target')).toBeNull();
+    expect(
+      selectReusablePlatinumTemplate(
+        [
+          { id: 'failed', name: 'kortix-ci-v2-other', state: 'failed' },
+          { id: 'ready', name: 'kortix-ci-v2-target', state: 'ready' },
+        ],
+        'kortix-ci-v2-target',
+      )?.id,
+    ).toBe('ready');
+    expect(
+      selectReusablePlatinumTemplate(
+        [{ id: 'failed', name: 'kortix-ci-v2-target', state: 'failed' }],
+        'kortix-ci-v2-target',
+      ),
+    ).toBeNull();
+  });
+
+  test('changes the create idempotency key after a cached template fails', () => {
+    const name = 'kortix-ci-v11-lock-base';
+    expect(platinumTemplateCreateIdempotencyKey(name, [])).toBe(`kortix-ci-template-${name}`);
+
+    const firstFailure = platinumTemplateCreateIdempotencyKey(name, [
+      { id: 'tpl-failed-a', name, state: 'failed' },
+    ]);
+    const sameFailure = platinumTemplateCreateIdempotencyKey(name, [
+      { id: 'tpl-failed-a', name, state: 'FAILED' },
+    ]);
+    const nextFailure = platinumTemplateCreateIdempotencyKey(name, [
+      { id: 'tpl-failed-a', name, state: 'failed' },
+      { id: 'tpl-failed-b', name, state: 'failed' },
+    ]);
+
+    expect(firstFailure).toBe(sameFailure);
+    expect(firstFailure).toMatch(new RegExp(`^kortix-ci-template-${name}-retry-[0-9a-f]{12}$`));
+    expect(nextFailure).not.toBe(firstFailure);
   });
 
   test('retries only transient provider failures with bounded attempts', async () => {
@@ -291,7 +326,9 @@ describe('Platinum CI worker plan', () => {
     const result = await retryPlatinumOperation({
       label: 'test',
       attempts: 4,
-      sleep: async (delay) => { delays.push(delay); },
+      sleep: async (delay) => {
+        delays.push(delay);
+      },
       operation: async () => {
         calls += 1;
         if (calls < 3) throw new PlatinumHttpError('gateway timeout', 504);
@@ -304,9 +341,11 @@ describe('Platinum CI worker plan', () => {
     expect(isRetryablePlatinumError(new PlatinumHttpError('bad request', 400))).toBe(false);
     expect(isRetryablePlatinumError(new PlatinumHttpError('gateway timeout', 504))).toBe(true);
     expect(isRetryablePlatinumError(new SyntaxError('truncated JSON response'))).toBe(true);
-    expect(isRetryablePlatinumError(
-      new PlatinumHttpError('500: {"error":"The operation was aborted."}', 500),
-    )).toBe(true);
+    expect(
+      isRetryablePlatinumError(
+        new PlatinumHttpError('500: {"error":"The operation was aborted."}', 500),
+      ),
+    ).toBe(true);
     expect(isRetryablePlatinumError(new PlatinumHttpError('internal bug', 500))).toBe(false);
   });
 
@@ -321,7 +360,9 @@ describe('Platinum CI worker plan', () => {
       timeoutMs: 100,
       pollMs: 1,
       now: () => now,
-      sleep: async (delay) => { now += delay; },
+      sleep: async (delay) => {
+        now += delay;
+      },
       checkExitCode: async () => {
         statusChecks += 1;
         return statusChecks === 3 ? 0 : null;
@@ -334,8 +375,12 @@ describe('Platinum CI worker plan', () => {
         return { size: 4 };
       },
       readLog: async () => new TextEncoder().encode('done'),
-      write: (chunk) => { output.push(chunk); },
-      warn: (message) => { warnings.push(message); },
+      write: (chunk) => {
+        output.push(chunk);
+      },
+      warn: (message) => {
+        warnings.push(message);
+      },
     });
 
     expect(result).toBe(0);
@@ -356,14 +401,18 @@ describe('Platinum CI worker plan', () => {
       timeoutMs: 100,
       pollMs: 10,
       now: () => now,
-      sleep: async (delay) => { now += delay; },
+      sleep: async (delay) => {
+        now += delay;
+      },
       readSandbox: async () => {
         checks += 1;
         return checks === 1
           ? { id: 'worker', state: 'starting' }
           : { id: 'worker', state: 'running', via: 'restore' };
       },
-      write: (state) => { states.push(state); },
+      write: (state) => {
+        states.push(state);
+      },
     });
 
     expect(sandbox).toMatchObject({ id: 'worker', state: 'running', via: 'restore' });
@@ -372,28 +421,34 @@ describe('Platinum CI worker plan', () => {
   });
 
   test('allows 45 minutes for a capacity-blocked Platinum worker to start', async () => {
-    await expect(observePlatinumSandboxStart({
-      sandbox: { id: 'worker', state: 'provisioning' },
-      startedAt: 0,
-      now: () => 2_700_001,
-      sleep: async () => {},
-      readSandbox: async () => ({ id: 'worker', state: 'running' }),
-    })).rejects.toThrow('within 2700000ms');
+    await expect(
+      observePlatinumSandboxStart({
+        sandbox: { id: 'worker', state: 'provisioning' },
+        startedAt: 0,
+        now: () => 2_700_001,
+        sleep: async () => {},
+        readSandbox: async () => ({ id: 'worker', state: 'running' }),
+      }),
+    ).rejects.toThrow('within 2700000ms');
   });
 
   test('fails immediately when Platinum deletes a provisioning worker', async () => {
     let now = 0;
-    await expect(observePlatinumSandboxStart({
-      sandbox: { id: 'worker', state: 'provisioning' },
-      startedAt: 0,
-      timeoutMs: 100,
-      pollMs: 10,
-      now: () => now,
-      sleep: async (delay) => { now += delay; },
-      readSandbox: async () => {
-        throw new PlatinumHttpError('sandbox not found', 404);
-      },
-    })).rejects.toThrow('sandbox not found');
+    await expect(
+      observePlatinumSandboxStart({
+        sandbox: { id: 'worker', state: 'provisioning' },
+        startedAt: 0,
+        timeoutMs: 100,
+        pollMs: 10,
+        now: () => now,
+        sleep: async (delay) => {
+          now += delay;
+        },
+        readSandbox: async () => {
+          throw new PlatinumHttpError('sandbox not found', 404);
+        },
+      }),
+    ).rejects.toThrow('sandbox not found');
     expect(now).toBe(10);
   });
 

--- a/tests/unit/platinum-ci.test.ts
+++ b/tests/unit/platinum-ci.test.ts
@@ -46,7 +46,7 @@ describe('Platinum CI worker plan', () => {
   test('uses one content-addressed template for one lockfile', () => {
     expect(PLATINUM_CI_TEMPLATE_VERSION).toBe('v14');
     expect(platinumTemplateName(lockHash)).toBe('kortix-ci-v14-bbbbbbbbbbbbbbbb');
-    expect(platinumBaseTemplateName(lockHash)).toBe('kortix-ci-v11-bbbbbbbbbbbbbbbb-base');
+    expect(platinumBaseTemplateName(lockHash)).toBe('kortix-ci-v12-bbbbbbbbbbbbbbbb-base');
     const spec = buildPlatinumTemplateSpec({
       lockHash,
       repository: 'kortix-ai/suna',

--- a/tests/unit/web-ecs-workflow.test.ts
+++ b/tests/unit/web-ecs-workflow.test.ts
@@ -166,6 +166,12 @@ describe('web ECS migration', () => {
     // in this workflow may delete it any more.
     expect(workflow).not.toContain('labels/preview');
     expect(workflow).toContain('PREVIEW_BRANCH_ENV');
+    expect(workflow).toContain(
+      'persistent_branch=$([ "$EVENT_NAME" = workflow_dispatch ] && [ "$provider" = daytona ] && printf \'\' || printf \'%s\' "$branch")',
+    );
+    expect(workflow).toContain(
+      'PREVIEW_BRANCH_ENV: ${{ needs.authorize.outputs.persistent_branch }}',
+    );
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts deploy');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts teardown');
     expect(workflow).toContain('bun tests/bin/sandbox-preview.ts reconcile');


### PR DESCRIPTION
## Problem

Both preview providers fail before application deployment. The shared base image pins Node 22.22.0. The current lockfile resolves write-file-atomic@8.0.0, which requires Node ^22.22.2. Failed provider cache records also block deterministic recreation.

## Changes

- Pin the shared preview base image to Node 22.22.2 with its multi-platform digest.
- Invalidate Platinum base cache v12 and Daytona base cache v4.
- Change Platinum create idempotency after terminal template failures.
- Allow explicit manual Daytona verification without claiming the persistent Platinum branch identity.
- Record both incident rules in the append-only learnings register.

## Verification

- Exact pinned Node 22.22.0 container: pnpm install exits 1 with ERR_PNPM_UNSUPPORTED_ENGINE.
- Exact pinned Node 22.22.2 container: pnpm install exits 0 in 2m 21.7s.
- Preview unit tests: 45 passed, 0 failed.
- Preview Python contracts: 22 passed, 0 failed.
- tests package typecheck: passed.

## Delivery

Draft. This controller code must merge to main before a pull_request_target preview can execute it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791224418&installation_model_id=434224&pr_number=7135&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7135&signature=0dc22d59610ab07a8ffb21f5d9d4621a703fa449375b2b9849d2900edd9dfd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->