### PR TITLE
fix(billing): one upgrade dialog per page, so the accessibility tree can see it

### DIFF
--- a/apps/web/src/features/billing/global-upgrade-modal.tsx
+++ b/apps/web/src/features/billing/global-upgrade-modal.tsx
@@ -44,7 +44,8 @@ import {
   UserPlusIcon as UserPlus,
 } from '@phosphor-icons/react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { claimUpgradeModal } from './upgrade-modal-registry';
 
 export interface UpgradePlansModalProps {
   open: boolean;
@@ -394,7 +395,19 @@ function CreditTopUpModal({
   );
 }
 
+/**
+ * True for the one instance that may draw. See `upgrade-modal-registry`: four
+ * surfaces mount this component defensively, and two open Radix dialogs hide
+ * each other from the accessibility tree.
+ */
+function useIsUpgradeModalRenderer(): boolean {
+  const [isRenderer, setIsRenderer] = useState(false);
+  useEffect(() => claimUpgradeModal({}, setIsRenderer), []);
+  return isRenderer;
+}
+
 export function GlobalUpgradeModal() {
+  const isRenderer = useIsUpgradeModalRenderer();
   const {
     isOpen,
     closeUpgradeDialog,
@@ -414,6 +427,11 @@ export function GlobalUpgradeModal() {
   useEffect(() => {
     if (isOpen) invalidateAccountState(queryClient, true, true, accountId);
   }, [isOpen, queryClient, accountId]);
+
+  // Mounted but standing down: another instance on this page owns the dialog.
+  // Returning null keeps the hooks above unconditional and keeps this instance
+  // ready to be promoted the moment the owner unmounts.
+  if (!isRenderer) return null;
 
   return (
     <BillingAccountProvider accountId={accountId ?? null}>

--- a/apps/web/src/features/billing/upgrade-modal-registry.test.ts
+++ b/apps/web/src/features/billing/upgrade-modal-registry.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { claimUpgradeModal, upgradeModalClaimCount } from './upgrade-modal-registry';
+
+describe('upgrade modal single-instance registry', () => {
+  const releases: Array<() => void> = [];
+
+  beforeEach(() => {
+    while (releases.length) releases.pop()!();
+  });
+
+  function claim(name: string, seen: Record<string, boolean[]>) {
+    const token = {};
+    seen[name] = [];
+    const release = claimUpgradeModal(token, (owner) => seen[name]!.push(owner));
+    releases.push(release);
+    return release;
+  }
+
+  test('one claimant draws', () => {
+    const seen: Record<string, boolean[]> = {};
+    claim('a', seen);
+    expect(seen.a!.at(-1)).toBe(true);
+    expect(upgradeModalClaimCount()).toBe(1);
+  });
+
+  test('a second claimant never draws while the first is mounted', () => {
+    // The prod shape: `/new` mounts one renderer and the account hub's Plan
+    // pane mounts another. Two open Radix dialogs mark each other aria-hidden
+    // and the accessibility tree ends up with neither.
+    const seen: Record<string, boolean[]> = {};
+    claim('a', seen);
+    claim('b', seen);
+    expect(seen.a!.at(-1)).toBe(true);
+    expect(seen.b!.at(-1)).toBe(false);
+  });
+
+  test('the next claimant is promoted when the owner unmounts', () => {
+    const seen: Record<string, boolean[]> = {};
+    const releaseA = claim('a', seen);
+    claim('b', seen);
+    releaseA();
+    expect(seen.b!.at(-1)).toBe(true);
+  });
+
+  test('releasing a non-owner leaves the owner alone', () => {
+    const seen: Record<string, boolean[]> = {};
+    claim('a', seen);
+    const releaseB = claim('b', seen);
+    releaseB();
+    expect(seen.a!.at(-1)).toBe(true);
+    expect(upgradeModalClaimCount()).toBe(1);
+  });
+
+  test('releasing twice is harmless', () => {
+    const seen: Record<string, boolean[]> = {};
+    const releaseA = claim('a', seen);
+    claim('b', seen);
+    releaseA();
+    releaseA();
+    expect(seen.b!.at(-1)).toBe(true);
+    expect(upgradeModalClaimCount()).toBe(1);
+  });
+});

--- a/apps/web/src/features/billing/upgrade-modal-registry.ts
+++ b/apps/web/src/features/billing/upgrade-modal-registry.ts
@@ -1,0 +1,60 @@
+/**
+ * Exactly one upgrade dialog may be rendered at a time.
+ *
+ * `GlobalUpgradeModal` is mounted defensively in four places — the app
+ * providers, the account hub's Plan pane, the workspace Plan tab, and the new-
+ * workspace page — each with a comment explaining that without it a button on
+ * that surface would open a dialog with no renderer. Every one of those
+ * comments is right on its own, and together they mean two renderers can be
+ * mounted at once on the same page.
+ *
+ * Two Radix dialogs opened from one store is not a cosmetic duplicate. Each
+ * modal marks the rest of the document `aria-hidden` while it is open, so the
+ * two hide each other: the pixels look correct and the accessibility tree
+ * contains NEITHER dialog. Measured live on dev 2026-09-09 at
+ * `/new?accountId=…&accountTab=billing` — `document.querySelectorAll(
+ * '[role="dialog"]')` returned 3 nodes, 2 of them the subscribe dialog, and
+ * BOTH carried `aria-hidden="true"`. A screen reader is told there is nothing
+ * there, and every role-based query — including the release gate's
+ * `getByRole('heading', { name: 'Subscribe to Kortix' })`, which failed the
+ * v0.13.13 gate on staging three times — finds nothing.
+ *
+ * Which instance wins is a mount-order race, which is why the same click
+ * behaves differently on two environments. So the choice is made here instead:
+ * the FIRST mounted claimant renders, and if it unmounts the next one is
+ * promoted. Callers keep mounting the component wherever a button needs it —
+ * that stays correct — and only one of them draws.
+ */
+
+interface Claimant {
+  token: object;
+  setOwner: (owner: boolean) => void;
+}
+
+const claimants: Claimant[] = [];
+
+/** Recompute ownership after any change. Index 0 draws; everyone else stands down. */
+function settleOwnership(): void {
+  claimants.forEach((claimant, index) => claimant.setOwner(index === 0));
+}
+
+/**
+ * Register a renderer. Returns the release function.
+ *
+ * Exported for the hook and for tests; nothing else should call it.
+ */
+export function claimUpgradeModal(token: object, setOwner: (owner: boolean) => void): () => void {
+  claimants.push({ token, setOwner });
+  settleOwnership();
+  return () => {
+    const index = claimants.findIndex((claimant) => claimant.token === token);
+    if (index === -1) return;
+    claimants.splice(index, 1);
+    settleOwnership();
+  };
+}
+
+/** Test seam. */
+export function upgradeModalClaimCount(): number {
+  return claimants.length;
+}


### PR DESCRIPTION
Unblocks the v0.13.13 release gate, and fixes a real accessibility defect on every Subscribe/Upgrade button.

## What was wrong

Clicking **Subscribe to Team** opened a dialog that looked right and did not exist. Measured live on dev at `/new?accountId=…&accountTab=billing`, after the click:

```
document.querySelectorAll('[role="dialog"]')  → 3 nodes
  … 2 of them the subscribe dialog
  … both with aria-hidden="true"
```

`GlobalUpgradeModal` is mounted in four places (app providers, account hub Plan pane, workspace Plan tab, new-workspace page), each with a comment explaining that without it a button on that surface would open a dialog with no renderer. Each is right alone; together two renderers can be mounted on one page. Two Radix dialogs opened from the same store mark each other `aria-hidden`, so the pixels are correct and the accessibility tree contains neither dialog.

A screen reader is told there is nothing there. Every role-based query finds nothing.

## Why it failed the gate and not dev

Which instance wins is a mount-order race. On deployed staging it failed three times in the v0.13.13 gate (`10-billing-journey.spec.ts:147`, `getByRole('heading', { name: 'Subscribe to Kortix' })` → "element(s) not found") against a Playwright screenshot that plainly shows the dialog open. The same click on dev sometimes passed.

The Playwright a11y snapshot at failure is the whole story — the entire page reduced to:

```yaml
- region "Notifications alt+T"
```

## The fix

`upgrade-modal-registry` makes the choice instead of leaving it to mount order: the first mounted claimant draws, the rest render `null`, and the next claimant is promoted if the owner unmounts. Call sites keep mounting the component wherever a button needs it — that stays correct — and only one draws. The dialog portals to `document.body`, so the surviving instance renders identically wherever it sits, and the account comes from the store, not from the provider it happens to be under.

## Verified

- 5 registry unit tests pass: one claimant draws; a second never draws while the first is mounted; the next is promoted on unmount; releasing a non-owner and a double release are both harmless.
- `tsc --noEmit` in `apps/web` reports the same 16 known baseline errors as the unmodified base commit — none in the changed files.
- The reproduction above was taken on the deployed dev app; the release gate on staging is the post-fix proof and runs when this reaches staging.

https://claude.ai/code/session_01ECsZyxXpTLhyQxGsz3QtX2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791650196&installation_model_id=434224&pr_number=7193&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7193&signature=602b98dfb7a663893c00800182e2470e90aafa40c54e3a03326964ef0314ddb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->