### PR TITLE
fix(web): preserve valid auth during project loads

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Token publication must not look like sign-out to waiting requests (2026-09-08)
+
+**When:** fencing in-flight auth reads against cache writes. Distinguish a token
+publication from a clear. Return the fresh published token after hydration;
+return null when a clear occurred after the read began, including clear-then-sign-in.
+*Incident:* #7065 made a valid session return null when AuthProvider published
+during a token read. The project gate displayed "This project didn't load."
+*Enforcer:* `apps/web/src/lib/auth-token.test.ts` covers concurrent hydration,
+bootstrap, sign-out followed by sign-in, and expired publications.
+
 ### Verify the listening process before sharing a worktree URL (2026-09-07)
 
 **When:** sharing or verifying a local fix, check the web and API listener PIDs

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -31,6 +31,11 @@ during a token read. The project gate displayed "This project didn't load."
 *Enforcer:* `apps/web/src/lib/auth-token.test.ts` covers concurrent hydration,
 bootstrap, sign-out followed by sign-in, and expired publications.
 
+**Identity-change near-miss:** Cross-tab `SIGNED_IN` can replace a user without
+`SIGNED_OUT`. Clear bootstrap and cached tokens synchronously when `adoptUser`
+requires a reset, before its first await. Otherwise pending requests can inherit
+the incoming user's token. `auth-provider-identity.test.ts` pins this ordering.
+
 ### Verify the listening process before sharing a worktree URL (2026-09-07)
 
 **When:** sharing or verifying a local fix, check the web and API listener PIDs

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -36,6 +36,15 @@ bootstrap, sign-out followed by sign-in, and expired publications.
 requires a reset, before its first await. Otherwise pending requests can inherit
 the incoming user's token. `auth-provider-identity.test.ts` pins this ordering.
 
+**Cold-load ordering:** The project-access query must wait for AuthProvider's
+resolved user. Otherwise first-load identity cleanup cancels its token read and
+leaves the non-retrying gate on an error. Key access results by user and show
+pending while auth is unresolved. CI's fresh-browser localization journey
+reproduced the failure; `project-access-boundary.test.ts` pins the wiring.
+AuthProvider declares initial readiness only after bootstrap validation and
+cleanup finish, not from an earlier `INITIAL_SESSION` event. Keep the signed-out
+redirect above the pending gate and use the user-scoped key for admin bypass.
+
 ### Verify the listening process before sharing a worktree URL (2026-09-07)
 
 **When:** sharing or verifying a local fix, check the web and API listener PIDs

