### PR TITLE
fix(tests): a failed Turbopack cache restore must not take the browser shard with it

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,28 @@ linked, not inlined.
 
 ## Register
 
+### A shared long-lived process that dies mid-run must announce itself, or every test after it lies about the cause (2026-09-10)
+
+**When:** a test harness starts a server the whole run shares, or you enable a
+cache whose failed restore is fatal rather than a miss. `browser-2` reported
+4 failed specs; none of them were broken. Turbopack's dev filesystem cache
+(`experimental.turbopackFileSystemCacheForDev`, default-ON since Next 16.1)
+failed a restore and panicked OUTSIDE turbo-tasks' per-task panic boundary:
+`Restore of All for task TaskId 7979517 failed in another thread` → `Aborting.`
+That killed the Next dev server. Every spec scheduled afterwards then failed
+with `ERR_CONNECTION_REFUSED` on `localhost:3000` and named ITSELF, burying the
+one real line ~500 lines up a shared stdout. **Rules.** (1) A cache is only a
+cache if a failed read is a MISS. One whose failed restore aborts the process is
+a liability — a one-shot CI job starts cold and deletes it afterwards, so it
+gains nothing and can lose a whole shard. Turn it off there. (2) When the
+harness owns a long-lived process, watch its exit for the whole run, not just
+until readiness, and print one unmissable line the moment it dies. Diagnosis
+cost here was ~40 minutes of log archaeology for a cause that was one line.
+*Incident:* PR #7194's release-blocking lane, 2026-09-10, 14 min lane + a
+20 min re-run. *Enforcers:* `tests/unit/local-web-environment.test.ts` asserts
+the deterministic profile sets `KORTIX_TURBOPACK_FS_CACHE=off`;
+`ensureLocalWeb` logs the dev server's exit code for the life of the run.
+
 ### A self-authenticating route must populate the shared context the resolver reads (2026-09-09)
 
 **When:** adding a route that authenticates its own credential instead of running

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -193,6 +193,38 @@ function resolveTurbopackMemoryEviction(): false | 'auto' | 'full' {
   return 'auto';
 }
 
+// --- Turbopack dev filesystem cache ---------------------------------------
+// `experimental.turbopackFileSystemCacheForDev` is default-ON since Next 16.1.
+// It persists compiled tasks to `.next/dev/cache` and restores them lazily, so
+// a warm dev server starts fast. A restore that fails is NOT recoverable: it
+// panics outside turbo-tasks' per-task panic boundary and aborts the whole
+// dev server process.
+//
+//   thread 'tokio-rt-worker' panicked at
+//     turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs:292:17:
+//   Restore of All for task TaskId 7979517 failed in another thread: restoring failed
+//   turbo-tasks: an internal panic occurred outside the per-task panic boundary.
+//   Aborting.
+//
+// A one-shot CI job gains nothing from the cache — it starts cold and throws
+// the directory away — and loses the entire browser shard when the abort hits,
+// because every remaining spec then fails with ERR_CONNECTION_REFUSED against a
+// dead port. So the deterministic test stack sets KORTIX_TURBOPACK_FS_CACHE=off
+// and trades a cold compile for a dev server that cannot die this way.
+// Unset (every developer machine, every real deployment) keeps upstream's
+// default. See tests/src/core/local-stack.ts.
+function resolveTurbopackFileSystemCacheForDev(): boolean {
+  const raw = process.env.KORTIX_TURBOPACK_FS_CACHE;
+  if (raw === undefined || raw === '') return true;
+  if (raw === 'off' || raw === 'false') return false;
+  if (raw === 'on' || raw === 'true') return true;
+  console.warn(
+    `[next.config.ts] Ignoring KORTIX_TURBOPACK_FS_CACHE=${JSON.stringify(raw)} — ` +
+      `expected one of 'on', 'off'. Falling back to the Next default (on).`,
+  );
+  return true;
+}
+
 // Local `pnpm preview` (scripts/dev-local.sh --build) sets KORTIX_PREVIEW_BUILD=1
 // to trade prod-build fidelity for speed: skip the `standalone` file-tracing pass
 // (next start never reads .next/standalone) and skip ESLint.
