### PR TITLE
fix(web): anchor every session hover card at the same edge

### DIFF
--- a/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
+++ b/apps/web/src/features/workspace/project-sidebar/project-session-list.tsx
@@ -847,6 +847,72 @@ function ProjectSessionRow({
           {childCount}
         </Badge>
       )}
+
+      {/* Spawned-by · source (Slack/Telegram/email/schedule/webhook) · shared,
+          and whatever markers get added here later. These are ambient state,
+          readable at rest; the `⋯` is the action. They occupy the SAME slot,
+          so hovering the row (or leaving its menu open) hands the slot to the
+          trigger and hides the strip.
+
+          Inside the link, not after it. The link is the hover card's trigger,
+          and HoverCard exports no `Anchor`, so the card positions against the
+          link's right edge. As a sibling, the strip shortened the link by its
+          own width plus the row's `gap-2`: a Slack or shared session's card
+          opened 24-56px inside the sidebar while a plain chat session's card
+          cleared it. In here, every row's link ends at the row's `px-2` edge.
+
+          Hidden with `opacity-0`, never `hidden`/`w-0`: the strip stays in
+          flow at its natural width, so the title's truncation point is fixed
+          and the text cannot reflow as the pointer crosses the row. It goes
+          `pointer-events-none` at the same time — an invisible icon must not
+          swallow a click meant for the trigger above it.
+
+          The trade: those icons' tooltips are unreachable, because reaching
+          an icon means hovering the row, which hides it. Accepted — they are
+          markers to be glanced at, not controls.
+
+          No transition, matching the trigger: the `⋯` appears instantly, and
+          a fade would leave both drawn on top of each other mid-cross. */}
+      {hasIndicators && (
+        <div
+          className={cn(
+            'flex shrink-0 items-center gap-0 transition-none',
+            'max-md:hidden [@media(hover:none)]:hidden [@media(pointer:coarse)]:hidden',
+            'group-hover/session-list:pointer-events-none group-hover/session-list:opacity-0',
+            'group-has-data-[state=open]/session-list:pointer-events-none group-has-data-[state=open]/session-list:opacity-0',
+          )}
+          data-session-indicators="true"
+        >
+          {showSpawnedBy && spawnedBy && (
+            <Hint
+              side="top"
+              label={tI18nComplete('text4d67694a7607', { value0: spawnedBy.slice(0, 8) })}
+            >
+              <span className="text-muted-foreground/70 flex size-4 shrink-0 items-center justify-center">
+                <SpawnedBy className="size-3" />
+              </span>
+            </Hint>
+          )}
+          {SourceIcon && (
+            <span
+              className="flex size-4 shrink-0 items-center justify-center"
+              data-session-source="true"
+            >
+              <Hint
+                side="top"
+                label={
+                  source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label
+                }
+              >
+                <span className="text-muted-foreground/70 flex size-4 items-center justify-center">
+                  <SourceIcon className="size-3" />
+                </span>
+              </Hint>
+            </span>
+          )}
+          <SessionSharedIcon session={session} />
+        </div>
+      )}
     </HoverPrefetchLink>
   );
 
