### PR TITLE
Paint one brand mark across the whole sign-in to project path

### DIFF
--- a/apps/web/src/app/(app)/projects/start/loading.tsx
+++ b/apps/web/src/app/(app)/projects/start/loading.tsx
@@ -1,4 +1,5 @@
-import { useTranslations } from '@/i18n/use-translations';
+import { ProjectPendingScreen } from '@/components/projects/project-pending-screen';
+
 /**
  * Navigation Suspense boundary for /projects/start.
  *
@@ -11,35 +12,14 @@ import { useTranslations } from '@/i18n/use-translations';
  *     and every arrival pays a full server round-trip — which is what lets a
  *     bad RSC response turn the click into a full document load.
  *
- * Deliberately imports nothing: plain markup keeps the prefetched payload
- * small, which is the entire point of the boundary. It mirrors
- * `ProjectStartSkeleton` in `page.tsx` so the handover does not shift layout.
+ * A skeleton used to stand here — a header bar, two title bars, a composer
+ * block and three chips. It was guessing at a page this route never renders:
+ * the door resolves to `/projects/<id>` and the real project chrome replaces
+ * it, so the fake layout only ever flashed a shape the user was not about to
+ * get. `ProjectPendingScreen` is the one frame every "opening a project"
+ * surface shares, so the boundary, the client resolve below it, and a hard
+ * refresh of the project itself are now a single unbroken paint.
  */
 export default function ProjectStartLoading() {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
-  return (
-    <div className="flex min-h-screen flex-col" aria-busy="true" aria-live="polite">
-      <span className="sr-only">{tI18nComplete.raw('text9498be620d80')}</span>
-      <div className="w-full border-b">
-        <div className="kx-app-header px-mobile mx-auto flex w-full max-w-6xl shrink-0 items-center justify-between gap-2 py-4 sm:gap-3">
-          <div className="bg-muted-foreground/10 h-5 w-32 animate-pulse rounded-md" />
-          <div className="bg-muted-foreground/10 h-8 w-20 animate-pulse rounded-full" />
-        </div>
-      </div>
-      <main className="bg-background px-mobile flex flex-1 items-center py-10 sm:py-12">
-        <div className="mx-auto w-full max-w-3xl space-y-6">
-          <div className="space-y-3">
-            <div className="bg-muted-foreground/10 mx-auto h-9 w-64 animate-pulse rounded-md" />
-            <div className="bg-muted-foreground/10 mx-auto h-5 w-96 max-w-full animate-pulse rounded-md" />
-          </div>
-          <div className="bg-muted-foreground/10 h-32 w-full animate-pulse rounded-lg" />
-          <div className="flex flex-wrap justify-center gap-2">
-            <div className="bg-muted-foreground/10 h-8 w-28 animate-pulse rounded-full" />
-            <div className="bg-muted-foreground/10 h-8 w-36 animate-pulse rounded-full" />
-            <div className="bg-muted-foreground/10 h-8 w-24 animate-pulse rounded-full" />
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+  return <ProjectPendingScreen />;
 }

--- a/apps/web/src/app/(app)/projects/start/page.tsx
+++ b/apps/web/src/app/(app)/projects/start/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
+import { ProjectPendingScreen } from '@/components/projects/project-pending-screen';
 import Loading from '@/components/ui/loading';
-import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useAccountsList } from '@/hooks/account/use-accounts-list';
 import { performSignOut } from '@/lib/auth/perform-sign-out';
@@ -212,7 +212,7 @@ export default function ProjectStartPage() {
     );
   }
 
-  return <ProjectStartSkeleton />;
+  return <ProjectStartLoadingFrame />;
 }
 
 /**
@@ -285,35 +285,17 @@ function ProjectStartError({ onRetry }: { onRetry: () => void }) {
 }
 
 /**
- * The first frame. Shaped like the project page it is about to become — header
- * bar, title, composer — so the swap to `/projects/<id>` reads as the page
- * filling in rather than as a second navigation.
+ * The first frame.
+ *
+ * This used to be a skeleton of the project page — header bar, title, composer,
+ * chips. It was a guess: this route never renders that page, it resolves a
+ * project id and replaces the URL with `/projects/<id>`, so the skeleton only
+ * ever flashed a layout the user was not about to receive.
+ *
+ * `ProjectPendingScreen` is shared with `loading.tsx` above and with
+ * `ProjectAccessBoundary` on the far side of the redirect, so the whole
+ * open-a-project path paints one frame instead of three different ones.
  */
