### PR TITLE
fix: verify release flows and persist self-host frontend memory

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,16 @@ linked, not inlined.
 
 ## Register
 
+### Stop concurrent deployed suites when managed GitHub reports a secondary limit (2026-09-10)
+
+**When:** preview and staging tests share a managed GitHub organization.
+Stop content-creating runs, allow a quiet backoff interval, then retry unfinished
+shards serially. A primary rate-limit budget does not prove secondary capacity.
+*Near-miss:* 0.13.13 validation exhausted repository creation; preview and staging
+provisioning returned 503 with GitHub's secondary-limit response.
+*Enforcer:* manual serialized job reruns; TODO: a shared deployed-suite lease
+and secondary-limit backoff in the managed GitHub client.
+
 ### Give a shared modal store exactly one active renderer (2026-09-10)
 
 **When:** a page and its nested settings overlay both mount a global dialog.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4667,3 +4667,21 @@ drift, stale commit, unreadable manifest, cooldown),
 `apps/api/src/connectors/principal-access.test.ts`, and flow `CONN-27`
 (a real session-bound token: hot reload with provenance, glitch repair,
 channel guarantee, honest denials, ten calls after a mid-session add).
+
+
+## A failed artifact secret guard must prevent upload (2026-09-10)
+
+**Incident.** Release run `34510232187`, attempt 3, was canceled during browser
+shard 2. Cancellation left raw Playwright traces before reporter scrubbing.
+The secret guard rejected the traces, but `upload-artifact` used `always()`
+and uploaded them anyway. Artifact `10166938271` was deleted in this session.
+The earlier attempt 1 artifact guard passed. No secret value was printed
+during this investigation.
+
+**Rule.** Diagnostic uploads run after failed or canceled tests only when
+the artifact secret guard completed successfully. A failed or skipped guard
+blocks upload. Preserve the guard failure as the job result.
+
+**Enforcement.** `.github/workflows/tests-release.yml` gives both API and browser
+guards the `artifact-secrets` step ID. Both upload steps require
+`steps.artifact-secrets.outcome == 'success'` in addition to `always()`.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4685,3 +4685,45 @@ blocks upload. Preserve the guard failure as the job result.
 **Enforcement.** `.github/workflows/tests-release.yml` gives both API and browser
 guards the `artifact-secrets` step ID. Both upload steps require
 `steps.artifact-secrets.outcome == 'success'` in addition to `always()`.
+
+
+## Custom diagnostic headers require explicit artifact redaction (2026-09-10)
+
+**Incident.** Release run `34510198802` API shard 5 recorded
+`x-kortix-ci-passthrough` in its public `results.json`. The request-capture
+sensitive-header set did not mask it, and its hexadecimal value did not match
+the final secret-shape scrubber. A bounded report inspection also printed
+the captured header before this omission was identified.
+
+**Rule.** Add every credential-bearing diagnostic header to capture-time
+redaction when introducing it. Do not assume a final shape-based scrubber
+recognizes arbitrary secrets. Inspect only selected response fields while
+diagnosing a flow; do not print a whole request or result object.
+
+**Enforcement.** `tests/src/core/client.ts` masks this header.
+`tests/unit/client-ci-passthrough.test.ts` proves the outgoing request carries
+the credential while the captured artifact omits its full value. The new
+regression failed before the fix; all 32 focused client/scrubber tests pass.
+Both release artifact guards also reject the exact diagnostic credential.
+The staging Worker binding and matching GitHub Actions secret were rotated
+at `2026-09-10T18:49:37Z`. The current Worker no longer reads that legacy
+diagnostic binding; its HTTP health response remains `200` at source
+`2dd55445`.
+
+## Browser and runtime tests must express the current user interaction (2026-09-10)
+
+**Incident.** The v0.13.13 gate searched for a `Connected` heading behind an
+open connector dialog. The current page exposes a `Connected` tab. Both
+connector writes returned `200`, and the dialog showed `Reconnect`. The
+RUN-9 fixture separately said "Disregard everything above"; the model
+classified the latest user request as prompt injection and continued the
+previous essay after a successful abort.
+
+**Rule.** Close a modal before asserting on the page behind it. Match the
+current accessible role. A transport cancellation fixture uses an ordinary
+new user request, without asking the model to disregard prior instructions.
+Keep the network, persisted-state, abort, and second-turn marker assertions.
+
+**Enforcement.** `23-composio-connector.spec.ts` closes the detail dialog and
+asserts the selected `Connected` tab. `session-thread-reliability.flow.ts`
+uses an explicit essay cancellation followed by the same exact reply marker.