@@ -899,67 +965,8 @@ function ProjectSessionRow({
           changeRequests={changeRequests}
         />
 
-        {/* Spawned-by · source (Slack/Telegram/email/schedule/webhook) · shared,
-            and whatever markers get added here later. These are ambient state,
-            readable at rest; the `⋯` is the action. They occupy the SAME slot,
-            so hovering the row (or leaving its menu open) hands the slot to the
-            trigger and hides the strip.
-
-            Hidden with `opacity-0`, never `hidden`/`w-0`: the strip stays in
-            flow at its natural width, so the title's truncation point is fixed
-            and the text cannot reflow as the pointer crosses the row. It goes
-            `pointer-events-none` at the same time — an invisible icon must not
-            swallow a click meant for the trigger underneath it.
-
-            The trade: those icons' tooltips are unreachable, because reaching
-            an icon means hovering the row, which hides it. Accepted — they are
-            markers to be glanced at, not controls.
-
-            No transition, matching the trigger: the `⋯` appears instantly, and
-            a fade would leave both drawn on top of each other mid-cross. */}
-        {hasIndicators && (
-          <div
-            className={cn(
-              'flex shrink-0 items-center gap-0 transition-none',
-              'max-md:hidden [@media(hover:none)]:hidden [@media(pointer:coarse)]:hidden',
-              'group-hover/session-list:pointer-events-none group-hover/session-list:opacity-0',
-              'group-has-data-[state=open]/session-list:pointer-events-none group-has-data-[state=open]/session-list:opacity-0',
-            )}
-            data-session-indicators="true"
-          >
-            {showSpawnedBy && spawnedBy && (
-              <Hint
-                side="top"
-                label={tI18nComplete('text4d67694a7607', { value0: spawnedBy.slice(0, 8) })}
-              >
-                <span className="text-muted-foreground/70 flex size-4 shrink-0 items-center justify-center">
-                  <SpawnedBy className="size-3" />
-                </span>
-              </Hint>
-            )}
-            {SourceIcon && (
-              <span
-                className="flex size-4 shrink-0 items-center justify-center"
-                data-session-source="true"
-              >
-                <Hint
-                  side="top"
-                  label={
-                    source.triggerSlug ? `${source.label} · ${source.triggerSlug}` : source.label
-                  }
-                >
-                  <span className="text-muted-foreground/70 flex size-4 items-center justify-center">
-                    <SourceIcon className="size-3" />
-                  </span>
-                </Hint>
-              </span>
-            )}
-            <SessionSharedIcon session={session} />
-          </div>
-        )}
-
-        {/* Out of flow on purpose. This trigger is a sibling of the link and of
-            the indicator strip, absolutely positioned against the row itself —
+        {/* Out of flow on purpose. This trigger is a sibling of the link (which
+            holds the indicator strip), absolutely positioned against the row —
             it reserves NO width, so the title measures against the full row and
             truncates only at the real edge. It used to sit inside a `relative`
             wrapper at the end of the indicator strip; that wrapper was still a

--- a/apps/web/src/features/workspace/project-sidebar/session-brief-hover-card.test.ts
+++ b/apps/web/src/features/workspace/project-sidebar/session-brief-hover-card.test.ts
@@ -66,6 +66,20 @@ describe('session status agreement', () => {
   });
 });
 
+describe('session brief hover card anchor', () => {
+  const listSource = readFileSync(join(import.meta.dir, 'project-session-list.tsx'), 'utf8');
+
+  test('every row anchors the card at the same edge', () => {
+    // HoverCard exports no `Anchor`, so the card positions against its trigger,
+    // the session link. The indicator strip once sat AFTER the link as a
+    // sibling: a Slack, schedule or shared session had a link 24-56px shorter
+    // than a plain chat session, and its card opened that far inside the
+    // sidebar. Local data had no indicators, so only dev/staging/prod showed it.
+    const link = between(listSource, 'const sessionLink = (', '</HoverPrefetchLink>');
+    expect(link).toContain('data-session-indicators="true"');
+  });
+});
+
 describe('session brief hover card surface', () => {
   test('wears the shared floating-panel recipe rather than its own', () => {
     expect(hoverCardSource).toContain('FLOATING_PANEL');


### PR DESCRIPTION
## Summary

The session brief hover card in the project sidebar opened 24–56px inside the sidebar on dev, staging, and prod. Locally it cleared the sidebar edge.

The build is not the cause. `origin/prod`, `origin/staging`, and `main` have identical code for the card. The row data is the cause:

- Radix HoverCard exports no `Anchor`, so the card positions against its trigger, the session link (`flex-1`).
- The indicator strip (`data-session-indicators`: spawned-by, Slack/schedule/email source, shared) rendered after the link as a row sibling. It shortened the link by its width plus the row's `gap-2`.
- Sessions with those markers moved the card left. Plain chat sessions (local seed data) have no markers, so their card was correct.

Changes:

- `project-session-list.tsx`: the indicator strip renders inside `sessionLink`, after the child-count badge. Every row's link ends at the row's `px-2` edge. `sideOffset={14}` and `align="start"` are unchanged.
- Visible behavior of the strip is unchanged: same position, hidden on row hover, same title truncation point.
- Side effects: a click on the strip area now navigates to the session (it did nothing before). The shared icon's `aria-label` ("Shared by …") is now part of the link's accessible name.
- `session-brief-hover-card.test.ts`: new test `every row anchors the card at the same edge`. It failed before the fix and passes after it.

## Test plan

- [x] `bun test src/features/workspace/project-sidebar/` → 244 pass, 0 fail
- [x] `npx eslint src/features/workspace/project-sidebar/project-session-list.tsx src/features/workspace/project-sidebar/session-brief-hover-card.test.ts` → 0 errors
- [x] `npx tsc --noEmit` → 15 errors, all the known `test.each` baseline, none in changed files
- [x] `bun test src/sdk-boundary.test.ts` → 0 fail
- [x] `.claude/skills/kortix-brand-guidelines/audit.sh` on the changed file → clean
- [ ] Hover a Slack, scheduled, or shared session row: the card's left edge matches a plain chat session's card
- [ ] Hover a row with a child-count badge: same edge
- [ ] Electron, sidebar docked open: same edge
- [ ] e2e `21-trigger-session-access.spec.ts` stays green (it locates the strip as a descendant of the row)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/kortix-ai/codesmith/suna/pr/7214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791724994&installation_model_id=434224&pr_number=7214&repository=kortix-ai%2Fsuna&return_to=https%3A%2F%2Fgithub.com%2Fkortix-ai%2Fsuna%2Fpull%2F7214&signature=a1432d4959df58d0299185b556dfe7e6047c798d31e40c904863c87b66abda27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->