### PR TITLE
fix(web): inset markdown code blocks

### DIFF
--- a/apps/web/src/components/markdown/code/code-block.tsx
+++ b/apps/web/src/components/markdown/code/code-block.tsx
@@ -123,7 +123,7 @@ export function CodeBlock({
       <pre
         ref={scrollRef}
         className={cn(
-          'bg-popover max-h-[520px] overflow-auto py-2.5 tracking-tight',
+          'bg-popover max-h-[520px] overflow-auto px-2 py-2.5 tracking-tight',
           'text-foreground rounded-t-sm font-mono text-xs leading-[1.65]',
           '[&_code]:border-none [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-xs',
           '[&_.shiki]:!bg-transparent [&_span]:border-none [&_span]:!bg-transparent [&_span]:outline-none',

--- a/apps/web/src/components/markdown/code/markdown-code.test.tsx
+++ b/apps/web/src/components/markdown/code/markdown-code.test.tsx
@@ -31,6 +31,12 @@ const labelOf = (html: string) => {
 const CARD = 'not-prose';
 const COPY = 'aria-label="Copy code"';
 
+const classNameOf = (html: string, tagName: string) => {
+  const found = html.match(new RegExp(`<${tagName}\\b[^>]*\\bclass="([^"]*)"`));
+  if (!found) throw new Error(`no <${tagName}> with a class in the rendered markup`);
+  return found[1] ?? '';
+};
+
 describe('MarkdownCode — fenced blocks', () => {
   test('a mermaid fence takes the diagram path, not the code card', () => {
     // MermaidRenderer is lazy() inside a Suspense with a null fallback, and a
@@ -76,6 +82,13 @@ describe('MarkdownCode — fenced blocks', () => {
     expect(markup).toContain(CARD);
     expect(markup).toContain(COPY);
     expect(labelOf(markup)).toBe('typescript');
+  });
+
+  test('the code body keeps the same horizontal inset as the header', () => {
+    const markup = render({ className: 'language-bash', children: 'kortix apps deploy' });
+
+    expect(classNameOf(markup, 'figcaption')).toContain('px-2');
+    expect(classNameOf(markup, 'pre')).toContain('px-2');
   });
 
   test('isStreaming keeps the copy button and the label', () => {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791374757&installation_model_id=434224&pr_number=7147&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7147&signature=15bb3f722fcd4132cdbd00882199f566c4b93ef145badf5e04fc63a23be0b936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->