### PR TITLE
ci+test: unblock the v0.13.11 release gate (host-only cookie assert, engine-strict install, deployed-only test contracts)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,28 @@ linked, not inlined.
 
 ## Register
 
+### A test that only runs against a deployed target is a contract nobody runs before merge (2026-09-06)
+
+**When:** changing behaviour that a `tests/e2e` spec or `tests/src/flows` flow
+asserts, or writing such a test. Specs that `test.skip` without a provider
+(23-composio) or fixtures that differ by target (`createManifestProject`,
+`fixtures.project({ managedGit })`) run ONLY in `tests-release.yml` against
+staging. The v0.13.11 release gate went red on four of them while every PR
+lane had been green for a week: connector slugs became `<app>-<random>`
+(7f6b8087f3) and spec 23 still asserted `composio-search`; managed repos now
+seed the starter by default (4da295e50b), so `triggers[0]` is the starter's
+`harness-reflector` (model null) and TRG-2/TRG-3 read the wrong row; the seed
+and the trigger commit land through the mirror seconds later, so TRG-14's
+`kortix.yaml` history moved under it. **Rules.** (1) When a PR changes a
+deployed-only contract, grep `tests/e2e/specs` and `tests/src/flows` for the
+old value in the same PR. (2) A flow asserts on the row it wrote (find by
+slug), never on `[0]`. (3) A read that follows a managed-git write settles
+(two equal reads) before it is compared. (4) Before promoting, dispatch
+`tests-release.yml --ref staging -f expected_sha=<staging tip>` as a dry run;
+the gate is the first time these tests see the change. *Incident:* release
+gate red twice on 2026-09-05/06, ~2 h of release delay, no user impact.
+*Enforcer:* none yet — the dry run is manual.
+
 ### Edge middleware imports locale constants from a leaf module (2026-09-05)
 
 **When:** adding locale routing or other i18n behavior to Next.js middleware.

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -656,9 +656,17 @@ jobs:
           { [ "$cookie_status" = 200 ] || [ "$cookie_status" = 307 ] || [ "$cookie_status" = 308 ]; } || {
             echo "::error::staging ECS frontend shared-cookie status=$cookie_status"; exit 1;
           }