--- a/apps/web/src/components/projects/project-access-boundary.test.ts
+++ b/apps/web/src/components/projects/project-access-boundary.test.ts
@@ -38,6 +38,32 @@ function copyBlock(locale: string): Record<string, string> {
 
 const en = copyBlock('en');
 
+describe('project access waits for the authenticated identity', () => {
+  test('the query waits for auth hydration and is isolated by user', () => {
+    expect(componentSource).toContain('const { user, isLoading: isAuthLoading } = useAuth();');
+    expect(componentSource).toContain('const authReady = !isAuthLoading && !!user?.id;');
+    expect(componentSource).toContain('enabled: authReady && !!projectId');
+    expect(componentSource).toContain('queryKey: [QUERY_KEY, projectId, user?.id]');
+  });
+
+  test('unresolved auth shows pending before cached success or error screens', () => {
+    const pending = componentSource.indexOf('if (!authReady || query.isPending)');
+    const success = componentSource.indexOf('if (query.isSuccess)');
+    expect(pending).toBeGreaterThan(-1);
+    expect(success).toBeGreaterThan(pending);
+    expect(componentSource).toContain('const polling = authReady &&');
+  });
+
+  test('identity changes remount gate state and retain the signed-out escape', () => {
+    const boundary = componentSource.slice(componentSource.indexOf('export function ProjectAccessBoundary'), componentSource.indexOf('function ProjectAccessForUser'));
+    expect(boundary).toContain('useSignedOutRedirect();');
+    expect(boundary).toContain('key={`${props.projectId}:${user?.id ?? "pending"}`}');
+    expect(componentSource.match(/queryKey: \[QUERY_KEY, projectId, user\?\.id\]/g)).toHaveLength(2);
+    expect(componentSource).toContain('if (authReady) void refetch();');
+    expect(componentSource).toContain('if (!authReady) return;');
+  });
+});
+
 /** The English the user actually reads on a given screen. */
 function englishCopy(state: AccessGateState) {
   const keys = gateCopyKeys(state);
@@ -228,7 +254,7 @@ describe('polling lifecycle', () => {
     // This boundary wraps the project shell for the whole session, so a poll
     // that only checks `waiting` keeps calling getProject every 15s while the
     // user works. The guard must include the success case.
-    expect(componentSource).toContain('const polling = !query.isSuccess && shouldPollForApproval');
+    expect(componentSource).toContain('!query.isSuccess && shouldPollForApproval');
     expect(componentSource).toMatch(/if \(!polling\) return;/);
   });
 

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -14,6 +14,7 @@ import { AuthPendingScreen, DetailPanel, DetailRow } from '@/features/auth/auth-
 import { ErrorStrip, Rise, StepHeader } from '@/features/auth/auth-primitives';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
+import { useSignedOutRedirect } from '@/lib/auth/use-signed-out-redirect';
 import { PROJECT_LANDING_PATH } from '@/lib/onboarding/landing-destination';
 import { forgetLastProjectId } from '@/lib/onboarding/last-project-cookie';
 import { useAppHome } from '@/lib/onboarding/use-app-home';
@@ -179,38 +180,48 @@ interface ProjectAccessBoundaryProps {
   children: ReactNode;
 }
 
-export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoundaryProps) {
+export function ProjectAccessBoundary(props: ProjectAccessBoundaryProps) {
   const { user } = useAuth();
+  useSignedOutRedirect();
+  return <ProjectAccessForUser key={`${props.projectId}:${user?.id ?? "pending"}`} {...props} />;
+}
+
+function ProjectAccessForUser({ projectId, children }: ProjectAccessBoundaryProps) {
+  const { user, isLoading: isAuthLoading } = useAuth();
+  const authReady = !isAuthLoading && !!user?.id;
   // A submitted request is held HERE, above the error branch, so a transient
   // 401/500/offline poll result cannot unmount the waiting screen and hand the
   // user a fresh request form for a request they already sent.
   const [waiting, setWaiting] = useState<WaitingGateState | null>(null);
 
   const query = useQuery({
-    queryKey: [QUERY_KEY, projectId],
+    queryKey: [QUERY_KEY, projectId, user?.id],
     queryFn: () => getProject(projectId, { showErrors: false }),
-    enabled: !!projectId,
+    enabled: authReady && !!projectId,
     retry: false,
   });
 
   const { refetch } = query;
   // Background poll: silent, and must never touch the button's pending state.
-  const recheck = useCallback(() => void refetch(), [refetch]);
+  const recheck = useCallback(() => {
+    if (authReady) void refetch();
+  }, [authReady, refetch]);
 
   // The user's own "Check now" press, tracked separately so the 15s background
   // poll cannot disable the button under their cursor.
   const [manualRecheck, setManualRecheck] = useState(false);
   const recheckNow = useCallback(() => {
+    if (!authReady) return;
     setManualRecheck(true);
     void refetch().finally(() => setManualRecheck(false));
-  }, [refetch]);
+  }, [authReady, refetch]);
 
   const errorState = query.isError ? gateStateForError(query.error) : null;
   const state = resolveGateState(waiting, errorState);
   // Stop the moment access lands, or the interval outlives the gate: this
   // component wraps the shell for the whole session, so a poll that ignores
   // success keeps calling getProject every 15s while the user works.
-  const polling = !query.isSuccess && shouldPollForApproval(state);
+  const polling = authReady && !query.isSuccess && shouldPollForApproval(state);
 
   // Poll while waiting so "this page opens on its own" is a fact, not a promise
   // the user has to keep by reloading. `recheck` is stable, so the interval is
@@ -238,14 +249,16 @@ export function ProjectAccessBoundary({ projectId, children }: ProjectAccessBoun
     forgetLastProjectId(user?.id, projectId);
   }, [unrenderable, projectId, user?.id]);
 