--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -4727,3 +4727,24 @@ Keep the network, persisted-state, abort, and second-turn marker assertions.
 **Enforcement.** `23-composio-connector.spec.ts` closes the detail dialog and
 asserts the selected `Connected` tab. `session-thread-reliability.flow.ts`
 uses an explicit essay cancellation followed by the same exact reply marker.
+
+
+## Self-host memory adjustments must survive CLI regeneration (2026-09-10)
+
+**Incident.** Before the Essentia update, both frontend replicas had restarted
+234 times. Logs repeatedly reported `Reached heap limit`. Each container
+had a 512 MiB limit while the 16 GiB host had about 9.9 GiB available.
+The CLI hardcoded the frontend limit, so editing generated Compose would
+be overwritten by the next manual update.
+
+**Rule.** Expose per-service resource adjustments through persisted instance
+configuration. Map the configuration key to that service. Verify the actual
+CLI command and the resolved Docker Compose configuration before a rollout.
+
+**Enforcement.** `KORTIX_FRONTEND_MEMORY_LIMIT` overrides the frontend limit
+with a 512 MiB default. Its service mapping selects only `frontend`.
+The CLI regression verifies `env set` and a later `init` preserve the value.
+A real CLI/Docker Compose check resolves 536870912 bytes by default and
+1073741824 bytes after configuring `1024m`, including after another `init`.
+All 134 focused self-host tests pass. Live Essentia verification follows
+the production release and manual update.

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -249,6 +249,7 @@ jobs:
         continue-on-error: true
         run: bun tests/bin/ke2e.ts gc --run-id "$KE2E_RUN_ID"
       - name: Guard test artifacts against secrets
+        id: artifact-secrets
         if: always()
         run: |
           set -euo pipefail
@@ -265,7 +266,8 @@ jobs:
           fi
           echo "No secret-shaped values found."
       - uses: actions/upload-artifact@v7
-        if: always()
+        # Cancellation can leave raw Playwright traces before reporter scrubbing.
+        if: ${{ always() && steps.artifact-secrets.outcome == 'success' }}
         with:
           name: tests-release-api-shard-${{ matrix.shard }}
           path: |
@@ -348,6 +350,7 @@ jobs:
       # is nothing to scope to. sweep-before now covers those domains, which it
       # did not before, so their debris is reclaimed on the next run.
       - name: Guard test artifacts against secrets
+        id: artifact-secrets
         if: always()
         run: |
           set -euo pipefail
@@ -364,7 +367,8 @@ jobs:
           fi
           echo "No secret-shaped values found."
       - uses: actions/upload-artifact@v7
-        if: always()
+        # Cancellation can leave raw Playwright traces before reporter scrubbing.
+        if: ${{ always() && steps.artifact-secrets.outcome == 'success' }}
         with:
           name: tests-release-browser-shard-${{ matrix.shard }}
           path: |

--- a/.github/workflows/tests-release.yml
+++ b/.github/workflows/tests-release.yml
@@ -264,6 +264,11 @@ jobs:
             echo "::error::A test artifact contains a secret-shaped value."
             exit 1
           fi