-          grep -E $'^(#HttpOnly_)?\\.kortix\\.com\t' "$cookie_jar" >/dev/null || {
-            echo "::error::staging ECS frontend did not set the parent-domain access cookie"; exit 1;
+          # The access cookie is HOST-ONLY since #7065: the old Domain=.kortix.com
+          # cookie reached every subdomain (staging, prod, api.kortix.com) no
+          # matter which environment authorized it. curl writes a host-only
+          # cookie under the exact issuing host, so assert that row and refuse a
+          # Domain-scoped one — a `.kortix.com` row here means #7065 regressed.
+          awk -F'\t' -v h="$ECS_WEB_HOST" '$1 == h || $1 == "#HttpOnly_" h { found = 1 } END { exit !found }' "$cookie_jar" || {
+            echo "::error::staging ECS frontend did not set a host-only access cookie for ${ECS_WEB_HOST}"; exit 1;
           }
+          if awk -F'\t' '$1 == ".kortix.com" || $1 == "#HttpOnly_.kortix.com" { found = 1 } END { exit !found }' "$cookie_jar"; then
+            echo "::error::staging ECS frontend set a Domain-scoped .kortix.com access cookie (#7065 made it host-only)"; exit 1;
+          fi
           ecs_health="$(curl -fsS --max-time 20 "$ecs/api/health")"
           [ "$(jq -r '.commit // empty' <<<"$ecs_health")" = "$EXPECTED_COMMIT" ] || {
             echo "::error::staging ECS frontend commit mismatch"; exit 1;
@@ -681,7 +689,7 @@ jobs:
           {
             echo "### Staging verified"
             echo "- API: https://${PUBLIC_API_HOST}/v1/health reports staging ${EXPECTED_VERSION}"
-            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts the shared test cookie"
+            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts its host-only test cookie"
             echo "- Vercel web: https://${WEB_HOST} serves staging runtime config"
             echo "- GitOps: API ALB via ECS Fargate"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -90,6 +90,14 @@ jobs:
           cache: pnpm
       - name: Install runner dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       # Bounded at the STEP so a slow sweep ends as a job *failure* (which
       # continue-on-error absorbs) — never as a job *cancelled*: on run
       # 32226539107 the 15-minute job cap fired while gc was still deleting a
@@ -222,6 +230,14 @@ jobs:
           cache: pnpm
       - name: Install deployed-target dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       - name: Run this shard of the deployed staging API suite
         run: pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/6
       # A cancelled job is SIGKILLed before the runner's `finally` teardown, so
@@ -322,6 +338,9 @@ jobs:
         run: |
           pnpm install --frozen-lockfile --filter @kortix/tests...
           pnpm --dir tests exec playwright install --with-deps chromium
+        # See the same env on the API shard install above.
+        env:
+          npm_config_engine_strict: "false"
       - name: Run this shard of the deployed staging browser journeys
         run: pnpm test -- --target-browser-full --browser-shard=${{ matrix.shard }}/3
       # No --run-id sweep here: the Playwright specs mint their own Supabase
@@ -378,6 +397,14 @@ jobs:
           cache: pnpm
       - name: Install runner dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       - name: Reclaim this run's test accounts
         run: bun tests/bin/ke2e.ts gc --run-id ${{ github.run_id }}
 

--- a/tests/e2e/specs/23-composio-connector.spec.ts
+++ b/tests/e2e/specs/23-composio-connector.spec.ts
@@ -170,20 +170,25 @@ test.describe("23 — Composio managed connector", () => {
     expect(createBody).toEqual(
       expect.objectContaining({
         name: "Composio Search",
-        slug: "composio-search",
         provider: "composio",
         app: "composio_search",
         authorization_strategy: "project",
         create_only: true,
       }),
     );
+    // A proposed connector slug is `<app>-<6 random base36>` since 7f6b8087f3
+    // (so two connections to one app never collide). The suffix is random, so
+    // read the slug the UI actually proposed and follow it for the rest of the
+    // journey instead of asserting a fixed one.
+    expect(createBody.slug).toMatch(/^composio-search-[a-z0-9]{6}$/);
+    const connectorSlug = createBody.slug as string;
     expect(JSON.stringify(createBody)).not.toMatch(
       /api[_-]?key|credential|secret/i,
     );
     expect((await createResponsePromise).status()).toBe(200);
 
     await expect(page).toHaveURL(new RegExp(`[?&]scope=connected(?:&|$)`));
-    await expect(page).toHaveURL(new RegExp(`[?&]c=composio-search(?:&|$)`));
+    await expect(page).toHaveURL(new RegExp(`[?&]c=${connectorSlug}(?:&|$)`));
     const detail = page.getByRole("dialog", { name: "Composio Search" });
     await expect(detail).toBeVisible();
     await expect(
@@ -195,7 +200,7 @@ test.describe("23 — Composio managed connector", () => {
         request
           .url()
           .endsWith(
-            `/v1/connectors/projects/${project.id}/connectors/composio-search/connect`,
+            `/v1/connectors/projects/${project.id}/connectors/${connectorSlug}/connect`,
           ) && request.method() === "POST",
     );
     const connectResponsePromise = page.waitForResponse(
@@ -203,7 +208,7 @@ test.describe("23 — Composio managed connector", () => {
         response
           .url()
           .endsWith(
-            `/v1/connectors/projects/${project.id}/connectors/composio-search/connect`,
+            `/v1/connectors/projects/${project.id}/connectors/${connectorSlug}/connect`,
           ) && response.request().method() === "POST",
     );
     await detail.getByRole("button", { name: "Connect", exact: true }).click();
@@ -240,7 +245,7 @@ test.describe("23 — Composio managed connector", () => {
     );
     const connection = connections.connections.find(
       (item) =>
-        item.connector_alias === "composio-search" &&
+        item.connector_alias === connectorSlug &&
         item.owner_type === "project" &&
         item.is_default,
     );

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -3,8 +3,62 @@
  * Trigger create commits the project manifest (a real git commit).
  */
 import { flow } from '../core/flow';
+import { waitFor } from '../core/poll';
 import { createDatabaseSession } from '../fixtures/database-project';
 import { enableEnterpriseDemo } from '../fixtures/enterprise-demo';
+
+type TriggerRow = { slug: string; model: string | null };
+
+/**
+ * A managed-repo project is seeded from the starter by default (4da295e50b),
+ * and the starter ships a `harness-reflector` cron with no model. So the
+ * trigger a flow just wrote is NOT `triggers[0]`; find it by slug.
+ */
+function triggerBySlug(
+  body: { triggers: TriggerRow[] },
+  slug: string,
+): TriggerRow {
+  const row = body.triggers.find((trigger) => trigger.slug === slug);
+  if (!row) {
+    throw new Error(
+      `trigger "${slug}" missing from response; got ${JSON.stringify(body.triggers.map((t) => t.slug))}`,
+    );
+  }
+  return row;
+}
+
+function expectTriggerModel(body: { triggers: TriggerRow[] }, slug: string, model: string): void {
+  const row = triggerBySlug(body, slug);
+  if (row.model !== model) {
+    throw new Error(`triggers["${slug}"].model === ${JSON.stringify(model)} — got ${JSON.stringify(row.model)}`);
+  }
+}
+
+type ManifestCommit = { hash: string; message?: string };
+
+/**
+ * `kortix.yaml` history on a deployed target lags its writes: the starter seed
+ * and the trigger commit land through the managed-git mirror seconds after the
+ * API answered. Read until two consecutive reads agree, so a comparison
+ * against a later read counts only commits made in between.
+ */
+async function settledManifestHistory(
+  read: () => Promise<ManifestCommit[]>,
+): Promise<ManifestCommit[]> {
+  let previous: string | null = null;
+  const commits = await waitFor(read, {
+    until: (value) => {
+      const key = JSON.stringify(value.map((commit) => commit.hash));
+      const settled = previous === key;
+      previous = key;
+      return settled;
+    },
+    timeoutMs: 90_000,
+    intervalMs: 3_000,
+    description: 'kortix.yaml history settles',
+  });
+  return commits;
+}
 
 flow(
   'TRG-1',
@@ -56,7 +110,8 @@ flow(
         },
         { params: { projectId: p.id } },
       );
-      r.status(201).body().has('triggers[0].model', 'anthropic/claude-sonnet-4-6');
+      r.status(201);
+      expectTriggerModel(r.json<{ triggers: TriggerRow[] }>(), 'nightly', 'anthropic/claude-sonnet-4-6');
     });
     await ctx.step('duplicate slug → 409', async () => {
       const r = await ctx.client
@@ -115,7 +170,8 @@ flow(
           { model: 'openai/gpt-5' },
           { params: { projectId: p.id, slug: 'toggle-me' } },
         );
-      r.status(200).body().has('triggers[0].model', 'openai/gpt-5');
+      r.status(200);
+      expectTriggerModel(r.json<{ triggers: TriggerRow[] }>(), 'toggle-me', 'openai/gpt-5');
     });
   },
 );
@@ -755,14 +811,15 @@ flow(
       ) {
         throw new Error(`unexpected default session_access: ${JSON.stringify(access)}`);
       }
-      const history = await owner.get('/v1/projects/:projectId/files/history', {
-        params: { projectId: project.id },
-        query: { path: 'kortix.yaml' },
-      });
-      history.status(200);
-      manifestCommitHashes = history
-        .json<{ commits: Array<{ hash: string }> }>()
-        .commits.map((commit) => commit.hash);
+      const readHistory = async (): Promise<ManifestCommit[]> => {
+        const history = await owner.get('/v1/projects/:projectId/files/history', {
+          params: { projectId: project.id },
+          query: { path: 'kortix.yaml' },
+        });
+        history.status(200);
+        return history.json<{ commits: ManifestCommit[] }>().commits;
+      };
+      manifestCommitHashes = (await settledManifestHistory(readHistory)).map((commit) => commit.hash);
     });
 
     await ctx.step(
@@ -844,16 +901,21 @@ flow(
         ) {
           throw new Error(`selected session_access was not normalized: ${JSON.stringify(access)}`);
         }
-        const history = await owner.get('/v1/projects/:projectId/files/history', {
-          params: { projectId: project.id },
-          query: { path: 'kortix.yaml' },
+        const current = await settledManifestHistory(async () => {
+          const history = await owner.get('/v1/projects/:projectId/files/history', {
+            params: { projectId: project.id },
+            query: { path: 'kortix.yaml' },
+          });
+          history.status(200);
+          return history.json<{ commits: ManifestCommit[] }>().commits;
         });
-        history.status(200);
-        const currentHashes = history
-          .json<{ commits: Array<{ hash: string }> }>()
-          .commits.map((commit) => commit.hash);
-        if (JSON.stringify(currentHashes) !== JSON.stringify(manifestCommitHashes)) {
-          throw new Error('policy-only PATCH created a kortix.yaml commit');
+        const added = current.filter((commit) => !manifestCommitHashes.includes(commit.hash));
+        if (added.length > 0 || current.length !== manifestCommitHashes.length) {
+          throw new Error(
+            `policy-only PATCH created a kortix.yaml commit: ${JSON.stringify(
+              added.map((commit) => `${commit.hash.slice(0, 8)} ${commit.message ?? ''}`),
+            )}`,
+          );
         }
       },
     );


### PR DESCRIPTION
Two CI-only fixes found while releasing v0.13.11. No product code.

## 1. `deploy-staging.yml` — verify the host-only access cookie

The staging verify step asserted a `Domain=.kortix.com` row in the curl cookie jar. #7065 removed the `Domain` attribute on purpose: that cookie reached every subdomain (staging, prod, `api.kortix.com`) regardless of which environment authorized it. The first staging deploy carrying #7065 (run 33977538433) rolled API, gateway, ECS web and Vercel, then failed on that assertion and skipped the `:staging` tag move.

Now: assert the row curl writes for a host-only cookie (`$ECS_WEB_HOST` / `#HttpOnly_$ECS_WEB_HOST`) and refuse a Domain-scoped `.kortix.com` row, so a regression of #7065 fails with a message that names it.

Verified against the live host:

```
curl -sS -o /dev/null -c jar -u "kortix:$WEB_PROTECTION_PASSWORD" https://staging-fe-ecs.kortix.com/
jar row: #HttpOnly_staging-fe-ecs.kortix.com  FALSE  /  TRUE  1789248991  __Secure-kortix_test_access  …
host-only: PASS · domain-scoped: absent · cookie replay: 200
```

Note: `deploy-staging.yml` is `workflow_run`-triggered, so it executes the workflow file from the DEFAULT branch. This fix only takes effect once it is on `main`.

## 2. `tests-release.yml` — relax engine-strict on install

Every shard of the release gate died at install on the v0.13.11 release PR (run 33995649798):

```
ERR_PNPM_UNSUPPORTED_ENGINE  Your Node version is incompatible with "/write-file-atomic/8.0.0".
Expected version: ^22.22.2 || ^24.15.0 || >=26.0.0
Got: v22.22.0
```

`write-file-atomic@8.0.0` entered the lockfile with the docs move (#7121). `.npmrc` sets `engine-strict=true`, and `setup-node` resolves `node-version: 22` from the runner cache to 22.22.0. `tests.yml`, `deploy-prod.yml` and `deploy-staging.yml` already install with `npm_config_engine_strict: "false"`; `tests-release.yml` was the only workflow without it. Added to its four install steps.

## Checks

- `python3 -c 'yaml.safe_load(...)'` parses both files.
- `bun test tests/unit/web-ecs-workflow.test.ts tests/unit/sandbox-workflow.test.ts tests/unit/rerun-identity.test.ts tests/unit/shard.test.ts tests/unit/scrub-secret-shapes.test.ts` passes.

Both commits are cherry-picked onto `staging` (#7138 and a follow-up) so the 0.13.11 candidate's gate can run.

https://claude.ai/code/session_01GTiDEogMLLLuimhrTDF7FC