-  if (query.isSuccess) return <>{children}</>;
-
   // The same quiet spinner every auth sub-surface shows while it resolves —
   // minus the legal footer. This branch resolves into the project shell, which
   // carries no footer, so keeping it would flash Terms/Privacy for the length
   // of one fetch on every project open. The gate screens below still show it:
   // they are terminal, and there they are the whole page.
-  if (query.isLoading) return <AuthPendingScreen footer={false} />;
+  // A disabled query is pending, not loading. Wait for identity cleanup and
+  // token publication before interpreting any result as an access decision.
+  if (!authReady || query.isPending) return <AuthPendingScreen footer={false} />;
+
+  if (query.isSuccess) return <>{children}</>;
 
   return (
     <AccessGateScreen
@@ -331,7 +344,7 @@ function AccessGateScreen({
   });
 
   // Platform-admin escape hatch: flips the client-wide admin-bypass header on,
-  // then re-fetches the shared [QUERY_KEY, projectId] query so the boundary
+  // then re-fetches the same user-scoped query so the boundary
   // above renders the actual project. Read-only server-side (see
   // apps/api/src/projects/lib/access.ts) and audit-logged against the project's
   // own account on every use.
@@ -339,7 +352,7 @@ function AccessGateScreen({
     mutationFn: async () => {
       setAdminBypass(true);
       return queryClient.fetchQuery({
-        queryKey: [QUERY_KEY, projectId],
+        queryKey: [QUERY_KEY, projectId, user?.id],
         queryFn: () => getProject(projectId, { showErrors: false }),
       });
     },

--- a/apps/web/src/features/providers/auth-provider-identity.test.ts
+++ b/apps/web/src/features/providers/auth-provider-identity.test.ts
@@ -71,7 +71,7 @@ describe('the reset decision is the shared one, at BOTH entry points', () => {
     // that event, and it arrives before `getInitialSession()` finishes its
     // `getUser()` round trip. Without a case here the new user is published
     // while the previous one's caches are still mounted.
-    const listener = slice('supabase.auth.onAuthStateChange(', 'setIsLoading((prev)');
+    const listener = slice('supabase.auth.onAuthStateChange(', 'switch (event)');
     expect(listener).toContain("event === 'INITIAL_SESSION'");
     expect(listener).toContain("event === 'SIGNED_IN'");
 
@@ -79,6 +79,13 @@ describe('the reset decision is the shared one, at BOTH entry points', () => {
     const publish = listener.indexOf('setSession(newSession);');
     expect(adopt).toBeGreaterThan(-1);
     expect(publish).toBeGreaterThan(adopt);
+  });
+
+  test('initial auth events cannot declare readiness before bootstrap validation finishes', () => {
+    const listener = slice('supabase.auth.onAuthStateChange(', 'return () =>');
+    expect(listener).not.toContain('setIsLoading(');
+    const bootstrap = slice('const getInitialSession = async ()', 'getInitialSession();');
+    expect(bootstrap).toContain('setIsLoading(false);');
   });
 });
 

--- a/apps/web/src/features/providers/auth-provider-identity.test.ts
+++ b/apps/web/src/features/providers/auth-provider-identity.test.ts
@@ -83,6 +83,17 @@ describe('the reset decision is the shared one, at BOTH entry points', () => {
 });
 
 describe('the marker is held per-document as well as in origin-wide storage', () => {
+  test('cross-user adoption fences token reads before asynchronous cleanup, without requiring SIGNED_OUT', () => {
+    const adopt = slice('const adoptUser = async (', 'const getInitialSession');
+    const resetBranch = adopt.slice(adopt.indexOf('if (mustReset)'));
+    const bootstrapClear = resetBranch.indexOf('setBootstrapAuthToken(null);');
+    const cacheClear = resetBranch.indexOf('setCachedAuthToken(null);');
+    const cleanup = resetBranch.indexOf('await resetClientState();');
+    expect(bootstrapClear).toBeGreaterThan(-1);
+    expect(cacheClear).toBeGreaterThan(bootstrapClear);
+    expect(cleanup).toBeGreaterThan(cacheClear);
+  });
+
   test('a useRef carries the in-document half', () => {
     // One origin-wide localStorage key cannot describe several tabs: two tabs
     // signed into two accounts overwrite each other's marker while each keeps

--- a/apps/web/src/features/providers/auth-provider.tsx
+++ b/apps/web/src/features/providers/auth-provider.tsx
@@ -47,6 +47,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       });
 
       if (mustReset) {
+        // Cross-tab SIGNED_IN can replace the user without SIGNED_OUT.
+        // Fence pending requests before cleanup yields or the new token lands.
+        setBootstrapAuthToken(null);
+        setCachedAuthToken(null);
         try {
           await resetClientState();
         } catch (error) {

--- a/apps/web/src/features/providers/auth-provider.tsx
+++ b/apps/web/src/features/providers/auth-provider.tsx
@@ -126,11 +126,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setSession(newSession);
       setUser(newSession?.user ?? null);
 
-      // Functional update: the previous `if (isLoading)` read a stale
-      // `isLoading` captured at mount (the effect only depends on `supabase`),
-      // so the guard never short-circuited. This is behavior-equivalent but
-      // doesn't rely on a stale closure value.
-      setIsLoading((prev) => (prev ? false : prev));
+      // Only getInitialSession clears initial loading, after validation and
+      // identity cleanup. INITIAL_SESSION can arrive before either finishes.
       switch (event) {
         case 'SIGNED_IN': {
           if (newSession?.access_token) {

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -38,9 +38,9 @@ describe('session navigation loading boundaries', () => {
     // The mirror of the `return null` rule above: a runtime-not-ready RETRY
     // must stay invisible, but the very FIRST project fetch owns the whole
     // viewport, so it has to show something rather than a blank screen.
-    expect(projectAccessSource).toContain('if (query.isLoading)');
+    expect(projectAccessSource).toContain('if (!authReady || query.isPending)');
     expect(projectAccessSource).toContain('<AuthPendingScreen footer={false} />');
-    expect(projectAccessSource).not.toMatch(/query\.isLoading\)\s*return null/);
+    expect(projectAccessSource).not.toMatch(/query\.isPending\)\s*return null/);
   });
 
   test('the first-fetch loader carries no legal footer', () => {
@@ -61,7 +61,7 @@ describe('session navigation loading boundaries', () => {
     // key is a constant now because three call sites share it, so assert the
     // constant's value and its use rather than one inlined literal.
     expect(projectAccessSource).toContain("const QUERY_KEY = 'project-access-boundary'");
-    expect(projectAccessSource).toContain('queryKey: [QUERY_KEY, projectId]');
+    expect(projectAccessSource).toContain('queryKey: [QUERY_KEY, projectId, user?.id]');
     expect(projectAccessSource).not.toContain('queryKey: qk.project.access(projectId)');
     expect(projectHomeSource).not.toContain('queryKey: qk.project.access(projectId)');
     expect(projectHomeSource).not.toContain('listProjectAccess(projectId');

--- a/apps/web/src/lib/auth-token.test.ts
+++ b/apps/web/src/lib/auth-token.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 
 import {
   __resetAuthTokenCacheForTests,
   __setFetchTokenForTests,
   getSupabaseAccessToken,
+  setBootstrapAuthToken,
   setCachedAuthToken,
 } from './auth-token';
 
@@ -25,6 +26,59 @@ import {
 
 afterEach(() => {
   __resetAuthTokenCacheForTests();
+});
+
+describe('token publication during session hydration', () => {
+  test('all waiting requests receive the published session token', async () => {
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => fetch.promise);
+    const first = getSupabaseAccessToken();
+    const second = getSupabaseAccessToken();
+
+    // AuthProvider publishes the validated session, then exits bootstrap mode.
+    setCachedAuthToken('current-session');
+    setBootstrapAuthToken(null);
+    fetch.resolve('superseded-read');
+
+    expect(await Promise.all([first, second])).toEqual(['current-session', 'current-session']);
+    expect(await getSupabaseAccessToken()).toBe('current-session');
+  });
+
+  test('a bootstrap token replaces an in-flight empty session read', async () => {
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => fetch.promise);
+    const pending = getSupabaseAccessToken();
+    setBootstrapAuthToken('bootstrap-session');
+    fetch.resolve(null);
+    expect(await pending).toBe('bootstrap-session');
+  });
+
+  test('requests from before sign-out never receive the next signed-in token', async () => {
+    const fetch = deferred<string | null>();
+    __setFetchTokenForTests(() => fetch.promise);
+    const first = getSupabaseAccessToken();
+    const second = getSupabaseAccessToken();
+    setCachedAuthToken(null);
+    setCachedAuthToken('next-user-session');
+    fetch.resolve('previous-user-session');
+    expect(await Promise.all([first, second])).toEqual([null, null]);
+    expect(await getSupabaseAccessToken()).toBe('next-user-session');
+  });
+
+  test('a delayed read cannot return a publication older than the cache lifetime', async () => {
+    const clock = spyOn(Date, 'now').mockReturnValue(1_000);
+    try {
+      const fetch = deferred<string | null>();
+      __setFetchTokenForTests(() => fetch.promise);
+      const pending = getSupabaseAccessToken();
+      setCachedAuthToken('expired-publication');
+      clock.mockReturnValue(31_000);
+      fetch.resolve('superseded-read');
+      expect(await pending).toBeNull();
+    } finally {
+      clock.mockRestore();
+    }
+  });
 });
 
 /** A promise this test can resolve/reject on its own schedule. */

--- a/apps/web/src/lib/auth-token.ts
+++ b/apps/web/src/lib/auth-token.ts
@@ -50,6 +50,8 @@ let bootstrapToken: string | null = null;
  * identity must never land its answer on top of whatever replaced it.
  */
 let authEpoch = 0;
+/** A clear fences requests from the previous identity, even after another sign-in. */
+let lastClearEpoch = 0;
 
 // ── Inflight deduplication ──
 let inflight: Promise<string | null> | null = null;
@@ -118,12 +120,12 @@ export async function getSupabaseAccessToken(): Promise<string | null> {
   try {
     const token = await pending;
     if (authEpoch !== epochAtStart) {
-      // Invalidated (or reseeded) mid-flight. This result's provenance
-      // can't be trusted against whichever identity is current now —
-      // never commit it to the cache, and never hand it back either.
-      // Applies to EVERY caller waiting on this fetch, not just the
-      // one that started it.
-      return null;
+      // Discard this fetch's result. Hydration can publish a valid token
+      // while callers wait; use that publication unless a clear intervened.
+      // A request from before sign-out must never inherit the next identity.
+      if (lastClearEpoch > epochAtStart) return null;
+      if (bootstrapToken) return bootstrapToken;
+      return cachedToken && Date.now() - cachedAt < TOKEN_CACHE_TTL ? cachedToken : null;
     }
     cachedToken = token;
     cachedAt = Date.now();
@@ -188,6 +190,7 @@ export function setCachedAuthToken(token: string | null): void {
   cachedToken = token;
   cachedAt = token ? Date.now() : 0;
   if (!token) {
+    lastClearEpoch = authEpoch;
     inflight = null;
   }
 }
@@ -224,6 +227,7 @@ export function __resetAuthTokenCacheForTests(): void {
   cachedAt = 0;
   bootstrapToken = null;
   authEpoch = 0;
+  lastClearEpoch = 0;
   inflight = null;
   inflightEpoch = 0;
   fetchTokenImpl = () => fetchToken();


### PR DESCRIPTION
Signed-in project loads can fail before `GET /v1/projects/:id` is sent. AuthProvider publishes a valid token while an earlier token read is pending. The epoch guard then returns null to that waiting request.

Return the current, fresh publication when no cache clear intervened. Preserve the sign-out fence: requests started before a clear cannot receive a later user's token. This follows the approach in #7120 and adds a cache-expiry check.

Cross-user adoption also clears both token sources synchronously before cleanup. Supabase can broadcast a different user's SIGNED_IN without SIGNED_OUT; pending reads must not inherit that user's token. The independent review identified this boundary and verified the follow-up fix with no remaining findings. The incident learning records both cases.

The project gate now waits for AuthProvider's completed validation and identity cleanup. INITIAL_SESSION cannot publish readiness early. Access results and waiting state are user-scoped. Sign-out redirection remains mounted while the gate is pending; admin bypass updates the same user-scoped query. CI reproduced the exact error screen on a fresh session before this follow-up.

Verification:
- Token regression: 7 pass / 2 fail before the fix; all 9 pass after it.
- Auth and project-access regression tests: 125 pass / 0 fail. Cross-user, readiness, and gate-wiring tests failed before their fixes.
- ESLint passes for all seven changed TypeScript files.
- Full web suite: `node scripts/build-content-timestamps.mjs && bun test --isolate --parallel=4` → 9,512 pass, 0 fail, 731 files. Timestamp generation is required in this full-history checkout; its generated changes are excluded from the auth PR.
- `pnpm test`: all five lanes pass; 389/389 API/CLI flows pass, 0 failed or skipped.
- Chromium forced an expired stored session to refresh against local Supabase. Both matching-marker and unknown-marker cases render the project. Latest unknown-marker check: token endpoint 200, authenticated `GET /v1/projects/285aa639-ebaf-46d3-bbf0-9f5865edca6d` 200 with the exact project ID, visible project home, and no load-error screen. Web/API ran from this worktree on 16000/16008. Driver: `playwright_cli.sh -s=auth-cold run-code --filename output/playwright/auth-load.js`. Synthetic fixtures were removed afterward.
- Chromium delivered a native cross-tab SIGNED_OUT event after clearing this test session's cookies. The mounted project navigated to `/auth` and rendered `Welcome to Kortix`.
- `pnpm exec tsc --noEmit`: 15 existing errors in the three documented baseline test files; no errors in either changed file.
- Preview auth verification passes on `1e84913e2fc81bbf838efa1eb1dbd35c2fff4ce0`: forced token refresh 200, subsequent authenticated project GET 200 with exact project ID, and visible project shell without the error gate. Browser: `playwright_cli.sh -s=auth-preview run-code --filename output/playwright/auth-load.js` with preview/unknown-marker mode.
- Preview negative paths pass: authenticated missing-project GET 404 renders `This project is gone.` without an access-request action; cross-tab SIGNED_OUT from that terminal screen navigates to `/auth` and renders the login form. Synthetic account/project/user removed afterward.
- Final deployment [34165180404](https://github.com/kortix-ai/suna/actions/runs/34165180404) succeeded. API `/v1/health` reports `9c2925523f4b274c64de130d3bd5cad6f2226aea`. `docker inspect kortix-pr-7162-frontend-1` reports `kortix/kortix-frontend:pr-9c2925523f4b274c64de130d3bd5cad6f2226aea`, image ID `sha256:01af326d7655be50b64b56dd23930207dc458112289c55fe114be339ee94dc89`. The sole change since the browser-verified commit is the loading-boundary test assertion; application sources are identical.
- Preview: https://8080-01m1yw1e68p61snak6mr3cj6q4.eu-west.sbx.platinum.dev
- Full-suite caveat: this persistent branch environment skips the full suite, even though the generated success comment says it passed. The earlier full preview run failed on session-runtime startup and browser assertions. Do not treat the deployment check as a full test pass.
- CI [34164757985](https://github.com/kortix-ai/suna/actions/runs/34164757985), on the final application-code commit `1e84913e2f`: core and browser-1 pass; browser-2 is still running. Packages failed on one stale source assertion, corrected in test-only commit `9c2925523f` and covered by the 9,512-test local pass. The full CI suite is not green yet.
- `pnpm test -- --packages-only` initially failed the unchanged API pi-worker park test (`parked` undefined). That API test passed during the retry. The retry reached web tests and stopped on the stale generated timestamp manifest. Regenerating that manifest made the full web suite pass; the entire package command has not subsequently completed green.
- Independent review reports no remaining findings; 71 tests and delayed-validation/adoption probes passed independently. Cross-user fencing has token-behavior and provider-wiring coverage; a live cross-user write was not performed.

Next user check: reload a project with an existing session, including after it has been idle long enough to refresh. Sign out and sign into a different account to confirm previous-account requests cannot continue.

Branch: `project-not-found`; commit: `9c2925523f`. No merge or dev/production deployment yet. Merge requires explicit approval.

No SDK public API, permission decision, or retry policy changes.
