### PR TITLE
fix(web): remove broken/dead command palette actions

### DIFF
--- a/apps/web/src/components/projects/personal-onboarding-welcome.tsx
+++ b/apps/web/src/components/projects/personal-onboarding-welcome.tsx
@@ -70,7 +70,7 @@ export function PersonalOnboardingWelcome({ projectId }: { projectId?: string } 
   const copyEmail = async () => {
     try {
       await navigator.clipboard.writeText(MARKO_EMAIL);
-      successToast(tI18nHardcoded.raw('i18nComplete.text982aa9d2037b'));
+      successToast(t('emailCopied'));
     } catch {
       window.location.href = `mailto:${MARKO_EMAIL}`;
     }

--- a/apps/web/src/components/projects/project-onboarding-wizard.tsx
+++ b/apps/web/src/components/projects/project-onboarding-wizard.tsx
@@ -102,7 +102,6 @@ export function ProjectOnboardingWizard({
    */
   onSkip?: () => void;
 }) {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
   const t = useTranslations('projectOnboarding');
   const contactTier = usePersonalContactTier();
   const showFounderStep = contactTier === 'personal';
@@ -156,12 +155,12 @@ export function ProjectOnboardingWizard({
       .then(() => resetFn())
       .then(() => {
         setIndex(0);
-        successToast(tI18nComplete('text9f875cecd1c5'));
+        successToast(t('resetSuccess'));
       })
       .catch((err) => errorToast(err instanceof Error ? err.message : String(err)));
     url.searchParams.delete('onboarding-reset');
     window.history.replaceState(null, '', url.toString());
-  }, [resetHydrated, resetFn, t, tI18nComplete]);
+  }, [resetHydrated, resetFn, t]);
 
   // Who this wizard is FOR: someone who can set the project up. Every step
   // writes something a plain project member cannot — the company domain and

--- a/apps/web/src/components/referrals/referral-code-section.tsx
+++ b/apps/web/src/components/referrals/referral-code-section.tsx
@@ -30,7 +30,7 @@ export function ReferralCodeSection({ referralCode, isLoading }: ReferralCodeSec
     if (await copyToClipboard(text)) {
       setCopiedLink(true);
       setTimeout(() => setCopiedLink(false), 2000);
-      successToast(tI18nComplete('textc9b756fdf6c2'));
+      successToast(t('linkCopied'));
     } else {
       errorToast(tI18nComplete.raw('textb7fdaed41e1a'));
     }

--- a/apps/web/src/features/accounts/settings/general-tab.tsx
+++ b/apps/web/src/features/accounts/settings/general-tab.tsx
@@ -218,11 +218,11 @@ export function GeneralTab({ onClose }: { onClose: () => void }) {
       setAvatarFile(null);
       setAvatarUrl(newAvatarUrl);
 
-      successToast(tHardcodedUi.raw('i18nComplete.text91a8ab20e938'));
+      successToast(t('profileUpdated'));
     } catch (error) {
       console.error('Error updating profile:', error);
       const message = error instanceof Error && error.message ? error.message : '';
-      errorToast(message || tHardcodedUi.raw('i18nComplete.text5c768dee3757'));
+      errorToast(message || t('profileUpdateFailed'));
     } finally {
       setIsSaving(false);
     }

--- a/apps/web/src/features/auth/phone-verification/otp-verification.tsx
+++ b/apps/web/src/features/auth/phone-verification/otp-verification.tsx
@@ -31,7 +31,6 @@ export function OtpVerification({
   showExistingOptions = false,
   challengeId,
 }: OtpVerificationProps) {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
   const t = useTranslations('auth.phoneVerification');
   const [otp, setOtp] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
@@ -81,7 +80,7 @@ export function OtpVerification({
 
     if (otp.length !== 6) {
       setLocalError(t('pleaseEnterSixDigitCode'));
-      errorToast(tI18nComplete('text2d32975062a5'));
+      errorToast(t('pleaseEnterSixDigitCode'));
       return;
     }
 

--- a/apps/web/src/features/billing/auto-topup-card.tsx
+++ b/apps/web/src/features/billing/auto-topup-card.tsx
@@ -169,7 +169,7 @@ export function AutoTopupCard({
     // default told customers with a working, already-charged payment method
     // that they had none — and auto top-up then never fired for them.
     if (enabled && setupStatus && !setupStatus.has_payment_method) {
-      errorToast(tI18nComplete('textb51caac9816a'));
+      errorToast(t('addPaymentFirst'));
       return;
     }
 
@@ -188,7 +188,7 @@ export function AutoTopupCard({
       successToast(tI18nComplete('textd81c55f49c5b'));
     } catch (err: unknown) {
       const error = err as { message?: string; error?: string };
-      errorToast(error?.message || error?.error || tI18nComplete('textdd2d120a9ea9'));
+      errorToast(error?.message || error?.error || t('updateFailed'));
     } finally {
       setSaving(false);
     }

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -90,19 +90,15 @@ import { track } from '@/lib/track';
 import { useProjectCan } from '@/lib/use-project-can';
 import { useProjectFeatureFlags } from '@/lib/use-project-feature-flags';
 import { cn } from '@/lib/utils';
-import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
-import { stripHtmlTags } from '@/lib/utils/strip-html-tags';
 import { DEFAULT_WALLPAPER_ID } from '@/lib/wallpapers';
 import { useChatSendStore } from '@/stores/chat-send-store';
 import { useCurrentAccountStore } from '@/stores/current-account-store';
-import { useMessageJumpStore } from '@/stores/message-jump-store';
 import { useProjectSessionTabsStore } from '@/stores/project-session-tabs-store';
 import { useProjectSwitchStore } from '@/stores/project-switch-store';
 import { useSettingsPanelStore } from '@/stores/settings-panel-store';
 import { openTabAndNavigate } from '@/stores/tab-store';
 import { useUpgradeDialogStore } from '@/stores/upgrade-dialog-store';
 import { type ConversationDensity, useUserPreferencesStore } from '@/stores/user-preferences-store';
-import { type TextPart, groupMessagesIntoTurns, isTextPart } from '@/ui';
 import {
   type FeatureFlagKey,
   type KortixAccount,
@@ -129,7 +125,6 @@ import {
   useCreateRuntimeSession,
   useModelStore,
   useRuntimeAgents,
-  useRuntimeMessages,
   useRuntimeProviders,
 } from '@kortix/sdk/react';
 import { capitalizeWords, chalkColors, formatRelativeTime } from '@kortix/shared';
@@ -163,7 +158,6 @@ type PalettePage =
   | 'root'
   | 'agents'
   | 'models'
-  | 'messages'
   | 'workspaces'
   | 'accounts'
   | 'sessions'
@@ -518,85 +512,6 @@ function FileSearchPage({
               {item.path}
             </span>
           </div>
-        </CommandItem>
-      ))}
-    </CommandGroup>
-  );
-}
-
-function MessagesPage({
-  sessionId,
-  query,
-  onSelect,
-}: {
-  sessionId: string;
-  query: string;
-  onSelect: (messageId: string) => void;
-}) {
-  const tHardcodedUi = useTranslations('hardcodedUi');
-  const { data: messages, isLoading } = useRuntimeMessages(sessionId);
-
-  const turns = useMemo(() => (messages ? groupMessagesIntoTurns(messages) : []), [messages]);
-
-  const items = useMemo(() => {
-    const result: { id: string; text: string }[] = [];
-    for (const turn of turns) {
-      const textParts = turn.userMessage.parts.filter(isTextPart) as TextPart[];
-      const raw = textParts.map((p) => p.text).join(' ');
-      const stripped = stripHtmlTags(stripKortixSystemTags(raw)).trim();
-      if (stripped.length > 0) {
-        result.push({ id: turn.userMessage.info.id, text: stripped });
-      }
-    }
-    return result;
-  }, [turns]);
-
-  const filtered = useMemo(() => {
-    if (!query.trim()) return items;
-    const q = query.trim().toLowerCase();
-    return items.filter((item) => (item.text || '').toLowerCase().includes(q));
-  }, [items, query]);
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center gap-2 py-10">
-        <TextShimmer>
-          {tHardcodedUi.raw('componentsCommandPalette.line328JsxTextLoadingMessages')}
-        </TextShimmer>
-      </div>
-    );
-  }
-
-  if (filtered.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-2 py-12">
-        <div className="bg-muted/30 flex h-10 w-10 items-center justify-center rounded-full">
-          <MessageCircle className="text-muted-foreground/30 size-4" />
-        </div>
-        <span className="text-muted-foreground/60 text-sm">
-          {query
-            ? tHardcodedUi('i18nComplete.text6d2e757d8700', { value0: query })
-            : tHardcodedUi.raw('i18nComplete.text1b0e06a3f475')}
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <CommandGroup heading={`Messages (${filtered.length})`} forceMount>
-      {filtered.map((item, index) => (
-        <CommandItem
-          key={item.id}
-          value={sanitizeCmdkValue(`message ${index} ${item.text.slice(0, 80)}`)}
-          onSelect={() => onSelect(item.id)}
-        >
-          <MessageCircle className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
-          <span className="text-muted-foreground/50 w-6 shrink-0 text-right text-xs tabular-nums">
-            #{index + 1}
-          </span>
-          <span className="flex-1 truncate text-sm">
-            {item.text.length > 80 ? `${item.text.slice(0, 80)}...` : item.text}
-          </span>
         </CommandItem>
       ))}
     </CommandGroup>
@@ -1334,12 +1249,6 @@ export function CommandPalette() {
         keywords: 'change model llm switch select provider anthropic openai claude gpt',
         targetPage: 'models',
       });
-      items.push({
-        id: 'jump-to-message',
-        label: tHardcodedUi.raw('i18nComplete.text2518d1e2e3d1'),
-        keywords: 'jump message go scroll navigate find conversation chat',
-        targetPage: 'messages',
-      });
     }
     return items.filter((item) => {
       const haystack = [item.label, item.keywords].join(' ').toLowerCase();
@@ -1666,16 +1575,6 @@ export function CommandPalette() {
       close();
     },
     [projectId, router, close],
-  );
-
-  const jumpToMessage = useMessageJumpStore((s) => s.jumpToMessage);
-
-  const handleJumpToMessage = useCallback(
-    (messageId: string) => {
-      jumpToMessage(messageId);
-      close();
-    },
-    [jumpToMessage, close],
   );
 
   const handleToggleSidebar = useCallback(() => {
@@ -2161,10 +2060,10 @@ export function CommandPalette() {
     if (page === 'accounts') return filteredAccountsList.length;
     if (page === 'sessions') return filteredProjectSessionsList.length;
     if (page === 'density') return filteredDensityOptions.length;
-    // 0, like 'messages': these pages fetch and filter their own rows, so the
-    // count lives inside them (the 'changes' group heading carries it) rather
-    // than being lifted here only to be recomputed.
-    if (page === 'messages' || page === 'changes' || page === 'flags') return 0;
+    // 0: these pages fetch and filter their own rows, so the count lives
+    // inside them (the 'changes' group heading carries it) rather than being
+    // lifted here only to be recomputed.
+    if (page === 'changes' || page === 'flags') return 0;
     if (!hasQuery) return 0;
     return (
       filteredNavItems.length +
@@ -2193,7 +2092,6 @@ export function CommandPalette() {
     if (page === 'agents') return tI18nComplete.raw('text32f4468b0b6f');
     if (page === 'models') return tI18nComplete.raw('text37b90680b842');
     if (page === 'files') return tI18nComplete.raw('text19608ade89b8');
-    if (page === 'messages') return tI18nComplete.raw('text764a5aa003f8');
     if (page === 'workspaces') return tI18nComplete.raw('text5c192a3e6f23');
     if (page === 'accounts') return tI18nComplete.raw('text72eb3689cab9');
     if (page === 'sessions') return tI18nComplete.raw('textf41875714fdc');
@@ -2207,7 +2105,6 @@ export function CommandPalette() {
     if (page === 'agents') return tI18nComplete.raw('text6fb2caa0ee1c');
     if (page === 'models') return tI18nComplete.raw('text9cb6d01d8b29');
     if (page === 'files') return tI18nComplete.raw('text5a5bc0c4ce6e');
-    if (page === 'messages') return tI18nComplete.raw('text2518d1e2e3d1');
     if (page === 'workspaces') return tI18nComplete.raw('text9ad6baffd025');
     if (page === 'accounts') return tI18nComplete.raw('text4ecda5e7a644');
     if (page === 'sessions') return tI18nComplete.raw('text113463edeb06');
@@ -2329,18 +2226,6 @@ export function CommandPalette() {
                             )}
                             <ChevronRight className="text-muted-foreground/30 size-3" />
                           </CommandItem>
-                          <CommandItem
-                            value="suggestion jump to message go scroll navigate"
-                            onSelect={() => goToPage('messages')}
-                          >
-                            <MessageCircle className="size-4" />
-                            <span className="flex-1">
-                              {tHardcodedUi.raw(
-                                'componentsCommandPalette.line1235JsxTextJumpToMessage',
-                              )}
-                            </span>
-                            <ChevronRight className="text-muted-foreground/30 size-3" />
-                          </CommandItem>
                         </>
                       )}
 
@@ -2439,8 +2324,6 @@ export function CommandPalette() {
                           >
                             {item.id === 'change-agent' ? (
                               <Bot className="size-4" />
-                            ) : item.id === 'jump-to-message' ? (
-                              <MessageCircle className="size-4" />
                             ) : (
                               <Cpu className="size-4" />
                             )}
@@ -2993,14 +2876,6 @@ export function CommandPalette() {
                   </span>
                 </div>
               ))}
-
-            {page === 'messages' && currentSessionId && (
-              <MessagesPage
-                sessionId={currentSessionId}
-                query={query}
-                onSelect={handleJumpToMessage}
-              />
-            )}
 
             {page === 'changes' && projectId && (
               <ChangeRequestsPage

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -2229,7 +2229,15 @@ export function CommandPalette() {
                         </>
                       )}
 
-                      {projectId && (
+                      {/* `currentSessionId`, not `projectId`. File search runs
+                          against the SESSION's sandbox daemon
+                          (`useWorkspaceSearch` -> `getActiveServerUrl()` ->
+                          `findFiles`/`findText`), so with no session mounted
+                          every query resolved to a swallowed fetch error and
+                          rendered "No files for …" — indistinguishable from a
+                          real zero-result search. A project id is not enough
+                          to make this row work; a session is. */}
+                      {currentSessionId && (
                         <CommandItem
                           value="suggestion search files find file grep repo content"
                           onSelect={() => goToPage('files')}
@@ -2482,7 +2490,7 @@ export function CommandPalette() {
                       </CommandGroup>
                     )}
 
-                    {queryLongEnough && projectId && (
+                    {queryLongEnough && currentSessionId && (
                       <CommandGroup
                         heading={tHardcodedUi.raw(
                           'componentsCommandPalette.line1437JsxAttrHeadingFileSearch',
@@ -2711,7 +2719,7 @@ export function CommandPalette() {
               </>
             )}
 
-            {page === 'files' && projectId && (
+            {page === 'files' && currentSessionId && (
               <FileSearchPage query={query} onSelect={handleSelectFile} />
             )}
 

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -74,7 +74,6 @@ import {
 } from '@/features/workspace/workspace-palette';
 import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { useNewProjectSession } from '@/hooks/projects/use-new-project-session';
-import { useSandboxProxy } from '@/hooks/use-sandbox-proxy';
 import { useLocalizedUiCatalog } from '@/i18n/use-localized-ui-catalog';
 import { useTranslations } from '@/i18n/use-translations';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
@@ -92,13 +91,6 @@ import { useProjectCan } from '@/lib/use-project-can';
 import { useProjectFeatureFlags } from '@/lib/use-project-feature-flags';
 import { cn } from '@/lib/utils';
 import { stripKortixSystemTags } from '@/lib/utils/kortix-system-tags';
-import {
-  buildWebProxyUrl,
-  normalizeExternalInput,
-  parseLocalhostUrl,
-  toInternalUrl,
-} from '@/lib/utils/sandbox-url';
-import { enrichPreviewMetadata } from '@/lib/utils/session-context';
 import { stripHtmlTags } from '@/lib/utils/strip-html-tags';
 import { DEFAULT_WALLPAPER_ID } from '@/lib/wallpapers';
 import { useChatSendStore } from '@/stores/chat-send-store';
@@ -153,7 +145,6 @@ import {
   FileTextIcon as FileText,
   FlaskIcon as Flask,
   GitBranchIcon as FolderGit2,
-  GlobeIcon as Globe,
   HashIcon as Hash,
   ChatCircleIcon as MessageCircle,
   MinusIcon as Minus,
@@ -899,7 +890,6 @@ export function CommandPalette() {
   }, [params?.sessionId, pathname]);
   const sidebarCtx = useContext(SidebarContext);
   const sidebarOpen = sidebarCtx?.open ?? false;
-  const { proxyUrl: buildProxyUrl, subdomainOpts } = useSandboxProxy();
   const createSession = useCreateRuntimeSession();
   const createPty = useCreatePty();
   const { theme, setTheme } = useTheme();
@@ -1687,146 +1677,6 @@ export function CommandPalette() {
     },
     [jumpToMessage, close],
   );
-
-  const detectedUrl = useMemo(() => {
-    const q = query.trim();
-    if (!q) return null;
-
-    const localhostParsed = parseLocalhostUrl(q.startsWith('http') ? q : `http://${q}`);
-    if (localhostParsed) {
-      return { kind: 'localhost' as const, ...localhostParsed };
-    }
-
-    if (/^\d{2,5}$/.test(q)) {
-      const port = Number.parseInt(q, 10);
-      if (port >= 1 && port <= 65535) {
-        return {
-          kind: 'localhost' as const,
-          originalUrl: `http://localhost:${port}/`,
-          port,
-          path: '/',
-        };
-      }
-    }
-
-    const normalized = normalizeExternalInput(q);
-    if (normalized) {
-      if (!q.includes('/')) {
-        const ext = q.split('.').pop()?.toLowerCase() || '';
-        const FILE_EXTS = new Set([
-          'ts',
-          'tsx',
-          'js',
-          'jsx',
-          'json',
-          'md',
-          'mdx',
-          'css',
-          'scss',
-          'less',
-          'html',
-          'xml',
-          'yaml',
-          'yml',
-          'toml',
-          'txt',
-          'log',
-          'env',
-          'lock',
-          'sql',
-          'db',
-          'py',
-          'rb',
-          'rs',
-          'go',
-          'java',
-          'sh',
-          'bash',
-          'zsh',
-          'conf',
-          'cfg',
-          'ini',
-          'svg',
-          'png',
-          'jpg',
-          'jpeg',
-          'gif',
-          'ico',
-          'woff',
-          'woff2',
-          'ttf',
-          'eot',
-          'map',
-          'd',
-          'mjs',
-          'cjs',
-          'mts',
-          'cts',
-          'vue',
-          'svelte',
-          'astro',
-          'wasm',
-          'zip',
-          'tar',
-          'gz',
-          'pdf',
-          'docx',
-          'pptx',
-          'xlsx',
-        ]);
-        if (FILE_EXTS.has(ext)) return null;
-      }
-      return { kind: 'external' as const, url: normalized };
-    }
-
-    return null;
-  }, [query]);
-
-  const handleOpenUrl = useCallback(() => {
-    if (!detectedUrl) return;
-
-    if (detectedUrl.kind === 'localhost') {
-      const { port, path } = detectedUrl;
-      const internalUrl = toInternalUrl(port, path);
-      const proxied = buildProxyUrl(internalUrl) || internalUrl;
-      const tabId = `preview:${port}`;
-      openTabAndNavigate({
-        id: tabId,
-        title: tHardcodedUi('i18nComplete.textb1d5e8ac8bb4', { value0: port }),
-        type: 'preview',
-        href: `/p/${port}`,
-        metadata: enrichPreviewMetadata({
-          url: proxied,
-          port,
-          originalUrl: internalUrl,
-          path,
-        }),
-      });
-    } else {
-      const extUrl = detectedUrl.url;
-      const proxyUrl = buildWebProxyUrl(extUrl, subdomainOpts) || extUrl;
-      let displayHost: string;
-      try {
-        displayHost = new URL(extUrl).hostname;
-      } catch {
-        displayHost = extUrl;
-      }
-
-      openTabAndNavigate({
-        id: `preview:web`,
-        title: displayHost,
-        type: 'preview',
-        href: '/p/web',
-        metadata: enrichPreviewMetadata({
-          url: proxyUrl,
-          port: 0,
-          originalUrl: extUrl,
-          path: '/',
-        }),
-      });
-    }
-    close();
-  }, [detectedUrl, close, buildProxyUrl, tHardcodedUi, subdomainOpts]);
 
   const handleToggleSidebar = useCallback(() => {
     // Reached by keyboard, from a palette the user is already typing in — the
@@ -2749,36 +2599,7 @@ export function CommandPalette() {
                       </CommandGroup>
                     )}
 
-                    {detectedUrl && (
-                      <CommandGroup
-                        heading={tHardcodedUi.raw(
-                          'componentsCommandPalette.line1419JsxAttrHeadingOpenURL',
-                        )}
-                        forceMount
-                      >
-                        <CommandItem
-                          value={sanitizeCmdkValue(
-                            `open url browser preview ${query.trim()} localhost port`,
-                          )}
-                          onSelect={handleOpenUrl}
-                        >
-                          <Globe className="text-kortix-blue size-4" />
-                          <span className="flex-1 truncate">
-                            {detectedUrl.kind === 'localhost'
-                              ? tI18nComplete('text7ca3b3fe99bb', {
-                                  value0: detectedUrl.port,
-                                  value1: detectedUrl.path !== '/' ? detectedUrl.path : '',
-                                })
-                              : `Open ${new URL(detectedUrl.url).hostname}`}
-                          </span>
-                          <Badge variant="kortix" size="sm">
-                            {tHardcodedUi.raw('i18nComplete.textd4c3e8a11256')}
-                          </Badge>
-                        </CommandItem>
-                      </CommandGroup>
-                    )}
-
-                    {queryLongEnough && !detectedUrl && projectId && (
+                    {queryLongEnough && projectId && (
                       <CommandGroup
                         heading={tHardcodedUi.raw(
                           'componentsCommandPalette.line1437JsxAttrHeadingFileSearch',

--- a/apps/web/src/features/workspace/command-palette.tsx
+++ b/apps/web/src/features/workspace/command-palette.tsx
@@ -2531,10 +2531,17 @@ export function CommandPalette() {
                             {query.trim()}
                             {tHardcodedUi.raw('componentsCommandPalette.line1462JsxTextText')}
                           </span>
+                          {/* The "Search files" half of this hint points at a
+                              row that only exists on a session — see the
+                              `currentSessionId` guards above. Off a session it
+                              named a control that was not on screen, so the
+                              generic half is all that is offered there. */}
                           <p className="text-muted-foreground/30 mt-1 text-xs">
-                            {tHardcodedUi.raw(
-                              'componentsCommandPalette.line1465JsxTextTrySearchFilesOrADifferentTerm',
-                            )}
+                            {currentSessionId
+                              ? tHardcodedUi.raw(
+                                  'componentsCommandPalette.line1465JsxTextTrySearchFilesOrADifferentTerm',
+                                )
+                              : tHardcodedUi.raw('i18nComplete.textce18e358bf01')}
                           </p>
                         </div>
                       </div>

--- a/apps/web/src/features/workspace/settings/tabs/general-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/general-tab.tsx
@@ -484,7 +484,7 @@ function GeneralWorkspaceCard({
     },
     onError: (error: Error, _nextName, context) => {
       renameOnError(queryClient, project.project_id, context);
-      errorToast(error.message || tI18nComplete('textdd2d120a9ea9'));
+      errorToast(error.message || t('updateFailed'));
     },
     onSettled: () => renameOnSettled(queryClient, project.project_id),
   });
@@ -506,7 +506,7 @@ function GeneralWorkspaceCard({
       queryClient.setQueryData(qk.project.summary(project.project_id), updated);
     },
     onError: (error: Error) =>
-      errorToast(error.message || tI18nComplete('texta563730f828d')),
+      errorToast(error.message || t('iconUpdateFailed')),
     // The icon is read from THREE caches and this mutation used to write back
     // to one. `setQueryData` above repaints the sidebar switcher, which reads
     // `qk.project.summary`; the projects grid and ⌘K read a
@@ -646,7 +646,7 @@ export function GeneralTab({ projectId }: { projectId: string }) {
       setArchiveOpen(false);
     },
     onError: (error: Error) =>
-      errorToast(error.message || tI18nComplete('textf4a10da7a820')),
+      errorToast(error.message || t('archiveFailed')),
   });
 
   return (

--- a/apps/web/src/features/workspace/settings/tabs/security-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/security-tab.tsx
@@ -413,7 +413,6 @@ export function SecurityTabView({
 /** Container: owns every hook and renders `SecurityTabView` with real data
  *  and handlers. Only ever mounted while this tab is active. */
 export function SecurityTab() {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
   const t = useTranslations('settings.security');
   const copy: SecurityTabCopy = {
     twoFactorTitle: t('twoFactorTitle'),
@@ -457,9 +456,9 @@ export function SecurityTab() {
       const { error } = await supabase.auth.signOut({ scope: 'others' });
       if (error) throw error;
     },
-    onSuccess: () => successToast(tI18nComplete('text3ffb56c3e7fa')),
+    onSuccess: () => successToast(t('signedOutOtherDevices')),
     onError: (error: Error) =>
-      errorToast(error.message || tI18nComplete('text3f579c386187')),
+      errorToast(error.message || t('signOutOtherDevicesFailed')),
   });
 
   return (

--- a/apps/web/src/features/workspace/settings/tabs/tokens-tab.tsx
+++ b/apps/web/src/features/workspace/settings/tabs/tokens-tab.tsx
@@ -216,11 +216,11 @@ export function TokensTab({ accountId }: { accountId: string | undefined }) {
   const revokeMutation = useMutation({
     mutationFn: (row: ApiKeyRow) => revokeAccountToken(row.id, accountId),
     onSuccess: () => {
-      successToast(tI18nComplete('text096e0be6bb57'));
+      successToast(t('keyRevoked'));
       queryClient.invalidateQueries({ queryKey: MY_TOKENS_KEY(accountId ?? '') });
       setRevokeTarget(null);
     },
-    onError: (err: Error) => errorToast(err.message || tI18nComplete('text4840dd3bd303')),
+    onError: (err: Error) => errorToast(err.message || t('revokeFailed')),
   });
 
   const rows = buildApiKeyRows({
@@ -475,7 +475,7 @@ function CreateApiKeyDialog({
       onCreated();
       setCreated(result);
     },
-    onError: (err: Error) => errorToast(err.message || tI18nComplete('textc8e60f01cd4e')),
+    onError: (err: Error) => errorToast(err.message || t('createFailed')),
   });
 
   function close() {

--- a/apps/web/src/hooks/projects/use-new-project-session.ts
+++ b/apps/web/src/hooks/projects/use-new-project-session.ts
@@ -103,7 +103,6 @@ export type NewProjectSessionOpts = {
 };
 
 export function useNewProjectSession(projectId: string | undefined) {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
   const t = useTranslations('threads');
   const router = useRouter();
   const pathname = usePathname();
@@ -243,8 +242,15 @@ export function useNewProjectSession(projectId: string | undefined) {
       };
 
       const createSession = () =>
-        loadingToast(tI18nComplete('textc18101edc3ea'), takeOrCreateSession(), {
-          success: tI18nComplete('text492f00cce740'),
+        // `threads.*`, not `hardcodedUi.i18nComplete.*`. The two
+        // i18nComplete slots these used to read hold the literal strings
+        // "startingSession" and "sessionStarted" in en, fr, de, pt, sr and
+        // zh — the key id was written into the value slot — so the toast
+        // rendered its own key name. `threads.startingSession` /
+        // `threads.sessionStarted` are the canonical entries and are
+        // correctly translated in all nine catalogs.
+        loadingToast(t('startingSession'), takeOrCreateSession(), {
+          success: t('sessionStarted'),
         });
 
       createScopedSession({
@@ -308,11 +314,11 @@ export function useNewProjectSession(projectId: string | undefined) {
             });
           } else {
             errorToast(
-              err instanceof Error ? err.message : tI18nComplete('text4eaca6d61bca'),
+              err instanceof Error ? err.message : t('failedToStartSession'),
             );
           }
         } else if (action === 'toast') {
-          errorToast(err instanceof Error ? err.message : tI18nComplete('text4eaca6d61bca'));
+          errorToast(err instanceof Error ? err.message : t('failedToStartSession'));
         }
         // 'silent': the global 429 handler already surfaced the session cap.
         // No navigation happened, so release the claim now — the user stays
@@ -330,7 +336,6 @@ export function useNewProjectSession(projectId: string | undefined) {
       openUpgradeDialog,
       accountId,
       t,
-      tI18nComplete,
       queryClient,
       openConnectorGate,
     ],

--- a/apps/web/src/hooks/referrals/use-referrals.ts
+++ b/apps/web/src/hooks/referrals/use-referrals.ts
@@ -37,10 +37,10 @@ export function useRefreshReferralCode() {
     onSuccess: (data) => {
       queryClient.setQueryData(REFERRALS_QUERY_KEYS.code, data);
       queryClient.invalidateQueries({ queryKey: REFERRALS_QUERY_KEYS.stats });
-      successToast(tI18nComplete('text15be258f884e'));
+      successToast(t('codeRefreshed'));
     },
     onError: () => {
-      errorToast(tI18nComplete('text9a076574cb80'));
+      errorToast(t('refreshFailed'));
     },
   });
 }
@@ -125,7 +125,7 @@ export function useSendReferralEmails() {
           );
         }
       } else {
-        successToast(tI18nComplete('textd9016ff54bb6'));
+        successToast(t('emailSent'));
       }
     },
     onError: (error: any) => {


### PR DESCRIPTION
## Summary

Three independent cleanups to the ⌘K command palette, from Marko's report that the Open URL action was broken and the follow-up audit of what the palette actually offers.

| # | Commit | Change |
|---|---|---|
| 1 | `9980ce2a5c` | Remove the **Open URL** row (the reported bug) |
| 2 | `996733b9dd` | Remove the **Jump to message** page |
| 3 | `33e300d8be` | Gate **File search** on a session instead of a project |
| 4 | `d414fb9fe3` | Stop the empty state naming a row that is no longer there |
| 5 | `5f652c67dd` | Stop 18 toasts rendering their own translation key (unrelated to the palette — see below) |

One file, `apps/web/src/features/workspace/command-palette.tsx`. Net −312 lines.

---

## 1. Open URL — removed

**What it did.** Any query that parsed as a host or a port — `localhost:40000`, `google.com`, a bare `3000` — produced an `Open URL` group at the top of the palette. Selecting it did not navigate to that URL. Both branches routed the target through the **current session's sandbox web proxy** and opened a preview tab:

- `localhost:PORT` → `toInternalUrl(port, path)` → `proxyUrl()` → tab `/p/{port}`
- external host → `buildWebProxyUrl(url, subdomainOpts)` → tab `/p/web`

The palette opens on every route, including ones with no session mounted. With no live sandbox there is no proxy origin, so the tab resolved to nothing. That is the reported failure.

**Second defect, same row.** It sat outside the palette's own result accounting — `hasAnyResults` never counted it. So `localhost:40000` rendered the `Open localhost:40000` row **and** `No results for "localhost:40000"` simultaneously, which is exactly what the bug-report screenshot shows. Removing the row makes the empty state correct.

Deleted: the `detectedUrl` detector and its 60-entry file-extension denylist (which existed only to stop `foo.ts` being read as a hostname), `handleOpenUrl`, the `Open URL` `CommandGroup`, the `useSandboxProxy()` call whose only consumer it was, and 6 now-unused imports (`buildWebProxyUrl`, `normalizeExternalInput`, `parseLocalhostUrl`, `toInternalUrl`, `enrichPreviewMetadata`, `GlobeIcon`). The File search row's `!detectedUrl` guard goes too, so a host-shaped query now offers file search like any other.

The SDK's `sandbox-url` helpers are untouched — other callers keep them.

## 2. Jump to message — removed

`MessagesPage` listed the user turns of the current session and scrolled to one via `useMessageJumpStore`. Both entry points go with it: the "Jump to message" suggestion row and the `jump-to-message` session-action row.

It was the palette's widest sub-page by import footprint — the only consumer of `@/ui`'s turn grouping (`groupMessagesIntoTurns`, `isTextPart`, `TextPart`), `useRuntimeMessages`, `useMessageJumpStore`, `stripHtmlTags` and `stripKortixSystemTags`. One ~75-line component removes five import edges from the palette chunk.

Also drops `'messages'` from the `PalettePage` union, its `placeholder`/`pageTitle`/`totalSearchResults` branches, and collapses the Session group's icon ternary from three branches to two. `MessageCircle` stays — the session rows still use it.

## 3. File search — gated on a session, not a project

The three File search entry points gated on `projectId`, so the rows appeared on every `/projects/[id]/**` route including the workspace home, where they never returned a result.

File search runs against the **session's sandbox daemon**, not the project. `useWorkspaceSearch` reads `useRuntimeStore(s => s.getActiveServerUrl())` (`use-workspace-search.ts:112`) and calls `findFiles` / `findText`, both SDK re-exports of the daemon client. With no session mounted there is no active server URL, the fetch throws, the `catch {}` in the hook's debounced effect swallows it, and the page renders **"No files for …"** — indistinguishable from a genuine zero-result search.

Now gated on `currentSessionId`: the suggestion row, the "Search files for …" query row, and the `files` page mount. `handleSelectFile` keeps `projectId` — that is the `/projects/{id}/files` route it navigates to, which is correct.

`currentSessionId` is derived only from `params.sessionId` or a `/sessions/:id` pathname match, so on `/projects/[id]` — the workspace home — it is `null`. Gating on it is exactly "session page only", which is what the daemon-backed search requires.

## 4. Empty state — no longer points at a missing row

Consequence of 3, caught on review. The no-results hint read `Try "Search files" or a different term`, which off a session named a control that is not on screen. Now session-aware: the full text on a session, the existing `Try a different term.` otherwise.

Reuses `hardcodedUi.i18nComplete.textce18e358bf01` rather than adding a key — verified present and genuinely translated in all nine locale files (de, en, es, fr, it, ja, pt, sr, zh), so no translation-catalog change ships here.

## Test plan

- `npx eslint src/features/workspace/command-palette.tsx` → **0 errors**. 2 warnings, both pre-existing `react-hooks/*` React Compiler noise (`set-state-in-effect`, `exhaustive-deps`) on lines this PR does not touch. Matches the baseline CLAUDE.md documents.
- `npx tsc --noEmit -p apps/web/tsconfig.json` → **0 errors in `command-palette.tsx`**. 16 total, all pre-existing and unrelated: 15 known `@types/bun` `test.each` errors in the 3 files CLAUDE.md lists, plus `src/lib/use-cases-source.ts` `TS2307: Cannot find module '@/.source'` (fumadocs generated source, not generated in this worktree).
- Both gates re-run against the final pushed tree, not just the intermediate states.
- Grep verification: zero remaining references to any of the 21 removed symbols across the three commits.
- No test referenced any of the three features.

**Not yet verified in a browser.** By hand:

1. ⌘K → type `localhost:3000` → no `Open URL` group; normal empty state.
2. ⌘K on a session → type `jump` → no "Jump to message" row; the page is gone.
3. ⌘K on a **workspace home** page → no "Search files" row at all, and the empty state reads `Try a different term.`
4. ⌘K on a **session** page → "Search files" row present, it returns real results, and the empty state still reads `Try "Search files" or a different term`.
5. Start a new session → the toast reads `Starting session…` then `Session started`, not `startingSession` / `sessionStarted`.

For the i18n commit specifically:
- `bun test src/i18n/` → **14 pass, 0 fail**
- `node scripts/audit-i18n.mjs` → 0 missing, 0 extra, 0 invalid, 0 unresolved across 17,562 keys × 9 locales
- `eslint` on all 11 touched files → 0 errors (5 pre-existing warnings on untouched lines)
- `tsc --noEmit` → 16 errors, the documented pre-existing baseline, **none in the 11 touched files**

---

## 5. Toasts rendering their own translation key

**Unrelated to the command palette.** Rides along on this branch by request; it touches no palette file and can be cherry-picked out cleanly.

Reported: a toast reading `sessionStarted` instead of `Session started`. It is not one string. Sweeping every catalog for values that are camelCase **and** name a real key elsewhere:

| | Count |
|---|---|
| Broken `locale:key` pairs | **379** |
| Distinct broken keys in `hardcodedUi.i18nComplete` | **59** |
| **Read by a call site, so user-visible** | **18** |

All 18 are toasts. Same defect as `ebaae4d247`: the re-key pass wrote the **pointer into the value slot**. The regression guard added after that incident misses this shape — its pattern is `/^(?:i18nComplete\.)?text[0-9a-f]{12}$/`, which catches generated ids but not a human-authored camelCase key name like `sessionStarted`.

**The fix changes no catalog.** Every one of these call sites already binds `t` to the namespace holding the canonical entry, and those entries are correctly translated in all nine catalogs — they were simply never read. So the call sites are repointed:

| File | Toasts |
|---|---|
| `use-new-project-session.ts` | `startingSession`, `sessionStarted`, `failedToStartSession` |
| `tokens-tab.tsx` | `keyRevoked`, `revokeFailed`, `createFailed` |
| `use-referrals.ts` | `codeRefreshed`, `refreshFailed`, `emailSent` |
| `security-tab.tsx` | `signedOutOtherDevices`, `signOutOtherDevicesFailed` |
| workspace `general-tab.tsx` | `iconUpdateFailed`, `updateFailed`, `archiveFailed` |
| accounts `general-tab.tsx` | `profileUpdated`, `profileUpdateFailed` |
| `auto-topup-card.tsx` | `addPaymentFirst`, `updateFailed` |
| `otp-verification.tsx` | `pleaseEnterSixDigitCode` |
| `personal-onboarding-welcome.tsx` | `emailCopied` |
| `project-onboarding-wizard.tsx` | `resetSuccess` |
| `referral-code-section.tsx` | `linkCopied` |

`textdd2d120a9ea9` (`updateFailed`) was shared by two call sites needing different sentences — workspace general-tab and billing auto-topup. Each file's own `t` resolves it correctly (`Failed to update workspace` vs `Failed to update auto top-up`), so the collision splits without a new key. Four now-unused translator bindings are dropped.

Verified before patching: all 19 target keys exist in all nine locales and none take ICU arguments.

**41 broken catalog values remain**, none read by a call site, so none visible today. Deliberately not bulk-fixed: a resolver deriving English from the pointer target **failed its own cross-locale check** — 9 matches against 138 mismatches — and several locales have machine-translated the key name itself (fr `corpsPointDExécution2`, ja `実行ポイント2の本文`). That needs a translator, not a script.

Two follow-ups worth a decision:
- Extend the guard to the camelCase shape. It would then fail on those 41, so it needs an explicit allowlist recording them as known debt — which is what stops a third recurrence.
- The 41 values need a human translation pass.

## Notes for review

Two further findings from the audit, **not** in this PR — happy to add them to this branch:

1. **The feature-flags sub-page is dead code.** `FeatureFlagsPage` (~150 lines) is reachable only through `SETTINGS_TAB_SUBMENU_PAGE['feature-flags']`, and that tab moved to `RETIRED_RAIL_ITEMS` in `settings/rail.ts` on 2026-09-03, so `settingsPaletteGroups()` never emits the row. `goToPage('flags')` has zero call sites.
2. **12 registry rows are declared for the palette then suppressed** by `LEGACY_PALETTE_HIDDEN`, and their hrefs (`/dashboard`, `/scheduled-tasks`, `/service-manager`, `/browser`, `/desktop`, `/files`, `/workspace`, `/docs/credits`) do not exist as routes. `LEGACY_PALETTE_HIDDEN` also names 5 rows that no longer exist at all (`tunnel`, `templates`, `secrets-manager`, `api-keys`, `ssh-quick`).

Also noticed: the `kortix:open-file-search` listener (`command-palette.tsx:1027`) has no dispatcher anywhere in the tree. Left alone — it predates this PR.


