### PR TITLE
Promote main to staging with the session Git authorization fix

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,17 @@ linked, not inlined.
 
 ## Register
 
+### Intersect session Git ref grants with the effective IAM role (2026-09-10)
+
+**When:** exposing agent grants to the Git receive-pack ref gate. An explicit
+`project.gitops.ref.any` or `.ref.delete` grant narrows the effective identity;
+it never replaces that identity's role. Carry the session token and launcher
+into `actorForToken` so activated service accounts retain their own ceiling.
+*Near-miss:* staging PR #7186 blocked promotion of #7185, which exposed raw
+grants and let member-launched sessions request manager ref authority.
+*Enforcers:* `ref-scopes.test.ts`, `unit-git-proxy-authz.test.ts`, and real Git
+push assertions in `receive-pack-gate.test.ts`.
+
 ### A self-authenticating route must populate the shared context the resolver reads (2026-09-09)
 
 **When:** adding a route that authenticates its own credential instead of running

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,19 @@ linked, not inlined.
 
 ## Register
 
+### A self-authenticating route must populate the shared context the resolver reads (2026-09-09)
+
+**When:** adding a route that authenticates its own credential instead of running
+the standard auth middleware. Populate the same request-context slots the shared
+authorization resolver reads (`agentGrant`), or the resolver silently default-denies.
+*Incident:* the git proxy resolved a session's agent grant but never placed it on
+the Hono context, so `principalHoldsRefScope` default-denied every non-own-branch
+push even for `kortix_cli: all`. This broke the `ops/reliability-ledgers` rolling
+branch and froze monitoring ground truth for 6 days (2026-09-07 persistence incident).
+*Enforcers:* `receive-pack-gate.test.ts` drives the grant through
+`authorizeGitProxy` (no host-wrapper injection); `unit-git-proxy-authz.test.ts`
+asserts the surfaced grant for both the sandbox and session-PAT paths.
+
 ### Bind native commands to the configured frontend and its main frame (2026-09-08)
 
 **When:** changing desktop frontend selection, navigation, or native commands.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Verify the preview report SHA and result before accepting a green deployment (2026-09-10)
