### PR TITLE
feat(apps): a public App can recognise you without shutting anyone else out

### DIFF
--- a/apps/api/src/apps/public-proxy.ts
+++ b/apps/api/src/apps/public-proxy.ts
@@ -495,7 +495,22 @@ export function resolveAppViewerUserId(
   url: URL,
   app: Pick<AppAccessRow, 'appId' | 'accessMode' | 'accessRevision'>,
 ): string | null {
-  if (app.accessMode === 'public' || app.accessMode === 'password') return null;
+  // A PUBLIC App still recognises whoever the gate signed in.
+  //
+  // This used to bail here for `public`, so the cookie was never even read and
+  // `public` quietly meant two things: "anyone with the link may open this" AND
+  // "nobody is ever recognised". Only the first is what public is for. An App
+  // shared with an outside client still wants to know its own team when they
+  // open it, without shutting the client out.
+  //
+  // Identity is not authorization. A public App already authorizes everyone;
+  // this only answers WHO, and only when the gate's own signed, revision-bound
+  // cookie says so. A visitor with no cookie stays anonymous, which is what
+  // keeps the bare shared link working.
+  //
+  // `password` needs no special case: its cookie proves knowledge of a shared
+  // secret rather than a person, and the `kind !== 'kortix'` check below is
+  // already what keeps it out.
   const localHttp = url.protocol === 'http:' && url.hostname.endsWith('.apps.localhost');
   const raw = cookieValue(request, appAccessCookieName(localHttp));
   if (!raw) return null;
@@ -629,10 +644,13 @@ export async function authorizeAppRequest(
   app: AppAccessRow,
   verifyUserAccess: AppUserAccessVerifier = appAccessibleToUser,
 ): Promise<Response | null> {
-  if (app.accessMode === 'public') return null;
   const localHttp = url.protocol === 'http:' && url.hostname.endsWith('.apps.localhost');
   const secret = appAccessSecret();
   const queryToken = url.searchParams.get('__kortix_access');
+  // NOTE the public App does not return early here any more. It still redeems
+  // an access link — that exchange is the only way its identity cookie can ever
+  // exist — and only the DENIAL paths below are skipped for it. See the guard
+  // after this block.
   if (queryToken && (request.method === 'GET' || request.method === 'HEAD')) {
     const verified = verifyAppAccessToken(queryToken, app.appId, secret);
     if (await accessTokenAuthorizesRequest(verified, app, verifyUserAccess)) {
@@ -653,6 +671,13 @@ export async function authorizeAppRequest(
       });
     }
   }
+  // A public App is never gated. Everything from here down decides whether to
+  // REFUSE, and refusing is exactly what public means not doing — so it lets
+  // the request through, with or without an identity. A visitor who redeemed a
+  // link above is now carrying the cookie; the client who was sent the bare URL
+  // simply stays anonymous.
+  if (app.accessMode === 'public') return null;
+
   const browserToken = cookieValue(request, appAccessCookieName(localHttp));
   if (
     browserToken &&

--- a/apps/api/src/apps/routes.ts
+++ b/apps/api/src/apps/routes.ts
@@ -422,9 +422,19 @@ projectsApp.openapi(
     if (row.accessMode !== 'public' && row.accessMode !== 'password' && !(await appAccessibleToUser(row, loaded.userId))) {
       return c.json({ error: 'App access denied' }, 403);
     }
-    if (row.accessMode === 'public' || row.accessMode === 'password') {
+    // A PASSWORD App gets the bare URL: the door is the password prompt, and a
+    // Kortix session cannot stand in for knowing the secret.
+    if (row.accessMode === 'password') {
       return c.json({ url: appPublicUrl(row), expires_at: new Date(Date.now() + 5 * 60_000).toISOString() });
     }
+    // A PUBLIC App gets a real session URL, the same as a gated one.
+    //
+    // It used to get the bare URL, which meant a public App could never
+    // recognise anyone: no access link, so no identity cookie, so no viewer
+    // header — `public` silently also meant `anonymous`. Opening it from Kortix
+    // now carries who you are, while the bare URL underneath stays shareable
+    // with someone who has no Kortix account at all. The gate does not GATE a
+    // public App either way; this only decides whether it can greet you.
     const session = appAccessSessionUrl(appPublicUrl(row), row, loaded.userId);
     return c.json({ url: session.url, expires_at: session.expiresAt.toISOString() });
   },

--- a/apps/api/src/apps/viewer-gate.test.ts
+++ b/apps/api/src/apps/viewer-gate.test.ts
@@ -66,6 +66,7 @@ mock.module('./viewer', () => ({
 
 const {
   appUpstreamHeaders,
+  authorizeAppRequest,
   appViewerContextHeader,
   appViewerEndpointResponse,
   resolveAppViewerUserId,
@@ -109,6 +110,56 @@ function sessionCookie(revision = 3, kind: 'kortix' | 'password' = 'kortix') {
 const req = (init: RequestInit = {}, path = '/') =>
   new Request(`${URL_HTTPS.origin}${path}`, init);
 
+describe('a public App can still be entered AS someone', () => {
+  // The identity cookie has to come from somewhere. For a gated App the gate
+  // mints it when an access link is redeemed; a public App skipped the gate
+  // entirely, so no cookie ever existed and the change above would have had
+  // nothing to read.
+  //
+  // A public App now redeems an access link the same way — and ONLY that. It
+  // never demands one, so the bare link a client was sent still opens.
+  test('redeeming an access link sets the identity cookie and strips the token from the URL', async () => {
+    const token = createAppAccessToken(
+      // revision 3 = the App's current access revision (see appRow).
+      { appId: APP_ID, kind: 'kortix', userId: USER_ID, revision: 3, expiresAt: new Date(Date.now() + 300_000) },
+      appAccessSecret(),
+    );
+    const url = new URL(`${URL_HTTPS.origin}/reports?__kortix_access=${encodeURIComponent(token)}`);
+    const response = await authorizeAppRequest(
+      new Request(url.toString()),
+      url,
+      appRow({ accessMode: 'public' }),
+      async () => true,
+    );
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get('location')).toBe('/reports');
+    expect(response?.headers.get('set-cookie')).toContain('kortix_app_access=');
+  });
+
+  test('no access link: a public App still opens for anyone, ungated', async () => {
+    const url = new URL(`${URL_HTTPS.origin}/reports`);
+    const response = await authorizeAppRequest(
+      new Request(url.toString()),
+      url,
+      appRow({ accessMode: 'public' }),
+      async () => false,
+    );
+    // null means "let it through" — the outside client with the bare link.
+    expect(response).toBeNull();
+  });
+
+  test('a public App never turns a bad access link into a locked door', async () => {
+    const url = new URL(`${URL_HTTPS.origin}/reports?__kortix_access=not.a.token`);
+    const response = await authorizeAppRequest(
+      new Request(url.toString()),
+      url,
+      appRow({ accessMode: 'public' }),
+      async () => false,
+    );
+    expect(response).toBeNull();
+  });
+});
+
 describe('resolveAppViewerUserId', () => {
   test('reads the viewer out of the gate’s own session cookie', () => {
     const request = req({ headers: { cookie: sessionCookie() } });
@@ -120,10 +171,50 @@ describe('resolveAppViewerUserId', () => {
     expect(resolveAppViewerUserId(request, URL_HTTPS, appRow())).toBeNull();
   });
 
-  test('password and public Apps carry no identity at all', () => {
+  // CHANGED DELIBERATELY. This used to assert that a public App "carries no
+  // identity at all", and public returned null before the cookie was even read.
+  //
+  // That made `public` mean two things at once: "anyone with the link may open
+  // this" AND "nobody is ever recognised". The first is what public is for; the
+  // second was collateral. An App shared with an outside client still wants to
+  // know its own team when they open it — greet them, show them the edit
+  // controls, write their name into an audit trail — without shutting the
+  // client out.
+  //
+  // Identity is not authorization. A public App authorizes everyone by
+  // definition; the header only answers WHO, and only when the gate's own
+  // signed cookie says so. Reading it changes who the App can recognise, never
+  // who may enter.
+  test('a public App recognises a signed-in viewer instead of blinding itself', () => {
+    const request = req({ headers: { cookie: sessionCookie() } });
+    expect(resolveAppViewerUserId(request, URL_HTTPS, appRow({ accessMode: 'public' }))).toBe(USER_ID);
+  });
+
+  test('a public App with no cookie is still anonymous — sharing the bare link keeps working', () => {
+    expect(resolveAppViewerUserId(req(), URL_HTTPS, appRow({ accessMode: 'public' }))).toBeNull();
+  });
+
+  test('a public App still refuses a forged or stale cookie', () => {
+    // Revision 2 against an App on revision 1: a bumped access policy revokes
+    // outstanding cookies, and going public must not weaken that.
+    expect(
+      resolveAppViewerUserId(req({ headers: { cookie: sessionCookie(2) } }), URL_HTTPS, appRow({ accessMode: 'public' })),
+    ).toBeNull();
+    expect(
+      resolveAppViewerUserId(
+        req({ headers: { cookie: '__Host-kortix_app_access=not.a.token' } }),
+        URL_HTTPS,
+        appRow({ accessMode: 'public' }),
+      ),
+    ).toBeNull();
+  });
+
+  test('a PASSWORD App still carries no Kortix identity — its cookie is not a person', () => {
+    // A password session proves knowledge of a shared secret, not who you are.
+    // `kind !== 'kortix'` is what keeps it out, so this holds without a
+    // special case on access mode.
     const request = req({ headers: { cookie: sessionCookie(3, 'password') } });
     expect(resolveAppViewerUserId(request, URL_HTTPS, appRow({ accessMode: 'password' }))).toBeNull();
-    expect(resolveAppViewerUserId(request, URL_HTTPS, appRow({ accessMode: 'public' }))).toBeNull();
   });
 
   test('no cookie, a forged cookie, and another App’s cookie all answer null', () => {


### PR DESCRIPTION
## The problem

`public` meant two things at once: **"anyone with the link may open this"** *and* **"nobody is ever recognised"**. Only the first is what public is for. The second was collateral — and it made the mode useless for the common case: an App you share with an outside client that should still greet your own team, show them controls a visitor shouldn't see, and write their name into an audit trail.

## Three places guaranteed the blindness

| | before |
|---|---|
| `resolveAppViewerUserId` | returned null for `public` **before reading the cookie** |
| `authorizeAppRequest` | returned null for `public` as its first statement — an access link was never redeemed, so the cookie could never be minted |
| `access-session` route | handed a public App the bare URL, so nothing ever produced a link to redeem |

All three had to move, or the change would have been a no-op reading a cookie that never existed.

## After

- Opening a public App **from Kortix** carries who you are.
- The **bare URL** underneath still opens for someone with no Kortix account at all.

The gate does not *gate* a public App either way — this only decides whether it can greet you.

## Why this is not an authorization change

Identity is not authorization. A public App already authorizes everyone by definition; the header only answers **who**. It is still produced solely from the gate's own HMAC-signed, App-scoped, revision-bound cookie, so a bumped access policy revokes it exactly as before, and a forged or foreign cookie yields nothing. Every refusal path in `authorizeAppRequest` remains skipped for public — refusing is precisely what public means not doing.

`password` keeps the old behaviour deliberately: its cookie proves knowledge of a shared secret, not a person, so it carries no Kortix identity and its access-session still returns the bare URL. That falls out of the existing `kind !== 'kortix'` check rather than a special case on access mode.

## A test changed on purpose

`'password and public Apps carry no identity at all'` asserted exactly the behaviour this removes. It's **replaced, not deleted** — a public App now recognises a signed-in viewer, is still anonymous with no cookie, still refuses a forged or stale one, and password is asserted separately so its rule isn't lost in the rename.

## Verified

- `viewer-gate` **19 pass / 0 fail**; each new case watched failing first (identity `null`, then the access-link redemption returning no 303).
- Full `apps/api` suite **8417 pass**. Its 29 failures are all `Cannot find module '@composio/client'` — a dependency not installed in this worktree, in files this change does not touch.
- `tsc` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791651404&installation_model_id=434224&pr_number=7197&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7197&signature=a449d51fd792242430f8be2b56ad38832f4feabc600ebbf7ee9683a3f772db01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->