### PR TITLE
fix(api): loud provision/connector failures + deploy the prod API router Worker from deploy-prod

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,31 @@ linked, not inlined.
 
 ## Register
 
+### Verify a rotated credential with the WRITE it exists for, and every edge worker deploys from the same pipeline as its origin (2026-09-07)
+
+**When:** rotating any token/key (PAT, App permission, API key) or editing an
+`apps/api/.env.<env>` credential; and when changing what fronts an origin
+(`infra/cloudflare/workers/api-router`). PR #7063 (2026-08-30) swapped the
+managed-kortix classic PAT for a fine-grained one and "verified" it with
+`GET /orgs/managed-kortix/repos` = 200 — a read. Repo creation needs
+`Administration: write`, which it lacked, and the App fallback (install
+140097279) only had `contents:write`. **Every prod project creation failed
+for 8 days** (~500/day, 63 users/day), and nobody saw the reason: the prod
+`api-kortix-router` worker was a 2026-08-21 build (only `deploy-staging.yml`
+and the cutover workflow ever ran `wrangler deploy`), so it rewrote the 502
+body into "Kortix is temporarily unavailable" and Better Stack showed a
+maintenance page nobody had switched on. **Rules.** (1) A credential swap is
+verified by the operation it authorises — for a repo-creating token, a
+create+delete probe repo — never by a read. (2) An edge worker is part of the
+origin's release: `deploy-prod.yml` now deploys it (`deploy-api-router`) and
+asserts the script's `modified_on` moved. (3) A route that returns an error
+body without a log line is invisible once an edge or a proxy eats the body;
+`provision-core.ts` now logs `create_repo` failures. *Incident:* prod,
+2026-08-30 23:15 → 2026-09-07 20:28 UTC (worker) / credential fix pending.
+See memory [[prod-provision-dead-fine-grained-pat-2026-08-30]].
+*Enforcer:* `deploy-api-router` job in `deploy-prod.yml`; unit
+`unit-connector-invalid-source-address.test.ts` for the sibling 500s.
+
 ### Verify the listening process before sharing a worktree URL (2026-09-07)
 
 **When:** sharing or verifying a local fix, check the web and API listener PIDs

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -966,6 +966,66 @@ jobs:
   # call job — GitHub rejects the whole file (startup_failure, zero jobs).
   # A job-level `if:` IS valid, and a skipped job leaves the run green — the
   # same mechanism `verify-schema` uses with ENABLE_PROD_SCHEMA_GATE.
+  # ── Deploy the prod API router Worker ───────────────────────────────────────
+  # api.kortix.com and gateway.kortix.com are fronted by the Cloudflare Worker
+  # in infra/cloudflare/workers/api-router. Until 2026-09-07 NOTHING in this
+  # workflow deployed it: only deploy-staging.yml and the cutover workflow ran
+  # a Worker deploy, so prod served a 2026-08-21 build for 17 days. That build
+  # still rewrote every origin 502/503/504 into a synthetic "Kortix is
+  # temporarily unavailable" maintenance page (removed in #6831, 2026-08-24) —
+  # which is how 8 days of failed project creation (a rotated managed-git PAT
+  # without Administration:write, #7063) surfaced in Better Stack as a
+  # maintenance mode nobody had switched on. The Worker is part of the origin's
+  # release: it deploys here, from the same checkout, after the origin rolls.
+  #
+  # `wrangler deploy --env prod` reads infra/cloudflare/workers/api-router/
+  # wrangler.toml — bindings, routes and the custom domain come from that file,
+  # so there is one source of truth (no hand-maintained binding list as in
+  # deploy-staging's REST path). The scoped CLOUDFLARE_API_TOKEN (Workers
+  # Scripts:Edit + Workers Routes:Edit on kortix.com) is the credential that
+  # deployed it by hand on 2026-09-07.
+  #
+  # Non-blocking for the same reason deploy-staging's wire-cloudflare is: a
+  # dead Cloudflare credential must not freeze the release. The failed step
+  # stays visible here, and the modified_on assertion below fails LOUDLY when
+  # the upload was accepted but the live script did not change.
+  deploy-api-router:
+    name: Deploy prod API router Worker
+    needs: [deploy-ecs]
+    runs-on: ${{ vars.CI_RUNNER_S || 'blacksmith-2vcpu-ubuntu-2404' }}
+    continue-on-error: true
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID || '9785405a992435bb0c7bd19f9b6d26d5' }}
+      WORKER_NAME: api-kortix-router
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Deploy api-kortix-router from wrangler.toml [env.prod]
+        working-directory: infra/cloudflare/workers/api-router
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN is unset — the prod API router Worker was NOT deployed. Set the repository secret (Workers Scripts:Edit + Workers Routes:Edit on kortix.com)."
+            exit 1
+          fi
+          started="$(date -u +%s)"
+          npx --yes wrangler@4 deploy --env prod
+          # Prove the LIVE script changed in this run. A 200 from the upload
+          # is not proof: the API answered 200 for a script it later refused.
+          modified="$(curl -fsS \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts" \
+            | jq -r --arg name "$WORKER_NAME" '.result[] | select(.id == $name) | .modified_on')"
+          modified_epoch="$(date -u -d "$modified" +%s)"
+          echo "api-kortix-router modified_on=$modified (run started $(date -u -d "@$started" +%FT%TZ))"
+          if [ "$modified_epoch" -lt "$((started - 60))" ]; then
+            echo "::error::api-kortix-router modified_on ($modified) predates this run — the live Worker did not change."
+            exit 1
+          fi
+
   deploy-us-shadow:
     name: Deploy API + gateway to US East 2 shadow
     needs: [version, retag-images, verify-image-commits, migrate-db]

