### PR TITLE
fix(git-proxy): surface session agent grant so ref-scope widen works

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,19 @@ linked, not inlined.
 
 ## Register
 
+### A self-authenticating route must populate the shared context the resolver reads (2026-09-09)
+
+**When:** adding a route that authenticates its own credential instead of running
+the standard auth middleware. Populate the same request-context slots the shared
+authorization resolver reads (`agentGrant`), or the resolver silently default-denies.
+*Incident:* the git proxy resolved a session's agent grant but never placed it on
+the Hono context, so `principalHoldsRefScope` default-denied every non-own-branch
+push even for `kortix_cli: all`. This broke the `ops/reliability-ledgers` rolling
+branch and froze monitoring ground truth for 6 days (2026-09-07 persistence incident).
+*Enforcers:* `receive-pack-gate.test.ts` drives the grant through
+`authorizeGitProxy` (no host-wrapper injection); `unit-git-proxy-authz.test.ts`
+asserts the surfaced grant for both the sandbox and session-PAT paths.
+
 ### Bind native commands to the configured frontend and its main frame (2026-09-08)
 
 **When:** changing desktop frontend selection, navigation, or native commands.

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -22,6 +22,8 @@ let patResult: Record<string, unknown> = {};
 let apiKeyResult: Record<string, unknown> = {};
 let sandboxRow: Record<string, unknown> | null = null;
 let monitorBoxRow: Record<string, unknown> | null = null;
