### PR TITLE
fix(preview): accept an HS256-signed Supabase JWT on the preview origin

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,41 @@ linked, not inlined.
 
 ## Register
 
+### A `[skip ci]` release-prep commit deadlocks the lane that ships releases (2026-09-02)
+
+**When:** adding `[skip ci]` to any commit that lands on a branch whose deploy
+resolves an artifact BY that commit's SHA. `chore(release): staging VERSION ->
+0.13.10 [skip ci]` landed on `staging`, so `Build Staging Artifacts` never ran
+for it, so no `staging-e2586057` image existed — and `Deploy Staging` resolves
+staging HEAD and pulls that exact tag. Every staging deploy then failed with
+`docker.io/kortix/kortix-api:staging-e2586057: not found`, and staging served
+Aug-30 code for three days while the branch said otherwise. Nothing alerted:
+the deploy failure is one red run in a list, and staging's own `/health` keeps
+answering `ok` on the stale build. **The rule:** a commit that a deploy will
+resolve an image for must build. Either drop `[skip ci]` from release-prep
+commits, or make the deploy resolve the last BUILT ancestor instead of HEAD.
+*Blast radius:* prod could not have shipped wrong — `tests-release` asserts
+staging is serving `RELEASE_SOURCE_SHA` — but no release could ship at all,
+and a security fix (CVE-2026-56854, merged to `main` 2026-09-01) sat unshippable
+until an unrelated commit unwedged the lane. *Enforcement:* none yet — this is
+a TODO to build the enforcer. Related: [[a-read-that-fails-is-not-an-admin-decision]].
+
+### One health read during a rolling deploy proves nothing (2026-09-02)
+
+**When:** gating ANY promote, verification, or "is it deployed?" check on an
+HTTP health response. ECS rolls tasks gradually behind one load balancer, so
+old and new answer the same URL concurrently. Measured mid-roll on staging:
+10 consecutive `/v1/health` reads returned `8d5cf2ac, 8d5cf2ac, 8d5cf2ac,
+3693c556, 3693c556, 3693c556, 3693c556, 3693c556, 3693c556, 8d5cf2ac`. A
+single read had already fired a promote gate that then had to be revoked.
+**The rule:** require the deploy run to be `completed/success` AND N
+consecutive reads (>=8) agreeing on the expected SHA. The same shape applies to
+browser assertions: a redirect chain commits only its FINAL url, so
+`framenavigated` cannot see an intermediate hop — observe navigation REQUESTS.
+And any negative assertion ("it did NOT redirect") needs a positive control arm
+proving the mechanism fires at all, or it passes against dead code.
+*Incident:* caught pre-promote during the v0.13.10 release; no outage.
+
 ### A read that fails is not an admin decision — health flags fail open (2026-09-02)
 
 **When:** writing any code path that answers "is the platform in maintenance /

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,31 @@ linked, not inlined.
 
 ## Register
 
+### An inconclusive JWT verdict is not a rejection (2026-09-08)
+
+**When:** writing any code that calls `verifySupabaseJwt` and then decides what
+a FAILURE means. `sandbox-proxy/preview-auth.ts` — the authenticator for the
+preview ORIGIN and the preview WebSocket — compared reasons inline
+(`!== 'no-keys' && !== 'no-key-for-kid'`) instead of calling
+`isInconclusiveVerifyFailure`, so it missed `unsupported-alg:*`. Prod Supabase
+publishes an ES256 JWKS while its auth server still SIGNS HS256, so local verify
+answered `unsupported-alg:HS256` — a non-verdict only the auth server can
+settle. `combinedAuth` fell back to the network and served the token;
+preview-auth read the same string as a verdict and refused it. **The rule:**
+one predicate decides what a verify failure means; never re-state it inline.
+*Blast radius:* every browser preview origin on prod
+(`prod-p{port}-{label}.p.kortix.com`) answered 401 "Sign in to open this
+preview" to the sandbox's own owner, and the gate's sign-in link looped —
+`/preview/authorize` hands back `session.access_token`, the very token being
+refused. `/v1/p/<sandbox>/<port>/` kept working, which made it read as a token
+problem rather than an edge problem. Dev and staging were unaffected: their
+Supabase projects sign ES256. *Enforcement:*
+`apps/api/src/__tests__/unit-jwt-verify-callers.test.ts` fails any caller of
+`verifySupabaseJwt` that does not route through the shared predicate, or that
+compares a reason string by hand. *Also:* the machine-facing refusal now carries
+`x-kortix-preview-state`, because every gate answered the same 24-byte
+`{"error":"Unauthorized"}` and telling them apart took a code read.
+
 ### A `[skip ci]` release-prep commit deadlocks the lane that ships releases (2026-09-02)
 
 **When:** adding `[skip ci]` to any commit that lands on a branch whose deploy

--- a/apps/api/src/__tests__/unit-jwt-verify-callers.test.ts
+++ b/apps/api/src/__tests__/unit-jwt-verify-callers.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tripwire: every caller of `verifySupabaseJwt` must decide what a FAILURE
+ * means through `isInconclusiveVerifyFailure`, never by comparing reasons by
+ * hand.
+ *
+ * `jwt-verify-outcome.ts` says the two auth middlewares "route on this ONE
+ * predicate so they cannot drift apart". A third caller appeared anyway —
+ * `sandbox-proxy/preview-auth.ts`, the authenticator for the subdomain preview
+ * origin and the preview WebSocket — with its own inline
+ * `reason !== 'no-keys' && reason !== 'no-key-for-kid'`. It was missing
+ * `unsupported-alg:*`.
+ *
+ * The consequence was invisible until a Supabase project published an ES256
+ * JWKS while still SIGNING with the legacy HS256 secret. Local verification
+ * then returned `unsupported-alg:HS256` — inconclusive, only the auth server
+ * can check a symmetric signature. The middlewares fell back to the network and
+ * served the token; preview-auth read the same reason as a verdict and refused.
+ * Every browser preview origin answered 401 "Sign in to open this preview" to
+ * the owner, while `/v1/p/<sandbox>/<port>/` served the same sandbox to the
+ * same token.
+ *
+ * A comment could not stop that. This can: the next caller either uses the
+ * shared predicate or this test names the file.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dir, '..');
+
+/** Owns the reason strings; exempt by construction. */
+const OWNERS = new Set(['shared/jwt-verify.ts', 'shared/jwt-verify-outcome.ts']);
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      sourceFiles(full, acc);
+    } else if (entry.endsWith('.ts') && !entry.includes('.test.')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+const files = sourceFiles(SRC).map((full) => ({
+  path: full.slice(SRC.length + 1),
+  text: readFileSync(full, 'utf8'),
+}));
+
+describe('verifySupabaseJwt callers', () => {
+  test('the scan actually found the source tree', () => {
+    // A broken walk would make every assertion below vacuously true.
+    expect(files.length).toBeGreaterThan(100);
+    expect(files.some((f) => f.path === 'shared/jwt-verify.ts')).toBe(true);
+  });
+
+  test('every caller routes failures through isInconclusiveVerifyFailure', () => {
+    const callers = files.filter(
+      (f) => !OWNERS.has(f.path) && f.text.includes('verifySupabaseJwt('),
+    );
+    // If this drops to zero the predicate below stops guarding anything.
+    expect(callers.length).toBeGreaterThan(0);
+
+    const missing = callers
+      .filter((f) => !f.text.includes('isInconclusiveVerifyFailure'))
+      .map((f) => f.path);
+    expect(missing).toEqual([]);
+  });
+
+  test('nobody compares a verify reason by hand', () => {
+    const offenders = files
+      .filter((f) => !OWNERS.has(f.path))
+      .filter((f) => /reason\s*[!=]==\s*'(?:no-keys|no-key-for-kid)'/.test(f.text))
+      .map((f) => f.path);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
+++ b/apps/api/src/__tests__/unit-preview-auth-principal.test.ts
@@ -79,6 +79,10 @@ mock.module('../shared/jwt-verify', () => ({
     if (t === 'jwt-owner') return { ok: true, userId: 'user-owner' };
     if (t === 'jwt-other') return { ok: true, userId: 'user-other' };
     if (t === 'jwt-fallback') return { ok: false, reason: 'no-keys' };
+    // A project whose JWKS publishes an ES256 key while auth still SIGNS with
+    // the legacy HS256 secret: the local verifier loads a key, then meets an
+    // algorithm it does not implement. Only the auth server can judge it.
+    if (t === 'jwt-hs256') return { ok: false, reason: 'unsupported-alg:HS256' };
     return { ok: false, reason: 'invalid' };
   },
 }));
@@ -181,6 +185,21 @@ describe('authenticatePreviewPrincipal', () => {
   test('rejects network-fallback user without access', async () => {
     mockSupabaseUser = { id: 'user-fallback-other' };
     expect(await authenticatePreviewPrincipal('jwt-fallback', SANDBOX_ID)).toBeNull();
+  });
+
+  // An HS256-signed Supabase JWT is the SAME token combinedAuth accepts on
+  // /v1/*. The local verifier cannot check a symmetric signature, so
+  // `unsupported-alg:*` is inconclusive, not a verdict — it must reach the
+  // network path exactly like a cold JWKS does. Hard-rejecting it 401'd every
+  // browser preview on a project that had not yet migrated to asymmetric JWT
+  // signing keys, while the path proxy for the same sandbox worked.
+  test('falls back to the network verify path for an HS256-signed JWT', async () => {
+    mockSupabaseUser = { id: 'user-fallback-owner' };
+    expect(await authenticatePreviewPrincipal('jwt-hs256', SANDBOX_ID)).toBe('user-fallback-owner');
+  });
+  test('rejects an HS256 JWT whose user lacks sandbox access', async () => {
+    mockSupabaseUser = { id: 'user-fallback-other' };
+    expect(await authenticatePreviewPrincipal('jwt-hs256', SANDBOX_ID)).toBeNull();
   });
 });
 

--- a/apps/api/src/sandbox-proxy/preview-auth.ts
+++ b/apps/api/src/sandbox-proxy/preview-auth.ts
@@ -27,6 +27,10 @@ import { validateSecretKey } from '../repositories/api-keys';
 import { validateAccountToken } from '../repositories/account-tokens';
 import { validateServiceAccountToken } from '../repositories/service-accounts';
 import { verifySupabaseJwt } from '../shared/jwt-verify';
+// From the side-effect-free module, NOT from './jwt-verify': the suites that
+// `mock.module('../shared/jwt-verify', …)` replace it wholesale, and a name
+// imported from there would vanish under the mock. See jwt-verify-outcome.ts.
+import { isInconclusiveVerifyFailure } from '../shared/jwt-verify-outcome';
 import { getSupabase } from '../shared/supabase';
 import { canAccessPreviewSandbox } from '../shared/preview-ownership';
 
@@ -93,7 +97,14 @@ export async function authenticatePreviewPrincipalDetailed(
         ? { userId: local.userId, sessionId: null }
         : null;
     }
-    if (local.reason !== 'no-keys' && local.reason !== 'no-key-for-kid') return null;
+    // Inconclusive means the LOCAL verifier could not reach a verdict — cold
+    // JWKS, unknown kid, or an algorithm it does not implement. A Supabase
+    // project that still signs with the legacy HS256 secret lands in the last
+    // case, and only the auth server can check a symmetric signature. Route on
+    // the same predicate combinedAuth uses, or the two edges disagree about the
+    // same token: /v1/p/<sandbox>/<port> served it while every browser preview
+    // origin answered 401 'Sign in to open this preview'.
+    if (!isInconclusiveVerifyFailure(local.reason)) return null;
 
     const supabase = getSupabase();
     const { data: { user }, error } = await supabase.auth.getUser(token);

--- a/apps/api/src/sandbox-proxy/preview-origin-hs256.test.ts
+++ b/apps/api/src/sandbox-proxy/preview-origin-hs256.test.ts
@@ -1,0 +1,154 @@
+/**
+ * A preview ORIGIN request carrying an HS256-signed Supabase JWT, end to end
+ * through the real `handlePreviewOriginRequest` + the real `preview-auth`.
+ *
+ * The incident this locks down: a Supabase project whose JWKS publishes an
+ * ES256 key while the auth server still SIGNS with the legacy HS256 secret.
+ * `verifySupabaseJwt` then loads a key, meets an algorithm it cannot check, and
+ * answers `unsupported-alg:HS256` — inconclusive, not a verdict. `combinedAuth`
+ * routes that to the network `getUser`, so `/v1/*` and the path proxy
+ * `/v1/p/<sandbox>/<port>/` both served the token; `preview-auth` hard-rejected
+ * it, so EVERY browser preview origin answered 401 "Sign in to open this
+ * preview" for a signed-in owner whose token was fine.
+ *
+ * `preview-origin.test.ts` mocks `./preview-auth` wholesale and therefore
+ * cannot see this. Here only the verifier, the auth server, ownership and the
+ * upstream are stubbed; the credential travels the real path.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realPreviewOwnership from '../shared/preview-ownership';
+
+const configState: Record<string, unknown> = {
+  FRONTEND_URL: 'https://dev.kortix.com',
+  KORTIX_URL: 'https://dev-api.kortix.com',
+  INTERNAL_KORTIX_ENV: 'dev',
+  PORT: 8008,
+  API_KEY_SECRET: 'test-secret-value-32-chars-long!!',
+  KORTIX_PREVIEW_BASE_DOMAIN: undefined,
+};
+mock.module('../config', () => ({ config: configState }));
+
+/** The token under test — signature checked by the auth server, never locally. */
+const HS256_JWT = 'header.hs256.payload';
+/** A token the local verifier CAN judge, and rejects. Must never reach getUser. */
+const BAD_JWT = 'header.bad.payload';
+
+let getUserCalls: string[] = [];
+let supabaseUser: { id: string } | null = null;
+let allowedUsers = new Set<string>();
+let forwarded = 0;
+
+mock.module('./backend', () => ({
+  resolveExternalIdFromHostLabel: async (label: string) =>
+    label === 'sbx-known' ? 'sbx_KNOWN' : null,
+}));
+
+mock.module('../shared/jwt-verify', () => ({
+  decodeSupabaseJwtPayload: () => null,
+  verifySupabaseJwt: async (t: string) =>
+    t === HS256_JWT
+      ? { ok: false, reason: 'unsupported-alg:HS256' }
+      : { ok: false, reason: 'bad-signature' },
+}));
+
+mock.module('../shared/supabase', () => ({
+  getSupabase: () => ({
+    auth: {
+      getUser: async (t: string) => {
+        getUserCalls.push(t);
+        return {
+          data: { user: supabaseUser },
+          error: supabaseUser ? null : { message: 'invalid' },
+        };
+      },
+    },
+  }),
+}));
+
+// Spread the real module: `mock.module` replaces it wholesale, so a hand-listed
+// stub deletes every export it omits.
+mock.module('../shared/preview-ownership', () => ({
+  ...realPreviewOwnership,
+  canAccessPreviewSandbox: async ({ userId }: { userId?: string }) =>
+    !!userId && allowedUsers.has(userId),
+}));
+
+mock.module('./routes/preview', () => ({
+  forwardToSandbox: async () => {
+    forwarded += 1;
+    return new Response('upstream', { status: 200 });
+  },
+}));
+
+mock.module('../shared/session-public-shares', () => ({
+  PUBLIC_SHARE_BLOCKED_PORTS: new Set<number>([22, 4096, 8000, 3211]),
+  STATIC_FILE_SHARE_PORT: 3211,
+  PUBLIC_SHARE_VIEW_METHODS: new Set(['GET', 'HEAD', 'OPTIONS']),
+  isViewOnlyShare: () => true,
+  publicShareToken: (shareId: string) => `kps_${shareId.replaceAll('-', '')}`,
+  resolvePublicShare: async () => ({ ok: false }),
+  touchPublicShare: async () => {},
+}));
+
+const { handlePreviewOriginRequest } = await import('./preview-origin');
+const { PREVIEW_STATE_HEADER } = await import('./preview-state-page');
+
+const HOST = 'p8081-sbx-known.localhost:8008';
+
+function navigate(path: string): [Request, URL] {
+  const req = new Request(`http://127.0.0.1:8008${path}`, {
+    headers: { host: HOST, 'sec-fetch-dest': 'document' },
+  });
+  return [req, new URL(`http://${HOST.split(':')[0]}:8008${path}`)];
+}
+
+beforeEach(() => {
+  getUserCalls = [];
+  supabaseUser = { id: 'user-owner' };
+  allowedUsers = new Set(['user-owner']);
+  forwarded = 0;
+});
+
+describe('preview origin — HS256-signed Supabase JWT', () => {
+  test('the owner is signed in and bounced to the clean address, not to the gate', async () => {
+    const res = await handlePreviewOriginRequest(...navigate(`/?token=${HS256_JWT}`));
+
+    expect(res?.status).toBe(302);
+    expect(res?.headers.get('location')).toBe('/');
+    // Two cookie copies (see preview-session.ts) — the session really exists.
+    expect(res!.headers.getSetCookie().length).toBe(2);
+    // The auth server is the ONLY thing that can judge a symmetric signature,
+    // so the token must actually have reached it.
+    expect(getUserCalls).toEqual([HS256_JWT]);
+  });
+
+  test('the minted cookie then serves the app with no token in the URL', async () => {
+    const first = await handlePreviewOriginRequest(...navigate(`/?token=${HS256_JWT}`));
+    const cookie = first!.headers.getSetCookie().map((c) => c.split(';')[0]).join('; ');
+
+    const req = new Request('http://127.0.0.1:8008/', {
+      headers: { host: HOST, 'sec-fetch-dest': 'document', Cookie: cookie },
+    });
+    const res = await handlePreviewOriginRequest(req, new URL('http://p8081-sbx-known.localhost:8008/'));
+
+    expect(res?.status).toBe(200);
+    expect(forwarded).toBe(1);
+  });
+
+  test('an HS256 token whose user does not own the sandbox still gets the gate', async () => {
+    allowedUsers = new Set(['someone-else']);
+    const res = await handlePreviewOriginRequest(...navigate(`/?token=${HS256_JWT}`));
+
+    expect(res?.status).toBe(401);
+    expect(res?.headers.get(PREVIEW_STATE_HEADER)).toBe('signed-out');
+    expect(forwarded).toBe(0);
+  });
+
+  test('a locally-judged bad signature is refused without asking the auth server', async () => {
+    const res = await handlePreviewOriginRequest(...navigate(`/?token=${BAD_JWT}`));
+
+    expect(res?.status).toBe(401);
+    expect(getUserCalls).toEqual([]);
+  });
+});

