### PR TITLE
ci(deploy-staging): main must assert the host-only access cookie, like staging already does

### DIFF
--- a/.claude/skills/learnings/SKILL.md
+++ b/.claude/skills/learnings/SKILL.md
@@ -21,6 +21,31 @@ linked, not inlined.
 
 ## Register
 
+### A `workflow_run` job runs the DEFAULT BRANCH's copy of the workflow, not the branch it is deploying (2026-09-10)
+
+**When:** a workflow triggered by `workflow_run:` verifies or deploys another
+branch. `deploy-staging.yml` fires on `workflow_run` after Build Staging
+Artifacts. GitHub loads that YAML from the DEFAULT branch (`main`), while the
+job checks out and deploys `staging`. So staging can hold a corrected workflow
+and still be verified by main's stale one. Here staging's copy asserted the
+HOST-ONLY access cookie (correct since #7065 stopped `.kortix.com` sending
+dev's cookie to staging, prod and api.kortix.com alike); main's copy still
+demanded the parent-domain cookie the app deliberately no longer sets. The
+staging deploy for `40c750d5d6` deployed everything correctly and then failed
+its own verification, blocking the promote — while the previous deploy of the
+same code had PASSED because it ran via `workflow_dispatch`, which uses the
+selected branch's file. Same workflow, same environment, opposite verdicts,
+decided only by trigger type. **Rules.** (1) A fix to a `workflow_run` workflow
+is not live until it is on the DEFAULT branch — landing it on the branch under
+test changes nothing. (2) When a `workflow_run` deploy fails a check its
+`workflow_dispatch` twin passes, diff the workflow file between the two
+branches before touching anything else. (3) An assertion about a security
+property must be re-read when that property is deliberately changed; this one
+asserted the exact bug #7065 removed. *Incident:* v0.13.14 promote blocked,
+2026-09-10; second occurrence (v0.13.11, 2026-09-05, PR #7137 still open).
+*Enforcer:* the assertion now also REFUSES a `.kortix.com` row, so a #7065
+regression fails loudly instead of silently satisfying the old rule.
+
 ### A finished run must LEAVE — `process.exitCode` alone waits on a loop one leaked handle keeps alive forever (2026-09-10)
 
 **When:** writing the completion path of any long-running CLI, test runner, or

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -656,9 +656,17 @@ jobs:
           { [ "$cookie_status" = 200 ] || [ "$cookie_status" = 307 ] || [ "$cookie_status" = 308 ]; } || {
             echo "::error::staging ECS frontend shared-cookie status=$cookie_status"; exit 1;
           }
-          grep -E $'^(#HttpOnly_)?\\.kortix\\.com\t' "$cookie_jar" >/dev/null || {
-            echo "::error::staging ECS frontend did not set the parent-domain access cookie"; exit 1;
+          # The access cookie is HOST-ONLY since #7065: the old Domain=.kortix.com
+          # cookie reached every subdomain (staging, prod, api.kortix.com) no
+          # matter which environment authorized it. curl writes a host-only
+          # cookie under the exact issuing host, so assert that row and refuse a
+          # Domain-scoped one — a `.kortix.com` row here means #7065 regressed.
+          awk -F'\t' -v h="$ECS_WEB_HOST" '$1 == h || $1 == "#HttpOnly_" h { found = 1 } END { exit !found }' "$cookie_jar" || {
+            echo "::error::staging ECS frontend did not set a host-only access cookie for ${ECS_WEB_HOST}"; exit 1;
           }
+          if awk -F'\t' '$1 == ".kortix.com" || $1 == "#HttpOnly_.kortix.com" { found = 1 } END { exit !found }' "$cookie_jar"; then
+            echo "::error::staging ECS frontend set a Domain-scoped .kortix.com access cookie (#7065 made it host-only)"; exit 1;
+          fi
           ecs_health="$(curl -fsS --max-time 20 "$ecs/api/health")"
           [ "$(jq -r '.commit // empty' <<<"$ecs_health")" = "$EXPECTED_COMMIT" ] || {
             echo "::error::staging ECS frontend commit mismatch"; exit 1;
@@ -681,7 +689,7 @@ jobs:
           {
             echo "### Staging verified"
             echo "- API: https://${PUBLIC_API_HOST}/v1/health reports staging ${EXPECTED_VERSION}"
-            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts the shared test cookie"
+            echo "- ECS web: https://${ECS_WEB_HOST} reports ${EXPECTED_COMMIT} and accepts its host-only test cookie"
             echo "- Vercel web: https://${WEB_HOST} serves staging runtime config"
             echo "- GitOps: API ALB via ECS Fargate"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## A correct deploy failed its own verification

The staging deploy for `40c750d5d6` deployed everything — API, gateway, both web paths, migrations, Terraform, DNS — and then failed with:

```
staging ECS frontend did not set the parent-domain access cookie
```

The deployment was fine. The assertion was wrong, and it was **main's** assertion.

## Why main's file ran against staging

`deploy-staging.yml` fires on `workflow_run`. GitHub loads that YAML from the **default branch** while the job checks out and deploys `staging`. So staging can hold a corrected workflow and still be verified by main's stale one.

| Trigger | Workflow file used | Result on the same code |
| --- | --- | --- |
| `workflow_dispatch` | the selected branch's (`staging`) | **passed** |
| `workflow_run` | the default branch's (`main`) | **failed** |

Same workflow, same environment, opposite verdicts, decided only by trigger type.

## Why the old assertion is wrong

The access cookie is host-only by design since #7065. From `apps/web/src/middleware.ts`:

> No `domain` — this is the only Domain-scoped cookie in the repo, and `.kortix.com` sent it to EVERY subdomain: dev's middleware set a cookie that staging, prod, and api.kortix.com all received on every request too, regardless of which environment actually authorized it.

Main's check demanded exactly the cookie that was removed for that reason. It was asserting the bug.

Everything before it already passed: anonymous `401`, wrong password `401`, valid password `200`, cookie accepted. Only the domain scope was contested.

## This change

Cherry-picks the workflow half of the still-open #7137 (`ad9ace7cad`), so main stops failing deploys that succeeded. The file is now byte-identical to staging's copy.

The new assertion also **refuses** a `.kortix.com` row, so a regression of #7065 fails loudly rather than quietly satisfying the old rule.

## Verified

- `diff` against `origin/staging`'s copy of the file: identical
- The host-only behaviour is deliberate and documented in the middleware itself

## Note

#7137 remains open for its other two changes (engine-strict install, deployed-only test contracts). Only the workflow assertion is taken here, because that is what is currently blocking a release.

https://claude.ai/code/session_01ECsZyxXpTLhyQxGsz3QtX2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791674355&installation_model_id=434224&pr_number=7209&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7209&signature=f1e5eb16b112d3b73fedabe7886a6fd9af81c5c1992ca315a98bd9d446c3d31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->