### PR TITLE
staging: release-gate tests follow the deployed contracts main changed (cherry-pick of 8e518e3f52, #7137)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,28 @@ linked, not inlined.
 
 ## Register
 
+### A test that only runs against a deployed target is a contract nobody runs before merge (2026-09-06)
+
+**When:** changing behaviour that a `tests/e2e` spec or `tests/src/flows` flow
+asserts, or writing such a test. Specs that `test.skip` without a provider
+(23-composio) or fixtures that differ by target (`createManifestProject`,
+`fixtures.project({ managedGit })`) run ONLY in `tests-release.yml` against
+staging. The v0.13.11 release gate went red on four of them while every PR
+lane had been green for a week: connector slugs became `<app>-<random>`
+(7f6b8087f3) and spec 23 still asserted `composio-search`; managed repos now
+seed the starter by default (4da295e50b), so `triggers[0]` is the starter's
+`harness-reflector` (model null) and TRG-2/TRG-3 read the wrong row; the seed
+and the trigger commit land through the mirror seconds later, so TRG-14's
+`kortix.yaml` history moved under it. **Rules.** (1) When a PR changes a
+deployed-only contract, grep `tests/e2e/specs` and `tests/src/flows` for the
+old value in the same PR. (2) A flow asserts on the row it wrote (find by
+slug), never on `[0]`. (3) A read that follows a managed-git write settles
+(two equal reads) before it is compared. (4) Before promoting, dispatch
+`tests-release.yml --ref staging -f expected_sha=<staging tip>` as a dry run;
+the gate is the first time these tests see the change. *Incident:* release
+gate red twice on 2026-09-05/06, ~2 h of release delay, no user impact.
+*Enforcer:* none yet — the dry run is manual.
+
 ### Every streamed transcript mutation refreshes runtime activity (2026-09-05)
 
 **When:** adding or changing a wire event that mutates visible assistant output.

--- a/tests/e2e/specs/23-composio-connector.spec.ts
+++ b/tests/e2e/specs/23-composio-connector.spec.ts
@@ -170,20 +170,25 @@ test.describe("23 — Composio managed connector", () => {
     expect(createBody).toEqual(
       expect.objectContaining({
         name: "Composio Search",
-        slug: "composio-search",
         provider: "composio",
         app: "composio_search",
         authorization_strategy: "project",
         create_only: true,
       }),
     );
+    // A proposed connector slug is `<app>-<6 random base36>` since 7f6b8087f3
+    // (so two connections to one app never collide). The suffix is random, so
+    // read the slug the UI actually proposed and follow it for the rest of the
+    // journey instead of asserting a fixed one.
+    expect(createBody.slug).toMatch(/^composio-search-[a-z0-9]{6}$/);
+    const connectorSlug = createBody.slug as string;
     expect(JSON.stringify(createBody)).not.toMatch(
       /api[_-]?key|credential|secret/i,
     );
     expect((await createResponsePromise).status()).toBe(200);
 
     await expect(page).toHaveURL(new RegExp(`[?&]scope=connected(?:&|$)`));
-    await expect(page).toHaveURL(new RegExp(`[?&]c=composio-search(?:&|$)`));
+    await expect(page).toHaveURL(new RegExp(`[?&]c=${connectorSlug}(?:&|$)`));
     const detail = page.getByRole("dialog", { name: "Composio Search" });
     await expect(detail).toBeVisible();
     await expect(
@@ -195,7 +200,7 @@ test.describe("23 — Composio managed connector", () => {
         request
           .url()
           .endsWith(
-            `/v1/connectors/projects/${project.id}/connectors/composio-search/connect`,
+            `/v1/connectors/projects/${project.id}/connectors/${connectorSlug}/connect`,
           ) && request.method() === "POST",
     );
     const connectResponsePromise = page.waitForResponse(
@@ -203,7 +208,7 @@ test.describe("23 — Composio managed connector", () => {
         response
           .url()
           .endsWith(
-            `/v1/connectors/projects/${project.id}/connectors/composio-search/connect`,
+            `/v1/connectors/projects/${project.id}/connectors/${connectorSlug}/connect`,
           ) && response.request().method() === "POST",
     );
     await detail.getByRole("button", { name: "Connect", exact: true }).click();
@@ -240,7 +245,7 @@ test.describe("23 — Composio managed connector", () => {
     );
     const connection = connections.connections.find(
       (item) =>
-        item.connector_alias === "composio-search" &&
+        item.connector_alias === connectorSlug &&
         item.owner_type === "project" &&
         item.is_default,
     );

--- a/tests/src/flows/triggers.flow.ts
+++ b/tests/src/flows/triggers.flow.ts
@@ -3,8 +3,62 @@
  * Trigger create commits the project manifest (a real git commit).
  */
 import { flow } from '../core/flow';
+import { waitFor } from '../core/poll';
 import { createDatabaseSession } from '../fixtures/database-project';
 import { enableEnterpriseDemo } from '../fixtures/enterprise-demo';
+
+type TriggerRow = { slug: string; model: string | null };
+
+/**
+ * A managed-repo project is seeded from the starter by default (4da295e50b),
+ * and the starter ships a `harness-reflector` cron with no model. So the
+ * trigger a flow just wrote is NOT `triggers[0]`; find it by slug.
+ */
+function triggerBySlug(
+  body: { triggers: TriggerRow[] },
+  slug: string,
+): TriggerRow {
+  const row = body.triggers.find((trigger) => trigger.slug === slug);
+  if (!row) {
+    throw new Error(
+      `trigger "${slug}" missing from response; got ${JSON.stringify(body.triggers.map((t) => t.slug))}`,
+    );
+  }
+  return row;
+}
+
+function expectTriggerModel(body: { triggers: TriggerRow[] }, slug: string, model: string): void {
+  const row = triggerBySlug(body, slug);
+  if (row.model !== model) {
+    throw new Error(`triggers["${slug}"].model === ${JSON.stringify(model)} — got ${JSON.stringify(row.model)}`);
+  }
+}
+
+type ManifestCommit = { hash: string; message?: string };
+
+/**
+ * `kortix.yaml` history on a deployed target lags its writes: the starter seed
+ * and the trigger commit land through the managed-git mirror seconds after the
+ * API answered. Read until two consecutive reads agree, so a comparison
+ * against a later read counts only commits made in between.
+ */
+async function settledManifestHistory(
+  read: () => Promise<ManifestCommit[]>,
+): Promise<ManifestCommit[]> {
+  let previous: string | null = null;
+  const commits = await waitFor(read, {
+    until: (value) => {
+      const key = JSON.stringify(value.map((commit) => commit.hash));
+      const settled = previous === key;
+      previous = key;
+      return settled;
+    },
+    timeoutMs: 90_000,
+    intervalMs: 3_000,
+    description: 'kortix.yaml history settles',
+  });
+  return commits;
+}
 
 flow(
   'TRG-1',
@@ -56,7 +110,8 @@ flow(
         },
         { params: { projectId: p.id } },
       );
-      r.status(201).body().has('triggers[0].model', 'anthropic/claude-sonnet-4-6');
+      r.status(201);
+      expectTriggerModel(r.json<{ triggers: TriggerRow[] }>(), 'nightly', 'anthropic/claude-sonnet-4-6');
     });
     await ctx.step('duplicate slug → 409', async () => {
       const r = await ctx.client
@@ -115,7 +170,8 @@ flow(
           { model: 'openai/gpt-5' },
           { params: { projectId: p.id, slug: 'toggle-me' } },
         );
-      r.status(200).body().has('triggers[0].model', 'openai/gpt-5');
+      r.status(200);
+      expectTriggerModel(r.json<{ triggers: TriggerRow[] }>(), 'toggle-me', 'openai/gpt-5');
     });
   },
 );
@@ -755,14 +811,15 @@ flow(
       ) {
         throw new Error(`unexpected default session_access: ${JSON.stringify(access)}`);
       }
-      const history = await owner.get('/v1/projects/:projectId/files/history', {
-        params: { projectId: project.id },
-        query: { path: 'kortix.yaml' },
-      });
-      history.status(200);
-      manifestCommitHashes = history
-        .json<{ commits: Array<{ hash: string }> }>()
-        .commits.map((commit) => commit.hash);
+      const readHistory = async (): Promise<ManifestCommit[]> => {
+        const history = await owner.get('/v1/projects/:projectId/files/history', {
+          params: { projectId: project.id },
+          query: { path: 'kortix.yaml' },
+        });
+        history.status(200);
+        return history.json<{ commits: ManifestCommit[] }>().commits;
+      };
+      manifestCommitHashes = (await settledManifestHistory(readHistory)).map((commit) => commit.hash);
     });
 
     await ctx.step(
@@ -844,16 +901,21 @@ flow(
         ) {
           throw new Error(`selected session_access was not normalized: ${JSON.stringify(access)}`);
         }
-        const history = await owner.get('/v1/projects/:projectId/files/history', {
-          params: { projectId: project.id },
-          query: { path: 'kortix.yaml' },
+        const current = await settledManifestHistory(async () => {
+          const history = await owner.get('/v1/projects/:projectId/files/history', {
+            params: { projectId: project.id },
+            query: { path: 'kortix.yaml' },
+          });
+          history.status(200);
+          return history.json<{ commits: ManifestCommit[] }>().commits;
         });
-        history.status(200);
-        const currentHashes = history
-          .json<{ commits: Array<{ hash: string }> }>()
-          .commits.map((commit) => commit.hash);
-        if (JSON.stringify(currentHashes) !== JSON.stringify(manifestCommitHashes)) {
-          throw new Error('policy-only PATCH created a kortix.yaml commit');
+        const added = current.filter((commit) => !manifestCommitHashes.includes(commit.hash));
+        if (added.length > 0 || current.length !== manifestCommitHashes.length) {
+          throw new Error(
+            `policy-only PATCH created a kortix.yaml commit: ${JSON.stringify(
+              added.map((commit) => `${commit.hash.slice(0, 8)} ${commit.message ?? ''}`),
+            )}`,
+          );
         }
       },
     );


### PR DESCRIPTION
Cherry-pick of `8e518e3f52` (#7137, third commit) onto `staging`. Test files and the learnings register only; no product code.

`Tests - release` run 33996940707 on release PR #7139 (source `50f6e7f2ff`) failed four tests that only run against a deployed target:

- **23-composio-connector**: asserted slug `composio-search`; proposals are `<app>-<6 base36>` since 7f6b8087f3. Follows the slug the UI proposed.
- **TRG-2 / TRG-3**: asserted `triggers[0].model`; managed repos seed the starter by default (4da295e50b) and the starter's `harness-reflector` (model null) sorts first. Assert on the row the flow wrote, by slug.
- **TRG-14**: `kortix.yaml` history moved under the flow while the seed and trigger commits landed through the mirror. Reads settle (two equal reads) before comparing.

Verified on staging with a fresh account: `GET /triggers` on a seeded project → `[{slug:"harness-reflector",model:null}]`. `tests/ tsc --noEmit` exit 0.

Tree = `50f6e7f2ff` + these three files.

https://claude.ai/code/session_01GTiDEogMLLLuimhrTDF7FC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791243635&installation_model_id=434224&pr_number=7141&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7141&signature=d5b487c2951c02ceb1efac1a0bbe206611fd1d9254734c823edaa47999b502bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->