--- a/apps/api/src/__tests__/unit-connector-invalid-source-address.test.ts
+++ b/apps/api/src/__tests__/unit-connector-invalid-source-address.test.ts
@@ -41,9 +41,11 @@ import { describe, expect, test } from 'bun:test';
  */
 import {
   AllowedSourceValidationError,
+  assertAllowedEndpointUrl,
   assertAllowedSourceAddress,
   isAllowedSourceValidationError,
 } from '../marketplace/catalog';
+import { UnsafeEgressError } from '../shared/ssrf-guard';
 import {
   createConnectorRouter,
   type ConnectorPrincipal,
@@ -129,12 +131,54 @@ describe('assertAllowedSourceAddress throws a typed AllowedSourceValidationError
   });
 });
 
+/**
+ * Better Stack API prod 2026-09-07 — `UnsafeEgressError: url must be https`
+ * (10:10 UTC) and `UnsafeEgressError: invalid url` (09:45 UTC), both from
+ * `discoverConnectorAuthFromSource` → `safeEgressFetch`, both 500 + Sentry.
+ * `assertAllowedSourceAddress` had PASSED: its parser only treats lowercase
+ * `http://`/`https://` as a URL and reads anything else as GitHub `owner/repo`
+ * shorthand, so `HTTP://host/mcp`, `ws://host`, `localhost:3000/mcp` and
+ * `my server/mcp` all reached the egress guard. A connector endpoint is never
+ * shorthand — it is fetched verbatim — so it gets its own strict guard.
+ */
+describe('assertAllowedEndpointUrl (connector endpoints are absolute https URLs)', () => {
+  const rejected = [
+    'HTTP://example.com/mcp', // scheme case slipped past the source guard → "url must be https"
+    'http://example.com/mcp',
+    'ws://example.com/mcp',
+    'localhost:3000/mcp', // WHATWG parses this as scheme "localhost:" → "url must be https"
+    'my server/mcp', // → "invalid url"
+    'example.com/mcp',
+    'https://127.0.0.1/mcp',
+    'https://169.254.169.254/latest/meta-data',
+    'https://user:pw@example.com/mcp',
+    '',
+  ];
+  for (const address of rejected) {
+    test(`rejects ${JSON.stringify(address)} as a typed invalid_source_address`, () => {
+      let caught: unknown;
+      try {
+        assertAllowedEndpointUrl(address);
+      } catch (err) {
+        caught = err;
+      }
+      expect(isAllowedSourceValidationError(caught)).toBe(true);
+      expect((caught as AllowedSourceValidationError).code).toBe('invalid_source_address');
+    });
+  }
+
+  test('accepts an absolute https URL on a public host', () => {
+    expect(() => assertAllowedEndpointUrl('https://mcp.example.com/sse')).not.toThrow();
+    expect(() => assertAllowedEndpointUrl('  https://example.com/graphql  ')).not.toThrow();
+  });
+});
+
 // ── Route-level regression: the typed throw becomes a 400, not a 500 ────────
 
 /** Build a connector router whose `discoverConnectorAuth` throws the EXACT prod
  *  failure shape (the typed `AllowedSourceValidationError`). The route handler
  *  must catch it and return a structured 400 — NOT let it reach `app.onError`. */