+          if [ -n "${KE2E_CI_PASSTHROUGH_SECRET:-}" ] && [ -d tests/test-results ] \
+            && grep -rFq -- "$KE2E_CI_PASSTHROUGH_SECRET" tests/test-results; then
+            echo "::error::A test artifact contains the CI diagnostic credential."
+            exit 1
+          fi
           echo "No secret-shaped values found."
       - uses: actions/upload-artifact@v7
         # Cancellation can leave raw Playwright traces before reporter scrubbing.
@@ -363,6 +368,11 @@ jobs:
           pattern='kortix_(pat|sa)_[A-Za-z0-9]{12,}|sk-[A-Za-z0-9]{20,}|eyJ[A-Za-z0-9_-]{30,}\.'
           if [ -d tests/test-results ] && grep -rEIl "$pattern" tests/test-results; then
             echo "::error::A test artifact contains a secret-shaped value."
+            exit 1
+          fi
+          if [ -n "${KE2E_CI_PASSTHROUGH_SECRET:-}" ] && [ -d tests/test-results ] \
+            && grep -rFq -- "$KE2E_CI_PASSTHROUGH_SECRET" tests/test-results; then
+            echo "::error::A test artifact contains the CI diagnostic credential."
             exit 1
           fi
           echo "No secret-shaped values found."

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -111,6 +111,10 @@ Edge Runtime, Kong, Studio, Supavisor, Logflare, and Vector. Published ports
 bind to loopback by default, and all generated secret material is stored in the
 owner-only instance `.env`.
 
