### PR TITLE
fix(apps): a switched-off hosting provider showed "starting" forever instead of asking for a redeploy

### DIFF
--- a/apps/api/src/apps/public-proxy.test.ts
+++ b/apps/api/src/apps/public-proxy.test.ts
@@ -6,6 +6,8 @@ process.env.KORTIX_APPS_ALLOW_LOCAL_EDGE = 'true';
 
 const {
   appPublicUnavailableResponse,
+  assertAppProviderEnabled,
+  AppProviderDisabledError,
   appPublicBudgetResponse,
   appPublicResponseHeaders,
   appPublicStatusResponse,
@@ -597,6 +599,9 @@ describe('Apps public edge', () => {
       ['ready', 'Activating your App', 202, true],
       ['starting', 'Starting Storefront', 202, true],
       ['budget', 'App paused', 402, false],
+      // A provider that has been switched off is PERMANENT. It must not carry
+      // the auto-refresh, or the page promises to continue and never can.
+      ['provider_disabled', 'App needs a redeploy', 503, false],
       ['failed', 'Deployment failed', 503, false],
       ['cancelled', 'Deployment cancelled', 503, false],
     ] as const;
@@ -617,6 +622,21 @@ describe('Apps public edge', () => {
       expect(html).not.toContain('app_stopped');
       expect(html).not.toContain('App not found');
     }
+  });
+
+  // A deployment pins its provider at deploy time. When that provider is later
+  // switched off, waking can NEVER succeed again — only a redeploy fixes it.
+  // Guarding it is what turns an endless "starting" spinner into a page that
+  // names the problem.
+  //
+  // Essentia, 2026-09-08: their E2B stack was hibernated (ASGs to 0, its DNS
+  // pointing at a deleted load balancer) while all four live App deployments
+  // were still pinned to e2b and ALLOWED_SANDBOX_PROVIDERS had been narrowed to
+  // platinum. Every App rendered "Starting … This page will continue
+  // automatically" and refreshed every 3 s, forever.
+  test('a provider that is no longer enabled is refused, not retried forever', () => {
+    expect(() => assertAppProviderEnabled('e2b', ['platinum'])).toThrow(AppProviderDisabledError);
+    expect(() => assertAppProviderEnabled('platinum', ['platinum'])).not.toThrow();
   });
 
   test('returns machine-readable state to non-browser callers', async () => {

--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -109,7 +109,8 @@ type PublicAppStatus =
   | 'starting'
   | 'budget'
   | 'unfunded'
-  | 'capacity';
+  | 'capacity'
+  | 'provider_disabled';
 
 const PUBLIC_STATUS_COPY: Record<PublicAppStatus, {
   title: string;
@@ -179,6 +180,21 @@ const PUBLIC_STATUS_COPY: Record<PublicAppStatus, {
     code: 'app_account_unfunded',
     progress: false,
     httpStatus: 402,
+  },
+  provider_disabled: {
+    // TERMINAL, and it must never carry `progress: true`.
+    //
+    // A deployment pins its hosting provider at deploy time. If that provider
+    // is later switched off, every wake attempt fails the same way forever, and
+    // no amount of waiting fixes it — only a redeploy onto an allowed provider
+    // does. Rendering that as "starting" tells the viewer to keep waiting for
+    // something that cannot happen.
+    title: 'App needs a redeploy',
+    message:
+      'This App was deployed on a hosting provider that is no longer enabled. The owner can fix it with kortix apps deploy .',
+    code: 'app_provider_disabled',
+    progress: false,
+    httpStatus: 503,
   },
   capacity: {
     title: 'App paused',
@@ -843,6 +859,41 @@ export function appRuntimeNeedsWake(
   return Boolean(runtime.idleDeadlineAt && runtime.idleDeadlineAt.getTime() <= now.getTime());
 }
 
+/**
+ * The App's deployment names a hosting provider that is no longer enabled.
+ *
+ * Terminal by nature: a deployment pins its provider at deploy time, so no
+ * amount of retrying moves it onto a live one. Only `kortix apps deploy .`
+ * does.
+ */
+export class AppProviderDisabledError extends Error {
+  readonly code = 'app_provider_disabled';
+  constructor(readonly provider: string) {
+    super(`Hosting provider ${provider} is disabled — redeploy this App`);
+    this.name = 'AppProviderDisabledError';
+  }
+}
+
+/**
+ * Refuse to wake a runtime whose provider has been switched off.
+ *
+ * `deployment-worker` already refuses to DEPLOY onto a disabled provider. The
+ * wake path had no equivalent, so an App deployed while a provider was live
+ * kept trying to resume on it forever after it was disabled — and because
+ * `appPublicUnavailableResponse` renders the `starting` page, the viewer saw
+ * "This page will continue automatically" refreshing every 3 s and never
+ * continuing.
+ *
+ * The allow-list is passed in rather than read from `config` so the rule is
+ * testable without reaching for the process environment.
+ */
+export function assertAppProviderEnabled(
+  provider: string,
+  allowed: readonly string[] = config.ALLOWED_SANDBOX_PROVIDERS,
+): void {
+  if (!allowed.includes(provider)) throw new AppProviderDisabledError(provider);
+}
+
 export async function ensureAppRuntimeRunning(
   loaded: NonNullable<Awaited<ReturnType<typeof loadPublicApp>>>,
   hosting: AppHostingProvider,
@@ -867,6 +918,9 @@ export async function ensureAppRuntimeRunning(
   // it already holds its own live row, and counting it would stop an account at
   // exactly the cap from waking the very App it owns.
   await assertAppComputeAllowed(app, { excludeRuntimeId: loaded.runtime.runtimeId });
+
+  // Before the lease, so a dead provider can never park the row in `starting`.
+  assertAppProviderEnabled(loaded.runtime.provider);
 
   const owner = `${config.INTERNAL_KORTIX_ENV}:${process.pid}:${randomUUID()}`;
   const now = new Date();
@@ -1079,6 +1133,12 @@ export async function handleAppPublicRequest(request: Request): Promise<Response
     }
     if (error instanceof AppLimitError && error.code === 'app_concurrency_limit') {
       return appPublicStatusResponse(request, state.app, { status: 'capacity' });
+    }
+    // Not a cold start: this App can never wake until it is redeployed. Falling
+    // through to `appPublicUnavailableResponse` would render the `starting`
+    // page and promise a continuation that cannot arrive.
+    if (error instanceof AppProviderDisabledError) {
+      return appPublicStatusResponse(request, state.app, { status: 'provider_disabled' });
     }
     return appPublicUnavailableResponse(request, state.app);
   }


### PR DESCRIPTION
## What broke

Every App on the Essentia self-host box rendered **"Starting … This page will continue automatically"**, refreshing every 3 seconds, indefinitely. Nothing was starting, and nothing could.

## Why

A deployment pins its hosting provider at deploy time. On that box:

- their E2B stack was hibernated on 2026-09-06 — all four ASGs at `desired=0`, its DNS left pointing at a deleted load balancer
- `ALLOWED_SANDBOX_PROVIDERS` had been narrowed to `platinum`
- but **all four live App deployments were still pinned to `hosting_provider = e2b`**

So every wake attempt failed with `Unable to connect. Is the computer able to access the url? (provider status: unknown)` — 355 times in 24 hours on one runtime alone — and two runtimes sat in `status = starting` for two and five days.

`deployment-worker` already refuses to **deploy** onto a disabled provider. The **wake** path had no equivalent, and every wake failure funnels into `appPublicUnavailableResponse`, which renders the `starting` page. That is deliberate — it hides a provider's ingress lagging appd readiness on a resume behind the normal cold-start contract — and it is right for a *transient* failure. It also made a *permanent* one indistinguishable from starting, forever, on a page that actively promised to continue.

## The change

- `assertAppProviderEnabled(provider, allowed)` refuses to wake a runtime whose provider is no longer in the allow-list. It runs **before** the wake lease, so a dead provider can never park the row in `starting` again. The allow-list is a parameter rather than a config read, so the rule is testable without the process environment.
- A `provider_disabled` public status — "App needs a redeploy", `503`, `progress: false`, and therefore **no meta-refresh**. A terminal state must never carry the auto-refresh, or the page lies about what happens next.
- The handler maps the error to that page, beside the existing budget/unfunded/capacity cases whose comment already states the intent: *"a paused App, not a broken one. Say so instead of showing an endless spinner."*

## What this does not do

It does **not** repair an App already pinned to a dead provider — only `kortix apps deploy .` moves a deployment onto a live one. It replaces an endless spinner with the sentence that says so.

## Verified

- `public-proxy` suite: **30 pass / 0 fail**, including the new terminal-status and guard cases.
- Both new tests were watched failing first: the guard test with `assertAppProviderEnabled is not a function`, the status test with `copy.httpStatus` undefined.
- Full `apps/api` suite: **8394 pass**. Its 29 failures are all `Cannot find module '@composio/client'` — a dependency not installed in this worktree, in files this change does not touch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791488394&installation_model_id=434224&pr_number=7180&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7180&signature=eeebd3871a76fe1b19208f44fe9f783a83286e3a01d2c2c9b4a6ccfc7c5ff23e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->