### PR TITLE
Repair Node in persistent preview sandboxes

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4257,3 +4257,22 @@ Daytona base-cache versions. Failed caches must never retain the old runtime.
 force fresh builds. *Enforcer:* `tests/unit/platinum-ci.test.ts` and
 `tests/unit/daytona-ci.test.ts` assert both new cache names and the exact image
 digest.
+
+## A persistent sandbox does not inherit a replacement template runtime (2026-09-05)
+
+PR #7109 selected the ready Node `22.22.2` Platinum template. The workflow then
+reused the branch sandbox created with Node `22.22.0`. The sandbox rootfs did
+not change. Every checkout after the dependency floor change failed at
+`pnpm install --frozen-lockfile` with `ERR_PNPM_UNSUPPORTED_ENGINE`. The worker
+then reported stale test output from an earlier commit.
+
+**The rule.** A bootstrap that reuses a persistent sandbox must enforce its
+runtime floor inside that sandbox before it runs the package manager. A new
+template only affects newly created sandboxes. Runtime repair must use a pinned
+version and a verified checksum.
+
+*Fix:* `buildPreviewBootstrapScript()` installs the official Node `22.22.2`
+Linux x64 archive when the sandbox reports another version. It verifies the
+official SHA-256 before extraction. *Enforcer:*
+`tests/unit/sandbox-preview.test.ts` requires the repair before the first pnpm
+install and asserts the exact version and checksum.

--- a/tests/src/core/sandbox-preview.ts
+++ b/tests/src/core/sandbox-preview.ts
@@ -114,6 +114,18 @@ actual_sha="$(git -C "$ROOT" rev-parse HEAD)"
 test "$actual_sha" = "${input.sha}"
 
 cd "$ROOT"
+# A persistent branch environment keeps the rootfs it was created with. A new
+# template therefore does not update Node in an existing sandbox. Repair that
+# floor in place before pnpm reads dependency engine constraints. The archive
+# checksum comes from Node's v22.22.2 SHASUMS256.txt.
+if [ "$(node --version)" != "v22.22.2" ]; then
+  node_archive=/tmp/node-v22.22.2-linux-x64.tar.xz
+  curl -fsSL https://nodejs.org/dist/v22.22.2/node-v22.22.2-linux-x64.tar.xz -o "$node_archive"
+  printf '%s  %s\n' '88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a' "$node_archive" | sha256sum -c -
+  tar -xJf "$node_archive" -C /usr/local --strip-components=1
+  rm -f "$node_archive"
+fi
+test "$(node --version)" = "v22.22.2"
 corepack enable
 # A reused branch sandbox keeps the rootfs of the template it was created
 # from, so its pnpm store can predate a dependency the branch has since added.

--- a/tests/unit/sandbox-preview.test.ts
+++ b/tests/unit/sandbox-preview.test.ts
@@ -128,6 +128,23 @@ describe('provider-neutral preview lifecycle', () => {
     expect(script).toContain('-v /workspace/kortix-preview:/workspace/kortix-preview');
   });
 
+  it('repairs the Node floor inside a reused branch sandbox before pnpm runs', () => {
+    const script = buildPreviewBootstrapScript({
+      repository: 'kortix-ai/suna',
+      ref: 'i18n-complete-serbian',
+      sha: 'a'.repeat(40),
+      prNumber: 7109,
+      origin: 'https://preview.example.test',
+    });
+    const repair = script.indexOf('node-v22.22.2-linux-x64.tar.xz');
+    const install = script.indexOf('pnpm install --offline --frozen-lockfile');
+
+    expect(repair).toBeGreaterThan(-1);
+    expect(repair).toBeLessThan(install);
+    expect(script).toContain('88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a');
+    expect(script).toContain('test "$(node --version)" = "v22.22.2"');
+  });
+
   it('health-checks the stack locally, never through the public name', () => {
     // The public name is served by a proxy that is only re-pointed at this
     // sandbox AFTER the deploy returns. Checking through it would deadlock the


### PR DESCRIPTION
## Problem

A persistent Platinum branch sandbox keeps the rootfs from its creation template. PR #7109 selected the Node 22.22.2 template but reused a sandbox with Node 22.22.0. The package install failed its engine floor and returned stale test output.

## Change

The preview bootstrap checks Node before pnpm runs. It installs the official Node 22.22.2 Linux x64 archive only when needed. It verifies SHA-256 88fd1ce767091fd8d4a99fdb2356e98c819f93f3b1f8663853a2dee9b438068a before extraction.

## Verification

- 64 focused Vitest tests passed.
- The tests package TypeScript check passed.
- git diff --check passed.

## Delivery note

The pull_request_target deploy controller loads the bootstrap from main. This PR must merge before PR #7109 can verify the repair on its persistent preview.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791228586&installation_model_id=434224&pr_number=7136&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7136&signature=2880eae79d955cdbad611896838760191a85b1e0181708b765d730c4b05e968f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->