+/** The session connector-token grant the sandbox path resolves (account_tokens.agent_grant). */
+let grantRow: Record<string, unknown> | null = null;
 let authorizeAllowed = false;
 let authorizeCalls: Array<{
   userId: string;
@@ -33,11 +35,13 @@ let authorizeCalls: Array<{
 mock.module('../shared/db', () => ({
   db: {
     select: (fields?: Record<string, unknown>) => {
-      const rows = fields?.sessionMetadata
-        ? () => (sandboxRow ? [sandboxRow] : [])
-        : fields?.boxEpoch
-          ? () => (monitorBoxRow ? [monitorBoxRow] : [])
-          : () => (projectRow ? [projectRow] : []);
+      const rows = fields?.agentGrant
+        ? () => (grantRow ? [grantRow] : [])
+        : fields?.sessionMetadata
+          ? () => (sandboxRow ? [sandboxRow] : [])
+          : fields?.boxEpoch
+            ? () => (monitorBoxRow ? [monitorBoxRow] : [])
+            : () => (projectRow ? [projectRow] : []);
       return {
         from: () => ({
           innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
@@ -96,6 +100,7 @@ beforeEach(() => {
   patResult = { isValid: true, accountId: OWNER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
   apiKeyResult = { isValid: false };
   sandboxRow = null;
+  grantRow = null;
   authorizeAllowed = false;
   authorizeCalls = [];
 });
@@ -130,6 +135,29 @@ describe('authorizeGitProxy — CLI PAT', () => {
       status: 403,
       message: 'session workspace does not allow repository access',
     });
+  });
+
+  test('a session-scoped PAT surfaces the grant stamped on its token row', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      tokenId: 'tok-1',
+      projectId: PROJECT_ID,
+      sessionId: 'sandbox-1',
+      agentGrant: { agent: 'main', kortixCli: 'all', connectors: 'all' },
+    };
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
   });
 
   test('a PAT on another account passes when the user holds the git capability', async () => {
@@ -276,6 +304,36 @@ describe('authorizeGitProxy — sandbox token', () => {
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
 
     expect(res.ok).toBe(true);
+  });
+
+  test('a branch session surfaces its agent grant so the ref gate can widen the lane', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = { agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+  });
+
+  test('a session with no connector-token grant reads null, not widened', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = null;
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toBeNull();
   });
 
   // A monitor box has NO session_sandboxes row by design — its token scopes

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -25,6 +25,7 @@ import {
 } from '../projects';
 import type { GitScope, UpstreamGit } from '../projects/git-backends';
 import type { ProjectRow } from '../projects/lib/serializers';
+import type { AppEnv } from '../types';
 import { deriveRequestContext } from '../iam/cache';
 import {
   MAX_COMMAND_SECTION_BYTES,
@@ -80,7 +81,7 @@ import {
 import { prebuildDefaultBranchArtifacts } from './compiled-prebuild';
 import { config } from '../config';
 
-export const gitProxyApp = makeOpenApiApp();
+export const gitProxyApp = makeOpenApiApp<AppEnv>();
 
 /**
  * The git smart-HTTP protocol streams raw binary pack data (pkt-line framed),
@@ -901,6 +902,13 @@ gitProxyApp.openapi(
       if (auth.status === 401) return unauthorized(c, auth.message);
       return c.text(auth.message, auth.status as 403 | 404);
     }
+    // The ref-scope resolver reads the agent grant off the request context, the
+    // same slot the ordinary auth middleware fills on every non-git route. This
+    // route authenticates with its own token (git Basic/Bearer), so it must
+    // place the grant `authorizeGitProxy` resolved. Without it a session is
+    // default-denied beyond its own branch regardless of `project.gitops.ref.any`
+    // / `kortix_cli: all` — see projects/lib/git.ts.
+    c.set('agentGrant', auth.agentGrant ?? null);
     // Ref policy runs HERE, between authorization and transmission — the only
     // point where both the principal and the refs it wants to move are known.
     const gated = await gateReceivePack(c, auth);

--- a/apps/api/src/git-proxy/receive-pack-gate.test.ts
+++ b/apps/api/src/git-proxy/receive-pack-gate.test.ts
@@ -45,6 +45,11 @@ mock.module('../projects', () => ({
   authorizeGitProxy: async () => ({
     ok: true,
     principal,
+    // The real `authorizeGitProxy` resolves the session's agent grant and
+    // surfaces it here; the receive-pack route then places it on the request
+    // context for the ref-scope resolver. The test must NOT inject the grant
+    // through a host middleware, or it would mask the exact plumbing under test.
+    agentGrant,
     project: {
       projectId: PROJECT_ID,
       accountId: 'acc-1',
@@ -122,16 +127,12 @@ beforeAll(async () => {
   });
   upstreamUrl = `http://127.0.0.1:${upstreamServer.port}/upstream.git`;
 
-  // The scope resolver reads the agent grant off the request context, which the
-  // auth middleware sets in production. Hono collects handlers in REGISTRATION
-  // order and this app's routes exist at import time, so a `use('*')` added
-  // here would run AFTER them. A parent app shares the context with a routed
-  // sub-app, which injects the grant without mocking a module process-wide.
+  // The receive-pack route must place the grant it got from `authorizeGitProxy`
+  // onto the request context — the same contract the ordinary auth middleware
+  // fulfills on every non-git route. A parent app that injected the grant here
+  // would hide a missing `c.set('agentGrant', …)` in the route, so mount the
+  // app without one and let the route under test do the work.
   const host = new Hono();
-  host.use('*', async (c, next) => {
-    c.set('agentGrant' as never, agentGrant as never);
-    await next();
-  });
   host.route('/', gitProxyApp);
   proxyServer = Bun.serve({ port: 0, fetch: (req) => host.fetch(req) });
   proxyBase = `http://127.0.0.1:${proxyServer.port}/${PROJECT_ID}.git`;

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -12,7 +12,8 @@ import {
   getProjectSecretValueForConsumer,
 } from '../secrets';
 import { recordAuditEvent } from '../../shared/audit';
-import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, accountTokens, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import type { AgentGrant } from '@kortix/db';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { createHmac, randomBytes, randomUUID } from 'node:crypto';
 import { ttlMemo } from '../../shared/ttl-memo';
@@ -740,7 +741,20 @@ export async function resolveProjectUpstream(
 
 
 export type GitProxyAuth =
-  | { ok: true; project: ProjectRow; principal: GitPrincipal }
+  | {
+      ok: true;
+      project: ProjectRow;
+      principal: GitPrincipal;
+      /**
+       * The resolved agent grant for a session principal (null otherwise). The
+       * receive-pack route places this on the request context so the ref-scope
+       * resolver can honor `project.gitops.ref.any` / `kortix_cli: all` for the
+       * session pushing. Without it a session is default-denied beyond its own
+       * branch no matter what its manifest grants — the exact failure behind the
+       * 2026-09-07 monitoring-metadata persistence incident.
+       */
+      agentGrant: AgentGrant | null;
+    }
   | { ok: false; status: number; message: string };
 
 /**
@@ -920,6 +934,10 @@ async function authorizeGitProxyUncached(
           userId: result.userId ?? null,
           tokenId: result.tokenId ?? null,
         },
+      // A session-scoped PAT already carries the resolved grant on the token row
+      // (`validateAccountToken` returns it). Only meaningful for the session
+      // principal; null for the laptop-CLI-PAT user principal.
+      agentGrant: sessionPrincipal ? (result.agentGrant ?? null) : null,
     };
   }
 
@@ -966,7 +984,9 @@ async function authorizeGitProxyUncached(
           accountId: result.accountId,
           sandboxId: result.sandboxId,
         });
-        if (monitorBox) return { ok: true, project, principal: { kind: 'monitor' } };
+        if (monitorBox) {
+          return { ok: true, project, principal: { kind: 'monitor' }, agentGrant: null };
+        }
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
       }
       if (!workspaceMetadataAllowsRepositoryAccess(sandbox.sessionMetadata)) {
@@ -979,6 +999,23 @@ async function authorizeGitProxyUncached(
       if (!sandbox.branchName) {
         return { ok: false, status: 403, message: 'session has no branch to push' };
       }
+      // Resolve the session's agent grant so the ref-scope resolver can widen a
+      // session that deliberately holds `project.gitops.ref.any` / `kortix_cli:
+      // all`. The grant lives on the session's connector token(s) in
+      // `account_tokens`; a sandbox key carries no grant of its own. Missing row
+      // (or a project with no per-agent governance) reads null = default-deny.
+      const [grantRow] = await db
+        .select({ agentGrant: accountTokens.agentGrant })
+        .from(accountTokens)
+        .where(
+          and(
+            eq(accountTokens.sessionId, sandbox.sessionId),
+            eq(accountTokens.accountId, result.accountId),
+            eq(accountTokens.status, 'active'),
+            isNull(accountTokens.revokedAt),
+          ),
+        )
+        .limit(1);
       return {
         ok: true,
         project,
@@ -987,6 +1024,7 @@ async function authorizeGitProxyUncached(
           sessionId: sandbox.sessionId,
           branch: sandbox.branchName,
         },
+        agentGrant: grantRow?.agentGrant ?? null,
       };
     }
     // Account-scoped user API key. No per-project fallback here: an API key
@@ -995,7 +1033,7 @@ async function authorizeGitProxyUncached(
     if (result.accountId !== project.accountId) {
       return { ok: false, status: 403, message: 'token does not own this project' };
     }
-    return { ok: true, project, principal: { kind: 'user', userId: null } };
+    return { ok: true, project, principal: { kind: 'user', userId: null }, agentGrant: null };
   }
 
   return { ok: false, status: 401, message: 'git proxy requires a Kortix token' };


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies. This is a backend authorization fix on the git smart-HTTP proxy.

Proof (local, against `bun test`):

```
src/git-proxy/receive-pack-gate.test.ts   15 pass 0 fail   (GRANTED project.gitops.ref.any → CAN push another branch)
src/git-proxy/ref-scopes.test.ts          16 pass 0 fail
src/git-proxy/ref-policy.test.ts          34 pass 0 fail
src/__tests__/unit-git-proxy-authz.test.ts 21 pass 0 fail
apps/api: bun run typecheck                  clean
```

Before this change, a session granted `project.gitops.ref.any` (or `kortix_cli: all`) still got rejected pushing a non-own branch with `a session may only push its own branch (…)` — the exact failure behind the 2026-09-07 monitoring-metadata persistence incident.

## Why

The git receive-pack route authenticates its own token (git Basic/Bearer) and never runs the shared auth middleware, so the agent grant that `authorizeGitProxy` already resolves was silently dropped. `principalHoldsRefScope` reads the grant off the request context and default-denies when it is absent — which rejected every non-own-branch push regardless of the session's manifest grant. This broke the `ops/reliability-ledgers` rolling-branch lease pattern.

## What changed

- `apps/api/src/projects/lib/git.ts`: `GitProxyAuth` now carries `agentGrant: AgentGrant | null`. The session-scoped PAT path surfaces `result.agentGrant`; the sandbox path resolves the grant from `account_tokens.agent_grant` (active, unrevoked, scoped to the session + account).
- `apps/api/src/git-proxy/index.ts`: the receive-pack route places `auth.agentGrant` on the request context (`c.set('agentGrant', …)`) before the ref policy runs, and the app is typed `makeOpenApiApp<AppEnv>()` so that slot exists.
- Tests: `receive-pack-gate.test.ts` now drives the grant through the mocked `authorizeGitProxy` instead of injecting it via a host middleware (which was masking the bug); `unit-git-proxy-authz.test.ts` adds coverage for the surfaced grant on both credential paths.

## Verification

- `bun test` on the four affected files: 86 pass, 0 fail.
- `bun run typecheck` in `apps/api`: clean.
- Negative paths preserved: a session with no grant still default-denies; the default branch stays undeletable; a monitor still reads read-only.

## Risk / rollback

Low. The change only makes the already-resolved grant *visible* to the resolver; it widens nothing on its own — a session still needs `project.gitops.ref.any` or `kortix_cli: all` in its grant to push beyond its own branch, and the structural floor (default branch undeletable) is unchanged. The sandbox path adds one bounded `account_tokens` lookup on the push hot path, memoized with the existing 30s `authorizeGitProxy` verdict. Rollback = revert the PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791554839&installation_model_id=434224&pr_number=7185&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7185&signature=ba84caeabbef0c63275a1dc78d3a28468eeda59c329886c8c9a49f1229aa490c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->