### PR TITLE
fix(markdown): size ordered-list gutter to the widest marker

### DIFF
--- a/apps/web/src/components/markdown/doc-markdown.test.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.test.tsx
@@ -138,3 +138,18 @@ describe('DocMarkdown code fence inside a list', () => {
     expect(html).not.toContain('Click to preview');
   });
 });
+
+// The docs renderer shares `MarkdownOrderedList` with UnifiedMarkdown. See
+// `unified-markdown.test.tsx` for why the gutter grows with the digit count.
+
+describe('DocMarkdown ordered-list marker gutter', () => {
+  test('a list from 8 to 10 widens the gutter and keeps its start ordinal', () => {
+    const md = Array.from({ length: 3 }, (_, i) => `${8 + i}. item`).join('\n') + '\n';
+    const html = renderToStaticMarkup(withIntl(<DocMarkdown content={md} />));
+    const tag = /<ol\b[^>]*>/.exec(html)?.[0] ?? '';
+
+    expect(tag).toContain('start="8"');
+    expect(tag).toContain('marker:tabular-nums');
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 1ch)');
+  });
+});

--- a/apps/web/src/components/markdown/doc-markdown.tsx
+++ b/apps/web/src/components/markdown/doc-markdown.tsx
@@ -11,6 +11,7 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
+import { MarkdownOrderedList } from '@/components/markdown/ordered-list';
 import { isInternalUrl, isLinkSafeHref } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
@@ -91,11 +92,7 @@ export const DocMarkdown = React.memo<DocMarkdownProps>(
             {children}
           </ul>
         ),
