### PR TITLE
fix(web): stack modals opened over open modals; Switch hover contrast

### DIFF
--- a/apps/web/src/app/(system)/debug/debug-theme-toggle.tsx
+++ b/apps/web/src/app/(system)/debug/debug-theme-toggle.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect } from 'react';
+
+import { ThemeToggle } from '@/components/home/theme-toggle';
+
+// Above the dialog z-ladder (overlays start at 9998) so it stays visible while
+// modals are stacked; below the /debug/modal-stack inspector.
+const TOGGLE_Z = 2147482000;
+
+// Keys typed here belong to the control: text entry, select typeahead, menus.
+const KEY_OWNER_SELECTOR =
+  'input, textarea, select, [contenteditable="true"], [role="combobox"], [role="listbox"], [role="menu"]';
+
+function ownsKeys(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(KEY_OWNER_SELECTOR) !== null;
+}
+
+/**
+ * Theme control on every /debug page. A click cannot reach it while a modal is
+ * open — Radix sets `pointer-events: none` on `body` and treats the click as a
+ * backdrop dismiss — so `D` flips light/dark without closing the stack.
+ */
+export function DebugThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 'd') return;
+      if (event.metaKey || event.ctrlKey || event.altKey || event.repeat) return;
+      if (ownsKeys(event.target)) return;
+      setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [resolvedTheme, setTheme]);
+
+  return (
+    <div
+      data-testid="debug-theme-toggle"
+      className="bg-popover fixed bottom-4 left-4 flex items-center gap-2 rounded-md border py-1 pr-1 pl-3 shadow-md"
+      style={{ zIndex: TOGGLE_Z }}
+    >
+      <span className="text-muted-foreground text-xs">
+        Theme · <kbd className="bg-muted text-foreground rounded-sm px-1 font-mono text-xs">D</kbd>
+      </span>
+      <ThemeToggle variant="compact" />
+    </div>
+  );
+}

--- a/apps/web/src/app/(system)/debug/layout.tsx
+++ b/apps/web/src/app/(system)/debug/layout.tsx
@@ -1,11 +1,18 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
+import { DebugThemeToggle } from './debug-theme-toggle';
+
 // Dev-only visual harnesses — never a search result.
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
 export default function DebugLayout({ children }: { children: ReactNode }) {
-  return children;
+  return (
+    <>
+      {children}
+      <DebugThemeToggle />
+    </>
+  );
 }

