### PR TITLE
fix(git-proxy): surface session agent grant so ref-scope widen works (incident hotfix → staging)

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,19 @@ linked, not inlined.
 
 ## Register
 
+### A self-authenticating route must populate the shared context the resolver reads (2026-09-09)
+
+**When:** adding a route that authenticates its own credential instead of running
+the standard auth middleware. Populate the same request-context slots the shared
+authorization resolver reads (`agentGrant`), or the resolver silently default-denies.
+*Incident:* the git proxy resolved a session's agent grant but never placed it on
+the Hono context, so `principalHoldsRefScope` default-denied every non-own-branch
+push even for `kortix_cli: all`. This broke the `ops/reliability-ledgers` rolling
+branch and froze monitoring ground truth for 6 days (2026-09-07 persistence incident).
+*Enforcers:* `receive-pack-gate.test.ts` drives the grant through
+`authorizeGitProxy` (no host-wrapper injection); `unit-git-proxy-authz.test.ts`
+asserts the surfaced grant for both the sandbox and session-PAT paths.
+
 ### Bind native commands to the configured frontend and its main frame (2026-09-08)
 
 **When:** changing desktop frontend selection, navigation, or native commands.

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -22,6 +22,8 @@ let patResult: Record<string, unknown> = {};
 let apiKeyResult: Record<string, unknown> = {};
 let sandboxRow: Record<string, unknown> | null = null;
 let monitorBoxRow: Record<string, unknown> | null = null;
