### PR TITLE
staging: verify the host-only access cookie (cherry-pick of #7137)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -656,9 +656,17 @@ jobs:
           { [ "$cookie_status" = 200 ] || [ "$cookie_status" = 307 ] || [ "$cookie_status" = 308 ]; } || {
             echo "::error::staging ECS frontend shared-cookie status=$cookie_status"; exit 1;
           }
-          grep -E $'^(#HttpOnly_)?\\.kortix\\.com\t' "$cookie_jar" >/dev/null || {
-            echo "::error::staging ECS frontend did not set the parent-domain access cookie"; exit 1;
+          # The access cookie is HOST-ONLY since #7065: the old Domain=.kortix.com
+          # cookie reached every subdomain (staging, prod, api.kortix.com) no
+          # matter which environment authorized it. curl writes a host-only
+          # cookie under the exact issuing host, so assert that row and refuse a
+          # Domain-scoped one — a `.kortix.com` row here means #7065 regressed.
+          awk -F'\t' -v h="$ECS_WEB_HOST" '$1 == h || $1 == "#HttpOnly_" h { found = 1 } END { exit !found }' "$cookie_jar" || {
+            echo "::error::staging ECS frontend did not set a host-only access cookie for ${ECS_WEB_HOST}"; exit 1;
           }
+          if awk -F'\t' '$1 == ".kortix.com" || $1 == "#HttpOnly_.kortix.com" { found = 1 } END { exit !found }' "$cookie_jar"; then
+            echo "::error::staging ECS frontend set a Domain-scoped .kortix.com access cookie (#7065 made it host-only)"; exit 1;
+          fi
           ecs_health="$(curl -fsS --max-time 20 "$ecs/api/health")"
           [ "$(jq -r '.commit // empty' <<<"$ecs_health")" = "$EXPECTED_COMMIT" ] || {
             echo "::error::staging ECS frontend commit mismatch"; exit 1;
@@ -681,7 +689,7 @@ jobs:
           {
             echo "### Staging verified"
             echo "- API: https://${PUBLIC_API_HOST}/v1/health reports staging ${EXPECTED_VERSION}"
-            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts the shared test cookie"
+            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts its host-only test cookie"
             echo "- Vercel web: https://${WEB_HOST} serves staging runtime config"
             echo "- GitOps: API ALB via ECS Fargate"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Cherry-pick of `ad9ace7cad` (#7137) onto `staging`, workflow file only.

The 0.13.11 candidate (`d0be160a28`) deployed to staging in run 33977538433: API, gateway, ECS web and Vercel all rolled, then the verify step failed on a stale assertion that expected a `Domain=.kortix.com` access cookie. #7065 (in this candidate) made that cookie host-only on purpose. This lets the candidate's staging deploy verify green and move the `:staging` tag before promote.

No product code changes. Tree = `d0be160a28` + `.github/workflows/deploy-staging.yml`.

https://claude.ai/code/session_01GTiDEogMLLLuimhrTDF7FC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791236315&installation_model_id=434224&pr_number=7138&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7138&signature=2702a8d8000891418583f7dc6ceeb449dfdf675a4ea87522df8fe6450863ae54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->