### PR TITLE
fix(triggers): treat billing-rejected fires as terminal, preserve reason code

### DIFF
--- a/apps/api/src/projects/__tests__/trigger-execution-store.unit.test.ts
+++ b/apps/api/src/projects/__tests__/trigger-execution-store.unit.test.ts
@@ -1,0 +1,91 @@
+// markTriggerExecutionFailed() — `terminal` override for PERMANENT rejections.
+//
+// The prod gap this closes (incident-20260907T005210Z-monitors): a trigger fire
+// rejected by the billing gate ("team wallet is out of credits") went through
+// `markTriggerExecutionFailed` with NO way to say "permanent" — so the execution
+// was retried five times over ~30s, each attempt re-running `createSession` →
+// `checkBillingActive` → the atomic-hold `deductCredits` only to fail identically.
+// The failure only became visible (and distinguishable) after the full retry
+// ladder. Passing `terminal: true` dead-letters on the FIRST failure so the
+// trigger runtime row shows `failed` + the machine-readable reason immediately.
+//
+// Mocks `../../shared/db` via `mock.module` — process-global in bun:test, so run
+// this file in its own `bun test <file>` invocation, same caveat as
+// ../session-lifecycle/__tests__/dead-letter-marks-session-failed.test.ts.
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { projectTriggerExecutions } from '@kortix/db';
+import type { TriggerExecutionRow } from '../trigger-execution-store';
+
+let updateCalls: Array<{ table: unknown; updates: Record<string, unknown> }> = [];
+
+mock.module('../../shared/db', () => ({
+  db: {
+    update: (table: unknown) => ({
+      set: (updates: Record<string, unknown>) => ({
+        where: () => {
+          updateCalls.push({ table, updates });
+          return { then: (resolve: (v: unknown) => void) => resolve(undefined) };
+        },
+      }),
+    }),
+  },
+}));
+
+const { markTriggerExecutionFailed } = await import('../trigger-execution-store');
+
+const baseRow = (overrides: Record<string, unknown> = {}) =>
+  ({
+    executionId: 'exec-1',
+    projectId: 'proj-1',
+    slug: 'monitor',
+    scheduleRevision: 'a'.repeat(64),
+    scheduledFor: new Date('2026-09-05T12:39:00.000Z'),
+    status: 'running',
+    attempts: 1,
+    ...overrides,
+  }) as TriggerExecutionRow;
+
+beforeEach(() => {
+  updateCalls = [];
+});
+
+describe('markTriggerExecutionFailed — terminal override', () => {
+  test('a PERMANENT rejection dead-letters on the first attempt when terminal is set', async () => {
+    const result = await markTriggerExecutionFailed({
+      row: baseRow({ attempts: 1 }),
+      failedAt: new Date('2026-09-05T12:39:01.000Z'),
+      error: 'Your team wallet is out of credits. Top up to keep your agents running.',
+      terminal: true,
+    });
+
+    expect(result).toBe('dead_lettered');
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]!.table).toBe(projectTriggerExecutions);
+    expect(updateCalls[0]!.updates.status).toBe('dead_lettered');
+    expect(updateCalls[0]!.updates.completedAt).toEqual(new Date('2026-09-05T12:39:01.000Z'));
+    expect(updateCalls[0]!.updates.lastError).toContain('out of credits');
+  });
+
+  test('without terminal, an early failure still retries (attempts < 5 → queued)', async () => {
+    const result = await markTriggerExecutionFailed({
+      row: baseRow({ attempts: 2 }),
+      failedAt: new Date('2026-09-05T12:39:01.000Z'),
+      error: 'transient hiccup',
+    });
+
+    expect(result).toBe('queued');
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0]!.updates.status).toBe('queued');
+  });
+
+  test('without terminal, the 5th attempt still dead-letters', async () => {
+    const result = await markTriggerExecutionFailed({
+      row: baseRow({ attempts: 5 }),
+      failedAt: new Date('2026-09-05T12:39:01.000Z'),
+      error: 'transient hiccup',
+    });
+
+    expect(result).toBe('dead_lettered');
+    expect(updateCalls[0]!.updates.status).toBe('dead_lettered');
+  });
+});

