### PR TITLE
staging: relax engine-strict on the release gate install (cherry-pick of dbd11d2151, #7137)

### DIFF
--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -90,6 +90,14 @@ jobs:
           cache: pnpm
       - name: Install runner dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       # Bounded at the STEP so a slow sweep ends as a job *failure* (which
       # continue-on-error absorbs) — never as a job *cancelled*: on run
       # 32226539107 the 15-minute job cap fired while gc was still deleting a
@@ -222,6 +230,14 @@ jobs:
           cache: pnpm
       - name: Install deployed-target dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       - name: Run this shard of the deployed staging API suite
         run: pnpm test -- --target-api-full --api-shard=${{ matrix.shard }}/6
       # A cancelled job is SIGKILLed before the runner's `finally` teardown, so
@@ -322,6 +338,9 @@ jobs:
         run: |
           pnpm install --frozen-lockfile --filter @kortix/tests...
           pnpm --dir tests exec playwright install --with-deps chromium
+        # See the same env on the API shard install above.
+        env:
+          npm_config_engine_strict: "false"
       - name: Run this shard of the deployed staging browser journeys
         run: pnpm test -- --target-browser-full --browser-shard=${{ matrix.shard }}/3
       # No --run-id sweep here: the Playwright specs mint their own Supabase
@@ -378,6 +397,14 @@ jobs:
           cache: pnpm
       - name: Install runner dependencies
         run: pnpm install --frozen-lockfile --filter @kortix/tests...
+        # Every other workflow that installs from this lockfile (tests.yml,
+        # deploy-prod, deploy-staging) already relaxes engine-strict here. The
+        # runner cache resolves `node-version: 22` to 22.22.0, and
+        # write-file-atomic@8.0.0 (via apps/web, since #7121) declares
+        # `^22.22.2`; with .npmrc engine-strict=true that killed every shard at
+        # install (run 33995649798, release/v0.13.11).
+        env:
+          npm_config_engine_strict: "false"
       - name: Reclaim this run's test accounts
         run: bun tests/bin/ke2e.ts gc --run-id ${{ github.run_id }}
 


### PR DESCRIPTION
Cherry-pick of `dbd11d2151` (#7137, second commit) onto `staging`. Workflow file only.

Every shard of `Tests - release` on release PR #7139 (source `5dd5c9d12f`) died at install:

```
ERR_PNPM_UNSUPPORTED_ENGINE  Your Node version is incompatible with "/write-file-atomic/8.0.0".
Expected version: ^22.22.2 || ^24.15.0 || >=26.0.0
Got: v22.22.0
```

`tests-release.yml` was the only workflow installing without `npm_config_engine_strict: "false"`; `tests.yml`, `deploy-prod.yml` and `deploy-staging.yml` already set it. The gate runs the workflow file from the release PR head, which promote cuts from `staging`, so the fix has to be here before re-promoting.

Tree = `5dd5c9d12f` + `.github/workflows/tests-release.yml`. No product code, no migrations.

https://claude.ai/code/session_01GTiDEogMLLLuimhrTDF7FC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791239300&installation_model_id=434224&pr_number=7140&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7140&signature=8f42f3b49513bbac8a3952f62b3bd1a8447d1293093445eeaebca88a8b6f0037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->