+/** The session connector-token grant the sandbox path resolves (account_tokens.agent_grant). */
+let grantRow: Record<string, unknown> | null = null;
 let authorizeAllowed = false;
 let authorizeCalls: Array<{
   userId: string;
@@ -33,11 +35,13 @@ let authorizeCalls: Array<{
 mock.module('../shared/db', () => ({
   db: {
     select: (fields?: Record<string, unknown>) => {
-      const rows = fields?.sessionMetadata
-        ? () => (sandboxRow ? [sandboxRow] : [])
-        : fields?.boxEpoch
-          ? () => (monitorBoxRow ? [monitorBoxRow] : [])
-          : () => (projectRow ? [projectRow] : []);
+      const rows = fields?.agentGrant
+        ? () => (grantRow ? [grantRow] : [])
+        : fields?.sessionMetadata
+          ? () => (sandboxRow ? [sandboxRow] : [])
+          : fields?.boxEpoch
+            ? () => (monitorBoxRow ? [monitorBoxRow] : [])
+            : () => (projectRow ? [projectRow] : []);
       return {
         from: () => ({
           innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
@@ -96,6 +100,7 @@ beforeEach(() => {
   patResult = { isValid: true, accountId: OWNER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
   apiKeyResult = { isValid: false };
   sandboxRow = null;
+  grantRow = null;
   authorizeAllowed = false;
   authorizeCalls = [];
 });
@@ -130,6 +135,29 @@ describe('authorizeGitProxy — CLI PAT', () => {
       status: 403,
       message: 'session workspace does not allow repository access',
     });
+  });
+
+  test('a session-scoped PAT surfaces the grant stamped on its token row', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      tokenId: 'tok-1',
+      projectId: PROJECT_ID,
+      sessionId: 'sandbox-1',
+      agentGrant: { agent: 'main', kortixCli: 'all', connectors: 'all' },
+    };
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
   });
 
   test('a PAT on another account passes when the user holds the git capability', async () => {
@@ -276,6 +304,36 @@ describe('authorizeGitProxy — sandbox token', () => {
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
 
     expect(res.ok).toBe(true);
+  });
+
+  test('a branch session surfaces its agent grant so the ref gate can widen the lane', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = { agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+  });
+
+  test('a session with no connector-token grant reads null, not widened', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = null;
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toBeNull();
   });
 
   // A monitor box has NO session_sandboxes row by design — its token scopes

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -25,6 +25,7 @@ import {
 } from '../projects';
 import type { GitScope, UpstreamGit } from '../projects/git-backends';
 import type { ProjectRow } from '../projects/lib/serializers';
+import type { AppEnv } from '../types';
 import { deriveRequestContext } from '../iam/cache';
 import {
   MAX_COMMAND_SECTION_BYTES,
@@ -80,7 +81,7 @@ import {
 import { prebuildDefaultBranchArtifacts } from './compiled-prebuild';
 import { config } from '../config';
 
-export const gitProxyApp = makeOpenApiApp();
+export const gitProxyApp = makeOpenApiApp<AppEnv>();
 
 /**
  * The git smart-HTTP protocol streams raw binary pack data (pkt-line framed),
@@ -901,6 +902,13 @@ gitProxyApp.openapi(
       if (auth.status === 401) return unauthorized(c, auth.message);
       return c.text(auth.message, auth.status as 403 | 404);
     }
+    // The ref-scope resolver reads the agent grant off the request context, the
+    // same slot the ordinary auth middleware fills on every non-git route. This
+    // route authenticates with its own token (git Basic/Bearer), so it must
+    // place the grant `authorizeGitProxy` resolved. Without it a session is
+    // default-denied beyond its own branch regardless of `project.gitops.ref.any`
+    // / `kortix_cli: all` — see projects/lib/git.ts.
+    c.set('agentGrant', auth.agentGrant ?? null);
     // Ref policy runs HERE, between authorization and transmission — the only
     // point where both the principal and the refs it wants to move are known.
     const gated = await gateReceivePack(c, auth);

--- a/apps/api/src/git-proxy/receive-pack-gate.test.ts
+++ b/apps/api/src/git-proxy/receive-pack-gate.test.ts
@@ -45,6 +45,11 @@ mock.module('../projects', () => ({
   authorizeGitProxy: async () => ({
     ok: true,
     principal,
+    // The real `authorizeGitProxy` resolves the session's agent grant and
+    // surfaces it here; the receive-pack route then places it on the request
+    // context for the ref-scope resolver. The test must NOT inject the grant
+    // through a host middleware, or it would mask the exact plumbing under test.
+    agentGrant,
     project: {
       projectId: PROJECT_ID,
       accountId: 'acc-1',
@@ -122,16 +127,12 @@ beforeAll(async () => {
   });
   upstreamUrl = `http://127.0.0.1:${upstreamServer.port}/upstream.git`;
 
-  // The scope resolver reads the agent grant off the request context, which the
-  // auth middleware sets in production. Hono collects handlers in REGISTRATION
-  // order and this app's routes exist at import time, so a `use('*')` added
-  // here would run AFTER them. A parent app shares the context with a routed
-  // sub-app, which injects the grant without mocking a module process-wide.
+  // The receive-pack route must place the grant it got from `authorizeGitProxy`
+  // onto the request context — the same contract the ordinary auth middleware
+  // fulfills on every non-git route. A parent app that injected the grant here
+  // would hide a missing `c.set('agentGrant', …)` in the route, so mount the
+  // app without one and let the route under test do the work.
   const host = new Hono();
-  host.use('*', async (c, next) => {
-    c.set('agentGrant' as never, agentGrant as never);
-    await next();
-  });
   host.route('/', gitProxyApp);
   proxyServer = Bun.serve({ port: 0, fetch: (req) => host.fetch(req) });
   proxyBase = `http://127.0.0.1:${proxyServer.port}/${PROJECT_ID}.git`;

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -12,7 +12,8 @@ import {
   getProjectSecretValueForConsumer,
 } from '../secrets';
 import { recordAuditEvent } from '../../shared/audit';
-import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, accountTokens, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import type { AgentGrant } from '@kortix/db';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { createHmac, randomBytes, randomUUID } from 'node:crypto';
 import { ttlMemo } from '../../shared/ttl-memo';
@@ -740,7 +741,20 @@ export async function resolveProjectUpstream(
 
 
 export type GitProxyAuth =
-  | { ok: true; project: ProjectRow; principal: GitPrincipal }
+  | {
+      ok: true;
+      project: ProjectRow;
+      principal: GitPrincipal;
+      /**
+       * The resolved agent grant for a session principal (null otherwise). The
+       * receive-pack route places this on the request context so the ref-scope
+       * resolver can honor `project.gitops.ref.any` / `kortix_cli: all` for the
+       * session pushing. Without it a session is default-denied beyond its own
+       * branch no matter what its manifest grants — the exact failure behind the
+       * 2026-09-07 monitoring-metadata persistence incident.
+       */
+      agentGrant: AgentGrant | null;
+    }
   | { ok: false; status: number; message: string };
 
 /**
@@ -920,6 +934,10 @@ async function authorizeGitProxyUncached(
           userId: result.userId ?? null,
           tokenId: result.tokenId ?? null,
         },
+      // A session-scoped PAT already carries the resolved grant on the token row
+      // (`validateAccountToken` returns it). Only meaningful for the session
+      // principal; null for the laptop-CLI-PAT user principal.
+      agentGrant: sessionPrincipal ? (result.agentGrant ?? null) : null,
     };
   }
 
@@ -966,7 +984,9 @@ async function authorizeGitProxyUncached(
           accountId: result.accountId,
           sandboxId: result.sandboxId,
         });
-        if (monitorBox) return { ok: true, project, principal: { kind: 'monitor' } };
+        if (monitorBox) {
+          return { ok: true, project, principal: { kind: 'monitor' }, agentGrant: null };
+        }
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
       }
       if (!workspaceMetadataAllowsRepositoryAccess(sandbox.sessionMetadata)) {
@@ -979,6 +999,23 @@ async function authorizeGitProxyUncached(
       if (!sandbox.branchName) {
         return { ok: false, status: 403, message: 'session has no branch to push' };
       }
+      // Resolve the session's agent grant so the ref-scope resolver can widen a
+      // session that deliberately holds `project.gitops.ref.any` / `kortix_cli:
+      // all`. The grant lives on the session's connector token(s) in
+      // `account_tokens`; a sandbox key carries no grant of its own. Missing row
+      // (or a project with no per-agent governance) reads null = default-deny.
+      const [grantRow] = await db
+        .select({ agentGrant: accountTokens.agentGrant })
+        .from(accountTokens)
+        .where(
+          and(
+            eq(accountTokens.sessionId, sandbox.sessionId),
+            eq(accountTokens.accountId, result.accountId),
+            eq(accountTokens.status, 'active'),
+            isNull(accountTokens.revokedAt),
+          ),
+        )
+        .limit(1);
       return {
         ok: true,
         project,
@@ -987,6 +1024,7 @@ async function authorizeGitProxyUncached(
           sessionId: sandbox.sessionId,
           branch: sandbox.branchName,
         },
+        agentGrant: grantRow?.agentGrant ?? null,
       };
     }
     // Account-scoped user API key. No per-project fallback here: an API key
@@ -995,7 +1033,7 @@ async function authorizeGitProxyUncached(
     if (result.accountId !== project.accountId) {
       return { ok: false, status: 403, message: 'token does not own this project' };
     }
-    return { ok: true, project, principal: { kind: 'user', userId: null } };
+    return { ok: true, project, principal: { kind: 'user', userId: null }, agentGrant: null };
   }
 
   return { ok: false, status: 401, message: 'git proxy requires a Kortix token' };

--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -138,3 +138,18 @@ describe('DocMarkdown code fence inside a list', () => {
     expect(html).not.toContain('Click to preview');
   });
 });
+
+// The docs renderer shares `MarkdownOrderedList` with UnifiedMarkdown. See
+// `unified-markdown.test.tsx` for why the gutter grows with the digit count.
+
+describe('DocMarkdown ordered-list marker gutter', () => {
+  test('a list from 8 to 10 widens the gutter and keeps its start ordinal', () => {
+    const md = Array.from({ length: 3 }, (_, i) => `${8 + i}. item`).join('\n') + '\n';
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={md} />));
+    const tag = /<ol\b[^>]*>/.exec(html)?.[0] ?? '';
+
+    expect(tag).toContain('start="8"');
+    expect(tag).toContain('marker:tabular-nums');
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 1ch)');
+  });
+});

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -11,6 +11,7 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
+import { MarkdownOrderedList } from '@/components/markdown/ordered-list';
 import { isInternalUrl, isLinkSafeHref } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
@@ -91,11 +92,7 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
             {children}
           </ul>
         ),
-        ol: ({ children }: { children?: React.ReactNode }) => (
-          <ol className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 pl-6 marker:font-medium first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
-            {children}
-          </ol>
-        ),
+        ol: MarkdownOrderedList,
         li: ({ children }: { children?: React.ReactNode }) => (
           <li className="text-foreground/95 leading-relaxed font-medium">
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/ordered-list.test.ts
+++ b/apps/web/src/components/markdown/ordered-list.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { orderedListGutter, orderedListMarkerDigits } from './ordered-list';
+
+describe('orderedListMarkerDigits', () => {
+  test('counts the widest ordinal a default list paints', () => {
+    expect(orderedListMarkerDigits({ itemCount: 9 })).toBe(1);
+    expect(orderedListMarkerDigits({ itemCount: 10 })).toBe(2);
+    expect(orderedListMarkerDigits({ itemCount: 100 })).toBe(3);
+  });
+
+  test('offsets the count by the start ordinal', () => {
+    expect(orderedListMarkerDigits({ start: 8, itemCount: 2 })).toBe(1);
+    expect(orderedListMarkerDigits({ start: 8, itemCount: 3 })).toBe(2);
+    expect(orderedListMarkerDigits({ start: 98, itemCount: 3 })).toBe(3);
+  });
+
+  test('a reversed list counts down from its start', () => {
+    expect(orderedListMarkerDigits({ start: 10, itemCount: 3, reversed: true })).toBe(2);
+    expect(orderedListMarkerDigits({ itemCount: 12, reversed: true })).toBe(2);
+  });
+
+  test('counts a minus sign as a character', () => {
+    expect(orderedListMarkerDigits({ start: -12, itemCount: 2 })).toBe(3);
+  });
+
+  test('an empty list still reserves one digit', () => {
+    expect(orderedListMarkerDigits({ itemCount: 0 })).toBe(1);
+  });
+});
+
+describe('orderedListGutter', () => {
+  test('one digit is exactly the pl-6 scale step', () => {
+    expect(orderedListGutter(1)).toBe('calc(var(--spacing) * 6 + 0ch)');
+  });
+
+  test('every extra digit widens the gutter by one tabular digit', () => {
+    expect(orderedListGutter(2)).toBe('calc(var(--spacing) * 6 + 1ch)');
+    expect(orderedListGutter(3)).toBe('calc(var(--spacing) * 6 + 2ch)');
+  });
+});

--- a/apps/web/src/components/markdown/ordered-list.tsx
+++ b/apps/web/src/components/markdown/ordered-list.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+interface MarkerDigitsInput {
+  start?: number;
+  itemCount: number;
+  reversed?: boolean;
+}
+
+/**
+ * Characters in the widest ordinal the list paints, minus sign included.
+ * Mirrors the HTML list-item counter: `start` defaults to 1, or to the item
+ * count when the list is `reversed`.
+ */
+export function orderedListMarkerDigits({
+  start,
+  itemCount,
+  reversed = false,
+}: MarkerDigitsInput): number {
+  const count = Math.max(itemCount, 1);
+  const first =
+    start !== undefined && Number.isFinite(start) ? Math.trunc(start) : reversed ? count : 1;
+  const last = reversed ? first - count + 1 : first + count - 1;
+  return Math.max(String(first).length, String(last).length);
+}
+
+/**
+ * The `ol` inline-start padding for markers of `digits` characters.
+ *
+ * `list-outside` markers hang in this padding, end-aligned to the text. A
+ * fixed `pl-6` (22.08px) holds `9. ` (16.3px at 15px Roobert, weight 500,
+ * tabular) but not `10. ` (25.7px), so the leading digit painted past the list
+ * edge and any `overflow-hidden` ancestor cut it. Each extra digit adds `1ch`:
+ * Roobert's `0` advance (0.632em) covers its tabular digit (0.630em), so the
+ * slack left of the widest marker stays ~5.8px at every digit count and scales
+ * with the font size. No spacing step can express a glyph-relative width.
+ */
+export function orderedListGutter(digits: number): string {
+  return `calc(var(--spacing) * 6 + ${Math.max(digits - 1, 0)}ch)`;
+}
+
+interface MarkdownOrderedListProps {
+  children?: React.ReactNode;
+  start?: number | string;
+  reversed?: boolean;
+}
+
+function parseStart(start: number | string | undefined): number | undefined {
+  if (start === undefined) return undefined;
+  const value = typeof start === 'string' ? Number.parseInt(start, 10) : start;
+  return Number.isFinite(value) ? value : undefined;
+}
+
+// Shared by UnifiedMarkdown and DocMarkdown so the two renderers cannot drift.
+export function MarkdownOrderedList({ children, start, reversed }: MarkdownOrderedListProps) {
+  const startOrdinal = parseStart(start);
+  const itemCount = React.Children.toArray(children).filter(React.isValidElement).length;
+  const digits = orderedListMarkerDigits({ start: startOrdinal, itemCount, reversed });
+
+  return (
+    <ol
+      start={startOrdinal}
+      reversed={reversed}
+      className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 marker:font-medium marker:tabular-nums first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0"
+      style={{ paddingInlineStart: orderedListGutter(digits) }}
+    >
+      {children}
+    </ol>
+  );
+}

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -98,6 +98,58 @@ describe('UnifiedMarkdown table cells', () => {
   });
 });
 
+// ─── Ordered-list marker gutter ─────────────────────────────────────────────
+// Markers hang outside the `ol` padding box. A fixed `pl-6` gutter (22.08px)
+// holds `9. ` (16.3px at 15px Roobert) but not `10. ` (25.7px), so the first
+// digit painted past the list edge and an `overflow-hidden` ancestor cut it.
+// ────────────────────────────────────────────────────────────────────────────
+
+function orderedListTag(html: string): string {
+  const match = /<ol\b[^>]*>/.exec(html);
+  if (!match) throw new Error('no <ol> rendered');
+  return match[0];
+}
+
+function numberedList(count: number, start = 1): string {
+  return Array.from({ length: count }, (_, i) => `${start + i}. item`).join('\n') + '\n';
+}
+
+describe('UnifiedMarkdown ordered-list marker gutter', () => {
+  test('a single-digit list keeps the pl-6 gutter', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(9)} />)),
+    );
+
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 0ch)');
+  });
+
+  test('a ten-item list widens the gutter by one digit', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(10)} />)),
+    );
+
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 1ch)');
+  });
+
+  test('markers render with tabular digits', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(10)} />)),
+    );
+
+    expect(tag).toContain('marker:tabular-nums');
+    expect(tag).not.toMatch(/\bpl-6\b/);
+  });
+
+  test('forwards the start ordinal and sizes the gutter from it', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(3, 98)} />)),
+    );
+
+    expect(tag).toContain('start="98"');
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 2ch)');
+  });
+});
+
 // ─── A fenced block inside a list item ──────────────────────────────────────
 // `li` runs its children through `wrapChildrenWithPaths`. That walk used to
 // descend into the fence and swap the snippet for a React element, so

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -12,6 +12,7 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
+import { MarkdownOrderedList } from '@/components/markdown/ordered-list';
 import { isInternalUrl, shouldUseNextLink } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
@@ -91,11 +92,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
             {children}
           </ul>
         ),
-        ol: ({ children }: { children?: React.ReactNode }) => (
-          <ol className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 pl-6 marker:font-medium first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
-            {children}
-          </ol>
-        ),
+        ol: MarkdownOrderedList,
         li: ({ children }: { children?: React.ReactNode }) => (
           <li className="text-foreground/95 leading-relaxed font-medium [overflow-wrap:anywhere]">
             {wrapChildrenWithPaths(children)}


### PR DESCRIPTION
Promotes the 2026-09-09 monitoring-metadata persistence fix (#7185) to the release candidate.

Root cause: the git receive-pack route dropped the session's agent grant, so sessions default-denied every non-own-branch push regardless of `project.gitops.ref.any` / `kortix_cli: all`. This broke the `ops/reliability-ledgers` rolling branch and froze monitoring ground truth.

Merged to main as #7185 (squash `3009430`), verified on dev (commit 3009430, environment=dev). 86 unit tests pass, typecheck clean, deploy-dev CI green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791556070&installation_model_id=434224&pr_number=7186&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7186&signature=396e0f1ef260b9b8d422d8a2dbee989ac13dfa620378ffd43f0b30960a794880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->