### PR TITLE
test(e2e): spec 23 ignores the CORS preflight on every waitForResponse predicate

### DIFF
--- a/tests/e2e/specs/23-composio-connector.spec.ts
+++ b/tests/e2e/specs/23-composio-connector.spec.ts
@@ -115,6 +115,11 @@ test.describe("23 — Composio managed connector", () => {
       const search = page.getByPlaceholder("Search all connectors");
       for (const query of ["a", "sl", " G ", "gm", "gmail"]) {
         const response = page.waitForResponse((value) => {
+          // Only the real request: on the cross-site staging pair the Authorization
+          // header forces a CORS preflight — an OPTIONS on the SAME url and query that
+          // answers 204 and matched this predicate before the GET did (release gate
+          // v0.13.12, 2026-09-07/08, browser shard 3: "expected 200, received 204").
+          if (value.request().method() === "OPTIONS") return false;
           const url = new URL(value.url());
           return (
             url.pathname.endsWith("/connect/toolkits") &&
@@ -164,6 +169,11 @@ test.describe("23 — Composio managed connector", () => {
       }
       // Backspacing restores the broader one-letter result set.
       const backspaceResponse = page.waitForResponse((value) => {
+        // Only the real request: on the cross-site staging pair the Authorization
+        // header forces a CORS preflight — an OPTIONS on the SAME url and query that
+        // answers 204 and matched this predicate before the GET did (release gate
+        // v0.13.12, 2026-09-07/08, browser shard 3: "expected 200, received 204").
+        if (value.request().method() === "OPTIONS") return false;
         const url = new URL(value.url());
         return (
           url.pathname.endsWith("/connect/toolkits") &&
@@ -176,6 +186,11 @@ test.describe("23 — Composio managed connector", () => {
         page.getByRole("button", { name: /^GitHub\b/ }).first(),
       ).toBeVisible();
       const emptyResponse = page.waitForResponse((value) => {
+        // Only the real request: on the cross-site staging pair the Authorization
+        // header forces a CORS preflight — an OPTIONS on the SAME url and query that
+        // answers 204 and matched this predicate before the GET did (release gate
+        // v0.13.12, 2026-09-07/08, browser shard 3: "expected 200, received 204").
+        if (value.request().method() === "OPTIONS") return false;
         const url = new URL(value.url());
         return (
           url.pathname.endsWith("/connect/toolkits") &&


### PR DESCRIPTION
Release gate for v0.13.12 failed browser shard 3 on spec 23 with `expected 200, received 204` on `/connect/toolkits`. The response-header dump (diag branch run 34172295667) shows the matched response was the CORS preflight: method `OPTIONS`, `access-control-max-age: 600`, `cf-cache-status: DYNAMIC`. On the cross-site staging pair the Authorization header forces that preflight on the same url and query; the block-form predicates in this spec had no method filter. The arrow-form predicates already filtered by method.

Same change ships to staging as part of #7169 for the release candidate.

https://claude.ai/code/session_011wqNCmiifvxdr1UiQysnBX

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418554&installation_model_id=434224&pr_number=7170&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7170&signature=74d4b09b78f2e0f270faf6642605023b0c4e0254b06e2ba122a4fa16d7953403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->