### PR TITLE
fix(billing): keep the account subscription dialog accessible

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Give a shared modal store exactly one active renderer (2026-09-10)
+
+**When:** a page and its nested settings overlay both mount a global dialog.
+Select one renderer at the deepest dialog depth. Concurrent Radix dialogs can
+hide each other from the accessibility tree while both remain visibly open.
+*Near-miss:* the 0.13.13 preview opened two billing dialogs from the account hub;
+the checkout controls disappeared from Playwright's role locators.
+*Enforcer:* billing browser journey asserts one accessible dialog, repeated
+open/close, and Escape preserving the account hub.
+
 ### Verify the preview report SHA and result before accepting a green deployment (2026-09-10)
 
 **When:** using a persistent branch preview as release evidence. Push deploys

--- a/apps/web/src/features/billing/global-upgrade-modal.tsx
+++ b/apps/web/src/features/billing/global-upgrade-modal.tsx
@@ -19,6 +19,7 @@ import { useBillingReturnUrl } from '@/features/billing/billing-return';
 import { CreditTopupSection } from '@/features/billing/credit-topup-section';
 import { PricingPlanCard } from '@/features/billing/pricing-plan-card';
 import { UPGRADE_MODAL_PLANS, type UpgradeModalPlanId } from '@/features/billing/pricing-plans';
+import { useUpgradeModalHost } from '@/features/billing/use-upgrade-modal-host';
 import { useRequestDemo } from '@/features/contact/request-demo-provider';
 import {
   invalidateAccountState,
@@ -395,6 +396,11 @@ function CreditTopUpModal({
 }
 
 export function GlobalUpgradeModal() {
+  const selected = useUpgradeModalHost();
+  return selected ? <GlobalUpgradeModalContent /> : null;
+}
+
+function GlobalUpgradeModalContent() {
   const {
     isOpen,
     closeUpgradeDialog,

--- a/apps/web/src/features/billing/use-upgrade-modal-host.ts
+++ b/apps/web/src/features/billing/use-upgrade-modal-host.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useId, useLayoutEffect, useSyncExternalStore } from 'react';
+
+import { useDialogDepth } from '@/lib/z-stack';
+
+const hosts = new Map<string, number>();
+const listeners = new Set<() => void>();
+
+function selectedHost(): string | null {
+  let selected: string | null = null;
+  let selectedDepth = -1;
+  for (const [id, depth] of hosts) {
+    if (depth >= selectedDepth) {
+      selected = id;
+      selectedDepth = depth;
+    }
+  }
+  return selected;
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const serverSnapshot = () => null;
+
+/** Render the global billing dialog once, above the deepest mounted caller. */
+export function useUpgradeModalHost(): boolean {
+  const id = useId();
+  const depth = useDialogDepth();
+  const selected = useSyncExternalStore(subscribe, selectedHost, serverSnapshot);
+
+  useLayoutEffect(() => {
+    hosts.set(id, depth);
+    listeners.forEach((listener) => listener());
+    return () => {
+      hosts.delete(id);
+      listeners.forEach((listener) => listener());
+    };
+  }, [id, depth]);
+
+  return selected === id;
+}

--- a/tests/e2e/specs/10-billing-journey.spec.ts
+++ b/tests/e2e/specs/10-billing-journey.spec.ts
@@ -90,7 +90,7 @@ function expectStripeUrl(value: string | undefined, hosts: string[], pathPattern
 
 test.describe
   .serial('10 - Billing customer journey', () => {
-    test.skip(!enabled, 'The Stripe-backed billing journey runs only in strict staging QA.');
+    test.skip(!enabled, 'Billing UI is disabled in the default local profile.');
     test.setTimeout(300_000);
 
     let user: AuthUser;
@@ -122,6 +122,24 @@ test.describe
         ]).catch(() => {});
       }
       if (user?.id) await deleteAuthUser(user.id, authOptions);
+    });
+
+    test('the account hub opens one accessible billing dialog and stays open after Escape', async ({ page }) => {
+      await installBrowserSessionDirect(
+        page, session, `/new?accountId=${accountId}&accountTab=billing`, authOptions,
+      );
+      const subscribeButton = page.getByRole('button', { name: 'Subscribe to Team', exact: true });
+      await subscribeButton.click();
+      const dialog = page.getByRole('dialog', { name: /Subscribe to Kortix/ });
+      await expect(dialog).toHaveCount(1);
+      await expect(dialog.getByRole('button', { name: /^Subscribe —/ })).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(dialog).toHaveCount(0);
+      await expect(page.getByRole('heading', { name: 'Plan', exact: true })).toBeVisible();
+      await subscribeButton.click();
+      await expect(dialog).toHaveCount(1);
+      await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+      await expect(dialog).toHaveCount(0);
     });
 
     test('an owner starts checkout, reads the active plan, buys credits, and opens billing management', async ({


### PR DESCRIPTION
The account hub and its underlying page both mount the global billing dialog. Opening Subscribe creates two modal instances that hide each other from the accessibility tree. Select one renderer at the deepest dialog depth.

Validation:
- `KORTIX_PUBLIC_BILLING_ENABLED=true E2E_ENABLE_BILLING_JOURNEY=1 E2E_GREP="one accessible billing dialog" pnpm test -- --browser-only`: 1 passed.
- Web and test-project typechecks: exit 0.
- ESLint for both billing files: exit 0. Brand audit: clean.
- Preview billing failure reproduced with two dialogs in the trace. New preview verification pending.

The incident rule and browser regression are included. This release follow-up targets staging; draft main backport is #7196.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791652542&installation_model_id=434224&pr_number=7198&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7198&signature=400083c6a54995d0d54f39570ce3f60aae4110ec4ec881169f6ffc18ef1f6687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->