### PR TITLE
chore(web): add `eloqnt lint` to catch translation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,9 @@ jobs:
           pnpm --dir apps/web exec bun test src/sdk-boundary.test.ts
           pnpm --dir apps/web exec eslint src --quiet
 
+      - name: Lint translations
+        run: pnpm --dir apps/web run lint:i18n
+
       # Next.js 16.3 turns on Turbopack's FileSystem cache for `next build`
       # (`experimental.turbopackFileSystemCacheForBuild`, default true) and
       # writes it to apps/web/.next/cache/turbopack. A bare runner starts with

--- a/apps/web/.eloqnt/config.ts
+++ b/apps/web/.eloqnt/config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@eloqnt/cli';
+
+export default defineConfig({
+  srcPath: './src',
+  messages: {
+    path: './translations',
+    locales: 'infer',
+    sourceLocale: 'en',
+    format: 'json',
+  },
+  lint: {
+    rules: {
+      // Call sites go through the `@/i18n/*` wrappers around next-intl and
+      // `hardcodedUi` keys are looked up at runtime, so usage can't be
+      // resolved statically.
+      'orphan-message': 'off',
+    },
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "docs:build": "node -e \"import('./scripts/blume-docs.mjs').then(m => m.buildBlumeDocs())\"",
     "lint": "eslint .",
+    "lint:i18n": "eloqnt lint",
     "catalog:enrich": "bun scripts/enrich-llm-catalog-capabilities.ts",
     "wallpapers:generate": "node scripts/generate-wallpapers.mjs",
     "i18n:audit": "node scripts/audit-i18n.mjs",
@@ -196,6 +197,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@eloqnt/cli": "^0.6.29",
     "@embedpdf/pdfium": "2.14.4",
     "@kortix/manifest-schema": "workspace:*",
     "@playwright/test": "^1.57.0",

--- a/apps/web/translations/ja.json
+++ b/apps/web/translations/ja.json
@@ -271,7 +271,7 @@
       "totalCredits": "利用可能なクレジット合計",
       "allCredits": "すべてのクレジット",
       "monthlyCredits": "月額クレジット",
-      "renewalIn": "{days} {days, plural, one {日} other {日}}後に更新",
+      "renewalIn": "{days} {days, plural, other {日}}後に更新",
       "noRenewal": "更新予定なし",
       "extraCredits": "追加クレジット",
       "nonExpiring": "期限なし",
@@ -1023,7 +1023,7 @@
     "credits": {
       "loadFailed": "このアカウントを読み込めませんでした。",
       "availableBalance": "利用可能残高",
-      "creditCount": "{count, plural, one {{formatted} クレジット} other {{formatted} クレジット}}",
+      "creditCount": "{count, plural, other {{formatted} クレジット}}",
       "owed": "未払い",
       "buckets": {
         "monthly": {
@@ -1042,7 +1042,7 @@
       "includedInPlan": "プランに含まれる内容",
       "usedThisPeriod": "この期間の使用量",
       "planCreditsSpent": "プランクレジットを使い切りました。これ以降は購入済みクレジットを使用します。",
-      "grantRemaining": "{count, plural, one {この期間の付与分は残り {formatted} クレジットです。} other {この期間の付与分は残り {formatted} クレジットです。}}",
+      "grantRemaining": "{count, plural, other {この期間の付与分は残り {formatted} クレジットです。}}",
       "dailyAmountEvery": "{hours} 時間ごとに +{credits} クレジット",
       "dailyAmount": "+{credits} クレジット",
       "countdown": {
@@ -1541,7 +1541,7 @@
     "providerRecovery": {
       "savedPrompt": "保存済みプロンプト",
       "noText": "テキストプロンプトは添付されていません。",
-      "attachments": "{count, plural, one {添付ファイル} other {添付ファイル}}",
+      "attachments": "{count, plural, other {添付ファイル}}",
       "reattach": "再読み込み後にこれらのファイルを再添付してください。",
       "unavailable": "保存済みプロンプトはありません。",
       "retrying": "再試行中…",
@@ -1551,10 +1551,10 @@
     },
     "connectorRequired": {
       "title": "続行するには{connectors}を接続",
-      "description": "{count, plural, one {{connectors}が必要ですが、まだ何も接続されていません。処理は実行されておらず、料金も発生していません。アカウントを接続すると、メッセージが再送信されます。} other {{connectors}が必要ですが、まだ何も接続されていません。処理は実行されておらず、料金も発生していません。アカウントを接続すると、メッセージが再送信されます。}}",
+      "description": "{count, plural, other {{connectors}が必要ですが、まだ何も接続されていません。処理は実行されておらず、料金も発生していません。アカウントを接続すると、メッセージが再送信されます。}}",
       "connectOne": "{connector}を接続",
       "connectMany": "アカウントを接続",
-      "privateDescription": "{count, plural, one {{connectors}は一度に1つのアカウントを認証するため、このセッションを実行するアカウントで接続する必要があります。} other {{connectors}は一度に1つのアカウントを認証するため、このセッションを実行するアカウントで接続する必要があります。}}"
+      "privateDescription": "{count, plural, other {{connectors}は一度に1つのアカウントを認証するため、このセッションを実行するアカウントで接続する必要があります。}}"
     },
     "composerMenus": {
       "noMatches": "一致する項目はありません",
@@ -1691,7 +1691,7 @@
   },
   "billing": {
     "plan": {
-      "teamSeats": "{count, plural, one {チーム · # 席} other {チーム · # 席}}",
+      "teamSeats": "{count, plural, other {チーム · # 席}}",
       "cancels": "{date} に解約",
       "cancelsAtPeriodEnd": "期間終了時に解約",
       "renews": "{date} に更新",
@@ -9369,7 +9369,7 @@
       "text00d60e31a4e6": "実行",
       "text00d8d3f11739": "mail",
       "text00dd9d632755": "ブランチを検索",
-      "text00e99be56ba9": "{count, plural, one {# 行を削除しました} other {# 行を削除しました}}",
+      "text00e99be56ba9": "{count, plural, other {# 行を削除しました}}",
       "text00f5aae9f9d3": "このエージェントが呼び出すことができる外部サービス。 1 つを必須にマークすると、解決されるまでセッションは開始されません。",
       "text00f8ca92de43": "エージェントに判断が必要なときは、処理を永遠に止める代わりに、ボタン付きのカードを投稿します。クリックが判定となり、同じスレッドでそこからセッションが再開されます。",
       "text00ff22485ed6": "接続する",
@@ -10773,7 +10773,7 @@
       "text2a6b24ad2872": "クレジット",
       "text2a728809f134": "SAML SSO用に作成した同じCustom Applicationを再利用できます。SCIMはその「Identity Management」タブにあります。",
       "text2a78025de6aa": "選択",
-      "text2a8f24e937b7": "{count, plural, one {#個のツールをカスタマイズ済み} other {#個のツールをカスタマイズ済み}}",
+      "text2a8f24e937b7": "{count, plural, other {#個のツールをカスタマイズ済み}}",
       "text2a91147eb974": "招待の有効期限",
       "text2a94ea8db704": "{value0} キーを入手する場所",
       "text2a9575e3e816": "確認",
@@ -12242,7 +12242,7 @@
       "text53f71e08be88": "Stripeサブスクリプション",
       "text53f76274b923": "このチャネル接続にはプラットフォーム設定がありません。",
       "text5405931307e3": "設定完了、サービスを開始中…",
-      "text540afa4c53ff": "{label}: {count, plural, one {# メンバー} other {# メンバー}}",
+      "text540afa4c53ff": "{label}: {count, plural, other {# メンバー}}",
       "text54266bfe04ff": "メンテナンス構成の更新に失敗しました",
       "text5427e0ef4eba": "権限：",
       "text542d24012988": "person@example.com",
@@ -13945,7 +13945,7 @@
       "text854a397472d0": "スライド{value0}を正常に編集しました",
       "text854e6dd9d777": "タイプは登録時に固定されます。変更するには新しいアプリを登録してください。",
       "text8552ade1b621": "セッションのチャンバー：{inside}とは何か、{outside}とは何か。",
-      "text8559d8fd97d1": "{count, plural, one {# シートが有効} other {# シートが有効}} · ${credit} の利用クレジットを入金しました。",
+      "text8559d8fd97d1": "{count, plural, other {# シートが有効}} · ${credit} の利用クレジットを入金しました。",
       "text8564edf2cd1f": "サーバー側で解決されるコネクター認証情報",
       "text857be0b1fee8": "既存事例",
       "text8585b95f4600": "GitHubのKortix",
@@ -14704,7 +14704,7 @@
       "text9a6a77d58095": "作業を担うもの — それぞれの指示、モデル、アクセス権。",
       "text9a6b697e6d4c": "OpenAIおよびAnthropic互換のドロップインエンドポイントです。上のセクションのゲートウェイキーを使用してください。",
       "text9a70da1bb740": "どのグループにも所属していません",
-      "text9a719be343e8": "{count, plural, one {#件の結果} other {#件の結果}}",
+      "text9a719be343e8": "{count, plural, other {#件の結果}}",
       "text9a72221a2747": "質問",
       "text9a788c263969": "新しい通知サービスにはどのデータベースを使うべきですか？",
       "text9a7b1baef5f5": "SAML2ウェブアプリ → 設定",

--- a/apps/web/translations/zh.json
+++ b/apps/web/translations/zh.json
@@ -271,7 +271,7 @@
       "totalCredits": "总可用积分",
       "allCredits": "所有积分",
       "monthlyCredits": "月度积分",
-      "renewalIn": "在 {days} {days, plural, one {天} other {天}} 后续费",
+      "renewalIn": "在 {days} {days, plural, other {天}} 后续费",
       "noRenewal": "未安排续费",
       "extraCredits": "额外积分",
       "nonExpiring": "不过期",
@@ -1023,7 +1023,7 @@
     "credits": {
       "loadFailed": "无法加载此帐户。",
       "availableBalance": "可用余额",
-      "creditCount": "{count, plural, one {{formatted} 个积分} other {{formatted} 个积分}}",
+      "creditCount": "{count, plural, other {{formatted} 个积分}}",
       "owed": "欠款",
       "buckets": {
         "monthly": {
@@ -1042,7 +1042,7 @@
       "includedInPlan": "套餐包含",
       "usedThisPeriod": "本周期已用",
       "planCreditsSpent": "套餐积分已用完。接下来将使用已购买的积分。",
-      "grantRemaining": "{count, plural, one {本周期额度还剩 {formatted} 个积分。} other {本周期额度还剩 {formatted} 个积分。}}",
+      "grantRemaining": "{count, plural, other {本周期额度还剩 {formatted} 个积分。}}",
       "dailyAmountEvery": "每 {hours} 小时 +{credits} 个积分",
       "dailyAmount": "+{credits} 个积分",
       "countdown": {
@@ -1541,7 +1541,7 @@
     "providerRecovery": {
       "savedPrompt": "已保存的提示词",
       "noText": "未附加文本提示词。",
-      "attachments": "{count, plural, one {个附件} other {个附件}}",
+      "attachments": "{count, plural, other {个附件}}",
       "reattach": "重新加载后请重新附加这些文件。",
       "unavailable": "没有可用的已保存提示词。",
       "retrying": "正在重试…",
@@ -1551,10 +1551,10 @@
     },
     "connectorRequired": {
       "title": "连接{connectors}以继续",
-      "description": "{count, plural, one {此会话需要{connectors}，但目前尚未连接任何账户。尚未执行任何操作，也未产生任何费用——连接账户后，你的消息会重新发送。} other {此会话需要{connectors}，但目前尚未连接任何账户。尚未执行任何操作，也未产生任何费用——连接账户后，你的消息会重新发送。}}",
+      "description": "{count, plural, other {此会话需要{connectors}，但目前尚未连接任何账户。尚未执行任何操作，也未产生任何费用——连接账户后，你的消息会重新发送。}}",
       "connectOne": "连接{connector}",
       "connectMany": "连接账户",
-      "privateDescription": "{count, plural, one {{connectors}一次授权一个账户，因此必须使用此会话运行所用的账户进行连接。} other {{connectors}一次授权一个账户，因此必须使用此会话运行所用的账户进行连接。}}"
+      "privateDescription": "{count, plural, other {{connectors}一次授权一个账户，因此必须使用此会话运行所用的账户进行连接。}}"
     },
     "composerMenus": {
       "noMatches": "没有匹配项",
@@ -1691,7 +1691,7 @@
   },
   "billing": {
     "plan": {
-      "teamSeats": "{count, plural, one {团队 · # 个席位} other {团队 · # 个席位}}",
+      "teamSeats": "{count, plural, other {团队 · # 个席位}}",
       "cancels": "将于 {date} 取消",
       "cancelsAtPeriodEnd": "将在周期结束时取消",
       "renews": "将于 {date} 续订",
@@ -9369,7 +9369,7 @@
       "text00d60e31a4e6": "运行",
       "text00d8d3f11739": "mail",
       "text00dd9d632755": "搜索分支",
-      "text00e99be56ba9": "{count, plural, one {已删除 # 行} other {已删除 # 行}}",
+      "text00e99be56ba9": "{count, plural, other {已删除 # 行}}",
       "text00f5aae9f9d3": "该代理可以调用​​外部服务。将其标记为必需，并且在解决之前会话不会启动。",
       "text00f8ca92de43": "代理需要决定时，会发布带按钮的卡片，而不是让一次执行永久阻塞。你的点击就是裁决，会话会从该决定继续，并留在同一主题中。",
       "text00ff22485ed6": "连接它",
@@ -10773,7 +10773,7 @@
       "text2a6b24ad2872": "积分",
       "text2a728809f134": "可以复用为 SAML SSO 创建的同一个 Custom Application——SCIM 位于其“Identity Management”选项卡中。",
       "text2a78025de6aa": "选择",
-      "text2a8f24e937b7": "{count, plural, one {已自定义 # 个工具} other {已自定义 # 个工具}}",
+      "text2a8f24e937b7": "{count, plural, other {已自定义 # 个工具}}",
       "text2a91147eb974": "邀请过期时间",
       "text2a94ea8db704": "从哪里获取 {value0} 密钥",
       "text2a9575e3e816": "询问",
@@ -12242,7 +12242,7 @@
       "text53f71e08be88": "Stripe 订阅",
       "text53f76274b923": "此频道连接缺少平台设置。",
       "text5405931307e3": "配置完成，正在启动服务……",
-      "text540afa4c53ff": "{label}：{count, plural, one {# 位成员} other {# 位成员}}",
+      "text540afa4c53ff": "{label}：{count, plural, other {# 位成员}}",
       "text54266bfe04ff": "更新维护配置失败",
       "text5427e0ef4eba": "权限：",
       "text542d24012988": "person@example.com",
@@ -13945,7 +13945,7 @@
       "text854a397472d0": "幻灯片 {value0} 编辑成功",
       "text854e6dd9d777": "类型在注册时固定。要更改类型，请注册新应用。",
       "text8552ade1b621": "会话的隔间：{inside} 是什么，以及 {outside} 是什么。",
-      "text8559d8fd97d1": "{count, plural, one {# 个席位已启用} other {# 个席位已启用}} · 已存入 ${credit} 使用额度。",
+      "text8559d8fd97d1": "{count, plural, other {# 个席位已启用}} · 已存入 ${credit} 使用额度。",
       "text8564edf2cd1f": "由服务器端解析的连接器凭据",
       "text857be0b1fee8": "既有成果",
       "text8585b95f4600": "Kortix GitHub 仓库",
@@ -14704,7 +14704,7 @@
       "text9a6a77d58095": "谁来执行工作——每个代理的指令、模型和访问权限。",
       "text9a6b697e6d4c": "可直接替换的 OpenAI 和 Anthropic 兼容端点。使用上方部分中的网关密钥。",
       "text9a70da1bb740": "不属于任何群组",
-      "text9a719be343e8": "{count, plural, one {# 个结果} other {# 个结果}}",
+      "text9a719be343e8": "{count, plural, other {# 个结果}}",
       "text9a72221a2747": "问题",
       "text9a788c263969": "新的通知服务应使用哪个数据库？",
       "text9a7b1baef5f5": "SAML2 网络应用 → 设置",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1266,6 +1266,9 @@ importers:
         specifier: ^5.0.3
         version: 5.0.14(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0)
     devDependencies:
+      '@eloqnt/cli':
+        specifier: ^0.6.29
+        version: 0.6.29
       '@embedpdf/pdfium':
         specifier: 2.14.4
         version: 2.14.4
@@ -1708,6 +1711,18 @@ packages:
       zod: 3.25.76
     dev: false
 
+  /@ai-sdk/gateway@4.0.23(zod@4.5.4):
+    resolution: {integrity: sha512-f85diFdPMXYJpxCjOYZchMQkRH8h3r6lhK4Q2xmzJ7UA2OQ80L3W7tFu61742xGQK7zHWm5AhxYhNuc50H9SGQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.5.4)
+      '@vercel/oidc': 3.2.0
+      zod: 4.5.4
+    dev: true
+
   /@ai-sdk/gateway@4.0.74(zod@4.4.3):
     resolution: {integrity: sha512-6hpLUtAD162KLyyj9LN2OuEyze7lzq4wwj7PyQPYdMmA8PBYwyMbmvmu1C7OzfexLSPltZK29pX8R6hrJsqBqA==}
     engines: {node: '>=22'}
@@ -1766,6 +1781,19 @@ packages:
       zod: 3.25.76
     dev: false
 
+  /@ai-sdk/provider-utils@5.0.11(zod@4.5.4):
+    resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.5.4
+    dev: true
+
   /@ai-sdk/provider-utils@5.0.28(zod@3.25.76):
     resolution: {integrity: sha512-TnHUyd/rCYQqHg5RuiOaz/hUql6U+kbUaBW0Rp+0N5UhnAInA9CzzV0HXvuAAPwppDsK6fAx9Rd+tRawpJ/3pg==}
     engines: {node: '>=22'}
@@ -1806,7 +1834,6 @@ packages:
     engines: {node: '>=22'}
     dependencies:
       json-schema: 0.4.0
-    dev: false
 
   /@ai-sdk/provider@4.0.7:
     resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
@@ -3860,7 +3887,6 @@ packages:
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
-    dev: false
 
   /@clack/prompts@0.7.0:
     resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
@@ -3880,7 +3906,6 @@ packages:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
-    dev: false
 
   /@codemirror/autocomplete@6.20.3:
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -4448,6 +4473,55 @@ packages:
       plist: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eloqnt/cli@0.6.29:
+    resolution: {integrity: sha512-IEqOlk6vEBYTzgTRzhNNOoSLXKafJuudigC9hZSOQKTblMGZ+2Vy7I7oI/Jj2Lq/sDFPpSgN7jEuT4La2SDGQA==}
+    hasBin: true
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@eloqnt/sdk': 0.6.27
+      citty: 0.1.6
+      open: 11.0.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
+    dev: true
+
+  /@eloqnt/config@0.1.0:
+    resolution: {integrity: sha512-SLR6ZSHxu6XdZtmOz3xRmC3gsY/sCzqtLMD1gxbW2I3XXPBbupwL5RZbkLU/NcZm74AKZrIUPfz3CtEJfxUKqQ==}
+    dev: true
+
+  /@eloqnt/format-json@0.1.0:
+    resolution: {integrity: sha512-4Pkb+HyzgWNJXoU48aJhUyNZSjZvMGooPCNG1ZFmBm55xTiNNPQCNXH66Ob6sXS6RvbWZrRpCf+Uo/Jz9K9g+A==}
+    dependencies:
+      '@eloqnt/config': 0.1.0
+    dev: true
+
+  /@eloqnt/format-po@0.1.0:
+    resolution: {integrity: sha512-odgtuICWs67GdkNqY51/d2vaIukuOdlGalKASUGkI5c4cyWOmv/WIVyk5gZyn3xr614RzwWp57s9WB40lRLlBw==}
+    dependencies:
+      '@eloqnt/config': 0.1.0
+      po-parser: 2.2.0
+    dev: true
+
+  /@eloqnt/sdk@0.6.27:
+    resolution: {integrity: sha512-dIvAXFXyAYOdoCIc+RQk+q1avI7wb8e5VSbQyYy08UVbmjXilmyNl/hey5LuqWK1ZZZ5Qw3EajfyKQt92GFtVA==}
+    dependencies:
+      '@eloqnt/config': 0.1.0
+      '@eloqnt/format-json': 0.1.0
+      '@eloqnt/format-po': 0.1.0
+      '@formatjs/icu-messageformat-parser': 3.5.17
+      '@swc/core': 1.16.2
+      ai: 7.0.31(zod@4.5.4)
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      next-intl-swc-plugin-extractor: 4.14.3
+      tinyglobby: 0.2.17
+      yaml: 2.9.0
+      zod: 4.5.4
+    transitivePeerDependencies:
+      - '@swc/helpers'
     dev: true
 
   /@embedpdf/core@2.14.4(preact@10.29.4)(react-dom@19.2.8)(react@19.2.8)(svelte@5.56.4)(vue@3.5.39):
@@ -5657,8 +5731,18 @@ packages:
     dependencies:
       '@formatjs/icu-skeleton-parser': 2.1.10
 
+  /@formatjs/icu-messageformat-parser@3.5.17:
+    resolution: {integrity: sha512-cN9jhVqT7u0K9tix43fhjoUwL0nazyW6zsNIXs2QdPADr+nurPfYyssUiMqcSCGlPcCiqnYVxgSn7zBSuI+5Bg==}
+    dependencies:
+      '@formatjs/icu-skeleton-parser': 2.1.11
+    dev: true
+
   /@formatjs/icu-skeleton-parser@2.1.10:
     resolution: {integrity: sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==}
+
+  /@formatjs/icu-skeleton-parser@2.1.11:
+    resolution: {integrity: sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==}
+    dev: true
 
   /@formatjs/intl-localematcher@0.8.10:
     resolution: {integrity: sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==}
@@ -12641,7 +12725,6 @@ packages:
 
   /@standard-schema/spec@1.1.0:
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-    dev: false
 
   /@standard-schema/utils@0.3.0:
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
@@ -13126,6 +13209,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-darwin-arm64@1.16.2:
+    resolution: {integrity: sha512-i/j0HNbnn79qnTVPicvay92Nark8fW8NQqn1e2mGERjUXNpBV0+SwQxlRpk2zBhn6laJ8PDI6Kn1nHZhnz3LCA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-darwin-x64@1.15.43:
     resolution: {integrity: sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==}
     engines: {node: '>=10'}
@@ -13133,6 +13225,15 @@ packages:
     os: [darwin]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-darwin-x64@1.16.2:
+    resolution: {integrity: sha512-HrwqHyEyHVXO3qTk8EkNK7/b6sOZSEoNh+pot6RdE5x0LbNqfo8LtJUvi3UTXr+5ja/o5HbJdW80eCXo+NjbiA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm-gnueabihf@1.15.43:
@@ -13144,6 +13245,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-linux-arm-gnueabihf@1.16.2:
+    resolution: {integrity: sha512-MdXi83Z/gGp1LIrg+h7HKxiul/z/Bty/ZJSvYAFqDl9zteC1XLSAZdScquKtXPp50rdyXqritTDCqQBhwVfZKA==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-arm64-gnu@1.15.43:
     resolution: {integrity: sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==}
     engines: {node: '>=10'}
@@ -13151,6 +13261,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.16.2:
+    resolution: {integrity: sha512-/jcTmK6Ktz3owM3YtiKvjofV6p3VpHnYzTIrOGwDIOsDigRAAVuZ8east33wYO/7UTdKYFlyHNnJNT0WJqOA3Q==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-arm64-musl@1.15.43:
@@ -13162,6 +13281,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-linux-arm64-musl@1.16.2:
+    resolution: {integrity: sha512-4gFarKaFnlJTSlJYKmMhV4u+3YE4uYfiydpBoYjmgQhCf9lAieOq+WilZaK9vVSHeqLuQpTEiGULZqAdsRX5Dw==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-ppc64-gnu@1.15.43:
     resolution: {integrity: sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==}
     engines: {node: '>=10'}
@@ -13169,6 +13297,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-linux-ppc64-gnu@1.16.2:
+    resolution: {integrity: sha512-syqSLGd6KlZ1PciNzs6bIUlhOuFztZufebOHaERjc4N4SqNZxyqYd4I+jj/EfOYnpe0kNjccn9HJLN1p5dz3+w==}
+    engines: {node: '>=10'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-s390x-gnu@1.15.43:
@@ -13180,6 +13317,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-linux-s390x-gnu@1.16.2:
+    resolution: {integrity: sha512-ZBBLK+ewGyXLzWeMS7wbKtWBdnif6etn7xvPY/iOfbdsjX/+bgkp1pQt2lWF2wlu2hXYZuhJ/tHZE/QR8/apzg==}
+    engines: {node: '>=10'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-linux-x64-gnu@1.15.43:
     resolution: {integrity: sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==}
     engines: {node: '>=10'}
@@ -13187,6 +13333,15 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-linux-x64-gnu@1.16.2:
+    resolution: {integrity: sha512-LyHJgxCA4Tje0ysBMbEb0tt/ie8kgUKoFE3JAKFhpevmTmhYEoC0H9s47WuDsqiFckF1ITUguZIXJG6K5e0dvg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-linux-x64-musl@1.15.43:
@@ -13198,6 +13353,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-linux-x64-musl@1.16.2:
+    resolution: {integrity: sha512-PghXJlVM1cgtLfNUR1vxFo1z+PDRAe8cWAJlZZ7spmeiN7BospGXg/MHUg7oNSgwSX7Zo//YKv9P5yD9apsFJQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-arm64-msvc@1.15.43:
     resolution: {integrity: sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==}
     engines: {node: '>=10'}
@@ -13205,6 +13369,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-win32-arm64-msvc@1.16.2:
+    resolution: {integrity: sha512-StTOSefYBxemvNYYUI3UmO1a8y+hSPjjfHogC2TEHL+Z1PlEBim/XtLas5rS04jAzT9RrNmbtX911SZ42H9jSQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core-win32-ia32-msvc@1.15.43:
@@ -13216,6 +13389,15 @@ packages:
     dev: false
     optional: true
 
+  /@swc/core-win32-ia32-msvc@1.16.2:
+    resolution: {integrity: sha512-fycER209DYIzsibpTMC+chND05OfOjgztWL9U8OE6/uUlsOUZH3eh98isBLEnOymYUhlJLEt5++W1+KL/FOh5Q==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@swc/core-win32-x64-msvc@1.15.43:
     resolution: {integrity: sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==}
     engines: {node: '>=10'}
@@ -13223,6 +13405,15 @@ packages:
     os: [win32]
     requiresBuild: true
     dev: false
+    optional: true
+
+  /@swc/core-win32-x64-msvc@1.16.2:
+    resolution: {integrity: sha512-cSd1z6ivSrJPVr+moVwOHWjeKy6TpO4/Shwcv5KCrKYXCccxwh4pRy1C3fDioNx2PF1jPZWHKZjtXt+Be9VbaQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@swc/core@1.15.43:
@@ -13252,9 +13443,35 @@ packages:
       '@swc/core-win32-x64-msvc': 1.15.43
     dev: false
 
+  /@swc/core@1.16.2:
+    resolution: {integrity: sha512-95I4kiSMeveI/Mhi+tE4fiWcWLUMfzfKrk0jtr8LRMqHgOgq+xHS+zExkDqoO4b5OeeuXHMWVdD5MeP3X6sULw==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    peerDependencies:
+      '@swc/helpers': '>=0.5.17'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.28
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.16.2
+      '@swc/core-darwin-x64': 1.16.2
+      '@swc/core-linux-arm-gnueabihf': 1.16.2
+      '@swc/core-linux-arm64-gnu': 1.16.2
+      '@swc/core-linux-arm64-musl': 1.16.2
+      '@swc/core-linux-ppc64-gnu': 1.16.2
+      '@swc/core-linux-s390x-gnu': 1.16.2
+      '@swc/core-linux-x64-gnu': 1.16.2
+      '@swc/core-linux-x64-musl': 1.16.2
+      '@swc/core-win32-arm64-msvc': 1.16.2
+      '@swc/core-win32-ia32-msvc': 1.16.2
+      '@swc/core-win32-x64-msvc': 1.16.2
+    dev: true
+
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-    dev: false
 
   /@swc/helpers@0.5.23:
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -13267,6 +13484,12 @@ packages:
     dependencies:
       '@swc/counter': 0.1.3
     dev: false
+
+  /@swc/types@0.1.28:
+    resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
+    dependencies:
+      '@swc/counter': 0.1.3
+    dev: true
 
   /@szmarczak/http-timer@4.0.6:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
@@ -15231,7 +15454,6 @@ packages:
   /@vercel/oidc@3.2.0:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
-    dev: false
 
   /@vercel/oidc@3.8.5:
     resolution: {integrity: sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw==}
@@ -15614,7 +15836,6 @@ packages:
 
   /@workflow/serde@4.1.0:
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
-    dev: false
 
   /@wyw-in-js/processor-utils@0.6.0:
     resolution: {integrity: sha512-5YAZMUmF+S2HaqheKfew6ybbYBMnF10PjIgI7ieyuFxCohyqJNF4xdo6oHftv2z5Z4vCQ0OZHtDOQyDImBYwmg==}
@@ -15901,6 +16122,18 @@ packages:
       '@ai-sdk/provider-utils': 5.0.11(zod@3.25.76)
       zod: 3.25.76
     dev: false
+
+  /ai@7.0.31(zod@4.5.4):
+    resolution: {integrity: sha512-pJfwKXjF5kw0rKRTePwYo60EfWb8wfzJAgf3ojln/YkOsVVKttzZAJVcRPsg37Z3a06ZdKkxX+DSrMAFlPm5Mw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/gateway': 4.0.23(zod@4.5.4)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.11(zod@4.5.4)
+      zod: 4.5.4
+    dev: true
 
   /ai@7.0.92(zod@4.4.3):
     resolution: {integrity: sha512-9xb8Xo6aw7YMxuROznR02q4Hpne1DJ7JbKurpcOsabSSY3sd3xGoTANSqEs4gYLRpIz27MmT3IMfH8X3+oK1CQ==}
@@ -17135,6 +17368,13 @@ packages:
     dependencies:
       '@types/node': 20.19.43
 
+  /bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+    dependencies:
+      run-applescript: 7.1.0
+    dev: true
+
   /bundle-require@5.1.0(esbuild@0.28.1):
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -17430,7 +17670,6 @@ packages:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
     dependencies:
       consola: 3.4.2
-    dev: false
 
   /cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -18442,6 +18681,19 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  /default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+    dev: true
+
+  /default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
+    engines: {node: '>=18'}
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+    dev: true
+
   /defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
@@ -18463,6 +18715,11 @@ packages:
   /define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  /define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+    dev: true
 
   /define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
@@ -19785,7 +20042,6 @@ packages:
   /eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
-    dev: false
 
   /eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
@@ -20575,13 +20831,11 @@ packages:
 
   /fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
-    dev: false
 
   /fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
     dependencies:
       fast-string-truncated-width: 3.0.3
-    dev: false
 
   /fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
@@ -20590,7 +20844,6 @@ packages:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
     dependencies:
       fast-string-width: 3.0.2
-    dev: false
 
   /fast-xml-builder@1.3.0:
     resolution: {integrity: sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==}
@@ -22235,6 +22488,12 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  /is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+    dev: true
+
   /is-docker@4.0.0:
     resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
     engines: {node: '>=20'}
@@ -22289,6 +22548,19 @@ packages:
   /is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
     dev: false
+
+  /is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+    dev: true
+
+  /is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+    dependencies:
+      is-docker: 3.0.0
+    dev: true
 
   /is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -22435,6 +22707,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-docker: 2.2.1
+
+  /is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+    dependencies:
+      is-inside-container: 1.0.0
+    dev: true
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -22722,7 +23001,6 @@ packages:
 
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -25131,6 +25409,10 @@ packages:
     resolution: {integrity: sha512-Sxdgpp4y12zUYq8XzZoQQSIL9CU1T210l7dLrfVLeIykaRslBJEHNacGTy8CLqJc5uLFsmzukANbEOpa5XgAiQ==}
     dev: false
 
+  /next-intl-swc-plugin-extractor@4.14.3:
+    resolution: {integrity: sha512-aRbTpgeTF8nkTvKWWvh/IXwcQ1BJbLUpYmuk7T4CMXdfPpskiNGTJQ0snwF+yFkrHXcH9hyBz0eRKbV+4fGNIA==}
+    dev: true
+
   /next-intl@4.13.4(next@16.3.3)(react@19.2.8)(typescript@5.9.3):
     resolution: {integrity: sha512-jhPAT0u0lahIK6E4gVdZAehugWCosBhLG8sV7xMzgSVoJpxHObP+Fiu+z2FfkEW0XPPtr7uEXoUlLEfhxhNMTg==}
     peerDependencies:
@@ -25586,6 +25868,18 @@ packages:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  /open@11.0.2:
+    resolution: {integrity: sha512-RWqF+pBSkqecEvCKOn8QYhaNdRMJDZRIrlS/7rTDdLHaPcfXGCZ/h8zb413NfvdeAV0MR7T1yJcA34/q+CSm1Q==}
+    engines: {node: '>=20'}
+    dependencies:
+      default-browser: 5.5.1
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.2.1
+      wsl-utils: 1.0.0
+    dev: true
 
   /open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
@@ -26172,6 +26466,10 @@ packages:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
     dev: false
 
+  /po-parser@2.2.0:
+    resolution: {integrity: sha512-NdTrKgh0oO7+y+RFX8KKhOB438x/j94UGXEFzl/7pHH0JjWSn42iJ9tgmPksIO6n1JKDHmNDcejPJfKspljB9g==}
+    dev: true
+
   /points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
     dev: false
@@ -26326,6 +26624,16 @@ packages:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
     dev: false
+
+  /powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+    dev: true
+
+  /powershell-utils@0.2.1:
+    resolution: {integrity: sha512-C+y9x90UElAddDZmV4qOx9W53B61PO7cIqWz2dQsWlwswuq4mr8NEwytdGKboYbQlGZ3awrkTeNvcZiZNHnQ8A==}
+    engines: {node: '>=20'}
+    dev: true
 
   /pptx-react-viewer@1.25.5(fast-xml-parser@5.10.1)(framer-motion@12.43.0)(i18next@26.3.6)(jspdf@4.2.1)(jszip@3.10.1)(lucide-react@1.28.0)(react-dom@19.2.8)(react-i18next@17.0.11)(react-icons@5.7.0)(react@19.2.8):
     resolution: {integrity: sha512-IZCohWVwcYlxQ3qD351lFs8QdpY2CQvMwwiy4eiBzek2svVh31XXSxNsvfyYP/6oY/UNhQdqpZvPb+d0JIMbvw==}
@@ -28375,6 +28683,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+    dev: true
 
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -31370,6 +31683,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  /wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
+    engines: {node: '>=20'}
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+    dev: true
+
   /xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
@@ -31702,7 +32023,6 @@ packages:
 
   /zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
-    dev: false
 
   /zustand@5.0.14(@types/react@19.2.18)(react@19.1.0):
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}


### PR DESCRIPTION
## Summary

Hey! I'm the author of `next-intl` and recently started building [`eloqnt/cli`](https://cli.eloqnt.dev/docs), a linter for translation files. I have been running it against public repos to see whether their catalogs carry errors.

For `apps/web` it currently reports **24 [`unreachable-plural-case`](https://cli.eloqnt.dev/docs/lint-rules/unreachable-plural-case) errors**.

All of them are the same shape: 12 messages in `ja.json` and `zh.json` carry a `one {…}` plural case that Japanese and Chinese never select, since both languages only have `other`. It doesn't cause any errors, but it's dead weight that doesn't need to loaded into the app.


**Example:** 

```
{days} {days, plural, one {日} other {日}}後に更新
```

Up to you if you're interested in adopting `eloqnt/cli`, but you might want the translation fixes in this PR to fix the errors.

This adds `pnpm lint:i18n` to `apps/web` and runs it in CI next to the existing ESLint step.

## Type of change

- [x] Bug fix
- [x] Infrastructure / CI

## How was this tested?

`pnpm --dir apps/web run lint:i18n`: 24 errors before, 0 after. `node scripts/audit-translations.mjs` still passes.

## Security & data review

- [x] No secrets, keys, or credentials are committed (verified by secret scan / review)

The other items don't apply — this touches translation files, a package script and one CI step.

## Rollout / rollback

No migrations, flags or env vars. Revert the commit to roll back.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791647541&installation_model_id=434224&pr_number=7192&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7192&signature=ed9ab7418c7aa1549b3a205029573f45540ebe63ed5dc1a77d5d57789ad0d0ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->