### PR TITLE
fix(git-proxy): intersect session ref scope with the launcher's role

### DIFF
--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -137,7 +137,31 @@ describe('authorizeGitProxy — CLI PAT', () => {
     });
   });
 
-  test('a session-scoped PAT surfaces the grant stamped on its token row', async () => {
+  test('a session-scoped PAT surfaces its grant folded to the launcher role', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      tokenId: 'tok-1',
+      projectId: PROJECT_ID,
+      sessionId: 'sandbox-1',
+      agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' },
+    };
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    authorizeAllowed = true;
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+  });
+
+  test('a session-scoped PAT with a wildcard grant folds to null when the launcher lacks ref leaves', async () => {
     patResult = {
       isValid: true,
       accountId: OWNER_ACCOUNT,
@@ -153,11 +177,12 @@ describe('authorizeGitProxy — CLI PAT', () => {
       branchName: 'sandbox-1',
       sessionMetadata: { workspace_mode: 'branch' },
     };
+    authorizeAllowed = false;
 
     const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
 
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
+    if (res.ok) expect(res.agentGrant).toBeNull();
   });
 
   test('a PAT on another account passes when the user holds the git capability', async () => {
@@ -306,19 +331,45 @@ describe('authorizeGitProxy — sandbox token', () => {
     expect(res.ok).toBe(true);
   });
 
-  test('a branch session surfaces its agent grant so the ref gate can widen the lane', async () => {
+  test('a branch session surfaces its agent grant folded to the ref leaves the launcher holds', async () => {
     sandboxRow = {
       sandboxId: 'sandbox-1',
       sessionId: 'sandbox-1',
       branchName: 'sandbox-1',
       sessionMetadata: { workspace_mode: 'branch' },
     };
-    grantRow = { agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
+    grantRow = {
+      agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' },
+      userId: 'user-1',
+      tokenId: 'tok-1',
+    };
+    authorizeAllowed = true;
 
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
 
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+  });
+
+  test('a wildcard grant folds to null when the launcher holds neither ref leaf', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = {
+      agentGrant: { agent: 'main', kortixCli: 'all', connectors: 'all' },
+      userId: 'user-1',
+      tokenId: 'tok-1',
+    };
+    authorizeAllowed = false; // a member whose role denies ref delete/rewrite
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    // Folded to null → the ref-scope resolver default-denies the session.
+    if (res.ok) expect(res.agentGrant).toBeNull();
   });
 
   test('a session with no connector-token grant reads null, not widened', async () => {

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -746,16 +746,66 @@ export type GitProxyAuth =
       project: ProjectRow;
       principal: GitPrincipal;
       /**
-       * The resolved agent grant for a session principal (null otherwise). The
-       * receive-pack route places this on the request context so the ref-scope
-       * resolver can honor `project.gitops.ref.any` / `kortix_cli: all` for the
-       * session pushing. Without it a session is default-denied beyond its own
-       * branch no matter what its manifest grants — the exact failure behind the
-       * 2026-09-07 monitoring-metadata persistence incident.
+       * The resolved agent grant for a session principal (null otherwise),
+       * ALREADY intersected with the launching user's role (see
+       * `foldSessionGrantRefScopes`). The receive-pack route places this on the
+       * request context so the ref-scope resolver can honor
+       * `project.gitops.ref.any` / `kortix_cli: all` for the session pushing.
+       * Without it a session is default-denied beyond its own branch no matter
+       * what its manifest grants — the exact failure behind the 2026-09-07
+       * monitoring-metadata persistence incident.
        */
       agentGrant: AgentGrant | null;
     }
   | { ok: false; status: number; message: string };
+
+/**
+ * Fold a session's agent grant down to the ref leaves its launching principal
+ * actually holds.
+ *
+ * The ref-scope resolver (git-proxy/ref-scopes.ts) reads a session's grant
+ * alone — it performs no `userRole ∩ agentGrant` step — so the grant surfaced to
+ * it must already be that intersection. Without the fold, a project `member`
+ * who launches an agent whose manifest declares `project.gitops.ref.delete`
+ * (or `kortix_cli: all`) would gain manager-tier ref authority that the member's
+ * own role denies. Only the two ref leaves are consumed by the resolver, so only
+ * they are folded; `authorize(actorForToken(...))` re-applies the canonical
+ * identity fold (activated service account vs. launching user).
+ */
+async function foldSessionGrantRefScopes(
+  grant: AgentGrant | null,
+  launcherUserId: string | null | undefined,
+  sessionTokenId: string | null | undefined,
+  accountId: string,
+  projectId: string,
+  requestCtx: RequestContext,
+): Promise<AgentGrant | null> {
+  if (!grant || !launcherUserId) return null;
+  const refLeaves: string[] = [
+    PROJECT_ACTIONS.PROJECT_GITOPS_REF_ANY,
+    PROJECT_ACTIONS.PROJECT_GITOPS_REF_DELETE,
+  ];
+  const requested =
+    grant.kortixCli === 'all'
+      ? refLeaves
+      : grant.kortixCli.filter((action) => refLeaves.includes(action));
+  if (requested.length === 0) return grant;
+  const held: string[] = [];
+  for (const leaf of requested) {
+    const verdict = await authorize(
+      await actorForToken(launcherUserId, accountId, sessionTokenId, { ctx: requestCtx }),
+      leaf,
+      { type: 'project', id: projectId },
+    );
+    if (verdict.allowed) held.push(leaf);
+  }
+  if (grant.kortixCli === 'all') {
+    return held.length === 0 ? null : { ...grant, kortixCli: held };
+  }
+  const remaining = grant.kortixCli.filter((action) => !refLeaves.includes(action));
+  const next = [...remaining, ...held];
+  return next.length === 0 ? null : { ...grant, kortixCli: next };
+}
 
 /**
  * Authorize a Kortix git-proxy request: a bare credential (extracted from the
@@ -935,9 +985,19 @@ async function authorizeGitProxyUncached(
           tokenId: result.tokenId ?? null,
         },
       // A session-scoped PAT already carries the resolved grant on the token row
-      // (`validateAccountToken` returns it). Only meaningful for the session
-      // principal; null for the laptop-CLI-PAT user principal.
-      agentGrant: sessionPrincipal ? (result.agentGrant ?? null) : null,
+      // (`validateAccountToken` returns it). Fold it against the launching user's
+      // role so a member-launched agent cannot widen its ref authority beyond
+      // what that user holds. Null for the laptop-CLI-PAT user principal.
+      agentGrant: sessionPrincipal
+        ? await foldSessionGrantRefScopes(
+            result.agentGrant ?? null,
+            result.userId,
+            result.tokenId,
+            project.accountId,
+            projectId,
+            requestCtx,
+          )
+        : null,
     };
   }
 
@@ -999,13 +1059,18 @@ async function authorizeGitProxyUncached(
       if (!sandbox.branchName) {
         return { ok: false, status: 403, message: 'session has no branch to push' };
       }
-      // Resolve the session's agent grant so the ref-scope resolver can widen a
-      // session that deliberately holds `project.gitops.ref.any` / `kortix_cli:
-      // all`. The grant lives on the session's connector token(s) in
+      // Resolve the session's connector token (agent grant + launcher identity)
+      // so the ref-scope resolver can widen a session that deliberately holds
+      // `project.gitops.ref.any` / `kortix_cli: all` — intersected with the
+      // launcher's role. The grant lives on the session's connector token(s) in
       // `account_tokens`; a sandbox key carries no grant of its own. Missing row
       // (or a project with no per-agent governance) reads null = default-deny.
       const [grantRow] = await db
-        .select({ agentGrant: accountTokens.agentGrant })
+        .select({
+          agentGrant: accountTokens.agentGrant,
+          userId: accountTokens.userId,
+          tokenId: accountTokens.tokenId,
+        })
         .from(accountTokens)
         .where(
           and(
@@ -1024,7 +1089,17 @@ async function authorizeGitProxyUncached(
           sessionId: sandbox.sessionId,
           branch: sandbox.branchName,
         },
-        agentGrant: grantRow?.agentGrant ?? null,
+        // Fold the raw manifest grant against the launching user's role, so a
+        // member-launched agent cannot widen its ref authority beyond what that
+        // user holds.
+        agentGrant: await foldSessionGrantRefScopes(
+          grantRow?.agentGrant ?? null,
+          grantRow?.userId ?? null,
+          grantRow?.tokenId ?? null,
+          project.accountId,
+          projectId,
+          requestCtx,
+        ),
       };
     }
     // Account-scoped user API key. No per-project fallback here: an API key


### PR DESCRIPTION
## Demo

Non-visual change — no screen recording applies.

Proof (local, `bun test`):

```
src/__tests__/unit-git-proxy-authz.test.ts  23 pass 0 fail   (incl. wildcard→null fold)
src/git-proxy/receive-pack-gate.test.ts      15 pass 0 fail
src/git-proxy/ref-scopes.test.ts             16 pass 0 fail
src/git-proxy/ref-policy.test.ts             34 pass 0 fail
apps/api: bun run typecheck                    clean
```

## Why

Strix (MEDIUM, CWE-863) flagged #7185: the widen-lane fix surfaced a session's raw manifest grant but the ref-scope resolver reads that grant alone, with no `userRole ∩ agentGrant` step. A project `member` launching an agent whose manifest declares `project.gitops.ref.any` / `.ref.delete` (or `kortix_cli: all`) would gain manager-tier ref delete/rewrite the member's own role denies.

## What changed

- `apps/api/src/projects/lib/git.ts`: added `foldSessionGrantRefScopes`, which folds the surfaced session grant down to the two ref leaves the launching principal actually holds — via `authorize(actorForToken(...))` so the canonical identity fold (activated service account vs. launching user) still applies. Both the session-scoped PAT path and the sandbox-token path call it (the latter now selects `userId`/`tokenId` from `account_tokens`).

## Verification

- New tests: a wildcard grant folds to null when the launcher holds neither ref leaf; an explicit ref leaf survives when the launcher holds it; a missing connector-token grant reads null. 23 pass / 0 fail.
- `bun run typecheck` clean.

## Risk / rollback

Low. Narrower than #7185: it only restricts the grant surfaced to the ref resolver, restoring the ceiling every other authorization path already applies. Rollback = revert.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791560248&installation_model_id=434224&pr_number=7187&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7187&signature=ed6be17be454e91fae26e2c567fd4ff2631e032ca2fc3a74e25169aff23a27e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->