@@ -271,12 +303,12 @@ const nextConfig = (): NextConfig => ({
   // --- Next.js 16.3 posture ------------------------------------------------
   // Recording WHY each 16.3 knob is set or left alone, so nobody "adds the
   // missing config" later or wonders whether we missed the release. The only
-  // knob we set is turbopackMemoryEviction (below) — and only as an escape
-  // hatch, keeping upstream's default.
+  // knobs we set are turbopackMemoryEviction and turbopackFileSystemCacheForDev
+  // (both below) — and both only as escape hatches that default to upstream's
+  // value when their env var is unset.
   //
   // Already default-ON in 16.3 — restating them here would be dead config that
   // silently diverges the day upstream changes a default:
-  //   · experimental.turbopackFileSystemCacheForDev    (default true since 16.1)
   //   · experimental.turbopackFileSystemCacheForBuild  (default true as of 16.3)
   //     Measured: warm `next build` compile 36.3s -> 1.9s. Only pays off where
   //     .next/cache survives between builds — Vercel does this automatically;
@@ -384,6 +416,11 @@ const nextConfig = (): NextConfig => ({
     // when the laptop is thrashing. Disk cost is real either way:
     // .next/dev/cache grew 3.8GB -> 14-15GB.
     turbopackMemoryEviction: resolveTurbopackMemoryEviction(),
+    // Upstream's default (on) unless KORTIX_TURBOPACK_FS_CACHE=off. The
+    // deterministic test stack turns it off because a failed cache restore
+    // aborts the dev server and takes the whole browser shard with it — the
+    // full rationale is on resolveTurbopackFileSystemCacheForDev above.
+    turbopackFileSystemCacheForDev: resolveTurbopackFileSystemCacheForDev(),
     // Optimize package imports for faster builds and smaller bundles
     optimizePackageImports: [
       '@phosphor-icons/react',

--- a/tests/src/core/local-stack.ts
+++ b/tests/src/core/local-stack.ts
@@ -332,6 +332,46 @@ export async function localWebHealthy(webUrl: string): Promise<boolean> {
   }
 }
 
+/**
+ * The environment the deterministic local stack hands its Next dev server.
+ *
+ * Exported as a pure function so the contract is assertable without spawning a
+ * process — see local-web-environment.test.ts.
+ */
+export function localWebEnvironment(options: {
+  webPort: number;
+  webUrl: string;
+  apiUrl: string;
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+}): Record<string, string> {
+  const { webPort, webUrl, apiUrl, supabaseUrl, supabaseAnonKey } = options;
+  return {
+    WEB_PORT: String(webPort),
+    KORTIX_API_PROXY_TARGET: apiUrl.replace(/\/v1$/, ""),
+    NEXT_PUBLIC_BACKEND_URL: apiUrl,
+    KORTIX_PUBLIC_BACKEND_URL: apiUrl,
+    BACKEND_URL: apiUrl,
+    SUPABASE_URL: supabaseUrl,
+    NEXT_PUBLIC_SUPABASE_URL: supabaseUrl,
+    KORTIX_PUBLIC_SUPABASE_URL: supabaseUrl,
+    SUPABASE_ANON_KEY: supabaseAnonKey,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: supabaseAnonKey,
+    KORTIX_PUBLIC_SUPABASE_ANON_KEY: supabaseAnonKey,
+    NEXT_PUBLIC_APP_URL: webUrl,
+    KORTIX_PUBLIC_APP_URL: webUrl,
+    NEXT_PUBLIC_URL: webUrl,
+    NEXT_PUBLIC_BILLING_ENABLED: "false",
+    // A one-shot test run starts with a cold `.next/dev/cache` and deletes it
+    // afterwards, so Turbopack's dev filesystem cache saves nothing here. It
+    // can still cost the entire browser shard: a failed restore panics outside
+    // turbo-tasks' per-task boundary and aborts the dev server, after which
+    // every remaining spec fails with ERR_CONNECTION_REFUSED and names itself
+    // instead of the real cause. See apps/web/next.config.ts.
+    KORTIX_TURBOPACK_FS_CACHE: "off",
+  };
+}
+
 export async function ensureLocalWeb(
   topology: LocalTopology,
   options: { autoStart: boolean; supabase: LocalSupabaseEnvironment },
@@ -356,21 +396,13 @@ export async function ensureLocalWeb(
       detached: true,
       env: {
         ...process.env,
-        WEB_PORT: String(webPort),
-        KORTIX_API_PROXY_TARGET: topology.apiUrl.replace(/\/v1$/, ""),
-        NEXT_PUBLIC_BACKEND_URL: topology.apiUrl,
-        KORTIX_PUBLIC_BACKEND_URL: topology.apiUrl,
-        BACKEND_URL: topology.apiUrl,
-        SUPABASE_URL: API_URL,
-        NEXT_PUBLIC_SUPABASE_URL: API_URL,
-        KORTIX_PUBLIC_SUPABASE_URL: API_URL,
-        SUPABASE_ANON_KEY: ANON_KEY,
-        NEXT_PUBLIC_SUPABASE_ANON_KEY: ANON_KEY,
-        KORTIX_PUBLIC_SUPABASE_ANON_KEY: ANON_KEY,
-        NEXT_PUBLIC_APP_URL: webUrl,
-        KORTIX_PUBLIC_APP_URL: webUrl,
-        NEXT_PUBLIC_URL: webUrl,
-        NEXT_PUBLIC_BILLING_ENABLED: "false",
+        ...localWebEnvironment({
+          webPort,
+          webUrl,
+          apiUrl: topology.apiUrl,
+          supabaseUrl: API_URL,
+          supabaseAnonKey: ANON_KEY,
+        }),
       },
       stdin: "ignore",
       stdout: "inherit",
@@ -381,9 +413,27 @@ export async function ensureLocalWeb(
   const deadline = Date.now() + 180_000;
   while (Date.now() < deadline) {
     if (await localWebHealthy(webUrl)) {
+      // Nothing watches the dev server once it is ready, so a mid-run death
+      // used to reach the report as N unrelated spec failures — each one
+      // blaming itself for an ERR_CONNECTION_REFUSED against a dead port, the
+      // real cause hundreds of lines earlier in a shared stdout. Say it once,
+      // loudly, at the moment it happens.
+      let stopping = false;
+      void web.exited.then((code) => {
+        if (stopping) return;
+        console.error(
+          `[local-stack] the local web server exited with code ${code} while ` +
+            `tests were still running. Every browser spec from this point on ` +
+            `will fail against ${webUrl} with a connection error, whatever ` +
+            `each one reports. Look above this line for the cause.`,
+        );
+      });
       return {
         started: true,
-        stop: async () => stopOwnedStack(web),
+        stop: async () => {
+          stopping = true;
+          await stopOwnedStack(web);
+        },
       };
     }
     if (web.exitCode !== null) {

--- a/tests/unit/local-web-environment.test.ts
+++ b/tests/unit/local-web-environment.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { localWebEnvironment } from "../src/core/local-stack";
+
+const options = {
+  webPort: 3000,
+  webUrl: "http://127.0.0.1:3000",
+  apiUrl: "http://127.0.0.1:8008/v1",
+  supabaseUrl: "http://127.0.0.1:54321",
+  supabaseAnonKey: "anon-key",
+};
+
+describe("localWebEnvironment", () => {
+  // The regression this guards: Turbopack's dev filesystem cache is default-ON
+  // since Next 16.1. A failed restore panics outside turbo-tasks' per-task
+  // panic boundary and aborts the dev server:
+  //
+  //   thread 'tokio-rt-worker' panicked at
+  //     turbo-tasks-backend/src/backend/operation/mod.rs:292:17:
+  //   Restore of All for task TaskId 7979517 failed in another thread
+  //
+  // Every browser spec scheduled after that point then failed with
+  // ERR_CONNECTION_REFUSED and reported ITSELF as the failure. A one-shot CI
+  // job starts with a cold cache and deletes it afterwards, so it gains
+  // nothing from the cache and loses a whole shard when the abort lands.
+  it("turns off the Turbopack dev filesystem cache", () => {
+    expect(localWebEnvironment(options).KORTIX_TURBOPACK_FS_CACHE).toBe("off");
+  });
+
+  it("points the web app at the local api, supabase, and its own origin", () => {
+    const env = localWebEnvironment(options);
+    expect(env.NEXT_PUBLIC_BACKEND_URL).toBe("http://127.0.0.1:8008/v1");
+    expect(env.NEXT_PUBLIC_SUPABASE_URL).toBe("http://127.0.0.1:54321");
+    expect(env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("anon-key");
+    expect(env.NEXT_PUBLIC_APP_URL).toBe("http://127.0.0.1:3000");
+    expect(env.WEB_PORT).toBe("3000");
+  });
+
+  // The proxy target is the API ORIGIN, not the versioned base the SDK uses.
+  // Passing the /v1 suffix through would make every proxied path /v1/v1/....
+  it("strips the /v1 suffix from the proxy target", () => {
+    expect(localWebEnvironment(options).KORTIX_API_PROXY_TARGET).toBe(
+      "http://127.0.0.1:8008",
+    );
+  });
+
+  it("disables billing so the deterministic profile never reaches Stripe", () => {
+    expect(localWebEnvironment(options).NEXT_PUBLIC_BILLING_ENABLED).toBe(
+      "false",
+    );
+  });
+});


### PR DESCRIPTION
## The report was wrong

`browser-2` on PR #7194 reported 4 failed specs. None of them were broken.

Turbopack's dev filesystem cache (`experimental.turbopackFileSystemCacheForDev`, default-ON since Next 16.1) failed a restore and panicked **outside** turbo-tasks' per-task panic boundary:

```
thread 'tokio-rt-worker' (26258) panicked at
  turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs:292:17:
Restore of All for task TaskId 7979517 failed in another thread: restoring failed
turbo-tasks: an internal panic occurred outside the per-task panic boundary.
Aborting.
```

That aborted the Next dev server. What the report showed, and what actually happened:

| Spec | Reported | Actual |
| --- | --- | --- |
| `26-i18n-settings` | failed after 8.5m | mid-run when the server died, `ERR_CONNECTION_RESET` |
| `27-desktop-parity` (web + desktop) | failed in ~550ms | `ERR_CONNECTION_REFUSED`, dead port |
| `free-tier-pricing-onboarding` | failed | `ERR_CONNECTION_REFUSED`, dead port |

One process death, ~500 lines up a shared stdout, reported as four unrelated spec failures.

## Two changes

**1. The deterministic test stack turns the cache off.** `KORTIX_TURBOPACK_FS_CACHE=off` maps to `turbopackFileSystemCacheForDev: false`. A one-shot CI job starts with a cold cache and deletes it afterwards, so it gains nothing from the cache and loses a whole shard when the abort lands. Unset (every developer machine, every real deployment) keeps upstream's default.

Measured, same worktree, same routes compiled:

| `KORTIX_TURBOPACK_FS_CACHE` | `.next/dev/cache/turbopack/` |
| --- | --- |
| unset | present, 88M |
| `off` | absent |

**2. A dead dev server says so.** `ensureLocalWeb` only checked the process while waiting for readiness. Now it watches the exit for the life of the run and prints one line naming the real cause the moment it happens.

The web environment moves into an exported pure function, `localWebEnvironment`, so the contract is assertable without spawning a process.

## Verified

- `tests` typecheck clean; **44 files / 443 unit tests pass**
- the new test **fails** when `KORTIX_TURBOPACK_FS_CACHE` is removed and passes when restored
- `apps/web` `tsc --noEmit` shows only the 15 documented `@types/bun` `test.each` errors
- the cache-directory measurement above is from two real dev-server boots in this worktree

## Not fixed here

The upstream Turbopack panic itself. This removes the code path from CI and makes the next shared-process death legible in one line instead of 40 minutes of log archaeology.

https://claude.ai/code/session_01ECsZyxXpTLhyQxGsz3QtX2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791656134&installation_model_id=434224&pr_number=7201&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7201&signature=00012890b4f331d694a1172b19aa35421628e428af8d330a45b9aa57917dc2cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->