-        ol: ({ children }: { children?: React.ReactNode }) => (
-          <ol className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 pl-6 marker:font-medium first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
-            {children}
-          </ol>
-        ),
+        ol: MarkdownOrderedList,
         li: ({ children }: { children?: React.ReactNode }) => (
           <li className="text-foreground/95 leading-relaxed font-medium">
             {wrapChildrenWithPaths(children)}

--- a/apps/web/src/components/markdown/ordered-list.test.ts
+++ b/apps/web/src/components/markdown/ordered-list.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { orderedListGutter, orderedListMarkerDigits } from './ordered-list';
+
+describe('orderedListMarkerDigits', () => {
+  test('counts the widest ordinal a default list paints', () => {
+    expect(orderedListMarkerDigits({ itemCount: 9 })).toBe(1);
+    expect(orderedListMarkerDigits({ itemCount: 10 })).toBe(2);
+    expect(orderedListMarkerDigits({ itemCount: 100 })).toBe(3);
+  });
+
+  test('offsets the count by the start ordinal', () => {
+    expect(orderedListMarkerDigits({ start: 8, itemCount: 2 })).toBe(1);
+    expect(orderedListMarkerDigits({ start: 8, itemCount: 3 })).toBe(2);
+    expect(orderedListMarkerDigits({ start: 98, itemCount: 3 })).toBe(3);
+  });
+
+  test('a reversed list counts down from its start', () => {
+    expect(orderedListMarkerDigits({ start: 10, itemCount: 3, reversed: true })).toBe(2);
+    expect(orderedListMarkerDigits({ itemCount: 12, reversed: true })).toBe(2);
+  });
+
+  test('counts a minus sign as a character', () => {
+    expect(orderedListMarkerDigits({ start: -12, itemCount: 2 })).toBe(3);
+  });
+
+  test('an empty list still reserves one digit', () => {
+    expect(orderedListMarkerDigits({ itemCount: 0 })).toBe(1);
+  });
+});
+
+describe('orderedListGutter', () => {
+  test('one digit is exactly the pl-6 scale step', () => {
+    expect(orderedListGutter(1)).toBe('calc(var(--spacing) * 6 + 0ch)');
+  });
+
+  test('every extra digit widens the gutter by one tabular digit', () => {
+    expect(orderedListGutter(2)).toBe('calc(var(--spacing) * 6 + 1ch)');
+    expect(orderedListGutter(3)).toBe('calc(var(--spacing) * 6 + 2ch)');
+  });
+});

--- a/apps/web/src/components/markdown/ordered-list.tsx
+++ b/apps/web/src/components/markdown/ordered-list.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+interface MarkerDigitsInput {
+  start?: number;
+  itemCount: number;
+  reversed?: boolean;
+}
+
+/**
+ * Characters in the widest ordinal the list paints, minus sign included.
+ * Mirrors the HTML list-item counter: `start` defaults to 1, or to the item
+ * count when the list is `reversed`.
+ */
+export function orderedListMarkerDigits({
+  start,
+  itemCount,
+  reversed = false,
+}: MarkerDigitsInput): number {
+  const count = Math.max(itemCount, 1);
+  const first =
+    start !== undefined && Number.isFinite(start) ? Math.trunc(start) : reversed ? count : 1;
+  const last = reversed ? first - count + 1 : first + count - 1;
+  return Math.max(String(first).length, String(last).length);
+}
+
+/**
+ * The `ol` inline-start padding for markers of `digits` characters.
+ *
+ * `list-outside` markers hang in this padding, end-aligned to the text. A
+ * fixed `pl-6` (22.08px) holds `9. ` (16.3px at 15px Roobert, weight 500,
+ * tabular) but not `10. ` (25.7px), so the leading digit painted past the list
+ * edge and any `overflow-hidden` ancestor cut it. Each extra digit adds `1ch`:
+ * Roobert's `0` advance (0.632em) covers its tabular digit (0.630em), so the
+ * slack left of the widest marker stays ~5.8px at every digit count and scales
+ * with the font size. No spacing step can express a glyph-relative width.
+ */
+export function orderedListGutter(digits: number): string {
+  return `calc(var(--spacing) * 6 + ${Math.max(digits - 1, 0)}ch)`;
+}
+
+interface MarkdownOrderedListProps {
+  children?: React.ReactNode;
+  start?: number | string;
+  reversed?: boolean;
+}
+
+function parseStart(start: number | string | undefined): number | undefined {
+  if (start === undefined) return undefined;
+  const value = typeof start === 'string' ? Number.parseInt(start, 10) : start;
+  return Number.isFinite(value) ? value : undefined;
+}
+
+// Shared by UnifiedMarkdown and DocMarkdown so the two renderers cannot drift.
+export function MarkdownOrderedList({ children, start, reversed }: MarkdownOrderedListProps) {
+  const startOrdinal = parseStart(start);
+  const itemCount = React.Children.toArray(children).filter(React.isValidElement).length;
+  const digits = orderedListMarkerDigits({ start: startOrdinal, itemCount, reversed });
+
+  return (
+    <ol
+      start={startOrdinal}
+      reversed={reversed}
+      className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 marker:font-medium marker:tabular-nums first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0"
+      style={{ paddingInlineStart: orderedListGutter(digits) }}
+    >
+      {children}
+    </ol>
+  );
+}

--- a/apps/web/src/components/markdown/unified-markdown.test.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.test.tsx
@@ -98,6 +98,58 @@ describe('UnifiedMarkdown table cells', () => {
   });
 });
 