+
+**When:** using a persistent branch preview as release evidence. Push deploys
+set `PREVIEW_RUN_TESTS=0`; their success comment can still claim tests passed.
+Dispatch `deploy-preview.yml` explicitly, then check the report's `gitSha`,
+failures, and exclusions. A healthy runtime does not validate a retained report.
+*Near-miss:* PR #7190 deployed db5f0714 but retained c6b9685e's report with
+13 failures. The misleading green status was caught before staging promotion.
+*Enforcer:* manual report inspection; TODO: report skipped tests truthfully.
+
 ### Intersect session Git ref grants with the effective IAM role (2026-09-10)
 
 **When:** exposing agent grants to the Git receive-pack ref gate. An explicit

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -157,7 +157,10 @@ describe('authorizeGitProxy — CLI PAT', () => {
     const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
 
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
+    if (res.ok) {
+      expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
+      expect(res.principal).toMatchObject({ kind: 'session', userId: 'user-1', tokenId: 'tok-1' });
+    }
   });
 
   test('a PAT on another account passes when the user holds the git capability', async () => {
@@ -313,12 +316,15 @@ describe('authorizeGitProxy — sandbox token', () => {
       branchName: 'sandbox-1',
       sessionMetadata: { workspace_mode: 'branch' },
     };
-    grantRow = { agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
+    grantRow = { userId: 'launcher-1', tokenId: 'session-token-1', agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
 
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
 
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+    if (res.ok) {
+      expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+      expect(res.principal).toMatchObject({ kind: 'session', userId: 'launcher-1', tokenId: 'session-token-1' });
+    }
   });
 
   test('a session with no connector-token grant reads null, not widened', async () => {

--- a/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
+++ b/apps/api/src/__tests__/unit-git-proxy-authz.test.ts
@@ -22,6 +22,8 @@ let patResult: Record<string, unknown> = {};
 let apiKeyResult: Record<string, unknown> = {};
 let sandboxRow: Record<string, unknown> | null = null;
 let monitorBoxRow: Record<string, unknown> | null = null;
+/** The session connector-token grant the sandbox path resolves (account_tokens.agent_grant). */
+let grantRow: Record<string, unknown> | null = null;
 let authorizeAllowed = false;
 let authorizeCalls: Array<{
   userId: string;
@@ -33,11 +35,13 @@ let authorizeCalls: Array<{
 mock.module('../shared/db', () => ({
   db: {
     select: (fields?: Record<string, unknown>) => {
-      const rows = fields?.sessionMetadata
-        ? () => (sandboxRow ? [sandboxRow] : [])
-        : fields?.boxEpoch
-          ? () => (monitorBoxRow ? [monitorBoxRow] : [])
-          : () => (projectRow ? [projectRow] : []);
+      const rows = fields?.agentGrant
+        ? () => (grantRow ? [grantRow] : [])
+        : fields?.sessionMetadata
+          ? () => (sandboxRow ? [sandboxRow] : [])
+          : fields?.boxEpoch
+            ? () => (monitorBoxRow ? [monitorBoxRow] : [])
+            : () => (projectRow ? [projectRow] : []);
       return {
         from: () => ({
           innerJoin: () => ({ where: () => ({ limit: async () => rows() }) }),
@@ -96,6 +100,7 @@ beforeEach(() => {
   patResult = { isValid: true, accountId: OWNER_ACCOUNT, userId: 'user-1', tokenId: 'tok-1' };
   apiKeyResult = { isValid: false };
   sandboxRow = null;
+  grantRow = null;
   authorizeAllowed = false;
   authorizeCalls = [];
 });
@@ -130,6 +135,29 @@ describe('authorizeGitProxy — CLI PAT', () => {
       status: 403,
       message: 'session workspace does not allow repository access',
     });
+  });
+
+  test('a session-scoped PAT surfaces the grant stamped on its token row', async () => {
+    patResult = {
+      isValid: true,
+      accountId: OWNER_ACCOUNT,
+      userId: 'user-1',
+      tokenId: 'tok-1',
+      projectId: PROJECT_ID,
+      sessionId: 'sandbox-1',
+      agentGrant: { agent: 'main', kortixCli: 'all', connectors: 'all' },
+    };
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+
+    const res = await authorizeGitProxy('kortix_pat_x', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: 'all', connectors: 'all' });
   });
 
   test('a PAT on another account passes when the user holds the git capability', async () => {
@@ -276,6 +304,36 @@ describe('authorizeGitProxy — sandbox token', () => {
     const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'read');
 
     expect(res.ok).toBe(true);
+  });
+
+  test('a branch session surfaces its agent grant so the ref gate can widen the lane', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = { agentGrant: { agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' } };
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toEqual({ agent: 'main', kortixCli: ['project.gitops.ref.any'], connectors: 'all' });
+  });
+
+  test('a session with no connector-token grant reads null, not widened', async () => {
+    sandboxRow = {
+      sandboxId: 'sandbox-1',
+      sessionId: 'sandbox-1',
+      branchName: 'sandbox-1',
+      sessionMetadata: { workspace_mode: 'branch' },
+    };
+    grantRow = null;
+
+    const res = await authorizeGitProxy('kortix_abc', PROJECT_ID, 'write');
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.agentGrant).toBeNull();
   });
 
   // A monitor box has NO session_sandboxes row by design — its token scopes

--- a/apps/api/src/git-proxy/index.ts
+++ b/apps/api/src/git-proxy/index.ts
@@ -25,6 +25,7 @@ import {
 } from '../projects';
 import type { GitScope, UpstreamGit } from '../projects/git-backends';
 import type { ProjectRow } from '../projects/lib/serializers';
+import type { AppEnv } from '../types';
 import { deriveRequestContext } from '../iam/cache';
 import {
   MAX_COMMAND_SECTION_BYTES,
@@ -80,7 +81,7 @@ import {
 import { prebuildDefaultBranchArtifacts } from './compiled-prebuild';
 import { config } from '../config';
 
-export const gitProxyApp = makeOpenApiApp();
+export const gitProxyApp = makeOpenApiApp<AppEnv>();
 
 /**
  * The git smart-HTTP protocol streams raw binary pack data (pkt-line framed),
@@ -901,6 +902,13 @@ gitProxyApp.openapi(
       if (auth.status === 401) return unauthorized(c, auth.message);
       return c.text(auth.message, auth.status as 403 | 404);
     }
+    // The ref-scope resolver reads the agent grant off the request context, the
+    // same slot the ordinary auth middleware fills on every non-git route. This
+    // route authenticates with its own token (git Basic/Bearer), so it must
+    // place the grant `authorizeGitProxy` resolved. Without it a session is
+    // default-denied beyond its own branch regardless of `project.gitops.ref.any`
+    // / `kortix_cli: all` — see projects/lib/git.ts.
+    c.set('agentGrant', auth.agentGrant ?? null);
     // Ref policy runs HERE, between authorization and transmission — the only
     // point where both the principal and the refs it wants to move are known.
     const gated = await gateReceivePack(c, auth);

--- a/apps/api/src/git-proxy/receive-pack-gate.test.ts
+++ b/apps/api/src/git-proxy/receive-pack-gate.test.ts
@@ -45,6 +45,11 @@ mock.module('../projects', () => ({
   authorizeGitProxy: async () => ({
     ok: true,
     principal,
+    // The real `authorizeGitProxy` resolves the session's agent grant and
+    // surfaces it here; the receive-pack route then places it on the request
+    // context for the ref-scope resolver. The test must NOT inject the grant
+    // through a host middleware, or it would mask the exact plumbing under test.
+    agentGrant,
     project: {
       projectId: PROJECT_ID,
       accountId: 'acc-1',
@@ -122,16 +127,12 @@ beforeAll(async () => {
   });
   upstreamUrl = `http://127.0.0.1:${upstreamServer.port}/upstream.git`;
 
-  // The scope resolver reads the agent grant off the request context, which the
-  // auth middleware sets in production. Hono collects handlers in REGISTRATION
-  // order and this app's routes exist at import time, so a `use('*')` added
-  // here would run AFTER them. A parent app shares the context with a routed
-  // sub-app, which injects the grant without mocking a module process-wide.
+  // The receive-pack route must place the grant it got from `authorizeGitProxy`
+  // onto the request context — the same contract the ordinary auth middleware
+  // fulfills on every non-git route. A parent app that injected the grant here
+  // would hide a missing `c.set('agentGrant', …)` in the route, so mount the
+  // app without one and let the route under test do the work.
   const host = new Hono();
-  host.use('*', async (c, next) => {
-    c.set('agentGrant' as never, agentGrant as never);
-    await next();
-  });
   host.route('/', gitProxyApp);
   proxyServer = Bun.serve({ port: 0, fetch: (req) => host.fetch(req) });
   proxyBase = `http://127.0.0.1:${proxyServer.port}/${PROJECT_ID}.git`;

--- a/apps/api/src/git-proxy/receive-pack-gate.test.ts
+++ b/apps/api/src/git-proxy/receive-pack-gate.test.ts
@@ -192,7 +192,7 @@ async function push(...args: string[]): Promise<{ code: number; output: string }
 
 describe('a session principal', () => {
   beforeAll(() => {
-    principal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID };
+    principal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID, userId: 'user-1', tokenId: 'tok-1' };
   });
 
   test('is refused pushing the default branch, as a git rejection', async () => {
@@ -311,11 +311,23 @@ describe('a user principal', () => {
 
 describe('a session GRANTED project.gitops.ref.any', () => {
   beforeAll(() => {
-    principal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID };
+    principal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID, userId: 'user-1', tokenId: 'tok-1' };
     agentGrant = { agent: 'main', kortixCli: ['project.gitops.ref.any'] };
   });
   afterAll(() => {
     agentGrant = null;
+  });
+
+  test('cannot push another branch when IAM denies the granted scope', async () => {
+    iamAllowsHuman = false;
+    try {
+      const { code, output } = await push('--force', 'origin', 'HEAD:refs/heads/shared');
+      expect(code).not.toBe(0);
+      expect(output).toContain('[remote rejected]');
+      expect(upstreamReceived).toEqual([]);
+    } finally {
+      iamAllowsHuman = true;
+    }
   });
 
   test('CAN push another branch — the scope is what makes it deliberate', async () => {

--- a/apps/api/src/git-proxy/ref-policy.ts
+++ b/apps/api/src/git-proxy/ref-policy.ts
@@ -70,7 +70,14 @@ import { isDelete, type RefUpdate } from './receive-pack';
  */
 export type GitPrincipal =
   /** A session's sandbox token, or an account token scoped to that session. */
-  | { kind: 'session'; sessionId: string; branch: string }
+  | {
+      kind: 'session';
+      sessionId: string;
+      branch: string;
+      /** Identity and credential used for the IAM ceiling on wider ref access. */
+      userId?: string | null;
+      tokenId?: string | null;
+    }
   /** A monitor box's sandbox token — no session row by design. */
   | { kind: 'monitor' }
   /**

--- a/apps/api/src/git-proxy/ref-scopes.test.ts
+++ b/apps/api/src/git-proxy/ref-scopes.test.ts
@@ -36,7 +36,7 @@ beforeEach(() => {
 });
 
 const SESSION_ID = 'sess-1';
-const session: GitPrincipal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID };
+const session: GitPrincipal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID, userId: 'u1', tokenId: 'tok-1' };
 const monitor: GitPrincipal = { kind: 'monitor' };
 const user: GitPrincipal = { kind: 'user', userId: 'u1', tokenId: 'tok-1' };
 const internal: GitPrincipal = { kind: 'internal' };
@@ -57,6 +57,25 @@ const ANY: GitRefScope = 'project.gitops.ref.any';
 const DEL: GitRefScope = 'project.gitops.ref.delete';
 
 describe('principalHoldsRefScope — session', () => {
+  test('a wildcard grant cannot exceed the effective IAM role', async () => {
+    iamAllows = false;
+    const c = ctxWithGrant({ agent: 'main', kortixCli: 'all' });
+    expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(false);
+    expect(await principalHoldsRefScope(c, session, PROJECT, DEL)).toBe(false);
+    expect(iamAsked).toEqual([ANY, DEL]);
+  });
+
+  test('an explicit ref grant cannot exceed the effective IAM role', async () => {
+    iamAllows = false;
+    expect(await principalHoldsRefScope(ctxWithGrant({ agent: 'main', kortixCli: [ANY] }), session, PROJECT, ANY)).toBe(false);
+  });
+
+  test('a session without a launching identity cannot widen', async () => {
+    const unbound: GitPrincipal = { kind: 'session', sessionId: SESSION_ID, branch: SESSION_ID };
+    expect(await principalHoldsRefScope(ctxWithGrant({ agent: 'main', kortixCli: 'all' }), unbound, PROJECT, ANY)).toBe(false);
+    expect(iamAsked).toEqual([]);
+  });
+
   test('an UNGOVERNED project (null grant) does NOT widen a session', async () => {
     const c = ctxWithGrant(null);
     expect(await principalHoldsRefScope(c, session, PROJECT, ANY)).toBe(false);

--- a/apps/api/src/git-proxy/ref-scopes.ts
+++ b/apps/api/src/git-proxy/ref-scopes.ts
@@ -35,7 +35,7 @@ import type { GitPrincipal, GitRefScope } from './ref-policy';
 /**
  * True when the principal holds `scope`.
  *
- * A SESSION reads its agent grant; a PERSON is asked of the IAM engine, the
+ * A SESSION intersects its agent grant with IAM; a PERSON uses IAM, the
  * same way every other project route asks. `project.gitops.push` authorizes
  * *a* push, not every destructive shape of one: deleting a ref is not
  * recoverable from the client that issued it, and a branch is frequently
@@ -75,8 +75,18 @@ export async function principalHoldsRefScope(
     case 'session': {
       const grant = getAgentGrant(c);
       if (!grant) return false; // Default-deny — see the header note.
-      if (grant.kortixCli === 'all') return true;
-      return grant.kortixCli.includes(scope);
+      if (grant.kortixCli !== 'all' && !grant.kortixCli.includes(scope)) return false;
+      if (!principal.userId || !principal.tokenId) return false;
+      // actorForToken selects the activated service account or launcher. The
+      // manifest can narrow that identity's role; it cannot widen it.
+      const verdict = await authorize(
+        await actorForToken(principal.userId, project.accountId, principal.tokenId, {
+          ctx: deriveRequestContext(c),
+        }),
+        scope,
+        { type: 'project', id: project.projectId },
+      );
+      return verdict.allowed;
     }
   }
 }

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -12,7 +12,7 @@ import {
   getProjectSecretValueForConsumer,
 } from '../secrets';
 import { recordAuditEvent } from '../../shared/audit';
-import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, accountTokens, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { accountGithubInstallationStates, accountGithubInstallations, accountTokens, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
 import type { AgentGrant } from '@kortix/db';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { createHmac, randomBytes, randomUUID } from 'node:crypto';
@@ -916,6 +916,8 @@ async function authorizeGitProxyUncached(
         kind: 'session',
         sessionId: sessionRow.sessionId,
         branch: sessionRow.branchName,
+        userId: result.userId ?? null,
+        tokenId: result.tokenId ?? null,
       };
     }
     if (result.accountId !== project.accountId) {
@@ -1005,7 +1007,11 @@ async function authorizeGitProxyUncached(
       // `account_tokens`; a sandbox key carries no grant of its own. Missing row
       // (or a project with no per-agent governance) reads null = default-deny.
       const [grantRow] = await db
-        .select({ agentGrant: accountTokens.agentGrant })
+        .select({
+          agentGrant: accountTokens.agentGrant,
+          userId: accountTokens.userId,
+          tokenId: accountTokens.tokenId,
+        })
         .from(accountTokens)
         .where(
           and(
@@ -1023,6 +1029,8 @@ async function authorizeGitProxyUncached(
           kind: 'session',
           sessionId: sandbox.sessionId,
           branch: sandbox.branchName,
+          userId: grantRow?.userId ?? null,
+          tokenId: grantRow?.tokenId ?? null,
         },
         agentGrant: grantRow?.agentGrant ?? null,
       };

--- a/apps/api/src/projects/lib/git.ts
+++ b/apps/api/src/projects/lib/git.ts
@@ -12,7 +12,8 @@ import {
   getProjectSecretValueForConsumer,
 } from '../secrets';
 import { recordAuditEvent } from '../../shared/audit';
-import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import { accountGithubInstallationStates, accountGithubInstallations, accountMembers, accountTokens, projectGitConnections, projectGitCredentials, projectSessions, projects, sessionSandboxes } from '@kortix/db';
+import type { AgentGrant } from '@kortix/db';
 import { and, eq, gt, inArray, isNull } from 'drizzle-orm';
 import { createHmac, randomBytes, randomUUID } from 'node:crypto';
 import { ttlMemo } from '../../shared/ttl-memo';
@@ -740,7 +741,20 @@ export async function resolveProjectUpstream(
 
 
 export type GitProxyAuth =
-  | { ok: true; project: ProjectRow; principal: GitPrincipal }
+  | {
+      ok: true;
+      project: ProjectRow;
+      principal: GitPrincipal;
+      /**
+       * The resolved agent grant for a session principal (null otherwise). The
+       * receive-pack route places this on the request context so the ref-scope
+       * resolver can honor `project.gitops.ref.any` / `kortix_cli: all` for the
+       * session pushing. Without it a session is default-denied beyond its own
+       * branch no matter what its manifest grants — the exact failure behind the
+       * 2026-09-07 monitoring-metadata persistence incident.
+       */
+      agentGrant: AgentGrant | null;
+    }
   | { ok: false; status: number; message: string };
 
 /**
@@ -920,6 +934,10 @@ async function authorizeGitProxyUncached(
           userId: result.userId ?? null,
           tokenId: result.tokenId ?? null,
         },
+      // A session-scoped PAT already carries the resolved grant on the token row
+      // (`validateAccountToken` returns it). Only meaningful for the session
+      // principal; null for the laptop-CLI-PAT user principal.
+      agentGrant: sessionPrincipal ? (result.agentGrant ?? null) : null,
     };
   }
 
@@ -966,7 +984,9 @@ async function authorizeGitProxyUncached(
           accountId: result.accountId,
           sandboxId: result.sandboxId,
         });
-        if (monitorBox) return { ok: true, project, principal: { kind: 'monitor' } };
+        if (monitorBox) {
+          return { ok: true, project, principal: { kind: 'monitor' }, agentGrant: null };
+        }
         return { ok: false, status: 403, message: 'sandbox token is not scoped to this project' };
       }
       if (!workspaceMetadataAllowsRepositoryAccess(sandbox.sessionMetadata)) {
@@ -979,6 +999,23 @@ async function authorizeGitProxyUncached(
       if (!sandbox.branchName) {
         return { ok: false, status: 403, message: 'session has no branch to push' };
       }
+      // Resolve the session's agent grant so the ref-scope resolver can widen a
+      // session that deliberately holds `project.gitops.ref.any` / `kortix_cli:
+      // all`. The grant lives on the session's connector token(s) in
+      // `account_tokens`; a sandbox key carries no grant of its own. Missing row
+      // (or a project with no per-agent governance) reads null = default-deny.
+      const [grantRow] = await db
+        .select({ agentGrant: accountTokens.agentGrant })
+        .from(accountTokens)
+        .where(
+          and(
+            eq(accountTokens.sessionId, sandbox.sessionId),
+            eq(accountTokens.accountId, result.accountId),
+            eq(accountTokens.status, 'active'),
+            isNull(accountTokens.revokedAt),
+          ),
+        )
+        .limit(1);
       return {
         ok: true,
         project,
@@ -987,6 +1024,7 @@ async function authorizeGitProxyUncached(
           sessionId: sandbox.sessionId,
           branch: sandbox.branchName,
         },
+        agentGrant: grantRow?.agentGrant ?? null,
       };
     }
     // Account-scoped user API key. No per-project fallback here: an API key
@@ -995,7 +1033,7 @@ async function authorizeGitProxyUncached(
     if (result.accountId !== project.accountId) {
       return { ok: false, status: 403, message: 'token does not own this project' };
     }
-    return { ok: true, project, principal: { kind: 'user', userId: null } };
+    return { ok: true, project, principal: { kind: 'user', userId: null }, agentGrant: null };
   }
 
   return { ok: false, status: 401, message: 'git proxy requires a Kortix token' };

--- a/tests/spec/end-to-end.md
+++ b/tests/spec/end-to-end.md
@@ -743,6 +743,7 @@ supplied scope field without restarting the session.
 `GH-14` `POST /projects/create-repo` → PROJECT_CREATE; missing name → 400; no install → 409/503.
 `GH-15` `POST /projects/link-repository` → PROJECT_CREATE; missing repo → 400; no install → 400/409/502; bad token → 400.
 `GH-16` `GET /projects/github/repository-branches` → PROJECT_CREATE; returns the repository default plus every existing branch; missing installation → 409; wrong installation owner → 400.
+`GH-17` Real Git processes authenticate with session PATs. An owner session creates and deletes a shared branch. A member session with `kortix_cli: all` can push its own branch but cannot create another branch or delete the shared branch. HTTP ref read-back proves denied pushes leave the repository unchanged.
 `IAM-14` `GET …/iam/groups/:gid/project-grants` → 200; unknown → 404; NONMEMBER → 403.
 `IAM-15` `POST …/iam/members/:userId/effective:batch` → 200; non-array → 400.
 `IAM-16` `GET …/iam/members/:userId/project-access` → 200; NONMEMBER → 403.

--- a/tests/src/flows/git.flow.ts
+++ b/tests/src/flows/git.flow.ts
@@ -392,3 +392,156 @@ flow(
     });
   },
 );
+
+flow(
+  'GH-17',
+  {
+    domain: 'git',
+    requires: ['database'],
+    routes: [
+      'GET /v1/git/:project/info/refs',
+      'POST /v1/git/:project/git-upload-pack',
+      'POST /v1/git/:project/git-receive-pack',
+    ],
+  },
+  async (ctx) => {
+    const { randomUUID, randomBytes, scryptSync } = await import('node:crypto');
+    const { mkdtemp, rm } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { execFile } = await import('node:child_process');
+    const { promisify } = await import('node:util');
+    const { Client: PgClient } = await import('pg');
+    const exec = promisify(execFile);
+    const secretSalt = process.env.KE2E_API_KEY_SECRET ??
+      (ctx.env.target === 'local' ? 'local-flow-runner-api-key-secret' : null);
+    if (!secretSalt) throw new Error('GH-17 requires KE2E_API_KEY_SECRET to mint session credentials');
+    const team = await ctx.fixtures.team();
+    const member = await team.addMember('member');
+    const project = await team.project({ managedGit: true });
+    await team.grantProjectRole(project.id, member.userId!, 'member');
+    const databaseUrl = ctx.env.databaseUrl!;
+    const db = new PgClient({ connectionString: databaseUrl,
+      ssl: /localhost|127\.0\.0\.1/.test(databaseUrl) ? false : { rejectUnauthorized: false } });
+    await db.connect();
+    const root = await mkdtemp(join(tmpdir(), 'ke2e-ref-role-'));
+    const sessions: string[] = [];
+    let localGitServer: import('node:http').Server | null = null;
+    const mint = async (userId: string) => {
+      const sessionId = randomUUID();
+      sessions.push(sessionId);
+      const secret = `kortix_pat_${randomBytes(24).toString('hex')}`;
+      await db.query(`INSERT INTO kortix.project_sessions
+        (session_id, account_id, project_id, branch_name, created_by, metadata)
+        VALUES ($1, $2, $3, $1, $4, '{"workspace_mode":"branch"}'::jsonb)`,
+      [sessionId, team.id, project.id, userId]);
+      await db.query(`INSERT INTO kortix.session_sandboxes
+        (sandbox_id, session_id, account_id, project_id, status)
+        VALUES ($1::uuid, $1, $2, $3, 'active')`,
+      [sessionId, team.id, project.id]);
+      await db.query(`INSERT INTO kortix.account_tokens
+        (account_id, user_id, name, public_key, secret_key_hash, project_id, session_id, agent_grant)
+        VALUES ($1, $2, 'GH-17', $3, $4, $5, $6, $7::jsonb)`,
+      [team.id, userId, `kortix_pk_${randomBytes(16).toString('hex')}`,
+        `scrypt:v1:${scryptSync(secret, secretSalt, 32).toString('hex')}`,
+        project.id, sessionId, JSON.stringify({ agent: 'kortix', kortixCli: 'all', connectors: 'all', env: [] })]);
+      return { secret, sessionId };
+    };
+    const git = async (secret: string, args: string[], expected = 0) => {
+      let code = 0;
+      let output = '';
+      try {
+        const result = await exec('git', args, { cwd: root, timeout: 60_000,
+          env: { ...process.env, GIT_TERMINAL_PROMPT: '0', GIT_CONFIG_COUNT: '1',
+            GIT_CONFIG_KEY_0: 'http.extraHeader', GIT_CONFIG_VALUE_0: `Authorization: Bearer ${secret}` } });
+        output = result.stdout + result.stderr;
+      } catch (error: any) {
+        code = typeof error.code === 'number' ? error.code : -1;
+        output = String(error.stdout ?? '') + String(error.stderr ?? '');
+      }
+      if ((expected === 0 && code !== 0) || (expected !== 0 && code === 0)) {
+        throw new Error(`git ${args[0]}: expected ${expected === 0 ? 'success' : 'rejection'}, got ${code}: ${output.replaceAll(secret, '[redacted]')}`);
+      }
+      return output;
+    };
+    try {
+      if (ctx.env.target === 'local') {
+        // Serve the fixture's real bare repository through Git's CGI backend.
+        // The API proxy speaks HTTP; a filesystem repo_url is not an HTTP origin.
+        const { createServer } = await import('node:http');
+        const { spawn } = await import('node:child_process');
+        const { rows } = await db.query('SELECT repo_url FROM kortix.projects WHERE project_id = $1', [project.id]);
+        const repo = rows[0].repo_url as string;
+        localGitServer = createServer((req, res) => {
+          const url = new URL(req.url!, 'http://localhost');
+          const child = spawn('git', ['http-backend'], { env: { ...process.env,
+            GIT_PROJECT_ROOT: repo, GIT_HTTP_EXPORT_ALL: '1',
+            PATH_INFO: url.pathname, QUERY_STRING: url.search.slice(1),
+            REQUEST_METHOD: req.method!, CONTENT_TYPE: req.headers['content-type'] ?? '',
+            REMOTE_USER: 'ke2e', REMOTE_ADDR: '127.0.0.1' } });
+          const chunks: Buffer[] = [];
+          req.pipe(child.stdin);
+          child.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+          child.stderr.resume();
+          child.on('error', () => { res.writeHead(502); res.end(); });
+          child.on('close', () => {
+            const body = Buffer.concat(chunks);
+            const split = body.indexOf('\r\n\r\n');
+            if (split < 0) { res.writeHead(502); res.end(); return; }
+            for (const line of body.subarray(0, split).toString().split('\r\n')) {
+              const colon = line.indexOf(':');
+              if (colon < 0) continue;
+              const name = line.slice(0, colon); const value = line.slice(colon + 1).trim();
+              if (name.toLowerCase() === 'status') res.statusCode = Number(value.split(' ')[0]);
+              else res.setHeader(name, value);
+            }
+            res.end(body.subarray(split + 4));
+          });
+        });
+        await new Promise<void>((resolve) => localGitServer!.listen(0, '127.0.0.1', resolve));
+        const port = (localGitServer.address() as import('node:net').AddressInfo).port;
+        await db.query('UPDATE kortix.projects SET repo_url = $1 WHERE project_id = $2',
+          [`http://127.0.0.1:${port}`, project.id]);
+      }
+      const owner = await mint(ctx.P.OWNER.userId!);
+      const memberSession = await mint(member.userId!);
+      const remote = `${ctx.env.apiUrl.replace(/\/v1$/, '')}/v1/git/${project.id}`;
+      await ctx.step('owner session clones through HTTP and creates a shared branch; read-back finds it', async () => {
+        await git(owner.secret, ['clone', remote, '.']);
+        await git(owner.secret, ['push', 'origin', 'HEAD:refs/heads/gh17-shared']);
+        const refs = await git(owner.secret, ['ls-remote', '--heads', 'origin', 'gh17-shared']);
+        if (!refs.includes('refs/heads/gh17-shared')) throw new Error('shared branch missing after owner push');
+      });
+      await ctx.step('member session pushes its own branch with a wildcard agent grant', async () => {
+        await git(memberSession.secret, ['push', 'origin', `HEAD:refs/heads/${memberSession.sessionId}`]);
+      });
+      await ctx.step('member wildcard grant cannot create another branch or delete the shared branch; shared ref persists', async () => {
+        for (const args of [
+          ['push', 'origin', 'HEAD:refs/heads/gh17-member-forbidden'],
+          ['push', 'origin', '--delete', 'gh17-shared'],
+        ]) {
+          const output = await git(memberSession.secret, args, 1);
+          if (!output.includes('[remote rejected]')) throw new Error('expected a Git ref-policy rejection');
+        }
+        const refs = await git(owner.secret, ['ls-remote', '--heads', 'origin', 'gh17-shared', 'gh17-member-forbidden']);
+        if (!refs.includes('refs/heads/gh17-shared') || refs.includes('refs/heads/gh17-member-forbidden')) {
+          throw new Error('denied member push changed repository refs');
+        }
+      });
+      await ctx.step('owner session deletes the shared branch; read-back proves deletion', async () => {
+        await git(owner.secret, ['push', 'origin', '--delete', 'gh17-shared']);
+        const refs = await git(owner.secret, ['ls-remote', '--heads', 'origin', 'gh17-shared']);
+        if (refs.trim()) throw new Error('shared branch still exists after owner deletion');
+      });
+    } finally {
+      for (const sessionId of sessions) {
+        await db.query('DELETE FROM kortix.account_tokens WHERE session_id = $1', [sessionId]);
+        await db.query('DELETE FROM kortix.session_sandboxes WHERE session_id = $1', [sessionId]);
+        await db.query('DELETE FROM kortix.project_sessions WHERE session_id = $1', [sessionId]);
+      }
+      if (localGitServer) await new Promise<void>((resolve) => localGitServer!.close(() => resolve()));
+      await db.end();
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Promotes main `3009430815d37b086a491e38e11834fc156e779a` to staging with the session Git role fix. The candidate preserves staging's existing release test and deployment adjustments. This supersedes staging PR #7186.

Session Git pushes with an explicit ref grant can exceed the effective IAM role. A member-launched session with `kortix_cli: all` can request manager ref operations. This blocks staging PR #7186.

Carry the launcher and session token into the ref resolver. Require both the manifest grant and the canonical IAM verdict before widening ref access. `actorForToken` retains the activated service-account identity. Own-branch pushes retain the existing path.

Validation at db5f0714f75130205a426a5a709774214758363d:
- Before implementation: three new regression tests fail.
- Focused API tests: 90 pass, 0 fail across `ref-scopes`, `ref-policy`, `receive-pack-gate`, and `unit-git-proxy-authz`.
- API and test-project `tsc --noEmit`: exit 0.
- `pnpm test -- --id GH-17`: 1 pass, 0 fail. Real Git processes use session PATs through the HTTP API and a bare Git repository. Owner create/delete and member own-branch push succeed. Member create/delete outside its branch fails. Ref read-back confirms persisted state.
- CI: all four local test lanes pass: https://github.com/kortix-ai/suna/actions/runs/34492043096
- Preview deployment is healthy, but run 34492038107 skipped tests on push and incorrectly reported a test pass. Its retained report is for c6b9685e: 440 pass, 13 fail, 3 skipped. A manual full-test dispatch is pending. Do not treat this preview as verified.
- Preview `/v1/health` reports the exact PR SHA: https://8080-01m25wsyr97tmc09y9954fzb2f.eu-west.sbx.platinum.dev

Local full-run limitations:
- REST/CLI 390/390 pass. SDK, runner, coverage, and worktree lanes pass.
- Browser: 19 pass; localization fails after a Turbopack cache-restoration panic stops Next.js. A fresh-cache localization retry fails on the German company-dialog assertion. Both CI browser lanes pass.
- Package run: URL-autolink timing test exceeds its budget during the concurrent run. Isolated retry: 23 pass, 0 fail. CI packages lane passes.

No merge to main is part of this PR. Staging deployment and release QA run after this promotion. Production promotion remains gated on the deployed staging candidate.