+Set `KORTIX_FRONTEND_MEMORY_LIMIT=1024m` through `self-host env set` to raise
+only the frontend container's memory limit. The default is `512m` per replica.
+The setting persists through later updates.
+
 ### Enterprise AWS EC2
 
 ```sh

--- a/apps/cli/src/self-host/__tests__/secrets.test.ts
+++ b/apps/cli/src/self-host/__tests__/secrets.test.ts
@@ -73,6 +73,7 @@ describe('secrets-registry pure helpers', () => {
 
     expect(servicesForKeys(['NOT_A_REAL_KEY'])).toEqual(['kortix-api']);
     expect(servicesForKeys(['COMPOSIO_API_KEY'])).toEqual(['kortix-api']);
+    expect(servicesForKeys(['KORTIX_FRONTEND_MEMORY_LIMIT'])).toEqual(['frontend']);
     expect(servicesForKeys([])).toEqual([]);
   });
 

--- a/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
+++ b/apps/cli/src/self-host/__tests__/self-host-cli.test.ts
@@ -78,6 +78,19 @@ describe('kortix self-host (generic Docker CLI)', () => {
     return parse(readFileSync(join(configRoot, instanceName, 'docker-compose.yml'), 'utf8'));
   }
 
+  test('frontend memory override survives env set and a later init', async () => {
+    expect((await run(['init', '--yes'])).code).toBe(0);
+    expect((readCompose().services.frontend as { mem_limit: string }).mem_limit)
+      .toBe('${KORTIX_FRONTEND_MEMORY_LIMIT:-512m}');
+    const configured = await run(['env', 'set', 'KORTIX_FRONTEND_MEMORY_LIMIT=1024m']);
+    expect(configured.code).toBe(0);
+    expect(readEnv().KORTIX_FRONTEND_MEMORY_LIMIT).toBe('1024m');
+    expect((await run(['init', '--yes'])).code).toBe(0);
+    expect(readEnv().KORTIX_FRONTEND_MEMORY_LIMIT).toBe('1024m');
+    expect((readCompose().services.frontend as { mem_limit: string }).mem_limit)
+      .toBe('${KORTIX_FRONTEND_MEMORY_LIMIT:-512m}');
+  });
+
   test('init defaults to the shared auth+sandbox defaults and the stable channel', async () => {
     const { code } = await run(['init', '--yes']);
     expect(code).toBe(0);

--- a/apps/cli/src/self-host/compose-assets.ts
+++ b/apps/cli/src/self-host/compose-assets.ts
@@ -655,7 +655,7 @@ const MEM_LIMITS: Readonly<Record<string, MemSpec>> = {
   // 2 GiB default so a big image-heavy turn never OOM-kills the gateway; small
   // boxes can dial it back via KORTIX_GATEWAY_MEMORY_LIMIT.
   'llm-gateway': { limit: '${KORTIX_GATEWAY_MEMORY_LIMIT:-2048m}', reservation: '256m' },
-  frontend: { limit: '512m', reservation: '128m' },
+  frontend: { limit: '${KORTIX_FRONTEND_MEMORY_LIMIT:-512m}', reservation: '128m' },
   'kortix-migrate': { limit: '512m', reservation: '128m' },
   'kortix-updater': { limit: '256m', reservation: '64m' },
   'supabase-kong': { limit: '384m', reservation: '128m' },

--- a/apps/cli/src/self-host/secrets-registry.ts
+++ b/apps/cli/src/self-host/secrets-registry.ts
@@ -316,6 +316,7 @@ export const KEY_SERVICE_MAP: Record<string, readonly string[]> = {
   KORTIX_PREVIEW_BASE_DOMAIN: ['kortix-api', 'caddy'],
   KORTIX_PREVIEW_ALLOW_DIRECT_EDGE: ['kortix-api'],
   KORTIX_APPS_ALLOW_DIRECT_EDGE: ['kortix-api'],
+  KORTIX_FRONTEND_MEMORY_LIMIT: ['frontend'],
 
   // Internal tokens
   GATEWAY_INTERNAL_TOKEN: ['kortix-api', 'llm-gateway'],

--- a/docs/runbooks/self-hosting.md
+++ b/docs/runbooks/self-hosting.md
@@ -379,6 +379,16 @@ whether a newer release is available.
 
 ## Configuring email, Daytona, and other integrations later
 
+The frontend container defaults to a 512 MiB memory limit. If its logs report
+`Reached heap limit`, set a larger limit that fits the host's available memory:
+
+```bash
+kortix self-host env set KORTIX_FRONTEND_MEMORY_LIMIT=1024m
+```
+
+This setting restarts the frontend and persists through later CLI updates.
+For a rollout with two replicas, each replica receives the configured limit.
+
 Everything is `kortix self-host env set KEY=VALUE …` followed by
 `kortix self-host start` (or the interactive `kortix self-host configure`),
 whether at first boot or months later:

--- a/tests/e2e/specs/23-composio-connector.spec.ts
+++ b/tests/e2e/specs/23-composio-connector.spec.ts
@@ -381,9 +381,11 @@ test.describe("23 — Composio managed connector", () => {
     await expect(
       detail.getByRole("button", { name: "Reconnect", exact: true }),
     ).toBeVisible();
+    await detail.getByRole("button", { name: "Close", exact: true }).click();
+    await expect(detail).not.toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Connected", exact: true }),
-    ).toBeVisible();
+      page.getByRole("tab", { name: "Connected", exact: true }),
+    ).toHaveAttribute("aria-selected", "true");
 
     const connections = await api<ConnectionList>(
       session.access_token,

--- a/tests/src/core/client.ts
+++ b/tests/src/core/client.ts
@@ -68,6 +68,7 @@ const SENSITIVE_HEADERS = new Set([
   'cookie',
   'set-cookie',
   'x-kortix-token',
+  'x-kortix-ci-passthrough',
   'x-kortix-signature',
   'x-hub-signature',
   'x-hub-signature-256',

--- a/tests/src/flows/session-thread-reliability.flow.ts
+++ b/tests/src/flows/session-thread-reliability.flow.ts
@@ -374,7 +374,7 @@ flow(
             parts: [
               {
                 type: 'text',
-                text: `Disregard everything above. Reply with exactly this single token and nothing else: ${secondPromptMarker}`,
+                text: `The railway essay task is canceled. For this new turn, confirm the cancellation by replying with exactly this single token and nothing else: ${secondPromptMarker}`,
               },
             ],
           });

--- a/tests/unit/client-ci-passthrough.test.ts
+++ b/tests/unit/client-ci-passthrough.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { CI_PASSTHROUGH_HEADER, applyCiPassthrough } from '../src/core/client';
+import { randomBytes } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client, CI_PASSTHROUGH_HEADER, applyCiPassthrough } from '../src/core/client';
 
 describe('applyCiPassthrough — edge origin-status passthrough opt-in', () => {
   it('sends nothing when the secret is unset or blank', () => {
@@ -22,4 +23,25 @@ describe('applyCiPassthrough — edge origin-status passthrough opt-in', () => {
     applyCiPassthrough(h, 'from-env');
     expect(h.get(CI_PASSTHROUGH_HEADER)).toBe('explicit');
   });
+});
+
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+it('sends the diagnostic credential but redacts it from captured artifacts', async () => {
+  const secret = randomBytes(32).toString('hex');
+  vi.stubEnv('KE2E_CI_PASSTHROUGH_SECRET', secret);
+  const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+    expect(new Headers(init.headers).get(CI_PASSTHROUGH_HEADER)).toBe(secret);
+    return new Response('{}', { headers: { 'content-type': 'application/json' } });
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const response = await new Client('https://example.test/v1').get('/v1/health');
+  expect(fetchMock).toHaveBeenCalledOnce();
+  expect(response.captured.req.headers[CI_PASSTHROUGH_HEADER.toLowerCase()]).toBe(`${secret.slice(0, 6)}***[64]`);
+  expect(JSON.stringify(response.captured)).not.toContain(secret);
 });


### PR DESCRIPTION
Essentia’s frontend replicas repeatedly exhaust their JavaScript heaps under a hardcoded 512 MiB container limit. The CLI now supports `KORTIX_FRONTEND_MEMORY_LIMIT`, preserves it across updates, and maps changes only to the frontend. Its default stays 512 MiB; Essentia will use 1024 MiB during the manual update.

The v0.13.13 gate failed on a stale connector-page heading and a cancellation prompt that the model treated as prompt injection. This change closes the connector dialog and checks the selected Connected tab. RUN-9 uses a normal task-cancellation request while retaining its abort, reply-marker, and completed-message assertions.

The release workflow also uploaded raw browser traces after cancellation despite a failed secret guard. Uploads now require that guard to pass. Request capture masks the CI diagnostic header, and both artifact guards reject its exact value. The exposed staging diagnostic value was rotated in Cloudflare and GitHub at 18:49 UTC on September 10.

Validation:
- Self-host CLI, Compose, and secret/service-mapping tests: 134 passed; CLI typecheck: exit 0.
- Real CLI `init → env set → init`, resolved by `docker compose config`: 536870912-byte default; 1073741824-byte configured and persisted frontend limit.
- `pnpm --dir tests exec tsc --noEmit`: exit 0.
- `actionlint .github/workflows/tests-release.yml`: exit 0.
- Focused client/resilience/scrubber tests: 32 passed. The new credential-capture regression failed before the fix.
- Staging `bun bin/ke2e.ts run --id RUN-9`: 1 passed, 0 failed, 0 skipped; 95.4 seconds for the flow. An earlier attempt hit a Daytona provider-ingress 503 before cancellation.
- Staging `pnpm --dir tests run test:browser --grep 'connects a real no-auth toolkit through the UI'`: passed on retry. The first attempt had an aborted create request; the corrected tab assertion and persisted-connection checks passed.

API, gateway, and web application code remain identical to deployed staging source `2dd55445`. The CLI adds only the persisted memory override described above. The existing complete staging gate is finishing before this candidate replaces it. The next release gate must test the new exact source SHA.