-function buildRouter(throwFromCreate = false): {
+function buildRouter(throwFromCreate = false, discoveryError?: Error): {
   app: ReturnType<typeof createConnectorRouter>;
   createConnectorCalls: number;
 } {
@@ -155,6 +199,7 @@ function buildRouter(throwFromCreate = false): {
     listConnectors: async () => [],
     syncConnectors: async () => ({ synced: 0, errors: [] }),
     discoverConnectorAuth: async () => {
+      if (discoveryError) throw discoveryError;
       // The exact prod failure shape: the auth-discovery path calls
       // assertAllowedSourceAddress on the draft endpoint, which throws the
       // typed validation error for a non-https / private / local source.
@@ -180,6 +225,23 @@ function buildRouter(throwFromCreate = false): {
 const admin = { 'x-test-admin': ALICE };
 
 describe('connector router: assertAllowedSourceAddress throw → structured 400 (not 500)', () => {
+  test('POST /connectors/auth-discovery: an UnsafeEgressError from the egress guard is a 400 too', async () => {
+    // Better Stack API prod 2026-09-07: "url must be https" / "invalid url"
+    // escaped as 500s because only AllowedSourceValidationError was mapped.
+    const { app } = buildRouter(false, new UnsafeEgressError('url must be https', 'HTTP://example.com/mcp'));
+    const res = await app.fetch(
+      new Request(`http://x/projects/${PROJECT}/connectors/auth-discovery`, {
+        method: 'POST',
+        headers: { ...admin, 'content-type': 'application/json' },
+        body: JSON.stringify({ provider: 'mcp', url: 'HTTP://example.com/mcp' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe('invalid_source_address');
+    expect(body.message).toBe('Connector endpoint rejected: url must be https');
+  });
+
   test('POST /connectors/auth-discovery returns a typed 400 invalid_source_address', async () => {
     const { app } = buildRouter();
     const req = (path: string, init: RequestInit = {}) =>

--- a/apps/api/src/__tests__/unit-github-app-pat.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-pat.test.ts
@@ -92,6 +92,13 @@ describe('resolveManagedGitSource', () => {
       }),
     ).toBe('db');
   });
+});
+
+describe('verifyPastedGithubAppInstallation', () => {
+  function keyPair() {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    return privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+  }
 
   test('signs a JWT with the pasted creds and resolves the installation owner', async () => {
     const pem = keyPair();

--- a/apps/api/src/__tests__/unit-github-app-pat.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-pat.test.ts
@@ -20,6 +20,7 @@ import {
   resolveInstallationOwnerType,
   resolveManagedGitSource,
   verifyPastedGithubAppInstallation,
+  verifyRepoAdminToken,
 } from '../platform/routes/github-app';
 
 describe('resolveInstallationOwnerType', () => {
@@ -161,5 +162,86 @@ describe('verifyPastedGithubAppInstallation', () => {
     await expect(verifyPastedGithubAppInstallation('12345', pem, '987', fetchImpl)).rejects.toThrow(
       /resolve the installation owner/,
     );
+  });
+});
+
+/**
+ * `POST /pat` used to accept any token `GET /user` liked. That is how a
+ * fine-grained PAT without `Administration: write` reached production on
+ * 2026-08-30 and every project creation died on `POST /orgs/managed-kortix/repos`
+ * → 403 "Resource not accessible by personal access token" for 8 days. The
+ * probe now performs the write itself: create a private probe repo under the
+ * owner, then delete it.
+ */
+describe('verifyRepoAdminToken (a managed-git token is verified by the write it authorises)', () => {
+  type Call = { method: string; path: string };
+  function fakeGitHub(script: {
+    user?: number;
+    owner?: { status: number; type?: string };
+    create?: { status: number; body?: unknown };
+    del?: number;
+  }): { fetchImpl: typeof fetch; calls: Call[] } {
+    const calls: Call[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+      const method = (init?.method ?? 'GET').toUpperCase();
+      calls.push({ method, path: url.pathname });
+      if (url.pathname === '/user') return new Response('{"login":"bot"}', { status: script.user ?? 200 });
+      if (url.pathname.startsWith('/users/')) {
+        const o = script.owner ?? { status: 200, type: 'Organization' };
+        return new Response(JSON.stringify({ type: o.type ?? 'Organization' }), { status: o.status });
+      }
+      if (method === 'POST') {
+        const c = script.create ?? { status: 201 };
+        return new Response(JSON.stringify(c.body ?? { full_name: 'x' }), { status: c.status });
+      }
+      if (method === 'DELETE') return new Response(null, { status: script.del ?? 204 });
+      return new Response('unexpected', { status: 500 });
+    }) as typeof fetch;
+    return { fetchImpl, calls };
+  }
+
+  test('org owner: creates the probe under /orgs/<owner>/repos and deletes it', async () => {
+    const gh = fakeGitHub({});
+    const verdict = await verifyRepoAdminToken('tok', 'managed-kortix', gh.fetchImpl);
+    expect(verdict).toEqual({ ok: true });
+    const create = gh.calls.find((c) => c.method === 'POST');
+    expect(create?.path).toBe('/orgs/managed-kortix/repos');
+    const del = gh.calls.find((c) => c.method === 'DELETE');
+    expect(del?.path).toMatch(/^\/repos\/managed-kortix\/kortix-credential-probe-[0-9a-f]{12}$/);
+  });
+
+  test('personal owner: creates the probe under /user/repos', async () => {
+    const gh = fakeGitHub({ owner: { status: 200, type: 'User' } });
+    expect(await verifyRepoAdminToken('tok', 'bot-user', gh.fetchImpl)).toEqual({ ok: true });
+    expect(gh.calls.find((c) => c.method === 'POST')?.path).toBe('/user/repos');
+  });
+
+  test('the 2026-08-30 prod token: GET /user 200 but create → 403 is REJECTED with GitHub\'s reason', async () => {
+    const gh = fakeGitHub({
+      create: { status: 403, body: { message: 'Resource not accessible by personal access token' } },
+    });
+    const verdict = await verifyRepoAdminToken('github_pat_x', 'managed-kortix', gh.fetchImpl);
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) throw new Error('unreachable');
+    expect(verdict.message).toContain('cannot create repositories under "managed-kortix"');
+    expect(verdict.message).toContain('Resource not accessible by personal access token');
+    expect(gh.calls.some((c) => c.method === 'DELETE')).toBe(false);
+  });
+
+  test('expired / wrong token: GET /user 401 short-circuits before any write', async () => {
+    const gh = fakeGitHub({ user: 401 });
+    const verdict = await verifyRepoAdminToken('bad', 'managed-kortix', gh.fetchImpl);
+    expect(verdict.ok).toBe(false);
+    expect(gh.calls.map((c) => c.method)).toEqual(['GET']);
+  });
+
+  test('create ok but delete refused: rejected and names the leftover repo', async () => {
+    const gh = fakeGitHub({ del: 403 });
+    const verdict = await verifyRepoAdminToken('tok', 'managed-kortix', gh.fetchImpl);
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok) throw new Error('unreachable');
+    expect(verdict.message).toContain('cannot delete it');
+    expect(verdict.message).toMatch(/managed-kortix\/kortix-credential-probe-/);
   });
 });

--- a/apps/api/src/__tests__/unit-github-app-pat.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-pat.test.ts
@@ -73,7 +73,7 @@ describe('resolveManagedGitSource', () => {
     ).toBe('pat');
   });
 
-  test('a PAT wins over a DB App too', () => {
+  test('a PAT wins over a DB App as well — POST /app clears a stored PAT, but an env PAT still short-circuits a DB App', () => {
     expect(
       resolveManagedGitSource({
         dbAppConfigured: true,
@@ -83,22 +83,15 @@ describe('resolveManagedGitSource', () => {
     ).toBe('pat');
   });
 
-  test('DB App (manifest flow or pasted) wins over both an env App and a PAT', () => {
+  test('DB App wins over an env App when no PAT is configured', () => {
     expect(
       resolveManagedGitSource({
         dbAppConfigured: true,
         envAppConfigured: true,
-        patConfigured: true,
+        patConfigured: false,
       }),
     ).toBe('db');
   });
-});
-
-describe('verifyPastedGithubAppInstallation', () => {
-  function keyPair() {
-    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
-    return privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
-  }
 
   test('signs a JWT with the pasted creds and resolves the installation owner', async () => {
     const pem = keyPair();

--- a/apps/api/src/__tests__/unit-github-app-pat.test.ts
+++ b/apps/api/src/__tests__/unit-github-app-pat.test.ts
@@ -60,14 +60,27 @@ describe('resolveManagedGitSource', () => {
     ).toBe('pat');
   });
 
-  test('env App wins over a PAT', () => {
+  test('a PAT wins over an env App — it is what the git backend actually uses', () => {
+    // managedGithubToken() short-circuits managedAdminAuth/mintManagedWriteToken.
+    // Prod 2026-09-07: a PAT stored via POST /pat during the provisioning
+    // outage was live, but /status still said "env".
     expect(
       resolveManagedGitSource({
         dbAppConfigured: false,
         envAppConfigured: true,
         patConfigured: true,
       }),
-    ).toBe('env');
+    ).toBe('pat');
+  });
+
+  test('a PAT wins over a DB App too', () => {
+    expect(
+      resolveManagedGitSource({
+        dbAppConfigured: true,
+        envAppConfigured: true,
+        patConfigured: true,
+      }),
+    ).toBe('pat');
   });
 
   test('DB App (manifest flow or pasted) wins over both an env App and a PAT', () => {

--- a/apps/api/src/connectors/router.ts
+++ b/apps/api/src/connectors/router.ts
@@ -29,6 +29,8 @@ import type { FeatureFlagKey } from '../feature-flags/registry';
 import { agentMayUseConnector } from '../iam/agent-scope';
 import { isAllowedSourceValidationError } from '../marketplace/catalog';
 import { auth, errors, json, makeOpenApiApp } from '../openapi';
+import { INVALID_SOURCE_ADDRESS_CODE } from '../marketplace/catalog';
+import { UnsafeEgressError } from '../shared/ssrf-guard';
 import { canonicalConnectorAlias } from '../projects/lib/session-connector-bindings';
 import {
   type ConnectorAttachmentStore,
@@ -605,15 +607,32 @@ async function readAttachmentBytes(c: Context): Promise<Uint8Array> {
  * falls through to the generic handler for a genuine server failure.
  */
 function allowedSourceValidationResponse(c: Context, err: unknown): Response | null {
-  if (!isAllowedSourceValidationError(err)) return null;
-  return c.json(
-    {
-      error: err.code,
-      code: err.code,
-      message: err.message,
-    },
-    400,
-  );
+  if (isAllowedSourceValidationError(err)) {
+    return c.json(
+      {
+        error: err.code,
+        code: err.code,
+        message: err.message,
+      },
+      400,
+    );
+  }
+  // Defense in depth: the DNS-resolving egress guard (`safeEgressFetch`) is
+  // the last check before a connector endpoint is fetched. Whatever it
+  // rejects — a non-https scheme the source guard admitted as shorthand, a
+  // public hostname that resolves to a private address — is still a property
+  // of the URL the user typed, never a server defect. Same 400 envelope.
+  if (err instanceof UnsafeEgressError) {
+    return c.json(
+      {
+        error: INVALID_SOURCE_ADDRESS_CODE,
+        code: INVALID_SOURCE_ADDRESS_CODE,
+        message: `Connector endpoint rejected: ${err.message}`,
+      },
+      400,
+    );
+  }
+  return null;
 }
 
 export function createConnectorRouter(deps: ConnectorRouterDeps): OpenAPIHono {

--- a/apps/api/src/connectors/sync.ts
+++ b/apps/api/src/connectors/sync.ts
@@ -21,7 +21,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { parse as parseToml } from 'smol-toml';
 import { listAgentMailInstalls, loadSlackInstall } from '../channels/install-store';
 import { resolveFeatureFlag } from '../feature-flags/registry';
-import { assertAllowedSourceAddress } from '../marketplace/catalog';
+import { assertAllowedEndpointUrl, assertAllowedSourceAddress } from '../marketplace/catalog';
 import { safeEgressFetch } from '../shared/ssrf-guard';
 import { configuredTimeoutMs, withTimeout } from '../shared/with-timeout';
 import { config } from '../config';
@@ -276,7 +276,7 @@ async function discoverConnectorAuthFromSource(
           ? draft.baseUrl
           : null;
   if (typeof endpoint !== 'string' || !endpoint.trim()) return EMPTY_AUTH_DISCOVERY;
-  assertAllowedSourceAddress(endpoint);
+  assertAllowedEndpointUrl(endpoint);
   const response = await safeEgressFetch(
     endpoint,
     provider === 'mcp' || provider === 'graphql'
@@ -939,7 +939,7 @@ export async function resolveCatalog(
         };
       }
       case 'mcp': {
-        assertAllowedSourceAddress(spec.url!);
+        assertAllowedEndpointUrl(spec.url!);
         const tools = await listMcpTools({
           url: spec.url!,
           auth: spec.auth,
@@ -1169,7 +1169,7 @@ async function loadHttpRoutes(
 }
 
 async function introspectGraphql(endpoint: string): Promise<any> {
-  assertAllowedSourceAddress(endpoint);
+  assertAllowedEndpointUrl(endpoint);
   const query = `query{__schema{queryType{name} mutationType{name} types{name fields{name description args{name type{kind name ofType{name}}} type{name ofType{name}}}}}}`;
   const res = await safeEgressFetch(endpoint, {
     method: 'POST',

--- a/apps/api/src/marketplace/catalog.ts
+++ b/apps/api/src/marketplace/catalog.ts
@@ -971,6 +971,47 @@ export function assertAllowedSourceAddress(address: string): void {
   throw new AllowedSourceValidationError("This source type is not allowed.");
 }
 
+/**
+ * Throw with a clear reason if a CONNECTOR ENDPOINT (MCP server URL, GraphQL
+ * endpoint, HTTP base URL) isn't a safe absolute https URL on a public host.
+ *
+ * Distinct from {@link assertAllowedSourceAddress}: a registry SOURCE address
+ * may be GitHub shorthand (`owner/repo`), so that guard lets anything that is
+ * not `http://`/`https://` through as a repo reference. A connector endpoint
+ * is never shorthand — it is fetched verbatim — so `HTTP://host`, `ws://host`,
+ * `localhost:3000/mcp` and `my server/mcp` all slipped past the source guard,
+ * reached `safeEgressFetch`, and died as an unhandled `UnsafeEgressError`
+ * (500 + Sentry: Better Stack API prod 2026-09-07 "url must be https",
+ * "invalid url"). Parse with WHATWG `URL`, which normalises the scheme case,
+ * and reject everything that is not https on a public host as the typed
+ * {@link AllowedSourceValidationError} the routes already turn into a 400.
+ */
+export function assertAllowedEndpointUrl(address: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(address.trim());
+  } catch {
+    throw new AllowedSourceValidationError(
+      `Connector endpoint must be an absolute https URL: "${address}"`,
+    );
+  }
+  if (parsed.protocol !== "https:") {
+    throw new AllowedSourceValidationError(
+      "Connector endpoints must use https on a public host.",
+    );
+  }
+  if (isPrivateHost(parsed.hostname)) {
+    throw new AllowedSourceValidationError(
+      "Connector endpoints must use https on a public host.",
+    );
+  }
+  if (parsed.username || parsed.password) {
+    throw new AllowedSourceValidationError(
+      "Connector endpoints must not embed credentials.",
+    );
+  }
+}
+
 /** Start (or join) a build of the external catalog — resolves when every source
  *  is in. Sets `building`/`partial` SYNCHRONOUSLY so progressive readers see the
  *  loading state on the very first call. */

--- a/apps/api/src/platform/routes/github-app.ts
+++ b/apps/api/src/platform/routes/github-app.ts
@@ -861,16 +861,24 @@ export function resolveInstallationOwnerType(
 /**
  * Pure precedence rule behind `GET /status`'s `source` field — split out so
  * it's testable without a Hono context/DB (see unit-github-app-pat.test.ts).
- * Mirrors the accessors' own resolution order: App-DB > App-env > PAT.
+ *
+ * Mirrors what the git backend ACTUALLY does, not the order the config is
+ * stored in: `managedGithubToken()` (a PAT, DB or env) short-circuits the App
+ * path in `managedAdminAuth` and `mintManagedWriteToken`
+ * (git-backends/github.ts), so when a PAT exists every managed-repo call uses
+ * it and the App is inert. Until 2026-09-07 this reported App-DB > App-env >
+ * PAT, so an operator who had just stored a PAT via POST /pat (prod, during the
+ * provisioning outage) read `source: "env"` and could not tell whether the
+ * token they stored was in use.
  */
 export function resolveManagedGitSource(input: {
   dbAppConfigured: boolean;
   envAppConfigured: boolean;
   patConfigured: boolean;
 }): ManagedGitSource {
+  if (input.patConfigured) return 'pat';
   if (input.dbAppConfigured) return 'db';
   if (input.envAppConfigured) return 'env';
-  if (input.patConfigured) return 'pat';
   return 'none';
 }
 

--- a/apps/api/src/platform/routes/github-app.ts
+++ b/apps/api/src/platform/routes/github-app.ts
@@ -1131,6 +1131,93 @@ githubAppSetupRouter.openapi(
   },
 );
 
+/**
+ * Prove a managed-git token can do the ONE thing managed git needs it for:
+ * create (and delete) a repository under `owner`. A `GET /user` 200 proves
+ * only that the token exists — the exact check that admitted a fine-grained
+ * PAT without `Administration: write` into production on 2026-08-30 and killed
+ * every project creation for 8 days (`Resource not accessible by personal
+ * access token` on `POST /orgs/managed-kortix/repos`). The probe repo is
+ * private, empty, named `kortix-credential-probe-<random>`, and deleted in the
+ * same call; a delete failure is reported so an operator can remove it by hand.
+ *
+ * Pure over `fetchImpl` so unit tests drive it without the network
+ * (unit-github-app-pat.test.ts).
+ */
+export async function verifyRepoAdminToken(
+  token: string,
+  owner: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'User-Agent': 'kortix-api',
+    'Content-Type': 'application/json',
+  };
+  const call = (path: string, init: RequestInit = {}) =>
+    fetchImpl(`https://api.github.com${path}`, {
+      ...init,
+      headers: { ...headers, ...(init.headers ?? {}) },
+      signal: AbortSignal.timeout(15_000),
+    });
+  const detail = async (res: Response): Promise<string> => {
+    const text = await res.text().catch(() => '');
+    try {
+      const parsed = JSON.parse(text) as { message?: string };
+      if (parsed?.message) return parsed.message;
+    } catch {
+      /* not JSON */
+    }
+    return text || res.statusText;
+  };
+
+  const me = await call('/user');
+  if (!me.ok) {
+    return {
+      ok: false,
+      message:
+        me.status === 401
+          ? 'GitHub rejected that token — check it was copied correctly and has not expired'
+          : `GitHub rejected the token (${me.status}): ${await detail(me)}`,
+    };
+  }
+
+  const account = await call(`/users/${encodeURIComponent(owner)}`);
+  if (!account.ok) {
+    return {
+      ok: false,
+      message: `GitHub does not know the owner "${owner}" (${account.status}): ${await detail(account)}`,
+    };
+  }
+  const accountType = ((await account.json().catch(() => ({}))) as { type?: string }).type;
+  const isOrg = accountType !== 'User';
+
+  const name = `kortix-credential-probe-${randomBytes(6).toString('hex')}`;
+  const created = await call(isOrg ? `/orgs/${encodeURIComponent(owner)}/repos` : '/user/repos', {
+    method: 'POST',
+    body: JSON.stringify({ name, private: true, auto_init: false, description: 'Kortix managed-git credential probe — safe to delete' }),
+  });
+  if (created.status !== 201) {
+    return {
+      ok: false,
+      message:
+        `This token cannot create repositories under "${owner}" (GitHub ${created.status}: ${await detail(created)}). ` +
+        'Managed git needs Administration: read/write (fine-grained token) or the repo + delete_repo scopes (classic token) on that owner.',
+    };
+  }
+  const deleted = await call(`/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`, { method: 'DELETE' });
+  if (deleted.status !== 204) {
+    return {
+      ok: false,
+      message:
+        `This token created ${owner}/${name} but cannot delete it (GitHub ${deleted.status}: ${await detail(deleted)}). ` +
+        'Managed git needs delete permission too (rollback of a failed provision deletes the repo). Remove the probe repository by hand.',
+    };
+  }
+  return { ok: true };
+}
+
 // ─── POST /pat ────────────────────────────────────────────────────────────────
 // "Use a token" — the quickest managed-git setup, but deliberately framed
 // (here and in the web UI) as a dedicated fine-grained token scoped to the
@@ -1170,28 +1257,11 @@ githubAppSetupRouter.openapi(
       return c.json({ error: true, message: 'token and owner are required', status: 400 }, 400);
     }
 
+    // Verify with the WRITE managed git exists for — create + delete a probe
+    // repo — not with a read. See verifyRepoAdminToken.
+    let verdict: Awaited<ReturnType<typeof verifyRepoAdminToken>>;
     try {
-      const res = await fetch('https://api.github.com/user', {
-        headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${token}`,
-          'User-Agent': 'kortix-api',
-        },
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (!res.ok) {
-        return c.json(
-          {
-            error: true,
-            message:
-              res.status === 401
-                ? 'GitHub rejected that token — check it was copied correctly and has not expired'
-                : `GitHub rejected the token (${res.status})`,
-            status: 400,
-          },
-          400,
-        );
-      }
+      verdict = await verifyRepoAdminToken(token, owner);
     } catch (err) {
       return c.json(
         {
@@ -1201,6 +1271,9 @@ githubAppSetupRouter.openapi(
         },
         400,
       );
+    }
+    if (!verdict.ok) {
+      return c.json({ error: true, message: verdict.message, status: 400 }, 400);
     }
 
     await updateManagedGithubAppConfig({

--- a/apps/api/src/projects/provision-core.ts
+++ b/apps/api/src/projects/provision-core.ts
@@ -38,6 +38,7 @@ import {
 import { getCatalogItemDetail } from '../marketplace/catalog';
 import { remoteBranchExists } from './git';
 import { config } from '../config';
+import { logger as appLogger } from '../lib/logger';
 import { db } from '../shared/db';
 import { projects } from '@kortix/db';
 import { eq } from 'drizzle-orm';
@@ -326,7 +327,21 @@ export async function runProvision(ctx: ProvisionContext, emit: ProvisionEmit): 
       isPrivate: true,
     });
   } catch (error) {
-    return { status: 502, body: { error: (error as Error).message || 'Failed to provision managed repo' } };
+    // Loud, structured, and BEFORE the 502: this was silent from 2026-08-30 to
+    // 2026-09-07 while every prod provision died here (a rotated managed-git
+    // PAT without Administration:write → GitHub 403). Only the response body
+    // carried the reason, and the edge worker of the day replaced that body
+    // with a maintenance page. The log line is what Better Stack alerts on.
+    const message = (error as Error).message || 'Failed to provision managed repo';
+    appLogger.error('[projects] provision create_repo failed', {
+      stage: 'create_repo',
+      provider,
+      projectId,
+      accountId: scope.accountId,
+      slug: repoSlug,
+      message,
+    });
+    return { status: 502, body: { error: message } };
   }
 
   const authMethod = provider === 'github' ? 'github_app' : 'managed';

--- a/apps/api/src/projects/routes/project-audit.ts
+++ b/apps/api/src/projects/routes/project-audit.ts
@@ -8,6 +8,7 @@ import { approvalPageUrl } from '../../setup-links/token';
 import { auth, errors, json } from '../../openapi';
 import { db } from '../../shared/db';
 import { auditDb, isAuditContentionError } from '../../shared/audit-db';
+import { logger as appLogger } from '../../lib/logger';
 import { createRoute, z } from '@hono/zod-openapi';
 import { auditEvents, connectors, connectorCalls, projectSessions, sessionSandboxes, serviceAccounts } from '@kortix/db';
 import { and, asc, desc, eq, gt, inArray, isNull, or } from 'drizzle-orm';
@@ -47,6 +48,19 @@ const AUDIT_INGEST_CHUNK = (() => {
 
 /** Advertised backoff when the session's sequence lock is contended. */
 const AUDIT_INGEST_RETRY_AFTER_SECONDS = 5;
+
+/** The PostgreSQL SQLSTATE behind a contention error, following `cause`. */
+function auditErrorSqlState(error: unknown): string | null {
+  let current: unknown = error;
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth += 1) {
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+    const cause = (current as { cause?: unknown }).cause;
+    if (cause === current) break;
+    current = cause;
+  }
+  return null;
+}
 
 // GET /v1/projects/:projectId/audit
 // Canonical project slice. It returns the same event contract and cursor as
@@ -335,6 +349,21 @@ projectsApp.openapi(
         // The session lock is queued. Pushing the remaining chunks into it
         // would only lengthen the queue that just rejected this one. Stop and
         // tell the relay to come back — the batch is still in its spool.
+        //
+        // Say WHICH SQLSTATE and how far the batch got. A 503 that logs only
+        // `-> 503 [HTTPException]` hid a 7-day convoy (prod, from 2026-08-31
+        // 19:52 UTC: ~32 sessions × one retry per ~8 s, >74,000 503s per
+        // session) behind an opaque status code.
+        appLogger.warn('[audit] ingest contended', {
+          projectId,
+          sessionId,
+          sqlstate: auditErrorSqlState(error),
+          accepted: parsed.accepted,
+          attempted,
+          inserted: insertedCount,
+          remaining: toInsert.length - offset,
+          chunk: chunk.length,
+        });
         contended = true;
         break;
       }

--- a/docs/runbooks/api-router-worker.md
+++ b/docs/runbooks/api-router-worker.md
@@ -1,0 +1,94 @@
+# API router Worker and the managed-git credential
+
+Two things that broke silently together on 2026-08-30 → 2026-09-07 and how to
+check each in under a minute.
+
+## The Worker in front of `api.kortix.com` / `gateway.kortix.com`
+
+`infra/cloudflare/workers/api-router/worker.mjs` is the Cloudflare Worker that
+fronts the API and the LLM gateway in every environment. It picks the active
+backend, applies the admin maintenance state, and passes origin responses
+through unchanged (since #6831, 2026-08-24). Before #6831 it rewrote every
+origin 502/503/504 into a synthetic
+`503 {"message":"Kortix is temporarily unavailable. Service will resume automatically."}`.
+
+**Who deploys it**
+
+| env | job | trigger |
+|---|---|---|
+| prod (`api-kortix-router`) | `deploy-api-router` in `.github/workflows/deploy-prod.yml` | every prod release, after `deploy-ecs` |
+| staging (`staging-api-kortix-router`) | `wire-cloudflare` in `deploy-staging.yml` | every staging deploy |
+| dev (`dev-api-kortix-router`) | by hand | — |
+
+Until 2026-09-07 nothing deployed the prod Worker. It ran a 2026-08-21 build for
+17 days, and 8 days of failed project creation reached Better Stack as a
+maintenance page nobody had switched on.
+
+**Check what is live**
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/9785405a992435bb0c7bd19f9b6d26d5/workers/scripts" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  | jq -r '.result[] | select(.id|test("api-kortix-router")) | "\(.id) \(.modified_on)"'
+```
+
+Compare `modified_on` with the last commit to `worker.mjs`
+(`git log -1 --format=%ci -- infra/cloudflare/workers/api-router/worker.mjs`).
+If the live script is older than that commit, it is stale.
+
+**Deploy by hand** (the scoped `CLOUDFLARE_API_TOKEN` from `apps/api/.env` works;
+`wrangler.toml` `[env.<env>.vars]` is the single source of bindings):
+
+```bash
+cd infra/cloudflare/workers/api-router
+CLOUDFLARE_API_TOKEN=… npx --yes wrangler@4 deploy --env prod   # or staging / dev
+```
+
+**Prove the passthrough.** Send a request the origin will refuse and read the
+body. A real origin error body means the Worker is current; the maintenance
+message above means it is stale (or an admin really set `level: blocking` —
+check `GET https://api.kortix.com/v1/system/maintenance`).
+
+## The managed-git credential
+
+Managed projects live as repos in the GitHub org `managed-kortix`. The API
+creates them with, in this order (`apps/api/src/projects/git-backends/github.ts`):
+
+1. a PAT stored through `POST /v1/platform/github-app/pat`
+   (`platform_settings.managed_github_app.pat`, 30 s cache per task);
+2. `MANAGED_GIT_GITHUB_TOKEN` from the environment;
+3. an installation token of the GitHub App (`KORTIX_GITHUB_APP_*` +
+   `MANAGED_GIT_GITHUB_INSTALL_ID`).
+
+A PAT short-circuits the App everywhere. `GET /v1/platform/github-app/status`
+reports which one is in use (`source: pat | db | env`).
+
+**A credential is verified by the write it authorises, never by a read.**
+Creating an org repo needs `Administration: write` (fine-grained PAT, resource
+owner = the org) or the `repo` + `delete_repo` scopes (classic PAT), or an App
+installation with `administration: write`. `GET /orgs/managed-kortix/repos`
+returning 200 proves nothing about that. `POST /v1/platform/github-app/pat`
+performs a create+delete probe (`verifyRepoAdminToken`) before storing anything.
+To check a token by hand:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://api.github.com/orgs/managed-kortix/repos \
+  -H "Authorization: Bearer $TOKEN" -d '{"name":"kortix-credential-probe-manual","private":true}'
+# 201 → then DELETE /repos/managed-kortix/kortix-credential-probe-manual (expect 204)
+# 403 "Resource not accessible by personal access token" → the token cannot create repos
+```
+
+**Prove provisioning end to end** against the real environment:
+
+```bash
+curl -s -N -X POST https://api.kortix.com/v1/projects/provision-stream \
+  -H "Authorization: Bearer $KORTIX_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"name":"probe-provision"}'
+# expect frames validating → creating_repository → registering → seeding → done
+# then DELETE /v1/projects/<project_id>; the managed repo is NOT deleted with the
+# project (known gap) — delete managed-kortix/<slug>-<project_id> by hand.
+```
+
+Incident record: memory `prod-provision-dead-fine-grained-pat-2026-08-30`;
+learning "Verify a rotated credential with the WRITE it exists for" in
+`.claude/skills/learnings/SKILL.md`.


### PR DESCRIPTION
## Why

Prod project creation was 100% dead from **2026-08-30 23:15 UTC to 2026-09-07 20:42 UTC** (~500 failed provisions/day, 63 users/day). Root cause: PR #7063 rotated `MANAGED_GIT_GITHUB_TOKEN` to a fine-grained PAT that cannot create repos in `managed-kortix` (needs `Administration: write`); the App installation (140097279) only has `contents:write`. Origin answer: `GitHub /orgs/managed-kortix/repos failed (403): Resource not accessible by personal access token`.

It surfaced in Better Stack as `ApiError: Kortix is temporarily unavailable. Service will resume automatically.` because the prod `api-kortix-router` Worker was a **2026-08-21 build** (pre-#6831) that rewrote every origin 502/503/504 into that maintenance page. `deploy-prod.yml` never deployed the Worker.

## Prod actions already taken (2026-09-07)

1. `wrangler deploy --env prod` of the current Worker (20:28 UTC, version 40f84a1c) — `api.kortix.com` returns real origin bodies again.
2. `POST /v1/platform/github-app/pat` with the classic org-admin PAT that prod used until 2026-08-30 (20:42 UTC). Verified: `provision-stream` → `done`, plain `provision` → 201, probe projects and repos deleted. Better Stack shows only 201/200 on the provision routes since.

## What this PR changes

- `provision-core.ts`: `create_repo` failure is logged (stage/provider/project/account/slug/message) before the 502.
- `deploy-prod.yml`: `deploy-api-router` job (`wrangler deploy --env prod` after `deploy-ecs`, asserts `modified_on` moved). Non-blocking like staging's `wire-cloudflare`.
- `POST /github-app/pat`: verifies the token by **creating and deleting a probe repo** under the owner (`verifyRepoAdminToken`), not by `GET /user`. GitHub's refusal is returned as the 400 message.
- `GET /github-app/status`: `source` follows the git backend's precedence (a PAT short-circuits the App), so an operator who stored a PAT sees `pat`, not `env`.
- `project-audit.ts`: ingest 503 logs SQLSTATE + session + batch progress.
- Connectors: `assertAllowedEndpointUrl` for MCP/GraphQL/HTTP endpoints (`HTTP://…`, `ws://…`, `localhost:3000/mcp`, `my server/mcp` were admitted as GitHub shorthand and died as 500 `UnsafeEgressError`); `UnsafeEgressError` → 400 `invalid_source_address` in the router.
- `learnings` register entry.

## Verified

- `bash scripts/test.sh` in `apps/api` (full hermetic unit suite) → exit 0.
- `bunx tsc --noEmit` in `apps/api` → exit 0.
- Real local API (worktree :14408, minted user + project): five bad endpoints → 400 `invalid_source_address`, project deleted.
- Prod: see above.

## Follow-ups (not code)

- Proper credential: give App 3812697 `Administration: write`, accept on the managed-kortix installation, then drop the PAT. Or grant the fine-grained PAT Administration write. The classic PAT now stored is the pre-2026-08-30 state.
- Project DELETE does not delete the managed repo: 44 `*-probe-*` repos in managed-kortix.

https://claude.ai/code/session_011wqNCmiifvxdr1UiQysnBX