--- a/apps/api/src/sandbox-proxy/preview-origin.test.ts
+++ b/apps/api/src/sandbox-proxy/preview-origin.test.ts
@@ -64,6 +64,7 @@ mock.module('../shared/session-public-shares', () => ({
 }));
 
 const { handlePreviewOriginRequest } = await import('./preview-origin');
+const { PREVIEW_STATE_HEADER } = await import('./preview-state-page');
 const { mintPreviewSession } = await import('./preview-session');
 
 const HOST = 'p8081-sbx-known.localhost:8008';
@@ -158,6 +159,21 @@ describe('preview origin auth gate', () => {
     const res = await handlePreviewOriginRequest(req, url);
     expect(res?.status).toBe(401);
     expect(principalCalls).toEqual(['nope']);
+  });
+
+  test('a machine refusal names the state, so one request tells them apart', async () => {
+    // Both answers are the same 24-byte `{"error":"Unauthorized"}` body; only
+    // the header says whether the credential was rejected or the label is not
+    // a sandbox at all.
+    const rejected = await handlePreviewOriginRequest(...request('/api?token=nope'));
+    expect(rejected?.headers.get('content-type')).toContain('application/json');
+    expect(rejected?.headers.get(PREVIEW_STATE_HEADER)).toBe('signed-out');
+
+    const unknown = await handlePreviewOriginRequest(
+      ...request('/api?token=good', {}, 'p8081-sbx-missing.localhost:8008'),
+    );
+    expect(unknown?.status).toBe(404);
+    expect(unknown?.headers.get(PREVIEW_STATE_HEADER)).toBe('unknown');
   });
 
   test('a CORS preflight is answered before auth, but grants nothing to a stranger', async () => {

--- a/apps/api/src/sandbox-proxy/preview-origin.ts
+++ b/apps/api/src/sandbox-proxy/preview-origin.ts
@@ -121,10 +121,19 @@ export function isPreviewHost(req: Request, url: URL): boolean {
 /** Query parameters that carry a one-shot credential, never forwarded upstream. */
 const CREDENTIAL_PARAMS = ['token', 'public_share'] as const;
 
-function jsonError(status: number, message: string, origin: string): Response {
+function jsonError(
+  status: number,
+  message: string,
+  origin: string,
+  state?: PreviewState,
+): Response {
   return new Response(JSON.stringify({ error: message }), {
     status,
-    headers: { 'Content-Type': 'application/json', ...corsHeaders(origin) },
+    headers: {
+      'Content-Type': 'application/json',
+      ...(state ? { [PREVIEW_STATE_HEADER]: state } : {}),
+      ...corsHeaders(origin),
+    },
   });
 }
 
@@ -140,7 +149,12 @@ function gateResponse(
   input: { status: 401 | 403 | 404; state: PreviewState; message: string; origin: string; publicHost: string },
 ): Response {
   if (!isDocumentNavigation(req)) {
-    return jsonError(input.status, input.message, input.origin);
+    // Name the state here too. Both refusals mean different things — an unknown
+    // sandbox, an unsigned host, a rejected credential — and without the header
+    // every one of them is the same 24-byte `{"error":"Unauthorized"}` to a
+    // curl. Telling them apart from outside took a code read during the HS256
+    // preview outage; it should take one request.
+    return jsonError(input.status, input.message, input.origin, input.state);
   }
   const proto = req.headers.get('x-forwarded-proto') || url.protocol.replace(':', '');
   const returnTo = `${proto}://${input.publicHost}${url.pathname}${url.search}`;


### PR DESCRIPTION
## The problem

Every browser preview origin on **prod** answers `401` to the sandbox's own
owner, and the gate's "Sign in to Kortix" link loops forever —
`/preview/authorize` hands back `session.access_token`, the exact token being
refused.

Reported from `https://prod-p4173-sbx-01m1ytz7zm2c72eeqkzmemarm1.p.kortix.com/?token=<jwt>`.

Measured on prod with one user JWT (2026-09-08, before the fix):

| surface | result |
| --- | --- |
| `GET https://api.kortix.com/v1/accounts` | `200` |
| `GET https://api.kortix.com/v1/p/sbx_01M1YTZ.../4173/` | `503 sandbox not ready (status: stopped)` — past auth |
| `GET https://prod-p4173-sbx-01m1ytz....p.kortix.com/?token=<same jwt>` | `401 {"error":"Unauthorized"}` |
| same, via `Authorization: Bearer` | `401` |

Same token, same sandbox, two answers.

## The cause

`apps/api/src/sandbox-proxy/preview-auth.ts:96` re-stated the "is this failure a
verdict?" rule inline:

```ts
if (local.reason !== 'no-keys' && local.reason !== 'no-key-for-kid') return null;
```

That misses `unsupported-alg:*`. Prod Supabase publishes an **ES256** JWKS while
its auth server still **signs HS256**:

```
$ # JWT header from the reported URL
{'alg': 'HS256', 'kid': 'b2pXFwm+imtLLxBI', 'typ': 'JWT'}
$ curl -s https://jbriwassebxdwoieikga.supabase.co/auth/v1/.well-known/jwks.json
[{"alg": "ES256", "crv": "P-256", "kid": "1b9796fc-…", "kty": "EC", "use": "sig"}]
```

So `verifySupabaseJwt` loads a key, meets an algorithm it cannot check, and
answers `unsupported-alg:HS256` — **inconclusive**, only the auth server can
settle a symmetric signature. `combinedAuth` routes that to the network
`getUser` via `isInconclusiveVerifyFailure`; `preview-auth` read the same string
as a rejection. `jwt-verify-outcome.ts` says "both auth middlewares route on
this ONE predicate so they cannot drift apart" — a third caller had appeared.

**Dev and staging never showed it.** Their Supabase projects sign ES256:

```
$ # freshly minted dev token
header: {'alg': 'ES256', 'kid': '3558308f-d910-43e1-9234-74e9ea5e7531', 'typ': 'JWT'}
```

A local stack does not show it either: a project with no published JWKS answers
`no-keys`, which the inline check already allowed.

## The fix

Route `preview-auth` through `isInconclusiveVerifyFailure`. This also fixes the
preview **WebSocket** edge, which authenticates through the same function.

## Guardrails

- `apps/api/src/__tests__/unit-jwt-verify-callers.test.ts` — tripwire. A caller
  of `verifySupabaseJwt` that does not import the shared predicate, or that
  compares a reason string by hand, fails the suite. Verified it flags the
  original code: 2 fail / 1 pass against `preview-auth.ts` as it was.
- `apps/api/src/sandbox-proxy/preview-origin-hs256.test.ts` — drives the real
  `handlePreviewOriginRequest` with the real `preview-auth`. Only the verifier,
  the auth server, ownership and the upstream are stubbed.
  `preview-origin.test.ts` mocks `./preview-auth` wholesale and cannot see this.
- The machine-facing refusal now carries `x-kortix-preview-state`. Every gate
  answered the same 24-byte `{"error":"Unauthorized"}`; telling `signed-out`
  from `unknown` from `forbidden` took a code read.

## Verification

Before → after, same file, `preview-auth.ts` stashed and restored:

```
=== WITHOUT THE FIX ===
Expected: 302   Received: 401
(fail) preview origin — HS256-signed Supabase JWT > the owner is signed in and bounced to the clean address
Expected: 200   Received: 401
(fail) preview origin — HS256-signed Supabase JWT > the minted cookie then serves the app
 2 pass  2 fail

=== WITH THE FIX ===
 4 pass  0 fail
```

Each suite alone:

```
src/sandbox-proxy/preview-origin-hs256.test.ts       4 pass  0 fail
src/__tests__/unit-jwt-verify-callers.test.ts        3 pass  0 fail
src/__tests__/unit-preview-auth-principal.test.ts   25 pass  0 fail
src/sandbox-proxy/preview-origin.test.ts            31 pass  0 fail
src/__tests__/unit-jwt-alg-fallback.test.ts          5 pass  0 fail
apps/api tsc --noEmit                                exit 0
```

## Not yet verified

- **Prod is the only environment that reproduces this.** Dev and staging sign
  ES256, so a dev smoke test proves no regression, not the fix. The reported URL
  can only be re-tested after this reaches prod through a promote.
- The local full `apps/api` suite is unusable on this machine (867 failures
  across unrelated domains — Pipedream actions, Apps hostnames, billing — from
  cross-file `mock.module` collisions). The CI lanes are the authoritative run.

## Learnings

Appended to `.claude/skills/learnings/SKILL.md`: *"An inconclusive JWT verdict
is not a rejection"*, with the tripwire named as its enforcer.

https://claude.ai/code/session_01SCsyGH7QuoRNC2XNPN9qG5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791414077&installation_model_id=434224&pr_number=7168&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7168&signature=d748c477623dfda0691188fcc2f46493d74c465024f6123df954e686e07b2168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->