--- a/apps/web/src/app/(system)/debug/modal-stack/page.tsx
+++ b/apps/web/src/app/(system)/debug/modal-stack/page.tsx
@@ -1,0 +1,462 @@
+'use client';
+
+import { createContext, useContext, useState, useSyncExternalStore, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalContentInner,
+  ModalDescription,
+  ModalHeader,
+  ModalOverlay,
+  ModalPortal,
+  ModalTitle,
+  ModalTrigger,
+} from '@/components/ui/modal';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+import { dialogContentZ, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
+
+/**
+ * /debug/modal-stack
+ *
+ * Opening a modal while another is open must put the new overlay ABOVE the open
+ * card. Depth used to come only from React context, so a modal that is not
+ * nested in the open one's JSX (a global host, a store-driven modal) resolved
+ * depth 1 and its overlay rendered under the card it should dim.
+ * `lib/z-stack.tsx` now stacks by open order.
+ *
+ * Every scenario below opens several layers. The inspector (bottom right) reads
+ * the computed z-index of each open dialog and its overlay from the DOM and
+ * reports a conflict when a layer does not sit above the one opened before it.
+ * "Pre-fix stacking" pins the demo modal cards to their old tree-depth
+ * z-index, so the bug can be reproduced on the same page.
+ *
+ * Not linked from anywhere; just hit /debug/modal-stack.
+ */
+
+const LegacyStackingContext = createContext(false);
+
+// Wider card at the bottom of a stack, so each lower card stays visible.
+const WIDTH_BY_LEVEL = ['lg:max-w-xl', 'lg:max-w-md', 'lg:max-w-sm'];
+
+function DepthReadout({ legacyDepth }: { legacyDepth: number | null }) {
+  const stackDepth = useDialogDepth();
+  const depth = legacyDepth ?? stackDepth;
+  return (
+    <p className="text-muted-foreground text-xs tabular-nums">
+      {legacyDepth === null ? 'Layer' : 'Pre-fix layer'} {depth} · overlay z {dialogOverlayZ(depth)}{' '}
+      · card z {dialogContentZ(depth)}
+    </p>
+  );
+}
+
+function DemoModalContent({
+  title,
+  description,
+  treeDepth,
+  widthLevel,
+  children,
+}: {
+  title: string;
+  description: string;
+  /** Depth the pre-fix code derived from JSX nesting alone. */
+  treeDepth: number;
+  widthLevel: number;
+  children?: ReactNode;
+}) {
+  const legacy = useContext(LegacyStackingContext);
+  const width = WIDTH_BY_LEVEL[Math.min(widthLevel, WIDTH_BY_LEVEL.length - 1)];
+  const inner = (
+    <>
+      <ModalHeader>
+        <ModalTitle>{title}</ModalTitle>
+        <ModalDescription>{description}</ModalDescription>
+      </ModalHeader>
+      <ModalBody className="space-y-4">
+        <DepthReadout legacyDepth={legacy ? treeDepth : null} />
+        {children ? <div className="flex flex-wrap gap-2">{children}</div> : null}
+      </ModalBody>
+    </>
+  );
+
+  if (!legacy) return <ModalContent className={width}>{inner}</ModalContent>;
+
+  return (
+    <ModalPortal>
+      <ModalOverlay style={{ zIndex: dialogOverlayZ(treeDepth) }} />
+      <ModalContentInner className={width} style={{ zIndex: dialogContentZ(treeDepth) }}>
+        {inner}
+      </ModalContentInner>
+    </ModalPortal>
+  );
+}
+
+// ─── Layer inspector ────────────────────────────────────────────────────────
+
+type InspectedLayer = { title: string; overlayZ: number | null; contentZ: number };
+
+function subscribeToBody(onChange: () => void) {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['data-state', 'style'],
+  });
+  return () => observer.disconnect();
+}
+
+/** Serialized so an unchanged DOM yields an identical snapshot. */
+function readOpenLayers(): string {
+  const layers: InspectedLayer[] = [];
+  // Document order is open order: each Radix portal appends to `body`.
+  const dialogs = document.querySelectorAll<HTMLElement>(
+    '[role="dialog"][data-state="open"],[role="alertdialog"][data-state="open"],[role="dialog"][aria-modal="true"]',
+  );
+  for (const dialog of dialogs) {
+    // Popovers also carry role="dialog" but live inside a popper wrapper.
+    if (dialog.parentElement !== document.body) continue;
+    const titleId = dialog.getAttribute('aria-labelledby');
+    const title =
+      (titleId ? document.getElementById(titleId)?.textContent : null) ||
+      dialog.getAttribute('aria-label') ||
+      'Untitled layer';
+    const previous = dialog.previousElementSibling;
+    const overlay =
+      previous instanceof HTMLElement &&
+      !previous.hasAttribute('role') &&
+      getComputedStyle(previous).position === 'fixed'
+        ? previous
+        : null;
+    layers.push({
+      title,
+      overlayZ: overlay ? Number(getComputedStyle(overlay).zIndex) : null,
+      contentZ: Number(getComputedStyle(dialog).zIndex),
+    });
+  }
+  return JSON.stringify(layers);
+}
+
+const serverLayers = () => null;
+
+// Above every product layer, including toasts.
+const INSPECTOR_Z = 2147483000;
+
+function LayerInspector() {
+  const snapshot = useSyncExternalStore(subscribeToBody, readOpenLayers, serverLayers);
+  if (snapshot === null) return null;
+
+  const layers = JSON.parse(snapshot) as InspectedLayer[];
+  const results = layers.map((layer, index) => {
+    const below = layers[index - 1];
+    if (!below) return true;
+    const overlayAbove = layer.overlayZ === null || layer.overlayZ > below.contentZ;
+    return overlayAbove && layer.contentZ > below.contentZ;
+  });
+  const conflict = results.includes(false);
+
+  return createPortal(
+    <div
+      aria-hidden
+      data-testid="modal-stack-inspector"
+      className="bg-popover pointer-events-none fixed right-4 bottom-4 w-72 space-y-2 rounded-md border px-4 py-3 shadow-xl"
+      style={{ zIndex: INSPECTOR_Z }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium">Layer inspector</span>
+        {layers.length > 1 ? (
+          <Badge variant={conflict ? 'destructive' : 'success'} size="sm">
+            {conflict ? 'Conflict' : 'Stacked'}
+          </Badge>
+        ) : null}
+      </div>
+      {layers.length === 0 ? (
+        <p className="text-muted-foreground text-xs">No layer open.</p>
+      ) : (
+        <ol className="space-y-1.5">
+          {layers.map((layer, index) => (
+            <li key={`${layer.title}-${index}`} className="flex items-center gap-2 text-xs">
+              <span
+                className={cn(
+                  'size-1.5 shrink-0 rounded-full',
+                  results[index] ? 'bg-kortix-green' : 'bg-kortix-red',
+                )}
+              />
+              <span className="min-w-0 flex-1 truncate">{layer.title}</span>
+              <span className="text-muted-foreground shrink-0 tabular-nums">
+                {layer.overlayZ ?? '—'} / {layer.contentZ}
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+      <p className="text-muted-foreground text-xs">Opened first at the top · overlay z / card z</p>
+    </div>,
+    document.body,
+  );
+}
+
+// ─── Scenarios ──────────────────────────────────────────────────────────────
+
+const SIBLING_NAMES = ['Modal 1', 'Modal 2', 'Modal 3'];
+
+/** The reported bug: modals that share no React ancestor. */
+function SiblingScenario() {
+  const [open, setOpen] = useState([false, false, false]);
+  const setOne = (index: number, next: boolean) =>
+    setOpen((current) => current.map((value, i) => (i === index ? next : value)));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sibling modals</CardTitle>
+        <CardDescription>
+          Three modals mounted side by side at the page root, like a global host or a store-driven
+          modal. Open one from another, close the one below, reopen it: the most recently opened
+          modal must always be on top with its overlay dimming the rest.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Button size="sm" variant="secondary" onClick={() => setOne(0, true)}>
+          Open modal 1
+        </Button>
+        <Button size="sm" variant="outline" onClick={() => setOpen([true, true, true])}>
+          Open all three at once
+        </Button>
+      </CardContent>
+
+      {SIBLING_NAMES.map((name, index) => (
+        <Modal key={name} open={open[index]} onOpenChange={(next) => setOne(index, next)}>
+          <DemoModalContent
+            title={name}
+            description="A sibling of the other two. None is rendered inside another's JSX."
+            treeDepth={1}
+            widthLevel={index}
+          >
+            {SIBLING_NAMES.map((otherName, otherIndex) =>
+              otherIndex === index ? null : (
+                <Button
+                  key={otherName}
+                  size="sm"
+                  variant={open[otherIndex] ? 'outline' : 'secondary'}
+                  onClick={() => setOne(otherIndex, !open[otherIndex])}
+                >
+                  {open[otherIndex]
+                    ? `Close ${otherName.toLowerCase()}`
+                    : `Open ${otherName.toLowerCase()}`}
+                </Button>
+              ),
+            )}
+            {index === 2 ? (
+              <Select defaultValue="eu">
+                <SelectTrigger className="w-40" size="sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="eu">Europe</SelectItem>
+                  <SelectItem value="us">United States</SelectItem>
+                  <SelectItem value="ap">Asia Pacific</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : null}
+          </DemoModalContent>
+        </Modal>
+      ))}
+    </Card>
+  );
+}
+
+/** Modals nested in each other's JSX — the case context depth always handled. */
+function NestedScenario() {
+  const [outer, setOuter] = useState(false);
+  const [inner, setInner] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Nested modals</CardTitle>
+        <CardDescription>
+          Each modal is rendered inside the previous one. The third is uncontrolled. Opening the
+          outer and middle modal in the same click registers the child before its parent; the child
+          must still land on top.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Button size="sm" variant="secondary" onClick={() => setOuter(true)}>
+          Open outer modal
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => {
+            setOuter(true);
+            setInner(true);
+          }}
+        >
+          Open outer and middle together
+        </Button>
+      </CardContent>
+
+      <Modal open={outer} onOpenChange={setOuter}>
+        <DemoModalContent
+          title="Outer modal"
+          description="Contains the middle modal in its JSX."
+          treeDepth={1}
+          widthLevel={0}
+        >
+          <Button size="sm" variant="secondary" onClick={() => setInner(true)}>
+            Open middle modal
+          </Button>
+          <Modal open={inner} onOpenChange={setInner}>
+            <DemoModalContent
+              title="Middle modal"
+              description="Contains an uncontrolled modal with its own trigger."
+              treeDepth={2}
+              widthLevel={1}
+            >
+              <Modal>
+                <ModalTrigger asChild>
+                  <Button size="sm" variant="secondary">
+                    Open inner modal
+                  </Button>
+                </ModalTrigger>
+                <DemoModalContent
+                  title="Inner modal"
+                  description="Uncontrolled: Radix owns no state here, the stack still sees it."
+                  treeDepth={3}
+                  widthLevel={2}
+                />
+              </Modal>
+            </DemoModalContent>
+          </Modal>
+        </DemoModalContent>
+      </Modal>
+    </Card>
+  );
+}
+
+/** A modal that opens a sheet and a confirm, both rendered as siblings. */
+function MixedScenario() {
+  const [modal, setModal] = useState(false);
+  const [sheet, setSheet] = useState(false);
+  const [confirm, setConfirm] = useState(false);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Modal, sheet, and confirm</CardTitle>
+        <CardDescription>
+          The sheet and the confirm are siblings of the modal. Open the sheet from the modal, then
+          the confirm from the sheet: three different primitives, one stack.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Button size="sm" variant="secondary" onClick={() => setModal(true)}>
+          Open project settings
+        </Button>
+      </CardContent>
+
+      <Modal open={modal} onOpenChange={setModal}>
+        <DemoModalContent
+          title="Project settings"
+          description="The sheet and confirm below are not inside this modal's JSX."
+          treeDepth={1}
+          widthLevel={0}
+        >
+          <Button size="sm" variant="secondary" onClick={() => setSheet(true)}>
+            Open details sheet
+          </Button>
+          <Button size="sm" variant="destructive" onClick={() => setConfirm(true)}>
+            Delete project
+          </Button>
+        </DemoModalContent>
+      </Modal>
+
+      <Sheet open={sheet} onOpenChange={setSheet}>
+        <SheetContent>
+          <SheetHeader>
+            <SheetTitle>Project details</SheetTitle>
+            <SheetDescription>A sheet opened over a sibling modal.</SheetDescription>
+          </SheetHeader>
+          <SheetBody>
+            <DepthReadout legacyDepth={null} />
+            <Button size="sm" variant="destructive" onClick={() => setConfirm(true)}>
+              Delete project
+            </Button>
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
+
+      <ConfirmDialog
+        open={confirm}
+        onOpenChange={setConfirm}
+        title="Delete project?"
+        description="Demo only. Nothing is deleted."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={() => setConfirm(false)}
+      />
+    </Card>
+  );
+}
+
+export default function DebugModalStackPage() {
+  const [legacy, setLegacy] = useState(false);
+
+  return (
+    <LegacyStackingContext.Provider value={legacy}>
+      <div className="bg-background min-h-screen">
+        <div className="mx-auto w-full max-w-2xl space-y-5 px-4 py-10 pb-20 lg:py-20">
+          <header className="space-y-1">
+            <h1 className="text-foreground text-xl font-medium">Modal stack</h1>
+            <p className="text-muted-foreground text-sm text-balance">
+              Every modal opened while another is open must sit above it, with its overlay dimming
+              the card below. The inspector in the bottom right checks the real z-index of every
+              open layer.
+            </p>
+          </header>
+
+          <Card>
+            <CardContent className="flex items-center justify-between gap-4 pt-4">
+              <div className="min-w-0 space-y-1">
+                <p className="text-sm font-medium">Pre-fix stacking</p>
+                <p className="text-muted-foreground text-xs">
+                  Pins the demo modal cards to the z-index JSX nesting alone gave them. Open two
+                  sibling modals to reproduce the conflict.
+                </p>
+              </div>
+              <Switch checked={legacy} onCheckedChange={setLegacy} />
+            </CardContent>
+          </Card>
+
+          <SiblingScenario />
+          <NestedScenario />
+          <MixedScenario />
+        </div>
+      </div>
+      <LayerInspector />
+    </LegacyStackingContext.Provider>
+  );
+}

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -5,23 +5,35 @@ import * as React from 'react';
 
 import { ButtonProps, buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { DialogDepthProvider, dialogContentZ, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
+import {
+  DialogDepthProvider,
+  dialogContentZ,
+  dialogOverlayZ,
+  useDialogDepth,
+  useDialogRootLayer,
+} from '@/lib/z-stack';
 
-// Depth is derived from context on purpose — an alert that confirms for a
-// dialog must be rendered INSIDE that dialog's React tree, which nests it a
-// band above automatically. Rendering it as a sibling and hand-tuning a depth
-// looks right but still breaks: Radix reads pointer ownership off the React
-// tree, so the dialog underneath treats every click in the alert as an
-// outside-click and dismisses itself.
+// Depth follows the runtime layer stack, so an alert stacks above whatever is
+// open even when it is rendered as a sibling. Still prefer rendering an alert
+// that confirms for a dialog INSIDE that dialog's React tree: React events from
+// the alert then bubble through the dialog, so the dialog's own outside-click
+// and focus handlers never see the alert as "outside".
 function AlertDialog({
   children,
+  open,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
-  const parentDepth = useDialogDepth();
-  const depth = parentDepth + 1;
+  const layer = useDialogRootLayer({ open, defaultOpen, onOpenChange });
   return (
-    <DialogDepthProvider depth={depth}>
-      <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props}>
+    <DialogDepthProvider depth={layer.depth}>
+      <AlertDialogPrimitive.Root
+        data-slot="alert-dialog"
+        {...props}
+        open={layer.open}
+        onOpenChange={layer.onOpenChange}
+      >
         {children}
       </AlertDialogPrimitive.Root>
     </DialogDepthProvider>

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -3,18 +3,23 @@ import * as React from 'react';
 
 import { Close } from '@/features/icon/icons/close';
 import { cn } from '@/lib/utils';
-import { dialogContentZ, DialogDepthProvider, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
+import {
+  dialogContentZ,
+  DialogDepthProvider,
+  dialogOverlayZ,
+  useDialogDepth,
+  useDialogRootLayer,
+} from '@/lib/z-stack';
 import { cva, VariantProps } from 'class-variance-authority';
 import { buttonVariants } from './button';
 import { triggerVariants, type TriggerVariantProps } from './trigger-variants';
 
-const Dialog = ({ onOpenChange, ...props }: DialogPrimitive.DialogProps) => {
-  const parentDepth = useDialogDepth();
-  const depth = parentDepth + 1;
+const Dialog = ({ open, defaultOpen, onOpenChange, ...props }: DialogPrimitive.DialogProps) => {
+  const layer = useDialogRootLayer({ open, defaultOpen, onOpenChange });
 
   return (
-    <DialogDepthProvider depth={depth}>
-      <DialogPrimitive.Root onOpenChange={onOpenChange} {...props} />
+    <DialogDepthProvider depth={layer.depth}>
+      <DialogPrimitive.Root {...props} open={layer.open} onOpenChange={layer.onOpenChange} />
     </DialogDepthProvider>
   );
 };

--- a/apps/web/src/components/ui/modal.tsx
+++ b/apps/web/src/components/ui/modal.tsx
@@ -54,19 +54,21 @@ import {
   hasOpenFloatingLayer,
   isFloatingLayerTarget,
   useDialogDepth,
+  useDialogRootLayer,
 } from '@/lib/z-stack';
 import { Suspense, useEffect, useState } from 'react';
 import { Button } from './button';
 import Loading from './loading';
 import { triggerVariants, type TriggerVariantProps } from './trigger-variants';
 
-const Modal = ({ onOpenChange, ...props }: DialogPrimitive.DialogProps) => {
-  const parentDepth = useDialogDepth();
-  const depth = parentDepth + 1;
+// Stacks by open order, not only by JSX nesting: a Modal opened while another
+// is open sits above it even when the two share no React ancestor.
+const Modal = ({ open, defaultOpen, onOpenChange, ...props }: DialogPrimitive.DialogProps) => {
+  const layer = useDialogRootLayer({ open, defaultOpen, onOpenChange });
 
   return (
-    <DialogDepthProvider depth={depth}>
-      <DialogPrimitive.Root onOpenChange={onOpenChange} {...props} />
+    <DialogDepthProvider depth={layer.depth}>
+      <DialogPrimitive.Root {...props} open={layer.open} onOpenChange={layer.onOpenChange} />
     </DialogDepthProvider>
   );
 };

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -6,17 +6,27 @@ import * as React from 'react';
 
 import { Close } from '@/features/icon/icons/close';
 import { cn } from '@/lib/utils';
-import { DialogDepthProvider, dialogContentZ, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
+import {
+  DialogDepthProvider,
+  dialogContentZ,
+  dialogOverlayZ,
+  useDialogDepth,
+  useDialogRootLayer,
+} from '@/lib/z-stack';
 import { buttonVariants } from './button';
 import { triggerVariants, type TriggerVariantProps } from './trigger-variants';
 
-const Sheet = ({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) => {
-  const parentDepth = useDialogDepth();
-  const depth = parentDepth + 1;
+const Sheet = ({
+  open,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Root>) => {
+  const layer = useDialogRootLayer({ open, defaultOpen, onOpenChange });
 
   return (
-    <DialogDepthProvider depth={depth}>
-      <SheetPrimitive.Root {...props} />
+    <DialogDepthProvider depth={layer.depth}>
+      <SheetPrimitive.Root {...props} open={layer.open} onOpenChange={layer.onOpenChange} />
     </DialogDepthProvider>
   );
 };

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -4,22 +4,14 @@ import { spring } from '@/lib/springs';
 import { cn } from '@/lib/utils';
 import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { animate, m, useMotionValue } from 'motion/react';
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ComponentProps,
-  type CSSProperties,
-} from 'react';
+import { forwardRef, useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
 
 type SwitchProps = Omit<ComponentProps<typeof SwitchPrimitive.Root>, 'asChild'> & {
   label?: string;
 };
 
+// Track is `w-[34px] h-[20px]` in the className — keep it in sync with these.
 const TRACK_WIDTH = 34;
-const TRACK_HEIGHT = 20;
 const THUMB_SIZE = 16;
 const THUMB_OFFSET = 2;
 const THUMB_TRAVEL = TRACK_WIDTH - THUMB_SIZE - THUMB_OFFSET * 2;
@@ -27,13 +19,6 @@ const PILL_EXTEND = 2;
 const PRESS_EXTEND = 4;
 const PRESS_SHRINK = 4;
 const DRAG_DEAD_ZONE = 2;
-
-// Off-state ring + thumb gray: the lightest mix that still clears WCAG 1.4.11
-// (3:1) on every surface. Light #858585: ≥3.11:1 (worst: `bg-muted`), dark
-// #767676: ≥3.75:1. Below 78% the light `bg-card` and `bg-muted` pairs fail.
-// Hover steps to plain `--muted-foreground` (light #666, dark #999): ≥4.86:1.
-const SWITCH_EDGE = 'color-mix(in oklab, var(--muted-foreground) 78%, var(--background))';
-const SWITCH_EDGE_HOVER = 'var(--muted-foreground)';
 
 const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ label, checked, onCheckedChange, disabled = false, className, id, ...props }, ref) => {
@@ -148,25 +133,17 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
         disabled={disabled}
         tabIndex={0}
         className={cn(
-          'relative shrink-0 cursor-pointer touch-none rounded-full outline-none',
+          'group/switch relative h-[20px] w-[34px] shrink-0 cursor-pointer touch-none rounded-full outline-none',
           'transition-colors duration-80',
           'focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-1 focus-visible:ring-offset-2',
-          // WCAG 1.4.11 needs 3:1 for the track edge and the thumb. The off
-          // track (`--accent`) is ~1.1:1 against the page in both themes, so
-          // the edge comes from an inset ring and the thumb shares its gray.
-          // `inset-ring` composes with the focus `ring`; an inline box-shadow
-          // would erase it.
-          !isChecked && 'inset-ring inset-ring-(--switch-edge)',
+          // Colours come from Radix's `data-state`, never from JS state.
+          // Off is translucent ink, so one class reads in both themes and on
+          // any panel. Thumb vs track (WCAG 1.4.11, 3:1), worst of page /
+          // card / muted: rest 3.13:1, hover 4.13:1. On: white thumb 3.23:1.
+          'data-[state=checked]:bg-kortix-blue',
+          'data-[state=unchecked]:bg-foreground/10 data-[state=unchecked]:hover:bg-foreground/15',
           !label && className,
         )}
-        style={
-          {
-            width: TRACK_WIDTH,
-            height: TRACK_HEIGHT,
-            backgroundColor: isChecked ? 'var(--kortix-blue)' : 'var(--accent)',
-            '--switch-edge': isChecked ? undefined : hovered ? SWITCH_EDGE_HOVER : SWITCH_EDGE,
-          } as CSSProperties
-        }
         onPointerEnter={(e) => {
           if (e.pointerType === 'mouse') setHovered(true);
         }}
@@ -183,11 +160,13 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
         <SwitchPrimitive.Thumb asChild>
           <m.span
             className={cn(
-              'duration-fast absolute top-0 left-0 block rounded-full shadow-sm transition-colors',
-              // A white thumb on the light off track is 1.1:1 — invisible.
-              isChecked ? 'bg-white' : 'bg-(--switch-edge)',
+              'duration-fast absolute top-0 left-0 rounded-full shadow-sm transition-colors',
+              'data-[state=checked]:bg-white',
+              // A white thumb on the light off track would be ~1.25:1.
+              'data-[state=unchecked]:bg-foreground/45 group-hover/switch:data-[state=unchecked]:bg-foreground/55',
             )}
             initial={false}
+            // Motion value binding for drag, not a colour or layout style.
             style={{ x: motionX }}
             animate={{
               y: thumbY,

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -4,7 +4,15 @@ import { spring } from '@/lib/springs';
 import { cn } from '@/lib/utils';
 import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { animate, m, useMotionValue } from 'motion/react';
-import { forwardRef, useCallback, useEffect, useRef, useState, type ComponentProps } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ComponentProps,
+  type CSSProperties,
+} from 'react';
 
 type SwitchProps = Omit<ComponentProps<typeof SwitchPrimitive.Root>, 'asChild'> & {
   label?: string;
@@ -19,6 +27,13 @@ const PILL_EXTEND = 2;
 const PRESS_EXTEND = 4;
 const PRESS_SHRINK = 4;
 const DRAG_DEAD_ZONE = 2;
+
+// Off-state ring + thumb gray: the lightest mix that still clears WCAG 1.4.11
+// (3:1) on every surface. Light #858585: ≥3.11:1 (worst: `bg-muted`), dark
+// #767676: ≥3.75:1. Below 78% the light `bg-card` and `bg-muted` pairs fail.
+// Hover steps to plain `--muted-foreground` (light #666, dark #999): ≥4.86:1.
+const SWITCH_EDGE = 'color-mix(in oklab, var(--muted-foreground) 78%, var(--background))';
+const SWITCH_EDGE_HOVER = 'var(--muted-foreground)';
 
 const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
   ({ label, checked, onCheckedChange, disabled = false, className, id, ...props }, ref) => {
@@ -138,19 +153,20 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
           'focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-1 focus-visible:ring-offset-2',
           // WCAG 1.4.11 needs 3:1 for the track edge and the thumb. The off
           // track (`--accent`) is ~1.1:1 against the page in both themes, so
-          // the edge comes from an inset ring and the thumb takes the same ink.
-          // Off: ≥4.86:1 on every surface. Hover raises it to ≥17:1. On: the
-          // white thumb is 3.23:1 on `--kortix-blue`. `inset-ring` composes
-          // with the focus `ring`; an inline box-shadow would erase it.
-          !isChecked && 'inset-ring',
-          !isChecked && (hovered ? 'inset-ring-foreground' : 'inset-ring-muted-foreground'),
+          // the edge comes from an inset ring and the thumb shares its gray.
+          // `inset-ring` composes with the focus `ring`; an inline box-shadow
+          // would erase it.
+          !isChecked && 'inset-ring inset-ring-(--switch-edge)',
           !label && className,
         )}
-        style={{
-          width: TRACK_WIDTH,
-          height: TRACK_HEIGHT,
-          backgroundColor: isChecked ? 'var(--kortix-blue)' : 'var(--accent)',
-        }}
+        style={
+          {
+            width: TRACK_WIDTH,
+            height: TRACK_HEIGHT,
+            backgroundColor: isChecked ? 'var(--kortix-blue)' : 'var(--accent)',
+            '--switch-edge': isChecked ? undefined : hovered ? SWITCH_EDGE_HOVER : SWITCH_EDGE,
+          } as CSSProperties
+        }
         onPointerEnter={(e) => {
           if (e.pointerType === 'mouse') setHovered(true);
         }}
@@ -169,7 +185,7 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
             className={cn(
               'duration-fast absolute top-0 left-0 block rounded-full shadow-sm transition-colors',
               // A white thumb on the light off track is 1.1:1 — invisible.
-              isChecked ? 'bg-white' : hovered ? 'bg-foreground' : 'bg-muted-foreground',
+              isChecked ? 'bg-white' : 'bg-(--switch-edge)',
             )}
             initial={false}
             style={{ x: motionX }}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -136,18 +136,20 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
           'relative shrink-0 cursor-pointer touch-none rounded-full outline-none',
           'transition-colors duration-80',
           'focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-1 focus-visible:ring-offset-2',
+          // WCAG 1.4.11 needs 3:1 for the track edge and the thumb. The off
+          // track (`--accent`) is ~1.1:1 against the page in both themes, so
+          // the edge comes from an inset ring and the thumb takes the same ink.
+          // Off: ≥4.86:1 on every surface. Hover raises it to ≥17:1. On: the
+          // white thumb is 3.23:1 on `--kortix-blue`. `inset-ring` composes
+          // with the focus `ring`; an inline box-shadow would erase it.
+          !isChecked && 'inset-ring',
+          !isChecked && (hovered ? 'inset-ring-foreground' : 'inset-ring-muted-foreground'),
           !label && className,
         )}
         style={{
           width: TRACK_WIDTH,
           height: TRACK_HEIGHT,
-          backgroundColor: isChecked
-            ? hovered
-              ? 'var(--kortix-blue)'
-              : 'var(--kortix-blue)'
-            : hovered
-              ? 'color-mix(in oklab, var(--accent), rgb(var(--overlay)) 10%)'
-              : 'var(--accent)',
+          backgroundColor: isChecked ? 'var(--kortix-blue)' : 'var(--accent)',
         }}
         onPointerEnter={(e) => {
           if (e.pointerType === 'mouse') setHovered(true);
@@ -164,7 +166,11 @@ const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
       >
         <SwitchPrimitive.Thumb asChild>
           <m.span
-            className="absolute top-0 left-0 block rounded-full bg-white shadow-sm"
+            className={cn(
+              'duration-fast absolute top-0 left-0 block rounded-full shadow-sm transition-colors',
+              // A white thumb on the light off track is 1.1:1 — invisible.
+              isChecked ? 'bg-white' : hovered ? 'bg-foreground' : 'bg-muted-foreground',
+            )}
             initial={false}
             style={{ x: motionX }}
             animate={{

--- a/apps/web/src/features/file-viewer/file-preview-modal.tsx
+++ b/apps/web/src/features/file-viewer/file-preview-modal.tsx
@@ -6,7 +6,12 @@ import Hint from '@/components/ui/hint';
 import { errorToast, successToast } from '@/components/ui/toast';
 import { useTranslations } from '@/i18n/use-translations';
 import { cn } from '@/lib/utils';
-import { dialogContentZ, dialogOverlayZ, useDialogDepth } from '@/lib/z-stack';
+import {
+  dialogContentZ,
+  DialogDepthProvider,
+  dialogOverlayZ,
+  useDialogLayerDepth,
+} from '@/lib/z-stack';
 import {
   CaretLeftIcon as ChevronLeft,
   CaretRightIcon as ChevronRight,
@@ -113,13 +118,14 @@ export function FilePreviewModal({
   embedded = false,
 }: FilePreviewModalProps) {
   const tI18nHardcoded = useTranslations('hardcodedUi');
-  const dialogDepth = useDialogDepth();
   const isOpen = panelMode === 'viewer' && !!selectedFilePath;
 
   // Embedded viewers start inline (in the side panel); "Expand" pops them to
   // the full-screen overlay. Non-embedded viewers are always full-screen.
   const [expanded, setExpanded] = useState(false);
   const fullscreen = !embedded || expanded;
+  // Only the full-screen overlay is a layer; the inline panel sits in flow.
+  const dialogDepth = useDialogLayerDepth(isOpen && fullscreen);
 
   const fileName = selectedFilePath?.split('/').pop() || '';
   const hasNext = currentFileIndex < filePathList.length - 1;
@@ -495,11 +501,11 @@ export function FilePreviewModal({
   }
 
   const node = (
-    <>
+    <DialogDepthProvider depth={dialogDepth}>
       <div
         data-file-preview-overlay=""
         className="animate-in fade-in-0 pointer-events-auto fixed inset-0 bg-black/50 backdrop-blur-sm duration-150"
-        style={{ zIndex: dialogOverlayZ(dialogDepth + 1) }}
+        style={{ zIndex: dialogOverlayZ(dialogDepth) }}
         onClick={embedded ? () => setExpanded(false) : onClose}
       />
       <div
@@ -512,11 +518,11 @@ export function FilePreviewModal({
         })}
         tabIndex={-1}
         className="kx-fullscreen-modal border-border/60 bg-background animate-in fade-in-0 zoom-in-[0.98] pointer-events-auto fixed inset-3 flex flex-col overflow-hidden rounded-xl border shadow-lg duration-150 outline-none sm:inset-4"
-        style={{ zIndex: dialogContentZ(dialogDepth + 1) }}
+        style={{ zIndex: dialogContentZ(dialogDepth) }}
       >
         {panelInner}
       </div>
-    </>
+    </DialogDepthProvider>
   );
 
   return createPortal(node, document.body);

--- a/apps/web/src/lib/z-stack.test.ts
+++ b/apps/web/src/lib/z-stack.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import {
+  closeDialogLayer,
+  dialogContentZ,
+  dialogLayerLevel,
+  dialogOverlayZ,
+  openDialogLayer,
+  removeDialogLayer,
+} from './z-stack';
+
+// The store is module-global on purpose (it has to see modals that share no
+// React ancestor), so every test removes the ids it registered.
+const registered = new Set<string>();
+function open(id: string, minLevel = 1): number {
+  registered.add(id);
+  return openDialogLayer(id, minLevel);
+}
+
+afterEach(() => {
+  for (const id of registered) removeDialogLayer(id);
+  registered.clear();
+});
+
+describe('dialog layer stack', () => {
+  test('a sibling modal opened over an open modal gets the next level', () => {
+    // The reported bug: both modals mount at the app root, so React context
+    // gives each depth 1 and the second overlay renders UNDER the first card.
+    expect(open('first')).toBe(1);
+    expect(open('second')).toBe(2);
+    expect(dialogOverlayZ(2)).toBeGreaterThan(dialogContentZ(1));
+  });
+
+  test('three siblings stack in open order', () => {
+    expect([open('a'), open('b'), open('c')]).toEqual([1, 2, 3]);
+  });
+
+  test('a nested modal keeps its tree floor even when nothing else is open', () => {
+    expect(open('child', 2)).toBe(2);
+  });
+
+  test('a closing modal keeps its level through the exit animation', () => {
+    open('below');
+    open('above');
+    closeDialogLayer('above');
+    expect(dialogLayerLevel('above')).toBe(2);
+  });
+
+  test('a closed modal no longer raises the next one', () => {
+    open('below');
+    open('above');
+    closeDialogLayer('above');
+    expect(open('replacement')).toBe(2);
+  });
+
+  test('reopening re-levels above whatever opened meanwhile', () => {
+    open('x');
+    closeDialogLayer('x');
+    open('y');
+    expect(open('x')).toBe(2);
+  });
+
+  test('an open layer keeps its level when re-registered', () => {
+    open('stable');
+    open('sibling');
+    expect(open('stable')).toBe(1);
+  });
+
+  test('an open layer rises when its tree floor rises', () => {
+    open('grows');
+    expect(open('grows', 4)).toBe(4);
+  });
+
+  test('a nested pair that opens in the same commit still puts the child on top', () => {
+    // Layout effects run child-first, so the child registers before its parent.
+    const child = open('child', 2);
+    const parent = open('parent', 1);
+    // The child's floor then follows the parent's new level via context.
+    const childAfter = open('child', parent + 1);
+    expect(child).toBe(2);
+    expect(childAfter).toBeGreaterThan(parent);
+  });
+
+  test('removing a layer forgets it', () => {
+    open('gone');
+    removeDialogLayer('gone');
+    expect(dialogLayerLevel('gone')).toBe(0);
+  });
+});

--- a/apps/web/src/lib/z-stack.tsx
+++ b/apps/web/src/lib/z-stack.tsx
@@ -17,6 +17,129 @@ export function useDialogDepth(): number {
   return React.useContext(DialogDepthContext);
 }
 
+// ─── Runtime layer stack ────────────────────────────────────────────────────
+// Context depth alone only stacks modals nested in each other's JSX. A modal
+// mounted as a sibling (a global host, a store-driven dialog, one opened from a
+// toast or the palette) resolves depth 1 however many modals are open, so its
+// overlay lands UNDER the open modal's content. This registry sees every open
+// layer regardless of tree position: opening one takes the next level above
+// the highest open layer. Radix's DismissableLayer already stacks Escape and
+// outside-click this way (one global list), so only z-index needed it.
+
+type DialogLayer = { level: number; open: boolean };
+
+const dialogLayers = new Map<string, DialogLayer>();
+const dialogLayerListeners = new Set<() => void>();
+
+function subscribeDialogLayers(listener: () => void) {
+  dialogLayerListeners.add(listener);
+  return () => {
+    dialogLayerListeners.delete(listener);
+  };
+}
+
+/** Level held by `id`, or 0 when unregistered. Kept after close on purpose. */
+export function dialogLayerLevel(id: string): number {
+  return dialogLayers.get(id)?.level ?? 0;
+}
+
+/**
+ * Mark `id` open and return its level. A layer that is already open keeps its
+ * level (it only rises to `minLevel`, its React-tree floor), so a sibling
+ * opening above it never reshuffles it. A layer that is opening takes the next
+ * level above every other open layer.
+ */
+export function openDialogLayer(id: string, minLevel: number): number {
+  const current = dialogLayers.get(id);
+  let level: number;
+  if (current?.open) {
+    level = Math.max(current.level, minLevel);
+    if (level === current.level) return level;
+  } else {
+    let highest = 0;
+    for (const [otherId, layer] of dialogLayers) {
+      if (otherId !== id && layer.open) highest = Math.max(highest, layer.level);
+    }
+    level = Math.max(minLevel, highest + 1);
+  }
+  dialogLayers.set(id, { level, open: true });
+  dialogLayerListeners.forEach((listener) => listener());
+  return level;
+}
+
+/**
+ * Mark `id` closed. Its level is kept so the exit animation stays above the
+ * layer beneath it; it just stops raising layers that open afterwards.
+ */
+export function closeDialogLayer(id: string): void {
+  const current = dialogLayers.get(id);
+  if (current?.open) dialogLayers.set(id, { level: current.level, open: false });
+}
+
+export function removeDialogLayer(id: string): void {
+  dialogLayers.delete(id);
+}
+
+const serverDialogLayerLevel = () => 0;
+
+/**
+ * Depth for a layer that is `open`: its runtime level, never below the depth
+ * its React ancestors imply. Provide the result through `DialogDepthProvider`
+ * so nested selects, menus, and modals stack above it.
+ */
+export function useDialogLayerDepth(open: boolean): number {
+  const id = React.useId();
+  const parentDepth = useDialogDepth();
+  const level = React.useSyncExternalStore(
+    subscribeDialogLayers,
+    () => dialogLayerLevel(id),
+    serverDialogLayerLevel,
+  );
+
+  // Layout effect: the level lands in the store, and the store update
+  // re-renders synchronously before paint — the first open frame is never
+  // drawn at the wrong z-index.
+  React.useLayoutEffect(() => {
+    if (open) openDialogLayer(id, parentDepth + 1);
+    else closeDialogLayer(id);
+  }, [id, open, parentDepth]);
+
+  React.useLayoutEffect(() => () => removeDialogLayer(id), [id]);
+
+  return Math.max(level, parentDepth + 1);
+}
+
+type DialogRootOpenProps = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+/**
+ * `useDialogLayerDepth` for a Radix dialog root. The stack needs the open state
+ * of uncontrolled roots too, so this owns it and hands Radix a controlled
+ * `open` / `onOpenChange` pair — observable behaviour is unchanged.
+ */
+export function useDialogRootLayer({ open, defaultOpen, onOpenChange }: DialogRootOpenProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen ?? false);
+  const isControlled = open !== undefined;
+  const resolvedOpen = isControlled ? open : uncontrolledOpen;
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  return {
+    depth: useDialogLayerDepth(resolvedOpen),
+    open: resolvedOpen,
+    onOpenChange: handleOpenChange,
+  };
+}
+
 export function dialogOverlayZ(depth: number): number {
   const level = Math.max(1, depth);
   return 9998 + (level - 1) * 20;


### PR DESCRIPTION
## Summary

**Modal stacking.** Opening a modal while another modal is open rendered the new overlay *under* the open modal's card when the two modals were not nested in JSX (a global host, a store-driven modal). `Modal`, `Dialog`, `AlertDialog`, and `Sheet` took their depth only from React context, so both resolved depth 1: overlay `z 9998` under card `z 9999`.

- `lib/z-stack.tsx`: runtime layer stack. An opening layer takes `max(treeDepth + 1, highestOpenLevel + 1)` and keeps its level through the exit animation. Radix already stacks Escape and outside-click through one global layer list (`dismissable-layer` lines 49–95), so only z-index needed this.
- `Modal`, `Dialog`, `AlertDialog`, `Sheet` roots and `file-preview-modal.tsx` join the stack; uncontrolled roots are tracked.
- `file-preview-modal.tsx` provides its depth to children, so menus inside a preview opened from a modal render above it (was `floatingZ(1) = 10001` under content `10019`).
- New `/debug/modal-stack`: sibling, nested, and modal + sheet + confirm scenarios, a live z-index inspector (`Stacked` / `Conflict`), and a pre-fix toggle that reproduces the bug.

**Switch contrast (WCAG 2.2 SC 1.4.11), Tailwind classes only.** The off track was `--accent` (`#f4f4f4`), 1.10:1 against the page, so an off switch read as an empty outline. The hover color used `rgb(var(--overlay))`; `--overlay` is defined nowhere, so the hovered track rendered transparent. Colors were driven from an inline `style` and JS hover state.

Colors now come from Radix `data-state` plus `hover:` / `group-hover/switch:` only; no inline color styles (the one remaining `style` is the motion drag binding `x: motionX`). Off uses translucent ink, which flips with the theme and composites over any panel, so no `dark:` variants.

| State | Classes | Light on page | Thumb vs track (worst of page / card / muted, both themes) |
|---|---|---|---|
| Off | track `bg-foreground/10`, thumb `bg-foreground/45` | `#e5e5e5` / `#7e7e7e` | 3.13:1 |
| Off, hover | track `bg-foreground/15`, thumb `bg-foreground/55` | `#d9d9d9` / `#626262` | 4.13:1 |
| On | track `bg-kortix-blue`, thumb `bg-white` | unchanged | 3.23:1 |

Before: off track vs page 1.10:1, white thumb vs off track 1.10:1 (light), hovered off track transparent.

Known gap, not changed here: the on track (`--kortix-blue`) is 2.93:1 on light `bg-card` and 2.73:1 on light `bg-muted`. Fixing it needs a darker "on" color, which is a brand decision.

**Debug theme toggle.** `debug/layout.tsx` renders the compact `ThemeToggle` bottom-left on every `/debug/*` page. `D` flips light/dark from the keyboard, including while a modal stack is open (a click there is a backdrop dismiss). Keys in inputs, selects, and menus are ignored.

## Test plan

- [x] `bun test src/lib/z-stack.test.ts` — 10 pass (sibling, nested, close-keeps-level, reopen, same-commit parent+child).
- [x] `bun test` modal dismiss, dropdown-menu, type-to-confirm, file-viewer suites — 81 pass, 0 fail.
- [x] `tsc --noEmit` — 15 errors, all the documented baseline in 3 test files; 0 in changed files.
- [x] Compiled dev CSS contains every new selector (`data-[state=unchecked]:bg-foreground/10`, `…:hover:bg-foreground/15`, `group-hover/switch:data-[state=unchecked]:bg-foreground/55`, …).
- [x] `eslint` on changed files — 0 errors. `prettier --check` clean. Brand `audit.sh` clean on `switch.tsx` and the debug files.
- [ ] `/debug/modal-stack` → Sibling modals → open modal 1, then modal 2: modal 1 is dimmed, inspector shows `Stacked`.
- [ ] In modal 2, close modal 1 and reopen it: it opens on top.
- [ ] Toggle "Pre-fix stacking", repeat: modal 1 stays bright, inspector shows `Conflict`.
- [ ] "Open all three at once", "Open outer and middle together", and the Select in modal 3.
- [ ] With three modals open, press `D`: theme flips, no modal closes.
- [ ] Switch (the pre-fix toggle): off shows a soft gray filled track with a gray knob; hover darkens track and knob one step; on is blue with a white knob; same in dark; focus ring still shows on Tab.
- [ ] Theme toggle visible bottom-left on `/debug/connecting` and `/debug/wallpaper`.
- [ ] Desktop app: repeat the sibling-modal and Switch checks.