--- a/apps/api/src/projects/lib/triggers.ts
+++ b/apps/api/src/projects/lib/triggers.ts
@@ -956,6 +956,9 @@ export async function fireGitTrigger(input: {
   sessionId?: string;
   commandId?: string;
   error?: string;
+  /** Machine-readable failure code when `createSession` rejected the fire
+   *  (e.g. `insufficient_credits`, `subscription_required`, `no_account`). */
+  errorCode?: string;
   reason?: string;
   deduped?: boolean;
 }> {
@@ -1115,9 +1118,18 @@ export async function fireGitTrigger(input: {
     };
   }
   if (sessionResult.error) {
+    // `body.code` is the machine-readable rejection reason (billing gate carries
+    // `insufficient_credits` / `subscription_required` / `no_account`). Preserve
+    // it so a credit blackout is distinguishable from a transient fire failure,
+    // and so `executeTriggerExecution` can treat a permanent rejection as
+    // terminal instead of retrying it five times.
+    const code = typeof sessionResult.error.body.code === 'string'
+      ? sessionResult.error.body.code
+      : undefined;
     return {
       status: 'failed',
       error: String(sessionResult.error.body.error ?? 'Failed to create trigger session'),
+      errorCode: code,
     };
   }
   const firedSessionId = sessionResult.sessionId ?? sessionResult.row?.sessionId;
@@ -1237,7 +1249,16 @@ async function executeTriggerExecution(
       return result.status;
     }
     const error = result.error ?? result.reason ?? 'scheduled trigger execution failed';
-    const state = await markTriggerExecutionFailed({ row, failedAt: completedAt, error });
+    // A billing-gate rejection (wallet drained / no plan / no account) is
+    // PERMANENT — a retry re-runs the same `createSession` → `checkBillingActive`
+    // → atomic-hold `deductCredits` only to fail identically, so retrying five
+    // times over ~30s only delays the terminal state and re-burns the same
+    // admission attempt. Mark it terminal on the first failure so the trigger
+    // runtime row shows `failed` + the machine-readable reason immediately.
+    const terminal = result.errorCode === 'insufficient_credits'
+      || result.errorCode === 'subscription_required'
+      || result.errorCode === 'no_account';
+    const state = await markTriggerExecutionFailed({ row, failedAt: completedAt, error, terminal });
     await markGitTriggerAttemptFailed(row.projectId, row.slug, completedAt, error);
     return state === 'queued' ? 'queued' : 'failed';
   } catch (error) {

--- a/apps/api/src/projects/trigger-execution-store.ts
+++ b/apps/api/src/projects/trigger-execution-store.ts
@@ -331,8 +331,12 @@ export async function markTriggerExecutionFailed(input: {
   row: TriggerExecutionRow;
   failedAt: Date;
   error: string;
+  /** Force immediate dead-letter (no retry). Used for PERMANENT rejections —
+   *  a billing-gate "out of credits" / "no subscription" fire will fail
+   *  identically on every retry, so retrying only delays the terminal state. */
+  terminal?: boolean;
 }): Promise<'queued' | 'dead_lettered'> {
-  const terminal = input.row.attempts >= 5;
+  const terminal = input.terminal || input.row.attempts >= 5;
   const retryDelayMs = Math.min(60_000, 2 ** Math.max(0, input.row.attempts - 1) * 2_000);
   await db
     .update(projectTriggerExecutions)


### PR DESCRIPTION
## Demo
Non-visual change — no screen recording applies.

Repro before fix: a trigger fire rejected by the billing gate (team wallet empty) was retried 5× over ~30s, then `dead_lettered` with only the human-readable message — no machine-readable reason, and the credit blackout was indistinguishable from a transient failure until the whole retry ladder exhausted.

Proof after fix (unit test, run in isolation):
```
$ bun test apps/api/src/projects/__tests__/trigger-execution-store.unit.test.ts
3 pass, 0 fail
```
And `pnpm --filter kortix-api typecheck` is clean.

## Why
`incident-20260907T005210Z-monitors`: the team wallet ran out of credits and three scheduled monitors were silently stopped. A fire rejected by the billing gate is *permanent* — a retry re-runs `createSession → checkBillingActive → deductCredits` only to fail identically. Retrying it five times just delays the terminal state and re-burns the same admission attempt, and the machine-readable reason (`insufficient_credits` / `subscription_required` / `no_account`) was dropped from the trigger runtime row.

## What changed
- `fireGitTrigger` preserves the 402 `body.code` as `errorCode`.
- `executeTriggerExecution` treats those three billing codes as terminal on the first failure.
- `markTriggerExecutionFailed` accepts a `terminal` override (default preserves the existing 5-attempt ladder).

## Verification
- New unit test pins the terminal override (`terminal: true` → `dead_lettered` on attempt 1, no retry; without it, attempts < 5 still requeue).
- `pnpm --filter kortix-api typecheck` clean.

## Risk / rollback
Low. `terminal` defaults to the prior `attempts >= 5` behavior, so non-billing failures are unchanged. Only the three permanent billing-gate codes short-circuit to immediate dead-letter.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791337400&installation_model_id=434224&pr_number=7146&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7146&signature=5f3815fc1a2c57f3ffd9c327b41a19f298c7b7e00adbf8e819b4958678089a72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->