-function ProjectStartSkeleton() {
-  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
-  return (
-    <div className="flex min-h-screen flex-col" aria-busy="true" aria-live="polite">
-      <span className="sr-only">{tI18nComplete.raw('text9498be620d80')}</span>
-      <div className="w-full border-b">
-        <div className="kx-app-header px-mobile mx-auto flex w-full max-w-6xl shrink-0 items-center justify-between gap-2 py-4 sm:gap-3">
-          <Skeleton className="h-5 w-32 rounded-md" />
-          <Skeleton className="h-8 w-20 rounded-full" />
-        </div>
-      </div>
-      <main className="bg-background px-mobile flex flex-1 items-center py-10 sm:py-12">
-        <div className="mx-auto w-full max-w-3xl space-y-6">
-          <div className="space-y-3">
-            <Skeleton className="mx-auto h-9 w-64 rounded-md" />
-            <Skeleton className="mx-auto h-5 w-96 max-w-full rounded-md" />
-          </div>
-          <Skeleton className="h-32 w-full rounded-lg" />
-          <div className="flex flex-wrap justify-center gap-2">
-            <Skeleton className="h-8 w-28 rounded-full" />
-            <Skeleton className="h-8 w-36 rounded-full" />
-            <Skeleton className="h-8 w-24 rounded-full" />
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+function ProjectStartLoadingFrame() {
+  return <ProjectPendingScreen />;
 }

--- a/apps/web/src/app/(auth)/auth/page.tsx
+++ b/apps/web/src/app/(auth)/auth/page.tsx
@@ -24,6 +24,7 @@ import { type FormEvent, Suspense, lazy, useEffect, useMemo, useRef, useState } 
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { ProjectPendingScreen } from '@/components/projects/project-pending-screen';
 import Loading from '@/components/ui/loading';
 import { errorToast } from '@/components/ui/toast';
 import { AuthBrowserNoiseGuard } from '@/features/auth/auth-browser-noise-guard';
@@ -1035,14 +1036,19 @@ function AuthContent() {
   }, [trustedUser]);
 
   // A session is already established — the effect above is redirecting (or
-  // handing off to mobile). Keep the quiet branded frame up instead of a
-  // spinner, a blank screen, or a dead form.
+  // handing off to mobile). This is a hand-off, not a screen, so it shows the
+  // SAME frame the destination shows: `/projects/start` and the project access
+  // boundary both render `ProjectPendingScreen`, so the redirect produces no
+  // visual change at all.
+  //
+  // It used to render `<AuthFrame footerVariant="default">` with the entry
+  // step's own "Welcome to Kortix" / "Your AI Command Center" header. That is
+  // the headline a signed-OUT visitor is greeted with, so replaying it the
+  // instant a password is accepted read as the form bouncing backwards — and
+  // the legal footer it pinned then vanished one navigation later. Three
+  // different frames in a row is what made signing in look glitchy.
   if (trustedUser) {
-    return (
-      <AuthFrame footerVariant="default">
-        <StepHeader title={t('welcome')} tagline={t('tagline')} />
-      </AuthFrame>
-    );
+    return <ProjectPendingScreen />;
   }
 
   // Render the form immediately — even while the session check is still in

--- a/apps/web/src/components/projects/project-access-boundary.test.ts
+++ b/apps/web/src/components/projects/project-access-boundary.test.ts
@@ -420,8 +420,12 @@ describe('house dialect', () => {
         present: true,
       });
     }