+// ─── Ordered-list marker gutter ─────────────────────────────────────────────
+// Markers hang outside the `ol` padding box. A fixed `pl-6` gutter (22.08px)
+// holds `9. ` (16.3px at 15px Roobert) but not `10. ` (25.7px), so the first
+// digit painted past the list edge and an `overflow-hidden` ancestor cut it.
+// ────────────────────────────────────────────────────────────────────────────
+
+function orderedListTag(html: string): string {
+  const match = /<ol\b[^>]*>/.exec(html);
+  if (!match) throw new Error('no <ol> rendered');
+  return match[0];
+}
+
+function numberedList(count: number, start = 1): string {
+  return Array.from({ length: count }, (_, i) => `${start + i}. item`).join('\n') + '\n';
+}
+
+describe('UnifiedMarkdown ordered-list marker gutter', () => {
+  test('a single-digit list keeps the pl-6 gutter', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(9)} />)),
+    );
+
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 0ch)');
+  });
+
+  test('a ten-item list widens the gutter by one digit', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(10)} />)),
+    );
+
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 1ch)');
+  });
+
+  test('markers render with tabular digits', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(10)} />)),
+    );
+
+    expect(tag).toContain('marker:tabular-nums');
+    expect(tag).not.toMatch(/\bpl-6\b/);
+  });
+
+  test('forwards the start ordinal and sizes the gutter from it', () => {
+    const tag = orderedListTag(
+      renderToStaticMarkup(withIntl(<UnifiedMarkdown content={numberedList(3, 98)} />)),
+    );
+
+    expect(tag).toContain('start="98"');
+    expect(tag).toContain('padding-inline-start:calc(var(--spacing) * 6 + 2ch)');
+  });
+});
+
 // ─── A fenced block inside a list item ──────────────────────────────────────
 // `li` runs its children through `wrapChildrenWithPaths`. That walk used to
 // descend into the fence and swap the snippet for a React element, so

--- a/apps/web/src/components/markdown/unified-markdown.tsx
+++ b/apps/web/src/components/markdown/unified-markdown.tsx
@@ -12,6 +12,7 @@ import {
   normalizeClassName,
   prepareMarkdownForKatex,
 } from '@/components/markdown/katex-markdown';
+import { MarkdownOrderedList } from '@/components/markdown/ordered-list';
 import { isInternalUrl, shouldUseNextLink } from '@/components/markdown/unified-markdown-utils';
 import { SetupLinkButton } from '@/components/setup-links/setup-link-button';
 import { parseSetupLinkHref } from '@/components/setup-links/util';
@@ -91,11 +92,7 @@ export const UnifiedMarkdown = React.memo<UnifiedMarkdownProps>(
             {children}
           </ul>
         ),
-        ol: ({ children }: { children?: React.ReactNode }) => (
-          <ol className="marker:text-muted-foreground/80 my-4 list-outside list-decimal space-y-1 pl-6 marker:font-medium first:mt-0 last:mb-0 [&_p]:mb-2 [&_p]:last:mb-0">
-            {children}
-          </ol>
-        ),
+        ol: MarkdownOrderedList,
         li: ({ children }: { children?: React.ReactNode }) => (
           <li className="text-foreground/95 leading-relaxed font-medium [overflow-wrap:anywhere]">
             {wrapChildrenWithPaths(children)}


### PR DESCRIPTION
## Summary
- Ordered-list markers of 10+ items no longer clip. A fixed `pl-6` gutter (22.08px) held `9. ` (16.3px at 15px Roobert) but not `10. ` (25.7px); an `overflow-hidden` ancestor cut the leading digit.
- New shared `MarkdownOrderedList` (`components/markdown/ordered-list.tsx`) sets `padding-inline-start: calc(var(--spacing) * 6 + (digits - 1)ch)` from the start ordinal and item count. Single-digit lists keep the `pl-6` width.
- Markers render with `tabular-nums`, so digit columns align.
- The `start` ordinal is forwarded; `UnifiedMarkdown` and `DocMarkdown` dropped it before (`98.` rendered as `1.`).

## Test plan
- [x] `bun test src/components/markdown/ordered-list.test.ts src/components/markdown/unified-markdown.test.tsx src/components/markdown/doc-markdown.test.tsx` → 30 pass, 0 fail (6 failed before the fix)
- [x] `npx eslint` on the 6 changed files → 0 errors
- [x] `npx tsc --noEmit` → only the 15 known baseline errors, none in `components/markdown/`
- [x] `kortix-brand-guidelines/audit.sh` on `ordered-list.tsx` → clean
- [ ] Stream a 12-item numbered list in a session: `10.`–`12.` fully visible, periods aligned under `9.`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791644777&installation_model_id=434224&pr_number=7191&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7191&signature=e628fbccd5801159abf3c37701d1305f83c100a4d715953178204a31b9560342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->