-    // The quiet spinner every other auth sub-surface shows while it resolves.
-    expect(componentSource).toContain('<AuthPendingScreen ');
+    // The one exception to the auth vocabulary: the pending frame. It resolves
+    // into the project shell, not into an auth screen, so it is the shared
+    // "opening a project" mark rather than the consent flows' spinner. Paired
+    // with the absence, so a revert to AuthPendingScreen fails here.
+    expect(componentSource).toContain('<ProjectPendingScreen />');
+    expect(componentSource).not.toContain('<AuthPendingScreen');
   });
 
   test('does not re-introduce a bespoke frame, card or wallpaper', () => {

--- a/apps/web/src/components/projects/project-access-boundary.tsx
+++ b/apps/web/src/components/projects/project-access-boundary.tsx
@@ -10,7 +10,8 @@ import { Button } from '@/components/ui/button';
 import Loading from '@/components/ui/loading';
 import { Textarea } from '@/components/ui/textarea';
 import { AuthFrame } from '@/features/auth/auth-card-shell';
-import { AuthPendingScreen, DetailPanel, DetailRow } from '@/features/auth/auth-consent';
+import { ProjectPendingScreen } from '@/components/projects/project-pending-screen';
+import { DetailPanel, DetailRow } from '@/features/auth/auth-consent';
 import { ErrorStrip, Rise, StepHeader } from '@/features/auth/auth-primitives';
 import { useAuth } from '@/features/providers/auth-provider';
 import { useAdminRole } from '@/hooks/admin/use-admin-role';
@@ -249,14 +250,22 @@ function ProjectAccessForUser({ projectId, children }: ProjectAccessBoundaryProp
     forgetLastProjectId(user?.id, projectId);
   }, [unrenderable, projectId, user?.id]);
 
-  // The same quiet spinner every auth sub-surface shows while it resolves —
-  // minus the legal footer. This branch resolves into the project shell, which
-  // carries no footer, so keeping it would flash Terms/Privacy for the length
-  // of one fetch on every project open. The gate screens below still show it:
-  // they are terminal, and there they are the whole page.
+  // The full-page frame every "opening a project" surface shares — the Kortix
+  // mark, nothing else. This is what a hard refresh of `/projects/<id>` or of
+  // a session route shows for the length of one session check plus one
+  // getProject, so it is the most-seen loading surface in the product.
+  //
+  // It used to be `AuthPendingScreen footer={false}` — the auth sub-flows'
+  // quiet spinner with its legal line switched off. Two things were wrong with
+  // it: a bare spinner on an empty field is the least branded frame we ship,
+  // and `footer={false}` existed only to stop Terms/Privacy flashing for the
+  // length of one fetch on the way into a shell that has no footer. Neither
+  // problem exists once the frame is the mark. `AuthPendingScreen` still owns
+  // the consent flows, and the gate screens below still use `AuthFrame`.
+  //
   // A disabled query is pending, not loading. Wait for identity cleanup and
   // token publication before interpreting any result as an access decision.
-  if (!authReady || query.isPending) return <AuthPendingScreen footer={false} />;
+  if (!authReady || query.isPending) return <ProjectPendingScreen />;
 
   if (query.isSuccess) return <>{children}</>;
 
@@ -301,7 +310,7 @@ function AccessGateScreen({
   // `/projects` list.
   //
   // `useAppHome` reads a cookie, so it is browser-only. This screen never
-  // reaches the server render — the boundary above returns AuthPendingScreen
+  // reaches the server render — the boundary above returns the pending frame
   // while its getProject query is loading, which is its state on the server —
   // so the value can go straight into an href without desyncing hydration.
   const appHome = useAppHome();

--- a/apps/web/src/components/projects/project-pending-screen.tsx
+++ b/apps/web/src/components/projects/project-pending-screen.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { KortixLogo } from '@/components/ui/kortix-logo';
+import { useTranslations } from '@/i18n/use-translations';
+
+/**
+ * The full-viewport frame shown while a project is being opened.
+ *
+ * Four surfaces render it, and together they are the whole "getting into a
+ * project" path, so they must not each invent their own frame:
+ *  - `(auth)/auth/page.tsx` — the hand-off after a password is accepted,
+ *    while the redirect runs.
+ *  - `projects/start/loading.tsx` — the navigation Suspense boundary.
+ *  - `projects/start/page.tsx` — the client frame, while the landing
+ *    destination resolves.
+ *  - `project-access-boundary.tsx` — every hard refresh of `/projects/<id>`
+ *    and of a session route, while Supabase resolves the session and the
+ *    first `getProject` is in flight.
+ *
+ * They run back to back, so sharing one frame is the point: signing in now
+ * paints this mark once and holds it across three navigations instead of
+ * flashing a welcome headline, then a legal footer, then a spinner, then a
+ * skeleton.
+ *
+ * It used to be two different things: a skeleton of a page this route never
+ * renders, and `AuthPendingScreen`'s spinner on a blank field. The mark says
+ * the same thing without guessing at a layout, and it is the same mark the
+ * account gets on a branded workspace — `variant="icon"` reads `useBranding()`
+ * (see `@/components/ui/kortix-logo`).
+ *
+ * `AuthPendingScreen` still owns the consent sub-flows (OAuth, CLI, tunnel,
+ * GitHub setup, preview). There the spinner sits inside a frame that carries a
+ * mark and a legal footer already, so a second mark would be a duplicate.
+ *
+ * Motion: opacity only, so `prefers-reduced-motion` leaves a static mark
+ * rather than no feedback at all. The mark never spins — `Loading` is this
+ * app's only spinner.
+ */
+export function ProjectPendingScreen() {
+  const tI18nComplete = useTranslations('hardcodedUi.i18nComplete');
+  return (
+    <div
+      className="bg-background flex min-h-svh items-center justify-center"
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <span className="sr-only">{tI18nComplete.raw('text9498be620d80')}</span>
+      <KortixLogo
+        size={28}
+        variant="icon"
+        className="text-foreground motion-safe:animate-pulse"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/features/session/sandbox-loading-boundary.test.ts
+++ b/apps/web/src/features/session/sandbox-loading-boundary.test.ts
@@ -19,6 +19,10 @@ const setupChecklistSource = readFileSync(
   join(import.meta.dir, '../workspace/project-layout/home/setup-checklist.tsx'),
   'utf8',
 );
+const projectPendingSource = readFileSync(
+  join(import.meta.dir, '../../components/projects/project-pending-screen.tsx'),
+  'utf8',
+);
 
 describe('session navigation loading boundaries', () => {
   test('runtime-not-ready retries never render the full-page ASCII logo', () => {
@@ -39,15 +43,29 @@ describe('session navigation loading boundaries', () => {
     // must stay invisible, but the very FIRST project fetch owns the whole
     // viewport, so it has to show something rather than a blank screen.
     expect(projectAccessSource).toContain('if (!authReady || query.isPending)');
-    expect(projectAccessSource).toContain('<AuthPendingScreen footer={false} />');
+    expect(projectAccessSource).toContain('<ProjectPendingScreen />');
     expect(projectAccessSource).not.toMatch(/query\.isPending\)\s*return null/);
+  });
+
+  test('the first-fetch loader is the brand mark, not the auth spinner', () => {
+    // This frame is what a hard refresh of /projects/<id> and of every session
+    // route shows, so it is the most-seen loading surface in the product. It
+    // used to be AuthPendingScreen — the consent flows' spinner on an empty
+    // field. Paired assertions: the old frame is gone AND the mark is there,
+    // because an absence-only test passes on a version that renders nothing.
+    expect(projectAccessSource).not.toContain('<AuthPendingScreen');
+    expect(projectPendingSource).toContain('<KortixLogo');
+    expect(projectPendingSource).toContain("variant=\"icon\"");
   });
 
   test('the first-fetch loader carries no legal footer', () => {
     // It resolves into the project shell, which has no footer of its own, so a
     // pinned Terms/Privacy line would flash once per project open and vanish.
-    // The gate screens below it keep theirs — they are terminal pages.
-    expect(projectAccessSource).toContain('<AuthPendingScreen footer={false} />');
+    // The footer is now impossible rather than switched off: the frame is its
+    // own component and never mounts the auth shell. The gate screens below it
+    // keep theirs — they are terminal, and there they are the whole page.
+    expect(projectPendingSource).not.toContain('AuthFrame');
+    expect(projectPendingSource).not.toContain('AuthLegalFooter');
     expect(projectAccessSource).toContain('<AuthFrame>');
   });
 


### PR DESCRIPTION
## Summary

Signing in painted **four different frames back to back**. Each one was defensible on its own; nobody owned the sequence, so four local decisions composed into a stutter.

| # | Frame | Source |
|---|---|---|
| 1 | Kortix mark + "Welcome to Kortix" + "Your AI Command Center" + legal footer | `app/(auth)/auth/page.tsx` — the `trustedUser` branch |
| 2 | Blank field + small orbit spinner | `project-access-boundary.tsx` → `AuthPendingScreen footer={false}` |
| 3 | Fake header bar, two title bars, composer block, three chips | `projects/start/loading.tsx` + `ProjectStartSkeleton` |
| 4 | The project | — |

Frame 1 replays the **entry-step headline** — the greeting a signed-*out* visitor gets — the instant a password is accepted, so the form appears to bounce backwards, and the legal footer it pins disappears one navigation later.

Frame 2 is the most-seen loading surface in the product: it is what **every hard refresh** of `/projects/<id>` and of a session route renders, while the Supabase session resolves and the first `getProject` runs in series behind it.

Frame 3 is a guess. `/projects/start` never renders that page — it resolves a project id and replaces the URL with `/projects/<id>` — so the skeleton only ever flashed a layout the user was not about to receive.

### The change

One new component, `components/projects/project-pending-screen.tsx`, rendered at all four sites:

- The Kortix mark centered on `bg-background`, `size={28}` — the same mark size every other auth surface uses.
- Opacity-only pulse behind `motion-safe:`, so `prefers-reduced-motion` leaves a static mark rather than no feedback at all.
- `aria-busy` + `aria-live` + an sr-only "Opening your project" (existing key, no new string).
- It never spins. `Loading` stays this app's only spinner.
- `variant="icon"` reads `useBranding()`, so a branded workspace gets its own icon here for free.

Signing in now paints the mark **once** and holds it across three navigations.

### What is deliberately unchanged

- **`AuthPendingScreen`** still owns the six consent sub-flows (OAuth, CLI, tunnel, GitHub setup, preview, chat identity). A spinner is right there — it sits inside a frame that already carries a mark and a legal footer, so a second mark would be a duplicate. The `footer={false}` prop was the tell that it was on the wrong surface; the new frame cannot mount a footer at all, so that rule is structural rather than a prop now.
- **`projects/[id]/loading.tsx`** keeps its skeleton. It renders *inside* already-painted project chrome, where a bare mark would be a downgrade, and its shape is pinned by `project-loading-contract.test.ts`.

### Known inaccuracy

The `trustedUser` branch also covers handing off to the mobile app, where the sr-only "Opening your project" is slightly off. Harmless, but introduced here rather than inherited.

## Test plan

- `bun test` across every affected suite — **368 pass, 0 fail** (28 files).
- Two source-text contracts this invalidated were **rewritten to their intent, not deleted**:
  - `sandbox-loading-boundary.test.ts` — "first project access still keeps its intentional full-page loader" and "the first-fetch loader carries no legal footer".
  - `project-access-boundary.test.ts` — "is built from the shared auth consent primitives".
- **Mutation-checked** the new assertions: reverting the boundary to `<AuthPendingScreen footer={false} />` fails **3** of them, so they can actually fail.
- `npx eslint` on all changed files — **0 errors**. Two pre-existing `react-hooks/*` warnings in untouched code.
- `npx tsc --noEmit` on `apps/web` — clean against the known three-file `@types/bun` baseline.
- `.claude/skills/kortix-brand-guidelines/audit.sh` — clean on every touched path. (`components/projects/` reports 2 hits in `policies-panel.tsx` and `onboarding/motion.ts`; both pre-existing, neither touched.)

### Not yet verified

Verified by code, tests, lint and typecheck only — no stack was booted and no browser was driven. The visual result needs a look on a preview origin or locally: sign in, hard-refresh a project home, hard-refresh a session route, and confirm the mark holds without a headline or footer flash. Add the `preview` label to get an origin for that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791481135&installation_model_id=434224&pr_number=7179&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7179&signature=6c661be250761a1371af241ecb176881d1a95c922f9ad9bf2d7568b32a4e08fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->